### PR TITLE
Fix restore for UNC backups

### DIFF
--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -171,7 +171,7 @@ namespace Duplicati.Library.Main.Database
                             var oldlen = maxpath.Length;
                             var lix = maxpath.LastIndexOf(dirsep, maxpath.Length - 2, StringComparison.Ordinal);
                             maxpath = maxpath.Substring(0, lix + 1);
-                            if (string.IsNullOrWhiteSpace(maxpath) || maxpath.Length == oldlen)
+                            if (string.IsNullOrWhiteSpace(maxpath) || maxpath.Length == oldlen || maxpath == "\\\\")
                                 maxpath = "";
                         }
                     }


### PR DESCRIPTION
Stop iterating though the path if remaining path is \\
Fixes crash when restoring files backuped from unc paths 

Fixes #2469