### PR TITLE
Updated all references to code.google.com/p/duplicati to the new githhub repo

### DIFF
--- a/Installer/debian help/debian/control
+++ b/Installer/debian help/debian/control
@@ -5,7 +5,7 @@ Maintainer: Kenneth Skovhede <kenneth@duplicati.com>
 Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.4
 Homepage: http://www.duplicati.com
-Vcs-Git: https://code.google.com/p/duplicati
+Vcs-Git: https://github.com/duplicati/duplicati.git
 
 Package: duplicati
 Architecture: all

--- a/Installer/debian help/duplicati-make-git-snapshot.sh
+++ b/Installer/debian help/duplicati-make-git-snapshot.sh
@@ -21,7 +21,7 @@ echo HEAD ${1:-HEAD}
 rm -rf $DIRNAME
 
 git clone ${REF:+--reference $REF} \
-         https://code.google.com/p/duplicati/ $DIRNAME
+         https://github.com/duplicati/duplicati.git $DIRNAME
 
 cd "$DIRNAME"
 if [ -e "../oem.js" ]; then

--- a/Installer/fedora/duplicati-make-git-snapshot.sh
+++ b/Installer/fedora/duplicati-make-git-snapshot.sh
@@ -20,7 +20,7 @@ echo HEAD ${1:-HEAD}
 rm -rf $DIRNAME
 
 git clone ${REF:+--reference $REF} \
-         https://code.google.com/p/duplicati/ $DIRNAME
+         https://github.com/duplicati/duplicati.git $DIRNAME
 
 cd "$DIRNAME"
 if [ -e "../oem.js" ]; then


### PR DESCRIPTION
This was causing debian builds to fail to pull the most recent code. Looks like it would also affect the fedora builds.