### PR TITLE
Renamed option for beta

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -510,7 +510,7 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("repair-only-paths", CommandLineArgument.ArgumentType.Boolean, Strings.Options.RepaironlypathsShort, Strings.Options.RepaironlypathsLong, "false"),
                     new CommandLineArgument("force-locale", CommandLineArgument.ArgumentType.String, Strings.Options.ForcelocaleShort, Strings.Options.ForcelocaleLong),
 
-                    new CommandLineArgument("enable-piped-downstreams", CommandLineArgument.ArgumentType.Boolean, Strings.Options.EnablepipingShort, Strings.Options.EnablepipingLong, "false"),
+                    new CommandLineArgument("enable-piped-streaming", CommandLineArgument.ArgumentType.Boolean, Strings.Options.EnablepipingShort, Strings.Options.EnablepipingLong, "false"),
                 });
 
                 return lst;
@@ -940,9 +940,9 @@ namespace Duplicati.Library.Main
         public bool DisableStreamingTransfers { get { return GetBool("disable-streaming-transfers"); } }
 
         /// <summary>
-        /// A value indicating if multithreaded pipes may be used for decryption on downloads
+        /// A value indicating if multithreaded pipes may be used for hashing and crypting on up-/downloads
         /// </summary>
-        public bool EnablePipedDownstreams { get { return GetBool("enable-piped-downstreams"); } }
+        public bool EnablePipedStreaming { get { return GetBool("enable-piped-streaming"); } }
 
         /// <summary>
         /// Gets the timelimit for removal

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -205,8 +205,8 @@ namespace Duplicati.Library.Main.Strings
         public static string RepaironlypathsLong { get { return LC.L(@"Use this option to build a searchable local database which only contains path information. This option is usable for quickly building a database to locate certain content without needing to reconstruct all information. The resulting database can be searched, but cannot be used to restore data with."); } }
         public static string ForcelocaleShort { get { return LC.L(@"Force the locale setting"); } }
         public static string ForcelocaleLong { get { return LC.L(@"By default, your system locale and culture settings will be used. In some cases you may prefer to run with another locale, for example to get messages in another language. This option can be used to set the locale. Supply a blank string to choose the ""Invariant Cultute""."); } }
-        public static string EnablepipingShort{ get { return LC.L(@"Handle downloads with threaded pipes"); } }
-        public static string EnablepipingLong { get { return LC.L(@"Use this option to enable an experimental multithreaded download handling, that can significantly speed up restore operations or backup verifications depending on the hardware you're running on and your fileset. This operation mode is experimental and by default disabled."); } }
+        public static string EnablepipingShort{ get { return LC.L(@"Handle file communication with backend using threaded pipes"); } }
+        public static string EnablepipingLong { get { return LC.L(@"Use this option to enable an experimental multithreaded handling of up- and downloads, that can significantly speed up backend operations depending on the hardware you're running on and the transfer rate of your backend. This mode of operation is considered experimental and by default disabled."); } }
     }
 
     internal static class Common 


### PR DESCRIPTION
I'm planning to implement piping for uploads, too.
So I renamed the option 'enable-piped-downstreams' --> 'enable-piped-streaming'
to generalize for up / downloads. With that users of the coming beta will not have to switch options later.