### PR TITLE
Default 'time' option to 'now' when not set

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -592,10 +592,12 @@ namespace Duplicati.Library.Main
         {
             get
             {
+                string time;
                 if (!m_options.ContainsKey("time") || string.IsNullOrEmpty(m_options["time"]))
-                    return new DateTime(0, DateTimeKind.Utc);
+                    time = "now";
                 else
-                    return Library.Utility.Timeparser.ParseTimeInterval(m_options["time"], DateTime.Now);
+                    time = m_options["time"];
+                return Library.Utility.Timeparser.ParseTimeInterval(time, DateTime.Now);
             }
         }
         


### PR DESCRIPTION
This fixes problems with restore that complains about no fileset. The
reason there is no fileset is because 'time' was defaulting to beginning
of time, so no backup files are ever before the beginning of time.