### PR TITLE
Prevent backup-pop-up menu from top-values lower than 0 (hiding the top entries)

### DIFF
--- a/Duplicati/Server/webroot/greeno/scripts/app.js
+++ b/Duplicati/Server/webroot/greeno/scripts/app.js
@@ -1231,6 +1231,9 @@ $(document).ready(function() {
         if (top + menuheight > $(document).outerHeight())
             top -= menuheight;
 
+        if (top < 0)
+            top = 0;
+
         if (menu.is(':visible')) {
             menu.css({
                 position: 'absolute',


### PR DESCRIPTION
As adressed in #1183 the menu is displayed cut-off in situations where the vertical heigth of the screen does not allow showing all entries. Especially if the logic decides to pop-up the menu to the top, essential buttons of the pop-up menu may be hidden.

This commit prevents the menu from being displayed with negative top values, which hides the topmost menu entries.