### PR TITLE
Add support for wildcards in source paths on Windows.

### DIFF
--- a/Duplicati/CommandLine/Help.cs
+++ b/Duplicati/CommandLine/Help.cs
@@ -98,6 +98,7 @@ namespace Duplicati.CommandLine
                 tp = tp.Replace("%APP_PATH%", System.IO.Path.GetFileName(System.Reflection.Assembly.GetExecutingAssembly().Location));
                 tp = tp.Replace("%PATH_SEPARATOR%", System.IO.Path.PathSeparator.ToString());
                 tp = tp.Replace("%EXAMPLE_SOURCE_PATH%", Library.Utility.Utility.IsClientLinux ? "/source" : "D:\\source");
+                tp = tp.Replace("%EXAMPLE_WILDCARD_DRIVE_SOURCE_PATH%", Library.Utility.Utility.IsClientLinux ? "/source" : "*:\\source");
                 tp = tp.Replace("%EXAMPLE_SOURCE_FILE%", Library.Utility.Utility.IsClientLinux ? "/source/myfile.txt" : "D:\\source\\file.txt");
                 tp = tp.Replace("%EXAMPLE_RESTORE_PATH%", Library.Utility.Utility.IsClientLinux ? "/restore" : "D:\\restore");
                 tp = tp.Replace("%ENCRYPTIONMODULES%", string.Join(", ", Library.DynamicLoader.EncryptionLoader.Keys));
@@ -105,6 +106,17 @@ namespace Duplicati.CommandLine
                 tp = tp.Replace("%DEFAULTENCRYPTIONMODULE%", opts.EncryptionModule);
                 tp = tp.Replace("%DEFAULTCOMPRESSIONMODULE%", opts.CompressionModule);
                 tp = tp.Replace("%GENERICMODULES%", string.Join(", ", Library.DynamicLoader.GenericLoader.Keys));
+
+                if (!Library.Utility.Utility.IsClientWindows)
+                {
+                    // Specifying the Singleline option allows . to match newlines, so this will detect spans that cover multiple lines
+                    tp = System.Text.RegularExpressions.Regex.Replace(tp, "\\%IF_WINDOWS\\%.*\\%END_IF_WINDOWS\\%", string.Empty, System.Text.RegularExpressions.RegexOptions.Singleline);
+                }
+                else
+                {
+                    tp = tp.Replace("%IF_WINDOWS%", string.Empty);
+                    tp = tp.Replace("%END_IF_WINDOWS%", string.Empty);
+                }
 
                 if (tp.Contains("%MAINOPTIONS%"))
                 {

--- a/Duplicati/CommandLine/help.txt
+++ b/Duplicati/CommandLine/help.txt
@@ -73,7 +73,9 @@ Usage: backup <storage-URL> "<source-path>" [<options>]
   Makes a backup of <source-path> and stores it in <storage-URL>. The format for <storage-URL> is 
     protocol://username:password@hostname:port/path?backend_option1=value1&backend_option2=value2. 
   Multiple source paths can be specified if they are separated by a space.
-
+%IF_WINDOWS%
+  On Windows clients, the source paths can be specified using a wildcard (*) in place of the drive name, for example, "%EXAMPLE_WILDCARD_DRIVE_SOURCE_PATH%". In this case, the source path will be backed up from all drives on which the path exists. This can be especially useful when backing up sources on removable drives, whose drive letters may not be reliable. When using --allow-missing-source, the backup will succeed as long as at least one path matches the wildcarded path.
+%END_IF_WINDOWS%
   <username> must not contain : and <password> must not contain @. If they do, specify username and password using --auth-username and --auth-password, or url-encode them.
 
   --auth-password=<string>

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -196,27 +196,72 @@ namespace Duplicati.Library.Main
                 if (inputsources == null || inputsources.Length == 0)
                     throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.NoSourceFoldersError);
 
-                var sources = new List<string>(inputsources);
+                var sources = new List<string>(inputsources.Length);
+
+                System.IO.DriveInfo[] drives = null;
 
                 //Make sure they all have the same format and exist
-                for(int i = 0; i < sources.Count; i++)
+                for (int i = 0; i < inputsources.Length; i++)
                 {
-                    try
+                    List<string> expandedSources = new List<string>();
+                    if (inputsources[i].StartsWith("*:"))
                     {
-                        sources[i] = System.IO.Path.GetFullPath(sources[i]);
+                        // Lazily load the drive info
+                        if (drives == null)
+                        {
+                            // *: drive paths are only supported on Windows clients
+                            if (Library.Utility.Utility.IsClientWindows)
+                            {
+                                drives = System.IO.DriveInfo.GetDrives();
+                            }
+                            else
+                            {
+                                throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.SourceFolderWildcardDriveNotSupportedError(inputsources[i]));
+                            }
+                        }
+
+                        // Replace the drive letter with each available drive
+                        string sourcePath = inputsources[i].Substring(1);
+                        foreach (System.IO.DriveInfo drive in drives)
+                        {
+                            expandedSources.Add(drive.Name[0] + sourcePath);
+                        }
                     }
-                    catch (Exception ex)
+                    else
                     {
-                        throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.InvalidPathError(sources[i], ex.Message), ex);
+                        expandedSources.Add(inputsources[i]);
                     }
 
-                    var fi = new System.IO.FileInfo(sources[i]);
-                    var di = new System.IO.DirectoryInfo(sources[i]);
-                    if (!(fi.Exists || di.Exists) && !m_options.AllowMissingSource)
-                        throw new System.IO.IOException(Strings.Controller.SourceIsMissingError(sources[i]));
+                    bool foundAnyPaths = false;
+                    foreach (string expandedSource in expandedSources)
+                    {
+                        string source;
+                        try
+                        {
+                            source = System.IO.Path.GetFullPath(expandedSource);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Note that we use the original source (with the *) in the error
+                            throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.InvalidPathError(inputsources[i], ex.Message), ex);
+                        }
 
-                    if (!fi.Exists)
-                        sources[i] = Library.Utility.Utility.AppendDirSeparator(sources[i]);
+                        var fi = new System.IO.FileInfo(source);
+                        var di = new System.IO.DirectoryInfo(source);
+                        if (fi.Exists || di.Exists)
+                        {
+                            foundAnyPaths = true;
+
+                            if (!fi.Exists)
+                                source = Library.Utility.Utility.AppendDirSeparator(source);
+
+                            sources.Add(source);
+                        }
+                    }
+
+                    // If no paths were found, and we aren't allowed to have missing sources, throw an error
+                    if (!foundAnyPaths && !m_options.AllowMissingSource)
+                        throw new System.IO.IOException(Strings.Controller.SourceIsMissingError(inputsources[i]));
                 }
 
                 //Sanity check for duplicate files/folders

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -24,6 +24,7 @@ namespace Duplicati.Library.Main.Strings
         public static string FailedOperationMessage(OperationMode operationname, string errormessage) { return LC.L(@"The operation {0} has failed with error: {1}", operationname, errormessage); }
         public static string InvalidPathError(string path, string message) { return LC.L(@"Invalid path: ""{0}"" ({1})", path, message); }
         public static string FailedForceLocaleError(string exMsg) { return LC.L(@"Failed to apply 'force-locale' setting. Please try to update .NET-Framework. Exception was: ""{0}"" ", exMsg); }
+        public static string SourceFolderWildcardDriveNotSupportedError(string foldername) { return LC.L(@"The source folder {0} uses a wildcard drive, which is only supported on Windows, aborting backup", foldername); }
     }
 
     internal static class Options


### PR DESCRIPTION
This causes backup to run for the given path on all drives, and can be useful in the case where removable drives may change letters randomly.

This change is a partial resolution for the root problem of issue #2036, though it is not quite as elegant as the suggested solution since it attempts to back up all drives rather than providing a better specification for the specific drive to backup.