### PR TITLE
Added support for executing non-SQL code when performing a database upgrade

### DIFF
--- a/Duplicati/Library/SQLiteHelper/DBSchemaUpgrades/DbUpgradesRegistry.cs
+++ b/Duplicati/Library/SQLiteHelper/DBSchemaUpgrades/DbUpgradesRegistry.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Duplicati.Library.SQLiteHelper.DBUpdates;
+
+namespace Duplicati.Library.SQLiteHelper.DBSchemaUpgrades
+{
+    class DbUpgradesRegistry
+    {
+        /// <summary>
+        /// Registry of custom code to be executed along a SQL schema upgrade. The key of the map
+        /// represents a 1-based version the upgrade code applies to (after performing the update 
+        /// the database will be at that version), the value is an instance of upgrader that 
+        /// implements the hooks code.
+        /// </summary>
+        public static readonly IDictionary<int, IDbSchemaUpgrade> CodeChanges = 
+            new Dictionary<int, IDbSchemaUpgrade>()
+            {
+            };
+    }
+}

--- a/Duplicati/Library/SQLiteHelper/DBSchemaUpgrades/IDbSchemaUpgrade.cs
+++ b/Duplicati/Library/SQLiteHelper/DBSchemaUpgrades/IDbSchemaUpgrade.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Duplicati.Library.SQLiteHelper.DBUpdates
+{
+
+    // TODO: Consider passing in a transaction and performing everything in one go.
+
+    public interface IDbSchemaUpgrade
+    {
+        /// <summary>
+        /// Executed before the textual SQL command is executed.
+        /// </summary>
+        /// <param name="connection"></param>
+        void BeforeSql(System.Data.IDbConnection connection);
+
+        /// <summary>
+        /// Executed after the textual SQL command is executed.
+        /// </summary>
+        /// <param name="connection"></param>
+        void AfterSql(System.Data.IDbConnection connection);
+    }
+}

--- a/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
+++ b/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
@@ -23,13 +23,24 @@ using System.Text;
 using System.Data;
 using System.Text.RegularExpressions;
 using System.Linq;
+using Duplicati.Library.SQLiteHelper.DBUpdates;
+using Duplicati.Library.SQLiteHelper.DBSchemaUpgrades;
 
 namespace Duplicati.Library.SQLiteHelper
 {
     /// <summary>
     /// This class will read embedded files from the given folder.
     /// Updates should have the form &quot;1.Sample upgrade.sql&quot;.
-    /// When the database schema changes, simply put a new file into the folder.
+    /// When the database schema changes, simply put a new file into the folder
+    /// and set it to be emnbedded in the binary.
+    /// 
+    /// Additionally, it's possible to execute custom code before and after 
+    /// the SQL is executed. To set up a custom upgrade stage, add your
+    /// code to DbUpgradesRegistry along with the DB version to apply it with.
+    /// 
+    /// Even if all the DB upgrade code is handled in C#, you still have to add
+    /// a dummy SQL file to indicate the version ID is already taken.
+    /// 
     /// Each upgrade file should ONLY upgrade from the previous version.
     /// If done correctly, a user may be upgrade from the very first version
     /// to the very latest.
@@ -235,7 +246,9 @@ namespace Duplicati.Library.SQLiteHelper
                 }
                 else if (versions.Count > dbversion)
                 {
-                    string backupfile = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(sourcefile), Strings.DatabaseUpgrader.BackupFilenamePrefix + " " + DateTime.Now.ToString("yyyyMMddhhmmss", System.Globalization.CultureInfo.InvariantCulture) + ".sqlite");
+                    string backupfile = System.IO.Path.Combine(
+                        System.IO.Path.GetDirectoryName(sourcefile), 
+                        Strings.DatabaseUpgrader.BackupFilenamePrefix + " " + DateTime.Now.ToString("yyyyMMddhhmmss", System.Globalization.CultureInfo.InvariantCulture) + ".sqlite");
 
                     try
                     {
@@ -247,6 +260,16 @@ namespace Duplicati.Library.SQLiteHelper
 
                         for (int i = dbversion; i < versions.Count; i++)
                         {
+                            IDbSchemaUpgrade dbCodeUpgrade;
+
+                            // The versions in the registry are 1-based, the loop index is zero based.
+                            bool hookFound = DbUpgradesRegistry.CodeChanges.TryGetValue(i + 1, out dbCodeUpgrade);
+
+                            if (hookFound)
+                            {
+                                dbCodeUpgrade.BeforeSql(connection);
+                            }
+
                             //TODO: Find a better way to split SQL statements, as there may be embedded semicolons
                             //in the SQL, like "UPDATE x WHERE y = ';';"
 
@@ -260,6 +283,11 @@ namespace Duplicati.Library.SQLiteHelper
                                     cmd.CommandText = c;
                                     cmd.ExecuteNonQuery();
                                 }
+
+                            if (hookFound)
+                            {
+                                dbCodeUpgrade.AfterSql(connection);
+                            }
 
                             // after upgrade, db_version should have changed to i + 1. If logic changes, just requery.
                             preparserVars["db_version"] = i + 1;

--- a/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
+++ b/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
@@ -38,8 +38,8 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DbUpgradesRegistry.cs" />
-    <Compile Include="IDbSchemaUpgrade.cs" />
+    <Compile Include="DBSchemaUpgrades\DbUpgradesRegistry.cs" />
+    <Compile Include="DBSchemaUpgrades\IDbSchemaUpgrade.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DatabaseUpgrader.cs" />
     <Compile Include="SQLiteLoader.cs" />

--- a/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
+++ b/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
@@ -38,6 +38,8 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DbUpgradesRegistry.cs" />
+    <Compile Include="IDbSchemaUpgrade.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DatabaseUpgrader.cs" />
     <Compile Include="SQLiteLoader.cs" />

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,7 +35,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DatabaseUpgraderTest.cs" />
     <Compile Include="SVNCheckoutsTest.cs" />
     <Compile Include="GeneralBlackBoxTesting.cs" />
     <Compile Include="CommandLineOperationsTests.cs" />
@@ -170,8 +169,5 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,6 +35,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DatabaseUpgraderTest.cs" />
     <Compile Include="SVNCheckoutsTest.cs" />
     <Compile Include="GeneralBlackBoxTesting.cs" />
     <Compile Include="CommandLineOperationsTests.cs" />
@@ -169,5 +170,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Some of the database migrations I'm planning to perform are very slow if using SQL only
or entirely impossible using the standard SQLite toolchain. I added a simple interface
with "before SQL" and "after SQL" hooks so that a database upgrade can perform custom
code operations as well.