### PR TITLE
Improved database performance and logging

### DIFF
--- a/Duplicati/Library/Main/Database/ExtensionMethods.cs
+++ b/Duplicati/Library/Main/Database/ExtensionMethods.cs
@@ -87,7 +87,7 @@ namespace Duplicati.Library.Main.Database
                     self.AddParameter(n);
             }
 
-            using(new Logging.Timer(LC.L("ExecuteScalar: {0}", self.CommandText)))
+            using(new Logging.Timer(LC.L("ExecuteScalarInt64: {0}", self.CommandText)))
                 using(var rd = self.ExecuteReader())
                     if (rd.Read())
                         return ConvertValueToInt64(rd, 0, defaultvalue);

--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -86,8 +86,6 @@ namespace Duplicati.Library.Main.Database
         
         private PathLookupHelper<PathEntryKeeper> m_pathLookup;
         
-        private long m_missingBlockHashes;
-        
         private long m_filesetId;
 
         public LocalBackupDatabase(string path, Options options)
@@ -243,8 +241,6 @@ namespace Duplicati.Library.Main.Database
                     {
                         throw new InvalidDataException("Duplicate file entries detected, run repair to fix it", ex);
                     }
-                                                        
-                m_missingBlockHashes = cmd.ExecuteScalarInt64(@"SELECT COUNT (*) FROM (SELECT DISTINCT ""Block"".""Hash"", ""Block"".""Size"" FROM ""Block"", ""RemoteVolume"" WHERE ""RemoteVolume"".""ID"" = ""Block"".""VolumeID"" AND ""RemoteVolume"".""State"" NOT IN (?,?,?,?))", 0, RemoteVolumeState.Temporary.ToString(), RemoteVolumeState.Uploading.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString());
 
                 var tc = cmd.ExecuteScalarInt64(@"SELECT COUNT(*) FROM ""Remotevolume"" WHERE ""ID"" IN (SELECT DISTINCT ""VolumeID"" FROM ""Block"") AND ""State"" NOT IN (?, ?, ?, ?);", 0, RemoteVolumeState.Temporary.ToString(), RemoteVolumeState.Uploading.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString());
                 if (tc > 0)

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1315,8 +1315,8 @@ ORDER BY
 
                 tr.Commit();
             }
-            using(var cmd = m_connection.CreateCommand())
-                cmd.ExecuteNonQuery("VACUUM");
+
+            Vacuum();
         }
         
         public virtual void Dispose()

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -838,7 +838,6 @@ namespace Duplicati.Library.Main.Operation
                                 m_transaction.Commit();
                                 
                             m_transaction = null;
-                            m_database.Vacuum();
 
 							if (m_result.TaskControlRendevouz() != TaskControlState.Stop)
 							{


### PR DESCRIPTION
 - Don't use Vacuum() just before PurgeLogData (which performs vacuum() already)
 - Removed unncessary poorly performning query (after optimizing it I found out it's unused)
 - Correctly log calls for ExecuteScalarInt64