### PR TITLE
Updated the Application's name on the balloon tooltip

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Properties/AssemblyInfo.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Duplicati.GUI.TrayIcon")]
+[assembly: AssemblyTitle("Duplicati")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Duplicati Team")]

--- a/Duplicati/Server/Duplicati.Server.Serialization/Properties/AssemblyInfo.cs
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Duplicati.GUI.Serialization")]
+[assembly: AssemblyTitle("Duplicati.Server.Serialization")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Duplicati Team")]
-[assembly: AssemblyProduct("Duplicati.GUI.Serialization")]
+[assembly: AssemblyProduct("Duplicati.Server.Serialization")]
 [assembly: AssemblyCopyright("LGPL, Copyright © Duplicati Team 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
Balloon tooltip on Windows 10 used to say 'message' and then as the owner 'Duplicati.GUI.TrayIcon'. I changed that to just 'Duplicati'.

And for the Server.Serialization, I just fixed the name, it was wrong.