### PR TITLE
Proposed fix, --deleted-files causes Fatal error / System.FormatException

### DIFF
--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -620,7 +620,8 @@ namespace Duplicati.Library.Main.Database
         public void AppendFilesFromPreviousSet(System.Data.IDbTransaction transaction, IEnumerable<string> deleted, long filesetid, long prevId, DateTime timestamp)
         {
             using(var cmd = m_connection.CreateCommand())
-            using (var tr = new TemporaryTransactionWrapper(m_connection, transaction))
+            using(var cmdDelete = m_connection.CreateCommand())
+            using(var tr = new TemporaryTransactionWrapper(m_connection, transaction))
             {
                 long lastFilesetId = prevId < 0 ? GetPreviousFilesetID(cmd, timestamp, filesetid) : prevId;
 
@@ -629,14 +630,15 @@ namespace Duplicati.Library.Main.Database
 
                 if (deleted != null)
                 {
-                    cmd.CommandText = @"DELETE FROM ""FilesetEntry"" WHERE ""FilesetID"" = ? AND ""FileID"" IN (SELECT ""ID"" FROM ""File"" WHERE ""Path"" = ?) ";
-                    cmd.AddParameter(filesetid);
-                    cmd.AddParameter();
+                    cmdDelete.Transaction = tr.Parent;
+                    cmdDelete.CommandText = @"DELETE FROM ""FilesetEntry"" WHERE ""FilesetID"" = ? AND ""FileID"" IN (SELECT ""ID"" FROM ""File"" WHERE ""Path"" = ?) ";
+                    cmdDelete.AddParameters(2);
+                    cmdDelete.SetParameterValue(0, filesetid);
 
                     foreach (string s in deleted)
                     {
-                        cmd.SetParameterValue(1, s);
-                        cmd.ExecuteNonQuery();
+                        cmdDelete.SetParameterValue(1, s);
+                        cmdDelete.ExecuteNonQuery();
                     }
                 }
 


### PR DESCRIPTION

A simple backup that specifies --deleted-files causes a Fatal error.
Shortened repro steps:
(See Github comment for full repro steps)
>duplicati.commandline.exe backup file://C:\data\local\testchangedfiles\destination "C:\data\local\testchangedfiles\source\\" --encryption-module="none" --no-encryption="true" --dbpath="testchangedfiles.sqlite"  --compression-module="zip" --keep-versions=-1  --no-auto-compact="true"
>del source\file6.txt
>duplicati.commandline.exe backup file://C:\data\local\testchangedfiles\destination "C:\data\local\testchangedfiles\source\\" --changed-files="C:\data\local\testchangedfiles\source\file1.txt;C:\data\local\testchangedfiles\source\file2.txt" --deleted-files="C:\data\local\testchangedfiles\source\file6.txt" --encryption-module="none" --no-encryption="true"  --dbpath="testchangedfiles.sqlite"  --compression-module="zip" --keep-versions=-1  --no-auto-compact="true"

Results in:
Fatal error => Input string was not in a correct format.
System.FormatException: Input string was not in a correct format.
   at System.Number.StringToNumber
   at System.Number.ParseInt64
   at System.String.System.IConvertible.ToInt64
   at System.Convert.ToInt64
   at System.Data.SQLite.SQLiteStatement.BindParameter
   at System.Data.SQLite.SQLiteStatement.BindParameters
   at System.Data.SQLite.SQLiteCommand.BuildNextCommand
   at System.Data.SQLite.SQLiteCommand.GetStatement
   at System.Data.SQLite.SQLiteDataReader.NextResult
   at System.Data.SQLite.SQLiteDataReader..ctor
   at System.Data.SQLite.SQLiteCommand.ExecuteReader
   at System.Data.SQLite.SQLiteCommand.ExecuteNonQuery
   at System.Data.SQLite.SQLiteCommand.ExecuteNonQuery
   at Duplicati.Library.Main.Database.LocalBackupDatabase.AppendFilesFromPreviousSet
   at Duplicati.Library.Main.Database.LocalBackupDatabase.AppendFilesFromPreviousSet
   at Duplicati.Library.Main.Operation.BackupHandler.RunMainOperation
   at Duplicati.Library.Main.Operation.BackupHandler.Run
   at Duplicati.Library.Main.Controller.RunAction[T]
   at Duplicati.Library.Main.Controller.Backup
   at Duplicati.CommandLine.Commands.Backup
   at Duplicati.CommandLine.Program.RunCommandLine
>Exit code: 100

With this patch, backup completes successfully.