### PR TITLE
Update manager : Ignore webroot Folder

### DIFF
--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -51,8 +51,6 @@ namespace Duplicati.CommandLine
                 var options = tmpparsed.Item1;
                 var filter = tmpparsed.Item2;
 
-                Duplicati.Library.AutoUpdater.UpdaterManager.IgnoreWebrootFolder = true;
-
                 verboseErrors = Library.Utility.Utility.ParseBoolOption(options, "debug-output");
                 verbose = Library.Utility.Utility.ParseBoolOption(options, "verbose");
 

--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -33,6 +33,7 @@ namespace Duplicati.CommandLine
         [STAThread]
         public static int Main(string[] args)
         {
+            Duplicati.Library.AutoUpdater.UpdaterManager.IgnoreWebrootFolder = true;
             return Duplicati.Library.AutoUpdater.UpdaterManager.RunFromMostRecent(typeof(Program).GetMethod("RealMain"), args);
         }
 
@@ -49,6 +50,8 @@ namespace Duplicati.CommandLine
                 var tmpparsed = Library.Utility.FilterCollector.ExtractOptions(cargs);
                 var options = tmpparsed.Item1;
                 var filter = tmpparsed.Item2;
+
+                Duplicati.Library.AutoUpdater.UpdaterManager.IgnoreWebrootFolder = true;
 
                 verboseErrors = Library.Utility.Utility.ParseBoolOption(options, "debug-output");
                 verbose = Library.Utility.Utility.ParseBoolOption(options, "verbose");

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -49,6 +49,8 @@ namespace Duplicati.Library.AutoUpdater
 
         public static bool RequiresRespawn { get; set; }
 
+        public static bool IgnoreWebrootFolder { get; set; }
+
         private static KeyValuePair<string, UpdateInfo>? m_hasUpdateInstalled;
 
         public static readonly UpdateInfo SelfVersion;
@@ -602,6 +604,9 @@ namespace Duplicati.Library.AutoUpdater
                 {
                     var relpath = file.Substring(baselen);
                     if (string.IsNullOrWhiteSpace(relpath))
+                        continue;
+
+                    if (IgnoreWebrootFolder && relpath.StartsWith("webroot"))
                         continue;
 
                     FileEntry fe;


### PR DESCRIPTION
Added a property to ignore, if set, the webroot folder, when checking if
the update packages  are not tampered

fixes duplicati/duplicati#2266