### PR TITLE
Improve layout of notification area, fixing #2033

### DIFF
--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -224,7 +224,7 @@ ul.notification {
     left: 0px;
     right: 0px;
     margin: auto;
-    width: 300px;
+    width: 480px;
 }
 
 .notification {
@@ -255,7 +255,6 @@ ul.notification {
         padding: 2px;
         padding-left: 5px;
         padding-right: 5px;
-        padding-bottom: 30px;
         width: 100%;
     }
 
@@ -263,12 +262,15 @@ ul.notification {
         width: 100%;
         color: black;
     }
-    .buttons {
-        padding-top: 6px;
-    }
 
     .button {
         padding: 2px 10px;
+        margin-top: 6px;
+    }
+
+    .clear {
+        clear: right;
+        height: 1px;
     }
 
     .error {
@@ -2177,6 +2179,12 @@ div.modal-dialog {
 @media (max-width: 580px) {
     .advancedentry .longdescription {
         margin-left: 0;
+    }
+}
+
+@media (max-width: 492px) {
+    ul.notification {
+      width: auto;
     }
 }
 

--- a/Duplicati/Server/webroot/ngax/templates/notificationarea.html
+++ b/Duplicati/Server/webroot/ngax/templates/notificationarea.html
@@ -12,6 +12,7 @@
                 <a href ng-show="item.Action == 'backup:show-log'" ng-click="doShowLog(item.BackupID)" class="button showlog" translate>Show</a>
 
                 <a href ng-show="item.Action.indexOf('bug-report:created:') == 0 &amp;&amp; item.DownloadLink == null" ng-click="doDownloadBugreport(item)" class="button downloadbugreport" translate>Download</a>
+                <div class="clear"></div>
             </div>
 
 
@@ -27,6 +28,7 @@
                     <a href ng-show="state.updaterState == 'Downloading'" class="button" ng-disabled="true" ng-click="" translate>Downloading ...</a>
                     <a href ng-show="state.updaterState == 'Checking'" class="button" ng-disabled="true" ng-click="" translate>Verifying ...</a>
                     <a href ng-click="doShowUpdate()" class="button showupdate" translate>Show</a>
+                    <div class="clear"></div>
                 </div>
             </div>
 


### PR DESCRIPTION
- increase width to 480px
- make responsible with breakpoint at 492px (due to paddings and borders)
- reorganize buttons to allow height of notifiaction responding to buttons
  in multiple rows in very narrow viewports:
    - replace paddin-bottom by adding a float-clear element
    - move top-padding from div.buttons to top-margin of each button