### PR TITLE
Fixed time zone of log timestamps

### DIFF
--- a/Duplicati/Library/Logging/StreamLog.cs
+++ b/Duplicati/Library/Logging/StreamLog.cs
@@ -59,7 +59,7 @@ namespace Duplicati.Library.Logging
         /// <param name="exception">An exception, may be null</param>
         public virtual void WriteMessage(string message, LogMessageType type, Exception exception)
         {
-            m_stream.WriteLine("{0:u} - {1}: {2}", DateTime.Now, type, message);
+            m_stream.WriteLine("{0:u} - {1}: {2}", DateTime.Now.ToUniversalTime().ToString("u"), type, message);
             if (exception != null)
             {
                 m_stream.WriteLine(exception.ToString());


### PR DESCRIPTION
Fixed #2165 ("Log timestamps have wrong time zone") by making sure the date/time is correct in time zone UTC. So it will still log the date/times with "Z" suffix, but now they are really in UTC.

TL;DR: The default DateTime format seems to be same as Universal Sortable ("u") Format Specifier, and according to documentation it will always describe the date as in UTC but it does not automatically convert it, so therefore DateTime.Now needs to go through the ToUniversalTime method before formatting it.