### PR TITLE
Test write permissions on 'FTP Test connection'

### DIFF
--- a/Duplicati/Library/Backend/AlternativeFTP/Strings.cs
+++ b/Duplicati/Library/Backend/AlternativeFTP/Strings.cs
@@ -23,5 +23,8 @@ namespace Duplicati.Library.Backend.AlternativeFTP
         public static string DescriptionFtpEncryptionModeShort { get { return LC.L(@"Configure the FTP encryption mode"); } }
         public static string DescriptionSslProtocolsLong { get { return LC.L(@"This flag controls the SSL policy to use when encryption is enabled."); } }
         public static string DescriptionSslProtocolsShort { get { return LC.L(@"Configure the SSL policy to use when encryption is enabled"); } }
+        public static string ErrorDeleteFile { get { return LC.L(@"Error on deleting file: {0}"); } }
+        public static string ErrorReadFile { get { return LC.L(@"Error reading file: {0}"); } }
+        public static string ErrorWriteFile { get { return LC.L(@"Error writing file: {0}"); } }
     }
 }


### PR DESCRIPTION
Check access permissions (Read/Write/Delete) for AlternativeFTP Backend using test file during connection test (Issue: #2473).

The same checks may be applied to FTP backend and other backends with possible access restrictions.
