### PR TITLE
Added duration to last successful run on home page

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/HomeController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/HomeController.js
@@ -44,4 +44,7 @@ backupApp.controller('HomeController', function ($scope, $location, BackupList, 
         AppService.post('/backup/' + id + '/createreport');
     };
 
+    $scope.formatDuration = function(duration) {
+        return duration.substring(0, duration.length - duration.indexOf("."));
+    };
 });

--- a/Duplicati/Server/webroot/ngax/templates/home.html
+++ b/Duplicati/Server/webroot/ngax/templates/home.html
@@ -69,7 +69,7 @@
 
                 <dl>
                     <dt>Last successful run:</dt>
-                    <dd ng-hide="item.Backup.Metadata == null || item.Backup.Metadata.LastBackupFinished == null">{{item.Backup.Metadata.LastBackupFinished | date :'medium'}}</dd>
+                    <dd ng-hide="item.Backup.Metadata == null || item.Backup.Metadata.LastBackupFinished == null">{{item.Backup.Metadata.LastBackupFinished | date :'medium'}} (took {{formatDuration(item.Backup.Metadata.LastDuration)}})</dd>
                     <dd ng-show="item.Backup.Metadata == null || item.Backup.Metadata.LastBackupFinished == null">
                     Never - <a href class="action-link" ng-click="doRun(item.Backup.ID)">Run now</a>
                     </dd>


### PR DESCRIPTION
This small pull request adds the duration of the last successful run to the home page.

It looks like this:
![duration](https://cloud.githubusercontent.com/assets/4292951/14937258/56840504-0f02-11e6-8e24-4c86a6288ca4.PNG)

Thanks for your great work!
Fabian