### PR TITLE
Fix debian dependencies

### DIFF
--- a/Duplicati/Library/Snapshots/lvm-scripts/find-volume.sh
+++ b/Duplicati/Library/Snapshots/lvm-scripts/find-volume.sh
@@ -20,7 +20,7 @@ NAME=$1
 # Get the reported mount point for the current folder
 #
 VOLUME=`df -P "$NAME" | tail -1 | awk '{ print $1}'`
-if [ "$?" -ne 0 ] || [ "$VOLUME" == "" ]
+if [ "$?" -ne 0 ] || [ -z "$VOLUME" ]
 then
 	[[ "$?" -ne 0 ]] && EXIT_CODE=$? || EXIT_CODE=-1
 	echo "Error: unable to determine device for $NAME"
@@ -28,7 +28,7 @@ then
 fi
 
 MOUNTPOINT=`df -P "$NAME" | tail -1 | awk '{ print $NF}'`
-if [ "$?" -ne 0 ] || [ "MOUNTPOINT" == "" ]
+if [ "$?" -ne 0 ] || [ -z "$MOUNTPOINT" ]
 then
 	[[ "$?" -ne 0 ]] && EXIT_CODE=$? || EXIT_CODE=-1
 	echo "Error: unable to determine mount point for $NAME"
@@ -55,14 +55,13 @@ get_lvmid $VOLUME
 #
 # Get the LVM path for the mapped volume (second try)
 #
-if [ "$LVMID" == "" ]
+if [ -z "$LVMID" ]
 then
-	CMD="mount | awk '(\$3 == \"$MOUNTPOINT\") {print \$1}'" 
-	VOLUME=` eval $CMD`
+	VOLUME=`mount | awk '($3 == "'$MOUNTPOINT'") {print $1}'`
 	get_lvmid $VOLUME
 fi
 
-if [ "$LVMID" == "" ]
+if [ -z "$LVMID" ]
 then
 	EXIT_CODE=-1
 	echo "Error: unable to determine volume group (VG) for $NAME"

--- a/Duplicati/Library/Snapshots/lvm-scripts/find-volume.sh
+++ b/Duplicati/Library/Snapshots/lvm-scripts/find-volume.sh
@@ -20,17 +20,17 @@ NAME=$1
 # Get the reported mount point for the current folder
 #
 VOLUME=`df -P "$NAME" | tail -1 | awk '{ print $1}'`
-if [ "$?" -ne 0 ]
+if [ "$?" -ne 0 ] || [ "$VOLUME" == "" ]
 then
-	EXIT_CODE=$?
+	[[ "$?" -ne 0 ]] && EXIT_CODE=$? || EXIT_CODE=-1
 	echo "Error: unable to determine device for $NAME"
 	exit $EXIT_CODE
 fi
 
 MOUNTPOINT=`df -P "$NAME" | tail -1 | awk '{ print $NF}'`
-if [ "$?" -ne 0 ]
+if [ "$?" -ne 0 ] || [ "MOUNTPOINT" == "" ]
 then
-	EXIT_CODE=$?
+	[[ "$?" -ne 0 ]] && EXIT_CODE=$? || EXIT_CODE=-1
 	echo "Error: unable to determine mount point for $NAME"
 	exit $EXIT_CODE
 fi

--- a/Installer/debian/debian/control
+++ b/Installer/debian/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/duplicati/duplicati.git
 
 Package: duplicati
 Architecture: all
-Depends: mono-runtime (>= 3.0), libmono-2.0-1, libmono-system-core4.0-cil, libmono-system-configuration4.0-cil, libmono-system-configuration-install4.0-cil, libmono-system-data4.0-cil, libmono-system-drawing4.0-cil, libmono-system-net4.0-cil, libmono-system-net-http4.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-runtime-serialization4.0-cil, libmono-system-servicemodel4.0a-cil, libmono-system-servicemodel-discovery4.0-cil, libmono-system-serviceprocess4.0-cil, libmono-system-transactions4.0-cil, libmono-system-web4.0-cil, libmono-system-web-services4.0-cil, libmono-system-xml4.0-cil, libmono-microsoft-csharp4.0-cil, libsqlite3-0 (>= 3.6.12), libappindicator0.1-cil, gtk-sharp2
+Depends: mono-runtime (>= 3.0), libmono-2.0-1, libmono-system-core4.0-cil, libmono-system-configuration4.0-cil, libmono-system-configuration-install4.0-cil, libmono-system-data4.0-cil, libmono-system-drawing4.0-cil, libmono-system-net4.0-cil, libmono-system-net-http4.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-numerics4.0-cil, libmono-system-runtime-serialization4.0-cil, libmono-system-servicemodel4.0a-cil, libmono-system-servicemodel-discovery4.0-cil, libmono-system-serviceprocess4.0-cil, libmono-system-transactions4.0-cil, libmono-system-web4.0-cil, libmono-system-web-services4.0-cil, libmono-system-xml4.0-cil, libmono-microsoft-csharp4.0-cil, libsqlite3-0 (>= 3.6.12), libappindicator0.1-cil, gtk-sharp2
 Description: Backup client for encrypted online backups
  Duplicati is a free backup client that securely stores encrypted, incremental, 
  compressed backups on cloud storage services and remote file servers. It 


### PR DESCRIPTION
In Debian 8.1, Duplicati.Server.exe generates many error messages in console without installed libmono-system-numerics4.0-cil package.

Web page request generates attached errors.

[error.txt](https://github.com/duplicati/duplicati/files/538722/error.txt)
