### PR TITLE
Suggested fix for lookup of file's last backup entry

### DIFF
--- a/Duplicati/Library/Main/Database/Database schema/6. Optimize FileSetEntry-Table.sql
+++ b/Duplicati/Library/Main/Database/Database schema/6. Optimize FileSetEntry-Table.sql
@@ -1,0 +1,29 @@
+﻿BEGIN TRANSACTION;
+
+DROP INDEX "FilesetentryIndex";
+
+ALTER TABLE "FilesetEntry"
+  RENAME TO "UPGRADE_FilesetEntry";
+
+-- ["WITHOUT ROWID" works with SQLite v3.8.2 (eq System.Data.SQLite v1.0.90.0, rel 2013-12-23) and later]
+CREATE TABLE "FilesetEntry" (
+	"FilesetID" INTEGER NOT NULL,
+	"FileID" INTEGER NOT NULL,
+	"Lastmodified" INTEGER NOT NULL,
+	CONSTRAINT "FilesetEntry_PK_FilesetIdFileId" PRIMARY KEY ("FilesetID", "FileID")
+) {#if sqlite_version >= 3.8.2} WITHOUT ROWID {#endif};
+
+INSERT INTO "FilesetEntry" ("FilesetID", "FileID", "Lastmodified")
+     SELECT "FilesetID", "FileID", "Lastmodified" 
+	   FROM "UPGRADE_FilesetEntry";
+
+DROP TABLE "UPGRADE_FilesetEntry";
+
+/* Improved reverse lookup for joining Fileset and File table */
+CREATE INDEX "FilesetentryFileIdIndex" on "FilesetEntry" ("FileID");
+
+UPDATE "Version" SET "Version" = 6;
+
+COMMIT;
+
+VACUUM;

--- a/Duplicati/Library/Main/Database/Database schema/Schema.sql
+++ b/Duplicati/Library/Main/Database/Database schema/Schema.sql
@@ -70,14 +70,18 @@ a single operation. The scantime
 is the time the file was last 
 scanned in UNIX EPOCH format
 */
+
 CREATE TABLE "FilesetEntry" (
 	"FilesetID" INTEGER NOT NULL,
 	"FileID" INTEGER NOT NULL,
-	"Lastmodified" INTEGER NOT NULL
-);
+	"Lastmodified" INTEGER NOT NULL,
+	CONSTRAINT "FilesetEntry_PK_FilesetIdFileId" PRIMARY KEY ("FilesetID", "FileID")
+) {#if sqlite_version >= 3.8.2} WITHOUT ROWID {#endif};
 
-/* Improved lookup for joining Fileset and File table */
-CREATE UNIQUE INDEX "FilesetentryIndex" on "FilesetEntry" ("FilesetID", "FileID");
+/* Improved reverse lookup for joining Fileset and File table */
+CREATE INDEX "FilesetentryFileIdIndex" on "FilesetEntry" ("FileID");
+
+
 
 /*
 The FileEntry contains an ID
@@ -237,4 +241,4 @@ CREATE TABLE "Configuration" (
 	"Value" TEXT NOT NULL
 );
 
-INSERT INTO "Version" ("Version") VALUES (5);
+INSERT INTO "Version" ("Version") VALUES (6);

--- a/Duplicati/Library/Main/Duplicati.Library.Main.csproj
+++ b/Duplicati/Library/Main/Duplicati.Library.Main.csproj
@@ -166,6 +166,7 @@
   -->
   <ItemGroup>
     <EmbeddedResource Include="Database\Database schema\5. Optimize BlockSet-Tables.sql" />
+    <EmbeddedResource Include="Database\Database schema\6. Optimize FileSetEntry-Table.sql" />
     <Content Include="default_compressed_extensions.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
- Fixed SQL to create temp table for lookup of last backup's file
entries
- Removed temp table by writing directly to internal lookup struct.
- Direct lookup of single file entries from DB
- Added reverse lookup index to table FilesetEntry, also making it WITHOUT_ROWID.

Would still need an actual performance comparison.