### PR TITLE
Fix debian package build

### DIFF
--- a/Installer/debian/debian/rules
+++ b/Installer/debian/debian/rules
@@ -30,13 +30,14 @@ override_dh_clean:
 	find -maxdepth 1 -type d -name build | xargs rm -rf
 
 override_dh_auto_build:
+	nuget restore Duplicati.sln
+
 	xbuild /property:Configuration=Release BuildTools/UpdateVersionStamp/UpdateVersionStamp.csproj
 	mono BuildTools/UpdateVersionStamp/bin/Release/UpdateVersionStamp.exe --version=$(VERSION)
 
 	xbuild /property:Configuration=Release thirdparty/UnixSupport/UnixSupport.csproj
 	cp thirdparty/UnixSupport/bin/Release/UnixSupport.dll thirdparty/UnixSupport/UnixSupport.dll
 
-	nuget restore Duplicati.sln
 	xbuild /property:Configuration=Release Duplicati.sln
 
 override_dh_auto_install:


### PR DESCRIPTION
Hello. There is a problem building debian package with build-package.sh script. My request fixes this by earlier dependencies downloading. (Building fails on UpdateVersionStamp.exe compiling)

The following errors are produced:

`Errors:

/home/ale/progr/duplicati/Installer/debian/duplicati-2.0.1.27/BuildTools/UpdateVersionStamp/UpdateVersionStamp.csproj (default targets) ->
/usr/lib/mono/xbuild/14.0/bin/Microsoft.Common.targets (ResolveProjectReferences target) ->
/home/ale/progr/duplicati/Installer/debian/duplicati-2.0.1.27/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj (default targets) ->
/usr/lib/mono/xbuild/14.0/bin/Microsoft.Common.targets (ResolveProjectReferences target) ->
/home/ale/progr/duplicati/Installer/debian/duplicati-2.0.1.27/Duplicati/Library/Localization/Duplicati.Library.Localization.csproj (default targets) ->
/usr/lib/mono/xbuild/14.0/bin/Microsoft.CSharp.targets (CoreCompile target) ->

        MoLocalizationService.cs(24,7): error CS0246: The type or namespace name `NGettext' could not be found. Are you missing an assembly reference?
        MoLocalizationService.cs(36,17): error CS0246: The type or namespace name `ICatalog' could not be found. Are you missing an assembly reference?

         1 Warning(s)
         2 Error(s)

Time Elapsed 00:00:00.4771130
debian/rules:33: recipe for target 'override_dh_auto_build' failed
make[1]: *** [override_dh_auto_build] Error 1
make[1]: Leaving directory '/home/ale/progr/duplicati/Installer/debian/duplicati-2.0.1.27'
debian/rules:22: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2`