### PR TITLE
Solving datetime culture specific bug

### DIFF
--- a/Duplicati/Library/Main/Volumes/VolumeBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeBase.cs
@@ -97,7 +97,7 @@ namespace Duplicati.Library.Main.Volumes
                     Prefix = m.Groups["prefix"].Value,
                     FileType = t,
                     Guid = m.Groups["guid"].Success ? m.Groups["guid"].Value : null,
-                    Time = m.Groups["time"].Success ? DateTime.ParseExact(m.Groups["time"].Value, "yyyyMMdd'T'HHmmssK", null, System.Globalization.DateTimeStyles.AssumeUniversal).ToUniversalTime() : new DateTime(0, DateTimeKind.Utc),
+                    Time = m.Groups["time"].Success ? Duplicati.Library.Utility.DateTimeInvariant.ParseExact(m.Groups["time"].Value, System.Globalization.DateTimeStyles.AssumeUniversal).ToUniversalTime() : new DateTime(0, DateTimeKind.Utc),
                     CompressionModule = m.Groups["compression"].Value,
                     EncryptionModule = m.Groups["encryption"].Success ? m.Groups["encryption"].Value : null,
                     File = file

--- a/Duplicati/Library/Utility/DateTimeInvariant.cs
+++ b/Duplicati/Library/Utility/DateTimeInvariant.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Duplicati.Library.Utility
+{
+    public static class DateTimeInvariant
+    {
+        private static string _Format = "yyyyMMdd'T'HHmmssK";
+        public static DateTime ParseExact(string s, DateTimeStyles style)
+        {
+            try
+            {
+                return DateTime.ParseExact(s, _Format, DateTimeFormatInfo.InvariantInfo, style);
+            }
+            catch (Exception) //For compatibility with previous backed-up data using system specific culture (other than Gregorian calendar)
+            {
+                return DateTime.ParseExact(s, _Format, null, style);
+            }
+        }
+
+        public static bool TryParseExact(string s, DateTimeStyles style, out DateTime result)
+        {
+            bool r = DateTime.TryParseExact(s, _Format, DateTimeFormatInfo.InvariantInfo, style, out result);
+            if (!r) //For compatibility with previous backed-up data using system specific culture
+                r = DateTime.TryParseExact(s, _Format, null, style, out result);
+            return r;
+        }
+
+        public static string ToStringInvariant(this DateTime date)
+        {
+            return date.ToString(_Format, DateTimeFormatInfo.InvariantInfo);
+        }
+    }
+}

--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncHttpRequest.cs" />
+    <Compile Include="DateTimeInvariant.cs" />
     <Compile Include="KeyGenerator.cs" />
     <Compile Include="OverrideableStream.cs" />
     <Compile Include="ProgressReportingStream.cs" />

--- a/Duplicati/Library/Utility/TempFile.cs
+++ b/Duplicati/Library/Utility/TempFile.cs
@@ -56,9 +56,9 @@ namespace Duplicati.Library.Utility
 			foreach(var f in st.GetFrames())
 				if (f.GetMethod().DeclaringType.Assembly != typeof(TempFile).Assembly)
 				{
-					var n = string.Format("{0}_{1}_{2}_{3}", f.GetMethod().DeclaringType.FullName, f.GetMethod().Name, DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssK"), Guid.NewGuid().ToString().Substring(0, 8));
+					var n = string.Format("{0}_{1}_{2}_{3}", f.GetMethod().DeclaringType.FullName, f.GetMethod().Name, DateTime.UtcNow.ToStringInvariant(), Guid.NewGuid().ToString().Substring(0, 8));
 					if (n.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) >= 0)
-						n = string.Format("{0}_{1}_{2}_{3}", f.GetMethod().DeclaringType.Name, f.GetMethod().Name, DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmssK"), Guid.NewGuid().ToString().Substring(0, 8));
+						n = string.Format("{0}_{1}_{2}_{3}", f.GetMethod().DeclaringType.Name, f.GetMethod().Name, DateTime.UtcNow.ToStringInvariant(), Guid.NewGuid().ToString().Substring(0, 8));
 					if (n.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) < 0)
 					{
 						lock(m_lock)

--- a/Duplicati/Library/Utility/Timeparser.cs
+++ b/Duplicati/Library/Utility/Timeparser.cs
@@ -62,7 +62,7 @@ namespace Duplicati.Library.Utility
             if (DateTime.TryParse(datestring, System.Globalization.CultureInfo.CurrentUICulture, System.Globalization.DateTimeStyles.AssumeLocal, out t))
                 return t;
             
-            if (DateTime.TryParseExact(datestring, "yyyyMMdd'T'HHmmssK", null, System.Globalization.DateTimeStyles.AssumeUniversal, out t))
+            if (DateTimeInvariant.TryParseExact(datestring, System.Globalization.DateTimeStyles.AssumeUniversal, out t))
                 return t;
 
             char[] separators = new char[] { 's', 'm', 'h', 'D', 'W', 'M', 'Y' };

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -938,7 +938,7 @@ namespace Duplicati.Library.Utility
         public static string SerializeDateTime(DateTime dt)
         {
             //Note: Actually the K should be Z which is more correct as it is forced to be Z, but Z as a format specifier is fairly undocumented
-            return dt.ToUniversalTime().ToString("yyyyMMdd'T'HHmmssK");
+            return dt.ToUniversalTime().ToStringInvariant();
         }
 
         /// <summary>
@@ -949,7 +949,7 @@ namespace Duplicati.Library.Utility
         public static DateTime DeserializeDateTime(string str)
         {
             DateTime dt;
-            if (!DateTime.TryParseExact(str, "yyyyMMdd'T'HHmmssK", null, System.Globalization.DateTimeStyles.AssumeUniversal, out dt))
+            if (!DateTimeInvariant.TryParseExact(str, System.Globalization.DateTimeStyles.AssumeUniversal, out dt))
                 throw new Exception(Strings.Utility.InvalidDateError(str));
 
             return dt;

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -237,7 +237,9 @@ namespace Duplicati.Server
             //Set the %DUPLICATI_HOME% env variable, if it is not already set
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(DATAFOLDER_ENV_NAME)))
             {
-#if DEBUG
+                //Add DEBUG_USE_RELEASE_HOMEFOLDER to Conditional compilation symbols in the Duplicati.Server project settings
+                //to use release home folder while debugging
+#if DEBUG && !DEBUG_USE_RELEASE_HOMEFOLDER
                 //debug mode uses a lock file located in the app folder
                 Environment.SetEnvironmentVariable(DATAFOLDER_ENV_NAME, StartupPath);
 #else

--- a/Duplicati/Server/WebServer/BodyWriter.cs
+++ b/Duplicati/Server/WebServer/BodyWriter.cs
@@ -52,7 +52,17 @@ namespace Duplicati.Server.WebServer
                 m_resp.ContentLength = base.BaseStream.Length;
                 m_resp.Send();
             }
-            base.Dispose(disposing);
+#if DEBUG
+            try
+            {
+#endif
+                base.Dispose(disposing);
+#if DEBUG
+            }
+            catch (Exception)
+            {
+            }
+#endif
         }
 
         public void SetOK()


### PR DESCRIPTION
When you change your system default calendar, the previous backups will cause exceptions.
After these changes backups will be culture independent.
It will resolve issue #1449 