### PR TITLE
Added IBM Bluemix COS Offering

### DIFF
--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -42,6 +42,7 @@ namespace Duplicati.Library.Backend
             new KeyValuePair<string, string>("DreamHost", "objects.dreamhost.com"),
             new KeyValuePair<string, string>("dinCloud - Chicago", "d3-ord.dincloud.com"),
             new KeyValuePair<string, string>("dinCloud - Los Angeles", "d3-lax.dincloud.com"),
+            new KeyValuePair<string, string>("IBM COS (S3) Public US", "s3-api.us-geo.objectstorage.softlayer.net"),
         };
 
         //Updated list: http://docs.amazonwebservices.com/general/latest/gr/rande.html#s3_region


### PR DESCRIPTION
I am requesting that the new IBM Bluemix Cloud Object Storage (S3) offering be included in the list of Third Party providers. I have tested the backup and restore functionality with our new S3-Compatible offering and have hit no snags. 