### PR TITLE
prevent from including temporary files in verification file

### DIFF
--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -150,7 +150,7 @@ namespace Duplicati.Library.Main.Operation
         public static void CreateVerificationFile(LocalDatabase db, System.IO.StreamWriter stream)
         {
             var s = new Newtonsoft.Json.JsonSerializer();
-            s.Serialize(stream, db.GetRemoteVolumes().Cast<IRemoteVolume>().ToArray());
+            s.Serialize(stream, db.GetRemoteVolumes().Where(x => x.State != RemoteVolumeState.Temporary).Cast<IRemoteVolume>().ToArray());
         }
         
         /// <summary>


### PR DESCRIPTION
Temporary files are sometime included in verification file. This makes no sense, because they are cleaned and after that verification using script throws missing file error.