### PR TITLE
Fix exceptions when users and groups are not defined on the local sys…

### DIFF
--- a/Duplicati/Library/Snapshots/SystemIOLinux.cs
+++ b/Duplicati/Library/Snapshots/SystemIOLinux.cs
@@ -177,8 +177,14 @@ namespace Duplicati.Library.Snapshots
 
             var fse = UnixSupport.File.GetUserGroupAndPermissions(f);
             dict["unix:uid-gid-perm"] = string.Format("{0}-{1}-{2}", fse.UID, fse.GID, fse.Permissions);
-            dict["unix:owner-name"] = fse.OwnerName;
-            dict["unix:group-name"] = fse.GroupName;
+            if (fse.OwnerName != null)
+            {
+                dict["unix:owner-name"] = fse.OwnerName;
+            }
+            if (fse.GroupName != null)
+            {
+                dict["unix:group-name"] = fse.GroupName;
+            }
 
             return dict;
         }

--- a/thirdparty/UnixSupport/File.cs
+++ b/thirdparty/UnixSupport/File.cs
@@ -238,8 +238,26 @@ namespace UnixSupport
                 UID = fse.OwnerUserId;
                 GID = fse.OwnerGroupId;
                 Permissions = (long)fse.FileAccessPermissions;
-                OwnerName = fse.OwnerUser.UserName;
-                GroupName = fse.OwnerGroup.GroupName;
+
+				try
+				{
+					OwnerName = fse.OwnerUser.UserName;
+				}
+				catch (ArgumentException)
+				{
+					// Could not retrieve user name, possibly the user is not defined on the local system
+					OwnerName = null;
+				}
+
+				try
+				{
+					GroupName = fse.OwnerGroup.GroupName;
+				}
+				catch (ArgumentException)
+				{
+					// Could not retrieve group name, possibly the group is not defined on the local system
+					GroupName = null;
+				}
             }
         }
         


### PR DESCRIPTION
…tem (such as when a system is bound to Active Directory or a user or group has been deleted).

The Exception looks like this and happens when a user is either deleted from the system and the user/groupid is still used in some files or when a Mac system is linked to Active Directory and disconnected from the corporate network (it will use group ids that are not locally defined so retrieving the name fails.

```
Failed to process metadata for "/Users/driesg/Downloads/Untitled 2.rtf", storing empty metadata
System.ArgumentException: invalid group id
Parameter name: group
  at Mono.Unix.UnixGroupInfo..ctor (System.Int64 group) [0x00041] in <34b68016c17845bba60316001d489522>:0 
  at Mono.Unix.UnixFileSystemInfo.get_OwnerGroup () [0x00006] in <34b68016c17845bba60316001d489522>:0 
  at UnixSupport.File+FileInfo..ctor (Mono.Unix.UnixFileSystemInfo fse) [0x00036] in <31369f9a8c514024b3576f837e9db150>:0 
  at UnixSupport.File.GetUserGroupAndPermissions (System.String path) [0x00006] in <31369f9a8c514024b3576f837e9db150>:0 
  at Duplicati.Library.Snapshots.SystemIOLinux.GetMetadata (System.String file) [0x00071] in <d0d93e6e5fe943b7aabbba717dd702af>:0 
  at Duplicati.Library.Snapshots.NoSnapshotLinux.GetMetadata (System.String file) [0x00007] in <d0d93e6e5fe943b7aabbba717dd702af>:0 
  at Duplicati.Library.Main.Operation.BackupHandler.GenerateMetadata (Duplicati.Library.Snapshots.ISnapshotService snapshot, System.String path, System.IO.FileAttributes attributes) [0x00010] in <a77819cff3444adaaaec3c4bd04da83a>:0 
```