### PR TITLE
Dont create folder in AppData unnecessarily

### DIFF
--- a/Duplicati/Library/Main/Utility.cs
+++ b/Duplicati/Library/Main/Utility.cs
@@ -196,9 +196,6 @@ namespace Duplicati.Library.Main
                 try
                 {
                     var folder = Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AutoUpdater.AutoUpdateSettings.AppName);
-                    if (!Directory.Exists(folder))
-                        Directory.CreateDirectory(folder);
-                    
                     return File.Exists(Path.Combine(folder, SUPPRESS_DONATIONS_FILENAME));
                 }
                 catch


### PR DESCRIPTION
I am running Duplicati in portable setup by setting custom home path using environment variable DUPLICATI_HOME (or command line argument --server-datafolder), and noticed that an empty directory %AppData%\Duplicati was still being created as soon as I opened the web ui. Found out its the getter for SuppressDonationMessages that does it, when its about to check if a file in that directory exists... With this pull request I suggest removing the creation of the folder in this getter. In addition I would think it should check my custom home path for the "suppress_donation_messages.txt" file and not always %AppData%\Duplicati, but I could not easily see a way to do the necessary "plumbing" to get the home directory into this utility library.
