### PR TITLE
Fix the escaping of special characters of Amazon Cloud Drive API filtering

### DIFF
--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -160,7 +160,8 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
             var curpath = new List<string>();
             foreach(var p in (altpath ?? m_path).Split(new string[] {"/"}, StringSplitOptions.RemoveEmptyEntries))
             {
-                var self = m_oauth.GetJSONData<ListResponse>(string.Format("{0}/nodes?filters=kind:{1}%20and%20parents:{2}%20and%20name:{3}", MetadataUrl, CONTENT_KIND_FOLDER, Utility.Uri.UrlEncode(parent.ID), Utility.Uri.UrlEncode(p)));
+                var requestUrl = string.Format("{0}/nodes?filters=kind:{1}%20and%20parents:{2}%20and%20name:{3}", MetadataUrl, CONTENT_KIND_FOLDER, Utility.Uri.UrlEncode(parent.ID), Utility.Uri.UrlPathEncode(EscapeFiltersValue(p)));
+                var self = m_oauth.GetJSONData<ListResponse>(requestUrl);
                 if (self == null || self.Count == 0 || self.Data == null || self.Data.Length == 0)
                 {
                     if (!createMissing)
@@ -233,6 +234,15 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
             }
             
             throw new FileMissingException();
+        }
+        
+        private static System.Text.RegularExpressions.Regex FILTERS_VALUE_ESCAPECHAR = new System.Text.RegularExpressions.Regex(@"[+\-&|!(){}\[\]^'""~*?:\\ ]", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        public static string EscapeFiltersValue(string value)
+        {
+            return FILTERS_VALUE_ESCAPECHAR.Replace(value, (m) => {
+                return @"\" + m.Value;
+            });
         }
 
         #region IStreamingBackend implementation


### PR DESCRIPTION
For filtering parameters, prepend \ to special characters + - & | ! ( ) { } [ ] ^ ' " ~ * ? : \ and space according to Amazon Cloud Drive API documentation, and encode space as %20 instead of + to avoid mistaking space as plus sign in filtering parameter.

Amazon Cloud Drive API documentation on escaping special characters of filtering parameters:
[https://developer.amazon.com/public/apis/experience/cloud-drive/content/nodes#Filtering](https://developer.amazon.com/public/apis/experience/cloud-drive/content/nodes#Filtering)

These change will fix the problem in #1744 