### PR TITLE
Make progress bar more responsive when backing up large files

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
@@ -34,8 +34,8 @@ backupApp.controller('StateController', function($scope, $timeout, ServerStatus,
                     pg = 0;
                 } else {
                     var filesleft = $scope.state.lastPgEvent.TotalFileCount - $scope.state.lastPgEvent.ProcessedFileCount;
-                    var sizeleft = $scope.state.lastPgEvent.TotalFileSize - $scope.state.lastPgEvent.ProcessedFileSize;
-                    pg = $scope.state.lastPgEvent.ProcessedFileSize / $scope.state.lastPgEvent.TotalFileSize;
+                    var sizeleft = $scope.state.lastPgEvent.TotalFileSize - $scope.state.lastPgEvent.ProcessedFileSize - $scope.state.lastPgEvent.CurrentFileoffset;
+                    pg = ($scope.state.lastPgEvent.ProcessedFileSize + $scope.state.lastPgEvent.CurrentFileoffset) / $scope.state.lastPgEvent.TotalFileSize;
 
                     if ($scope.state.lastPgEvent.ProcessedFileCount == 0)
                         pg = 0;


### PR DESCRIPTION
When backing up large files, the progress bar appears to get stuck for long periods of time.  This PR adds in the progress of the current file to make it more responsive.