### PR TITLE
Fixes for #2038 and #2101

### DIFF
--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -652,6 +652,23 @@ namespace Duplicati.Library.Main.Database
                     return null;
         }
 
+        public RemoteVolumeEntry GetRemoteVolumeFromID(long id)
+        {
+            using (var cmd = m_connection.CreateCommand())
+            using (var rd = cmd.ExecuteReader(@"SELECT ""Name"", ""Type"", ""Size"", ""Hash"", ""State"", ""DeleteGraceTime"" FROM ""RemoteVolume"" WHERE ""ID"" = ?", id))
+                if (rd.Read())
+                    return new RemoteVolumeEntry(
+                        rd.GetValue(0).ToString(),
+                        (rd.GetValue(3) == null || rd.GetValue(3) == DBNull.Value) ? null : rd.GetValue(3).ToString(),
+                        rd.ConvertValueToInt64(2, -1),
+                        (RemoteVolumeType)Enum.Parse(typeof(RemoteVolumeType), rd.GetValue(1).ToString()),
+                        (RemoteVolumeState)Enum.Parse(typeof(RemoteVolumeState), rd.GetValue(4).ToString()),
+                        new DateTime(rd.ConvertValueToInt64(5, 0), DateTimeKind.Utc)
+                    );
+                else
+                    return default(RemoteVolumeEntry);
+        }
+
         public IEnumerable<string> GetMissingIndexFiles()
         {
             using(var cmd = m_connection.CreateCommand())

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -365,9 +365,9 @@ namespace Duplicati.Library.Main.Database
             RemoveRemoteVolumes(new string[] { name }, transaction);
         }
 
-        public void RemoveRemoteVolumes(ICollection<string> names, System.Data.IDbTransaction transaction = null)
+        public void RemoveRemoteVolumes(IEnumerable<string> names, System.Data.IDbTransaction transaction = null)
         {
-            if (names.Count == 0) return;
+            if (names == null || !names.Any()) return;
 
             using (var tr = new TemporaryTransactionWrapper(m_connection, transaction))
             using (var deletecmd = m_connection.CreateCommand())

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -110,7 +110,7 @@ namespace Duplicati.Library.Main.Operation
                 if (db.RepairInProgress)
                     throw new Exception("The database was attempted repaired, but the repair did not complete. This database may be incomplete and the repair process is not allowed to alter remote files as that could result in data loss.");
 
-                var tp = FilelistProcessor.RemoteListAnalysis(backend, m_options, db, m_result.BackendWriter);
+                var tp = FilelistProcessor.RemoteListAnalysis(backend, m_options, db, m_result.BackendWriter, null);
                 var buffer = new byte[m_options.Blocksize];
                 var blockhasher = System.Security.Cryptography.HashAlgorithm.Create(m_options.BlockHashAlgorithm);
                 var hashsize = blockhasher.HashSize / 8;

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -248,7 +248,8 @@ namespace Duplicati.Library.Main
                     "hardlink-policy",
                     "exclude-files-attributes",
                     "compression-extension-file",
-                    "full-remote-verification"
+                    "full-remote-verification",
+                    "disable-synthetic-filelist"
                 };
             }
         }
@@ -477,6 +478,8 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("disable-filepath-cache", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisablefilepathcacheShort, Strings.Options.DisablefilepathcacheLong, "true"),
                     new CommandLineArgument("changed-files", CommandLineArgument.ArgumentType.Path, Strings.Options.ChangedfilesShort, Strings.Options.ChangedfilesLong),
                     new CommandLineArgument("deleted-files", CommandLineArgument.ArgumentType.Path, Strings.Options.DeletedfilesShort, Strings.Options.DeletedfilesLong("changed-files")),
+                    new CommandLineArgument("disable-synthetic-filelist", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisablesyntheticfilelistShort, Strings.Options.DisablesyntehticfilelistLong, "false"),
+
 
                     new CommandLineArgument("threshold", CommandLineArgument.ArgumentType.Integer, Strings.Options.ThresholdShort, Strings.Options.ThresholdLong, DEFAULT_THRESHOLD.ToString()),
                     new CommandLineArgument("index-file-policy", CommandLineArgument.ArgumentType.Enumeration, Strings.Options.IndexfilepolicyShort, Strings.Options.IndexfilepolicyLong, IndexFileStrategy.Full.ToString(), null, Enum.GetNames(typeof(IndexFileStrategy))),
@@ -1409,7 +1412,14 @@ namespace Duplicati.Library.Main
             get { return !Library.Utility.Utility.ParseBoolOption(m_options, "skip-restore-verification"); }
         }
 
-        
+        /// <summary>
+        /// Gets a flag indicating if synthetic filelist generation is disabled
+        /// </summary>
+        public bool DisableSyntheticFilelist
+        {
+            get { return Library.Utility.Utility.ParseBoolOption(m_options, "disable-synthetic-filelist"); }
+        }
+
         /// <summary>
         /// Gets the file hash size
         /// </summary>

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -214,6 +214,8 @@ namespace Duplicati.Library.Main.Strings
         public static string DisablepipingLong { get { return LC.L(@"Use this option to disable multithreaded handling of up- and downloads, that can significantly speed up backend operations depending on the hardware you're running on and the transfer rate of your backend."); } }
         public static string HypervbackupvmShort { get { return LC.L(@"Perform backup of Hyper-V machines (Windows only)"); } }
         public static string HypervbackupvmLong { get { return LC.L(@"Use this option to specify the IDs of machines to include in the backup. Specify multiple machine IDs with a semicolon separator. (You can use this Powershell command to get ID 'Get-VM | ft VMName, ID')"); } }
+        public static string DisablesyntehticfilelistLong { get { return LC.L(@"If Duplicati detects that the previous backup did not complete, it will generate a filelist that is a merge of the last completed backup and the contents that were uploaded in the incomplete backup session."); } }
+        public static string DisablesyntheticfilelistShort { get { return LC.L(@"Disables synethic filelist"); } }
     }
 
     internal static class Common


### PR DESCRIPTION
Reworked the cleanup process to allow a dangling filelist, such that this dangling entry can be used as the basis for a synthetic filelist.

Also added an option to disable synthetic filelists.
This fixes #2038.
This fixes #2101