### PR TITLE
added working directory

### DIFF
--- a/Duplicati/Service/Runner.cs
+++ b/Duplicati/Service/Runner.cs
@@ -83,6 +83,7 @@ namespace Duplicati.Service
                         pr.UseShellExecute = false;
                         pr.RedirectStandardInput = true;
                         pr.RedirectStandardOutput = true;
+                        pr.WorkingDirectory = path;
 
                         if (!m_terminate)
                             m_process = System.Diagnostics.Process.Start(pr);


### PR DESCRIPTION
I have logging relative ".\log\log.txt".
Because it is expanded in code using System.IO.Path.GetFullPath and service is by default running in C:\windows\system32 after using new windows service logs were in system dir.
This should fix the problem.