### PR TITLE
don't use label  for "Advanced options" heading

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -248,13 +248,13 @@
                     </div>
                 </div>
                 <div class="input textarea" ng-show="ShowAdvancedTextArea">
-                    <h2><label for="backupOptions" translate>Advanced options</label></h2>
+                    <h2 translate>Advanced options</h2>
                     <a href ng-click="ShowAdvancedTextArea = false" class="advanced-toggle"><i class="fa fa-check"></i> <span translate>Edit as text</span></a>
                     <textarea id="backupOptions" ng-model="ExtendedOptions" string-array-as-text placeholder="{{AppUtils.format(AppUtils.exampleOptionString, '--dblock-size=100MB')}}"></textarea>
                 </div>
                 
                 <div class="input" ng-hide="ShowAdvancedTextArea">
-                    <h2><label for="backupOptions" translate>Advanced options</label></h2>
+                    <h2 translate>Advanced options</h2>
                     <a href ng-click="ShowAdvancedTextArea = true" class="advanced-toggle"><i class="fa"></i> {{'Edit as text' | translate}}</a>
                     <advanced-options-editor ng-option-list="ExtendedOptionList" ng-model="ExtendedOptions"></advanced-options-editor>
                 </div>


### PR DESCRIPTION
removing the `<label>` from the `Advanced option` heading to prevent line breaks, since label has a max width of 190px and also it isn't really a label...

**before:**
***
![before](https://cloud.githubusercontent.com/assets/5296073/19220932/3e41d24e-8e39-11e6-9e98-da03333e5288.png)

**after:**
***
![after](https://cloud.githubusercontent.com/assets/5296073/19220933/401af406-8e39-11e6-9e6c-a901f9aa1084.png)
