### PR TITLE
Fix for duplicati/duplicati#2617

### DIFF
--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -217,8 +217,11 @@ namespace Duplicati.Server
 
                 if (commandlineOptions.ContainsKey("log-file"))
                 {
+#if DEBUG
+                    // Only delete the --log-file when in DEBUG mode. Otherwise, don't delete and just append logs.
                     if (System.IO.File.Exists(commandlineOptions["log-file"]))
                         System.IO.File.Delete(commandlineOptions["log-file"]);
+#endif
 
                     var loglevel = Duplicati.Library.Logging.LogMessageType.Error;
 


### PR DESCRIPTION
I moved the "delete log file on service start" functionality into DEBUG mode so that release versions of duplicati won't wipe out it's logs on service restart.

I wanted to retain the functionality for testing (no point having gigantic debug logs when debugging).