### PR TITLE
Allow user to disable startup delay

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/SystemSettingsController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/SystemSettingsController.js
@@ -54,8 +54,8 @@ backupApp.controller('SystemSettingsController', function($rootScope, $scope, $l
         $scope.requireRemotePassword = data.data['server-passphrase'] != null && data.data['server-passphrase'] != '';
         $scope.remotePassword = data.data['server-passphrase'];
         $scope.allowRemoteAccess = data.data['server-listen-interface'] != 'loopback';
-        $scope.startupDelayDurationValue = data.data['startup-delay'].substr(0, data.data['startup-delay'].length - 1);
-        $scope.startupDelayDurationMultiplier = data.data['startup-delay'].substr(-1);
+        $scope.startupDelayDurationValue = data.data['startup-delay'].substr(0, data.data['startup-delay'].length - 1) == "" ? "0" : data.data['startup-delay'].substr(0, data.data['startup-delay'].length - 1);
+        $scope.startupDelayDurationMultiplier = data.data['startup-delay'].substr(-1) == "" ? "s" : data.data['startup-delay'].substr(-1);
         $scope.updateChannel = data.data['update-channel'];
         $scope.originalUpdateChannel = data.data['update-channel'];
         $scope.usageReporterLevel = data.data['usage-reporter-level'];

--- a/Duplicati/Server/webroot/ngax/templates/settings.html
+++ b/Duplicati/Server/webroot/ngax/templates/settings.html
@@ -17,6 +17,7 @@
         <div class="input mixed multiple">
             <label for="pauseTime" translate>Pause</label>
             <select id="pauseTime" name="pauseTime" ng-model="startupDelayDurationValue">
+                <option value="0">0</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>


### PR DESCRIPTION
This is a two fold "fix" to duplicati/duplicati#2715

Changes in settings.html adds the option to select "0 seconds", which wasn't previously possible.
Changes in SystemSettingsController.js adds logic in the controller that will check if the duration value and duration multipliers are set. If it finds that they are not it will set them to "0" and "s" respectively (instead of leaving them blank)