### PR TITLE
Fixed issue #2066: The command create-report appends zip even if outp…

### DIFF
--- a/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
+++ b/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
@@ -38,8 +38,8 @@ namespace Duplicati.Library.Main.Operation
         {
             var ext = System.IO.Path.GetExtension(m_targetpath);
             var module = m_options.CompressionModule;
-            
-            if (ext != module)
+
+            if (ext == "" || string.Compare(ext, 1, module, 0, module.Length, StringComparison.OrdinalIgnoreCase) != 0)
                 m_targetpath = m_targetpath + "." + module;
         
             if (System.IO.File.Exists(m_targetpath))


### PR DESCRIPTION
…ut-file name already ends with .zip. Reason is that System.IO.Path.GetExtension returns extension including the '.' character, so that needs to be excluded when comparing it to the compression module name. Also made the comparison case-insensitive so that MYFILE.ZIP will still be matched to compression module "zip" without making the file name MYFILE.ZIP.zip.