### PR TITLE
Use HTTPS for remote includes

### DIFF
--- a/Duplicati/Server/webroot/greeno/index.html
+++ b/Duplicati/Server/webroot/greeno/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=9" />
 <title>Backup</title>
 
-    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro' rel='stylesheet' type='text/css'>
 
     <link rel="stylesheet" type="text/css" href="stylesheets/green-theme/jquery-ui-1.10.3.min.css" />
     <link rel="stylesheet" type="text/css" href="stylesheets/common.css" />


### PR DESCRIPTION
It could optional to be the same as current connection but I see no downside to always putting it in HTTPS

Including HTTP in HTTPS pages can be blocked by the browser
Including HTTPS in HTTP pages causes no issue
