### PR TITLE
Type field inadecuate

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/backends/generic.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/generic.html
@@ -20,5 +20,5 @@
 </div>
 <div class="input password">
     <label for="generic_password">Password</label>
-    <input type="text" name="generic_password" id="generic_password" ng-model="$parent.Password" placeholder="Authentication password"  />
+    <input type="password" name="generic_password" id="generic_password" ng-model="$parent.Password" placeholder="Authentication password"  />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/generic.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/generic.html
@@ -20,5 +20,5 @@
 </div>
 <div class="input password">
     <label for="generic_password">Password</label>
-    <input type="password" name="generic_password" id="generic_password" ng-model="$parent.Password" placeholder="Authentication password"  />
+    <input type="text" name="generic_password" id="generic_password" ng-model="$parent.Password" placeholder="Authentication password"  />
 </div>


### PR DESCRIPTION
The field with id "generic_password" is the type "text" and password paraphrase is visible is better change to type "password".