### PR TITLE
Decrease server's CPU and IO scheduling priority

### DIFF
--- a/Installer/debian/debian/duplicati.service
+++ b/Installer/debian/debian/duplicati.service
@@ -3,6 +3,8 @@ Description=Duplicati web-server
 After=network.target
 
 [Service]
+Nice=19
+IOSchedulingClass=idle
 EnvironmentFile=-/etc/default/duplicati
 ExecStart=/usr/bin/duplicati-server $DAEMON_OPTS
 

--- a/Installer/fedora/duplicati.service
+++ b/Installer/fedora/duplicati.service
@@ -3,6 +3,8 @@ Description=Duplicati web-server
 After=network.target
 
 [Service]
+Nice=19
+IOSchedulingClass=idle
 EnvironmentFile=-/etc/sysconfig/duplicati
 ExecStart=/usr/bin/duplicati-server $DAEMON_OPTS
 


### PR DESCRIPTION
Setting low priority helps to run server process truly in background and provides CPU cycles to Duplicati only if no other process requires them.