### PR TITLE
prevent file picker from resizing too much

### DIFF
--- a/Duplicati/Server/webroot/ngax/styles/styles2.css
+++ b/Duplicati/Server/webroot/ngax/styles/styles2.css
@@ -550,6 +550,7 @@ ul.notification {
 
 .resizable {
   margin-bottom: 6px;
+  max-width: 100%;
 }
 
 .advanced-toggle {


### PR DESCRIPTION
at the moment you can resize the filepicker so much that the scrollbar and the resize element are unreachable:
![screen](https://cloud.githubusercontent.com/assets/5296073/19233862/7caf1e7e-8ee8-11e6-8c32-49ec283023bf.png)
