### PR TITLE
Enable Caching for static webroot files

### DIFF
--- a/Duplicati/Server/WebServer/Server.cs
+++ b/Duplicati/Server/WebServer/Server.cs
@@ -287,7 +287,7 @@ namespace Duplicati.Server.WebServer
                 server.Add(proxy_files);
             }
 
-            var fh = new FileModule("/", webroot);
+            var fh = new FileModule("/", webroot, true);
             AddMimeTypes(fh);
             server.Add(fh);
 


### PR DESCRIPTION
Change the FileModule constructor of "/" to enable "Last-modified" header which allows webbrowsers to cache static files.