### PR TITLE
WebUI title reflects machine name

### DIFF
--- a/Duplicati/Server/webroot/ngax/index.html
+++ b/Duplicati/Server/webroot/ngax/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html xmlns:ng="http://angularjs.org" ng-app="backupApp">
+<html xmlns:ng="http://angularjs.org" ng-app="backupApp" ng-controller="AppController">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Duplicati</title>
+    <title ng-bind-template="{{systemInfo.MachineName}} - {{brandingService.appName}}"></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -121,7 +121,7 @@
     <script type="text/javascript" src="../customized/customized.js"></script>
 
 </head>
-<body ng-controller="AppController" class="theme-{{active_theme}}">
+<body class="theme-{{active_theme}}">
      
     <div class="container">
         <div class="header">

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/SystemSettingsController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/SystemSettingsController.js
@@ -54,8 +54,8 @@ backupApp.controller('SystemSettingsController', function($rootScope, $scope, $l
         $scope.requireRemotePassword = data.data['server-passphrase'] != null && data.data['server-passphrase'] != '';
         $scope.remotePassword = data.data['server-passphrase'];
         $scope.allowRemoteAccess = data.data['server-listen-interface'] != 'loopback';
-        $scope.startupDelayDurationValue = data.data['startup-delay'].substr(0, data.data['startup-delay'].length - 1);
-        $scope.startupDelayDurationMultiplier = data.data['startup-delay'].substr(-1);
+        $scope.startupDelayDurationValue = data.data['startup-delay'].substr(0, data.data['startup-delay'].length - 1) == "" ? "0" : data.data['startup-delay'].substr(0, data.data['startup-delay'].length - 1);
+        $scope.startupDelayDurationMultiplier = data.data['startup-delay'].substr(-1) == "" ? "s" : data.data['startup-delay'].substr(-1);
         $scope.updateChannel = data.data['update-channel'];
         $scope.originalUpdateChannel = data.data['update-channel'];
         $scope.usageReporterLevel = data.data['usage-reporter-level'];

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
@@ -104,8 +104,6 @@ backupApp.service('EditUriBackendConfig', function(AppService, AppUtils, SystemI
     this.require_username_and_password = function(scope) {
         if ((scope.Username || '').trim().length == 0)
             return self.show_error_dialog(gettextCatalog.getString('You must fill in the username'));
-        if ((scope.Password || '').trim().length == 0)
-            return self.show_error_dialog(gettextCatalog.getString('You must fill in the password'));
 
         return true;
     };

--- a/Duplicati/Server/webroot/ngax/templates/settings.html
+++ b/Duplicati/Server/webroot/ngax/templates/settings.html
@@ -17,6 +17,7 @@
         <div class="input mixed multiple">
             <label for="pauseTime" translate>Pause</label>
             <select id="pauseTime" name="pauseTime" ng-model="startupDelayDurationValue">
+                <option value="0">0</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>


### PR DESCRIPTION
Changed the webpage title to be "MachineName - AppName" allowing users to discern between multiple tabs connecting to different remote machines.

I had to move the ng-controller tag from "< body>" to "< html>" because otherwise it wouldn't recognize ng-bindings in the header.

Related to duplicati/duplicati#2437