### PR TITLE
Increase LVM snapshot maxiumum size

### DIFF
--- a/Duplicati/Library/Snapshots/lvm-scripts/create-lvm-snapshot.sh
+++ b/Duplicati/Library/Snapshots/lvm-scripts/create-lvm-snapshot.sh
@@ -23,7 +23,7 @@ TMPDIR=$3$NAME
 #  the snapshot is active.
 # Adjust these numbers to your system needs.
 MIN_FREE_BLOCKS=20
-MAX_FREE_BLOCKS=100
+MAX_FREE_BLOCKS=1000
 
 #
 # Get the number of free blocks on the volume


### PR DESCRIPTION
Increase the maximum size of LVM snapshots to 1000 extents (4GiB with default).

Current default is 100 extents. The default size of extents is 4 MiB. This leads to maximun snapshot size of 400 MiB. Nowadays that is relatively small given that even weekly Fedora updates will exceed that several times a year. 

4 GiB is large enough that normal system operations should not regularly exceed that, but small enough that having maximum size is still relevant on most systems.