### PR TITLE
Mitigate slow volume deletion

### DIFF
--- a/Duplicati/Library/Main/Database/Database schema/5. Optimize BlockSet-Tables.sql
+++ b/Duplicati/Library/Main/Database/Database schema/5. Optimize BlockSet-Tables.sql
@@ -1,29 +1,4 @@
 ﻿
---CREATE TEMP TABLE "UPGRADE_BlocksetEntry"
---    AS SELECT "BlocksetID", "Index", "BlockID" 
---         FROM "BlocksetEntry";
-
---DROP INDEX "BlocksetEntryIds_Forward";
---DROP INDEX "BlocksetEntryIds_Backwards";
---DROP TABLE "BlocksetEntry";
-
----- ["WITHOUT ROWID" works with SQLite v3.8.2 (eq System.Data.SQLite v1.0.90.0, rel 2013-12-23) and later]
---CREATE TABLE "BlocksetEntry" (
---	"BlocksetID" INTEGER NOT NULL,
---	"Index" INTEGER NOT NULL,
---	"BlockID" INTEGER NOT NULL
---	CONSTRAINT "BlocksetEntry_PK_IdIndex" PRIMARY KEY ("BlocksetID", "Index")
---) WITHOUT ROWID;
-
---INSERT INTO "BlocksetEntry" ("BlocksetID", "Index", "BlockID")
---     SELECT "BlocksetID", "Index", "BlockID" 
---	   FROM "UPGRADE_BlocksetEntry";
-
---DROP TABLE "UPGRADE_BlocksetEntry";
-
---/* As this table is a cross table we need fast lookup */
---CREATE INDEX "BlocksetEntryIds_Backwards" ON "BlocksetEntry" ("BlockID");
-
 DROP INDEX "BlocksetEntryIds_Forward";
 DROP INDEX "BlocksetEntryIds_Backwards";
 
@@ -36,7 +11,7 @@ CREATE TABLE "BlocksetEntry" (
 	"Index" INTEGER NOT NULL,
 	"BlockID" INTEGER NOT NULL,
 	CONSTRAINT "BlocksetEntry_PK_IdIndex" PRIMARY KEY ("BlocksetID", "Index")
-) WITHOUT ROWID;
+) {#if sqlite_version >= 3.8.2} WITHOUT ROWID {#endif};
 
 INSERT INTO "BlocksetEntry" ("BlocksetID", "Index", "BlockID")
      SELECT "BlocksetID", "Index", "BlockID" 

--- a/Duplicati/Library/Main/Database/Database schema/5. Optimize BlockSet-Tables.sql
+++ b/Duplicati/Library/Main/Database/Database schema/5. Optimize BlockSet-Tables.sql
@@ -1,0 +1,55 @@
+﻿
+--CREATE TEMP TABLE "UPGRADE_BlocksetEntry"
+--    AS SELECT "BlocksetID", "Index", "BlockID" 
+--         FROM "BlocksetEntry";
+
+--DROP INDEX "BlocksetEntryIds_Forward";
+--DROP INDEX "BlocksetEntryIds_Backwards";
+--DROP TABLE "BlocksetEntry";
+
+---- ["WITHOUT ROWID" works with SQLite v3.8.2 (eq System.Data.SQLite v1.0.90.0, rel 2013-12-23) and later]
+--CREATE TABLE "BlocksetEntry" (
+--	"BlocksetID" INTEGER NOT NULL,
+--	"Index" INTEGER NOT NULL,
+--	"BlockID" INTEGER NOT NULL
+--	CONSTRAINT "BlocksetEntry_PK_IdIndex" PRIMARY KEY ("BlocksetID", "Index")
+--) WITHOUT ROWID;
+
+--INSERT INTO "BlocksetEntry" ("BlocksetID", "Index", "BlockID")
+--     SELECT "BlocksetID", "Index", "BlockID" 
+--	   FROM "UPGRADE_BlocksetEntry";
+
+--DROP TABLE "UPGRADE_BlocksetEntry";
+
+--/* As this table is a cross table we need fast lookup */
+--CREATE INDEX "BlocksetEntryIds_Backwards" ON "BlocksetEntry" ("BlockID");
+
+DROP INDEX "BlocksetEntryIds_Forward";
+DROP INDEX "BlocksetEntryIds_Backwards";
+
+ALTER TABLE "BlocksetEntry"
+  RENAME TO "UPGRADE_BlocksetEntry";
+
+-- ["WITHOUT ROWID" works with SQLite v3.8.2 (eq System.Data.SQLite v1.0.90.0, rel 2013-12-23) and later]
+CREATE TABLE "BlocksetEntry" (
+	"BlocksetID" INTEGER NOT NULL,
+	"Index" INTEGER NOT NULL,
+	"BlockID" INTEGER NOT NULL,
+	CONSTRAINT "BlocksetEntry_PK_IdIndex" PRIMARY KEY ("BlocksetID", "Index")
+) WITHOUT ROWID;
+
+INSERT INTO "BlocksetEntry" ("BlocksetID", "Index", "BlockID")
+     SELECT "BlocksetID", "Index", "BlockID" 
+	   FROM "UPGRADE_BlocksetEntry";
+
+DROP TABLE "UPGRADE_BlocksetEntry";
+
+/* As this table is a cross table we need fast lookup */
+CREATE INDEX "BlocksetEntry_IndexIdsBackwards" ON "BlocksetEntry" ("BlockID");
+
+
+/* Add index for faster volume based block access (for compacting) */
+CREATE INDEX "Block_IndexByVolumeId" ON "Block" ("VolumeID");
+
+
+UPDATE "Version" SET "Version" = 5;

--- a/Duplicati/Library/Main/Database/Database schema/Schema.sql
+++ b/Duplicati/Library/Main/Database/Database schema/Schema.sql
@@ -1,4 +1,14 @@
-﻿/* 
+﻿/*
+Syntax notes (Applying to schema.sql and versioning x.*.sql files):
+Be careful with semicolons, it is used as a simple Split-point for statements.
+For conditional schema statements, a preprocesossor exists. Example:
+{#if sqlite_version >= 3.8.2} DO_SOMETHING {#else} DO_SOMETHING_ELSE {#endif}
+Variables available: sqlite_version (type Version) and db_version (type int)
+Nesting is possible when appending a number in the form "_x" to the #if #else #endif.
+{#if sqlite_version >= 3.8.2} DO_SOMETHING_3.8 {#else} {#if_1 sqlite_version >= 3.6.5} DO_SOMETHING_3.6 {#else_1} DO_SOMETHING_ELSE {#endif_1} {#endif}
+*/
+
+/* 
 The operation table is a local table 
 that is used to record all operations
 for later debug inspection, and can be
@@ -127,7 +137,7 @@ CREATE TABLE "BlocksetEntry" (
 	"Index" INTEGER NOT NULL,
 	"BlockID" INTEGER NOT NULL,
 	CONSTRAINT "BlocksetEntry_PK_IdIndex" PRIMARY KEY ("BlocksetID", "Index")
-) WITHOUT ROWID;
+) {#if sqlite_version >= 3.8.2} WITHOUT ROWID {#endif};
 
 /* As this table is a cross table we need fast lookup */
 CREATE INDEX "BlocksetEntry_IndexIdsBackwards" ON "BlocksetEntry" ("BlockID");

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -154,8 +154,11 @@ namespace Duplicati.Library.Main.Database
         {
             return Library.Utility.Utility.EPOCH.AddSeconds(seconds);
         }
-        
-		public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string hash, System.Data.IDbTransaction transaction = null)
+
+        public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string hash, System.Data.IDbTransaction transaction = null)
+        { UpdateRemoteVolume(name, state, size, hash, false, transaction); }
+
+		public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string hash, bool suppressCleanup, System.Data.IDbTransaction transaction = null)
         {
             m_updateremotevolumeCommand.Transaction = transaction;
             m_updateremotevolumeCommand.SetParameterValue(0, m_operationid);
@@ -166,8 +169,8 @@ namespace Duplicati.Library.Main.Database
             var c = m_updateremotevolumeCommand.ExecuteNonQuery();
             if (c != 1)
                 throw new Exception(string.Format("Unexpected number of remote volumes detected: {0}!", c));
-            	
-           	if (state == RemoteVolumeState.Deleted)
+
+            if (!suppressCleanup && state == RemoteVolumeState.Deleted)
            		RemoveRemoteVolume(name, transaction);
         }
         
@@ -314,52 +317,85 @@ namespace Duplicati.Library.Main.Database
 
         public void RemoveRemoteVolume(string name, System.Data.IDbTransaction transaction = null)
         {
+            RemoveRemoteVolumes(new string[] { name }, transaction);
+        }
+
+        public void RemoveRemoteVolumes(ICollection<string> names, System.Data.IDbTransaction transaction = null)
+        {
+            if (names.Count == 0) return;
+
             using (var tr = new TemporaryTransactionWrapper(m_connection, transaction))
             using (var deletecmd = m_connection.CreateCommand())
             {
                 deletecmd.Transaction = tr.Parent;
-            	var volumeid = GetRemoteVolumeID(name, tr.Parent);
+
+                string temptransguid = Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
+                var volidstable = "DelVolSetIds-" + temptransguid;
+                var blocksetidstable = "DelBlockSetIds-" + temptransguid;
+
+                // Create and fill a temp table with the volids to delete. We avoid using too many parameters that way.
+                deletecmd.ExecuteNonQuery(string.Format(@"CREATE TEMP TABLE ""{0}"" (""ID"" INTEGER PRIMARY KEY)", volidstable));
+                deletecmd.CommandText = string.Format(@"INSERT OR IGNORE INTO ""{0}"" (""ID"") VALUES (?)", volidstable);
+                deletecmd.Parameters.Clear();
+                deletecmd.AddParameters(1);
+                foreach (var name in names)
+                {
+                    var volumeid = GetRemoteVolumeID(name, tr.Parent);
+                    deletecmd.SetParameterValue(0, volumeid);
+                    deletecmd.ExecuteNonQuery();
+                }
+                var volIdsSubQuery = string.Format(@"SELECT ""ID"" FROM ""{0}"" ", volidstable);
+                deletecmd.Parameters.Clear();
                 
 				// If the volume is a block or index volume, this will update the crosslink table, otherwise nothing will happen
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""IndexBlockLink"" WHERE ""BlockVolumeID"" = ? OR ""IndexVolumeID"" = ?", volumeid, volumeid);
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""IndexBlockLink"" WHERE ""BlockVolumeID"" IN ({0}) OR ""IndexVolumeID"" IN ({0})", volIdsSubQuery));
 				
                 // If the volume is a fileset, this will remove the fileset, otherwise nothing will happen
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""FilesetEntry"" WHERE ""FilesetID"" IN (SELECT ""ID"" FROM ""Fileset"" WHERE ""VolumeID"" = ?)", volumeid);
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""Fileset"" WHERE ""VolumeID"" = ?", volumeid);
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""FilesetEntry"" WHERE ""FilesetID"" IN (SELECT ""ID"" FROM ""Fileset"" WHERE ""VolumeID"" IN ({0}))", volIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Fileset"" WHERE ""VolumeID""  IN ({0})", volIdsSubQuery));
                                                 
-                var subQuery = @"SELECT ""BlocksetEntry"".""BlocksetID"" FROM ""BlocksetEntry"", ""Block"" WHERE ""BlocksetEntry"".""BlockID"" = ""Block"".""ID"" AND ""Block"".""VolumeID"" = ? UNION ALL SELECT ""BlocksetID"" FROM ""BlocklistHash"" WHERE ""Hash"" IN (SELECT ""Hash"" FROM ""Block"" WHERE ""VolumeID"" = ?)";
+                var bsIdsSubQuery = string.Format(
+                      @"SELECT ""BlocksetEntry"".""BlocksetID"" FROM ""BlocksetEntry"", ""Block"" "
+                    + @" WHERE ""BlocksetEntry"".""BlockID"" = ""Block"".""ID"" AND ""Block"".""VolumeID"" IN ({0}) "
+                    + @"UNION ALL "
+                    + @"SELECT ""BlocksetID"" FROM ""BlocklistHash"" "
+                    + @"WHERE ""Hash"" IN (SELECT ""Hash"" FROM ""Block"" WHERE ""VolumeID"" IN ({0}))"
+                    , volIdsSubQuery);
 
                 // Create a temporary table to cache subquery result, as it might take long (SQLite does not cache at all). 
-                var blocksetidstable = "DelBlockSetIds-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
                 deletecmd.ExecuteNonQuery(string.Format(@"CREATE TEMP TABLE ""{0}"" (""ID"" INTEGER PRIMARY KEY)", blocksetidstable));
-                deletecmd.ExecuteNonQuery(string.Format(@"INSERT OR IGNORE INTO ""{0}"" (""ID"") {1}", blocksetidstable, subQuery), volumeid, volumeid);
-                subQuery = string.Format(@"SELECT ""ID"" FROM ""{0}"" ", blocksetidstable);
+                deletecmd.ExecuteNonQuery(string.Format(@"INSERT OR IGNORE INTO ""{0}"" (""ID"") {1}", blocksetidstable, bsIdsSubQuery));
+                bsIdsSubQuery = string.Format(@"SELECT ""ID"" FROM ""{0}"" ", blocksetidstable);
                 deletecmd.Parameters.Clear();
 
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""File"" WHERE ""BlocksetID"" IN (" + subQuery + @") OR ""MetadataID"" IN (" + subQuery + ")");
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""Metadataset"" WHERE ""BlocksetID"" IN (" + subQuery + ")");
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""Blockset"" WHERE ""ID"" IN (" + subQuery + ")");
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""BlocksetEntry"" WHERE ""BlocksetID"" IN (" + subQuery + ")");
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""File"" WHERE ""BlocksetID"" IN ({0}) OR ""MetadataID"" IN ({0})", bsIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Metadataset"" WHERE ""BlocksetID"" IN ({0})", bsIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Blockset"" WHERE ""ID"" IN ({0})", bsIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""BlocksetEntry"" WHERE ""BlocksetID"" IN ({0})", bsIdsSubQuery));
 
-                deletecmd.ExecuteNonQuery(@"DELETE FROM ""BlocklistHash"" WHERE ""Hash"" IN (SELECT ""Hash"" FROM ""Block"" WHERE ""VolumeID"" = ?)", volumeid);
-				deletecmd.ExecuteNonQuery(@"DELETE FROM ""Block"" WHERE ""VolumeID"" = ?", volumeid);
-				deletecmd.ExecuteNonQuery(@"DELETE FROM ""DeletedBlock"" WHERE ""VolumeID"" = ?", volumeid);
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""BlocklistHash"" WHERE ""Hash"" IN (SELECT ""Hash"" FROM ""Block"" WHERE ""VolumeID"" IN ({0}))", volIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Block"" WHERE ""VolumeID"" IN ({0})", volIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""DeletedBlock"" WHERE ""VolumeID"" IN ({0})", volIdsSubQuery));
 
-                // Clean up temp table for subquery. We truncate content and then try to delete.
+                // Clean up temp tables for subqueries. We truncate content and then try to delete.
                 // Drop in try-block, as it fails in nested transactions (SQLite problem)
                 // System.Data.SQLite.SQLiteException (0x80004005): database table is locked
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""{0}"" ", blocksetidstable));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""{0}"" ", volidstable));
                 try
                 {
                     deletecmd.CommandTimeout = 2;
                     deletecmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}"" ", blocksetidstable));
+                    deletecmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}"" ", volidstable));
                 }
                 catch { /* Ignore, will be deleted on close anyway. */ }
 
-                m_removeremotevolumeCommand.SetParameterValue(0, name);
-                m_removeremotevolumeCommand.Transaction = tr.Parent;
-                m_removeremotevolumeCommand.ExecuteNonQuery();
-
+                foreach (var name in names)
+                {
+                    m_removeremotevolumeCommand.SetParameterValue(0, name);
+                    m_removeremotevolumeCommand.Transaction = tr.Parent;
+                    m_removeremotevolumeCommand.ExecuteNonQuery();
+                }
                 tr.Commit();
             }
         }

--- a/Duplicati/Library/Main/Duplicati.Library.Main.csproj
+++ b/Duplicati/Library/Main/Duplicati.Library.Main.csproj
@@ -168,6 +168,7 @@
   </Target>
   -->
   <ItemGroup>
+    <EmbeddedResource Include="Database\Database schema\5. Optimize BlockSet-Tables.sql" />
     <Content Include="default_compressed_extensions.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -233,6 +233,8 @@ namespace Duplicati.Library.Main.Operation
                     
             var missing = new List<RemoteVolumeEntry>();
             var missingHash = new List<Tuple<long, RemoteVolumeEntry>>();
+            var cleanupRemovedRemoteVolumes = new HashSet<string>();
+
             var locallist = database.GetRemoteVolumes();
             foreach(var i in locallist)
             {
@@ -266,7 +268,7 @@ namespace Duplicati.Library.Main.Operation
                             else
                             {
                                 log.AddMessage(string.Format("removing file listed as {0}: {1}", i.State, i.Name));
-                                database.RemoveRemoteVolume(i.Name, null);
+                                cleanupRemovedRemoteVolumes.Add(i.Name);
                             }
                         }
                         break;
@@ -279,7 +281,7 @@ namespace Duplicati.Library.Main.Operation
                         else if (!remoteFound)
                         {
                             log.AddMessage(string.Format("scheduling missing file for deletion, currently listed as {0}: {1}", i.State, i.Name));
-                            database.RemoveRemoteVolume(i.Name, null);
+                            cleanupRemovedRemoteVolumes.Add(i.Name);
                             database.RegisterRemoteVolume(i.Name, i.Type, RemoteVolumeState.Deleting, TimeSpan.FromHours(2), null);
                             database.UpdateRemoteVolume(i.Name, RemoteVolumeState.Deleting, i.Size, i.Hash, null);
                         }
@@ -316,6 +318,8 @@ namespace Duplicati.Library.Main.Operation
                 backend.FlushDbMessages();
             }
 
+            // cleanup deleted volumes in DB en block
+            database.RemoveRemoteVolumes(cleanupRemovedRemoteVolumes, null);
 
             foreach(var i in missingHash)
                 log.AddWarning(string.Format("remote file {1} is listed as {0} with size {2} but should be {3}, please verify the sha256 hash \"{4}\"", i.Item2.State, i.Item2.Name, i.Item1, i.Item2.Size, i.Item2.Hash), null);

--- a/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
+++ b/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
@@ -21,6 +21,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Data;
+using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace Duplicati.Library.SQLiteHelper
 {
@@ -47,6 +49,80 @@ namespace Duplicati.Library.SQLiteHelper
         
         //This is the name of the schema sql
         private const string SCHEMA_NAME = "Schema.sql";
+
+        /// <summary> Helper func to evaluate a condition like "sqlitever > 3.8.2" </summary>
+        private static bool evalCondition(string cond, IDictionary<string, IComparable> vars)
+        {
+            var ops = new Dictionary<string, Func<IComparable, IComparable, bool>>()
+             {
+                {"<=", (x,y) => x.CompareTo(y) <= 0},
+                {">=", (x,y) => x.CompareTo(y) >= 0},
+                {"!=", (x,y) => x.CompareTo(y) != 0},
+                {"==", (x,y) => x.CompareTo(y) == 0},
+                {"<",  (x,y) => x.CompareTo(y) <  0},
+                {">",  (x,y) => x.CompareTo(y) >  0},
+                {"=",  (x,y) => x.CompareTo(y) == 0},
+            };
+
+            // build RegEx list with operators
+            var opsList = "(" + string.Join("|", ops.Keys.Select(sop => Regex.Escape(sop) + (sop.Length == 1 ? @"(?!\=)" : ""))) + ")";
+            var condPattern = string.Format(@"^\s*(?<VARIABLE>[a-zA-Z_][a-zA-Z0-9_]*)\s*(?<OPERATOR>{0})(?<LITERAL>.*)$"
+                , opsList);
+
+            // match condition to retrieve parts
+            var m = Regex.Match(cond, condPattern, RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!m.Success) throw new ArgumentException(string.Format("Malformed condition '{0}'.", cond));
+            var variable = m.Groups["VARIABLE"].Value;
+            var op = m.Groups["OPERATOR"].Value;
+            var literal = m.Groups["LITERAL"].Value.Trim();
+
+            // find variable and convert literal to correct type
+            IComparable varVal;
+            if (!vars.TryGetValue(variable, out varVal))
+                throw new KeyNotFoundException(string.Format("Unknown variable '{0}' used in condition.", variable));
+
+            IComparable litVal;
+            try
+            {
+                if (varVal.GetType() == typeof(Version))
+                    litVal = Version.Parse(literal);
+                else // good for most other value types
+                    litVal = (IComparable)System.Convert.ChangeType(literal, varVal.GetType(), System.Globalization.CultureInfo.InvariantCulture);
+            }
+            catch (Exception ex)
+            { throw new FormatException(string.Format("Failed to convert literal '{0}' to desired type '{1}' for comparison", literal, varVal.GetType().Name), ex); }
+
+            return ops[op](varVal, litVal);
+        }
+
+        /// <summary>
+        /// Preparses an SQL in a very simple way to support conditional statements / clauses.
+        /// Nesting is supported by using {#if_xx} {#else_xx} {#endif_xx} with xx being a number inside the blocks.
+        /// </summary>
+        public static string PreparseSQL(string sql, IDictionary<string, IComparable> vars)
+        {
+            var prepPattern = @"\{\#if(?<NEST>(_\d*)?)\s+(?<CONDITION>[^\}]*)}(?<THENPART>.*?)(?:\{\#else\k<NEST>\}(?<ELSEPART>.*?))?\{\#endif\k<NEST>\}";
+            var parsePoints = Regex.Matches(sql, prepPattern, RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            StringBuilder retSql = new StringBuilder();
+            int curPos = 0;
+            foreach (Match pp in parsePoints)
+            {
+                var cond = pp.Groups["CONDITION"].Value;
+                var thenpart = pp.Groups["THENPART"].Value;
+                var elsepart = pp.Groups["ELSEPART"].Success ? pp.Groups["ELSEPART"].Value : null;
+
+                retSql.Append(sql.Substring(curPos, pp.Index - curPos));
+                if (evalCondition(cond, vars))
+                    retSql.Append(PreparseSQL(thenpart, vars));
+                else if (elsepart != null)
+                    retSql.Append(PreparseSQL(elsepart, vars));
+
+                curPos = pp.Index + pp.Length;
+            }
+            retSql.Append(sql.Substring(curPos, sql.Length - curPos));
+            return retSql.ToString();
+        }
 
         public static void UpgradeDatabase(IDbConnection connection, string sourcefile, Type eltype)
         {
@@ -132,20 +208,31 @@ namespace Duplicati.Library.SQLiteHelper
                 throw new Exception(Strings.DatabaseUpgrader.DatabaseFormatError(ex.Message), ex);
             }
 
+            Dictionary<string, IComparable> preparserVars = null;
+
+            if (dbversion > versions.Count)
+                throw new Exception(Strings.DatabaseUpgrader.InvalidVersionError(dbversion, versions.Count, System.IO.Path.GetDirectoryName(sourcefile)));
+            else if (dbversion < versions.Count) // will need action, collect vars for preparser
+            {
+                preparserVars = new Dictionary<string, IComparable>(StringComparer.InvariantCultureIgnoreCase);
+                cmd.CommandText = "SELECT sqlite_version()";
+                System.Version sqliteversion;
+                if (Version.TryParse(cmd.ExecuteScalar().ToString(), out sqliteversion))
+                    preparserVars["sqlite_version"] = sqliteversion;
+                
+                preparserVars["db_version"] = dbversion;
+            }
 
             //On a new database, we just load the most current schema, and upgrade from there
             //This avoids potentitally lenghty upgrades
             if (dbversion == -1)
             {
-                cmd.CommandText = schema;
+                cmd.CommandText = PreparseSQL(schema, preparserVars);
                 cmd.ExecuteNonQuery();
                 UpgradeDatabase(connection, sourcefile, schema, versions);
                 return;
             }
 
-
-            if (dbversion > versions.Count)
-                throw new Exception(Strings.DatabaseUpgrader.InvalidVersionError(dbversion, versions.Count, System.IO.Path.GetDirectoryName(sourcefile)));
 
             if (versions.Count > dbversion)
             {
@@ -168,7 +255,7 @@ namespace Duplicati.Library.SQLiteHelper
                         foreach (string c in versions[i].Split(';'))
                             if (c.Trim().Length > 0)
                             {
-                                cmd.CommandText = c;
+                                cmd.CommandText = PreparseSQL(c, preparserVars);
                                 cmd.ExecuteNonQuery();
                             }
                     }


### PR DESCRIPTION
This fix should mitigate the slow deletion of volumes (as explained in #1582 ) a little bit by caching a slow subquery in a a temporary table.
It is still far away from being optimal, but already helps by speeding up to about 2.5x speed.

Best way to speed things up is to process `RemoveRemoteVolume` for all removed volumes at once. This should be easy, as it seems the db-ops are collected anyway until `FlushDbMessages` is called, prior to being written to DB. I could implement a grouping with execution as whole there, but it would change the order of db-ops, which are alternating deletes and writes to dbLog in the list. Even though they are enclosed in a transaction anyway (all or nothing), it would change the timestamps in the db-log, which would also be written all at once. If you do not see a problem with this, I would implement the change.

Another small optimization would be adding an index for VolumeId to the database.
I added this with two other proposals (improve `BlocksetEntry`, delete `BlocklistHash` ) as comments to the `schema.sql` file. I was not sure how and when the database schema can be changed, so I didn't want to break anything. About the `BlocklistHash` table: I could not find a practical use and believe it is a remainder of some old schema. If so, it should be removed from code to not slow things down.


 