### PR TITLE
Add method to get fully-qualified path

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -984,7 +984,7 @@ namespace Duplicati.Library.Utility
         /// <param name="str">The string to expand.</param>
         public static string ExpandEnvironmentVariables(string str)
         {
-            return Environment.ExpandEnvironmentVariables(str.Replace("~", HOME_PATH));
+            return Environment.ExpandEnvironmentVariables(ExpandTilde(str));
         }
 
         /// <summary>
@@ -1014,8 +1014,20 @@ namespace Duplicati.Library.Utility
                 //IsClientLinux ? ENVIRONMENT_VARIABLE_MATCHER_LINUX : ENVIRONMENT_VARIABLE_MATCHER_WINDOWS
 
                 ENVIRONMENT_VARIABLE_MATCHER_WINDOWS
-                    .Replace(str.Replace("~", Regex.Escape(HOME_PATH)), (m) => 
+                    .Replace(Regex.Escape(ExpandTilde(str)), (m) => 
                         Regex.Escape(lookup(m.Groups["name"].Value)));
+        }
+
+        /// <summary>
+        /// On Unix-like systems, expand the '~' character to the user's home directory.
+        /// </summary>
+        /// <param name="path">The path to expand.</param>
+        /// <returns>An expanded version of <paramref name="path"/>, with '~' replaced by the user's home directory.</returns>
+        public static string ExpandTilde(string path)
+        {
+            // We only replace '~' on Unix-like systems to avoid potential issues
+            // with paths like c:\Progra~1\ on Windows.
+            return IsClientLinux ? path.Replace("~", HOME_PATH) : path;
         }
 
         /// <summary>
@@ -1031,9 +1043,7 @@ namespace Duplicati.Library.Utility
         /// <returns>The fully-qualified location of <paramref name="path"/>.</returns>
         public static string GetFullPath(string path)
         {
-            // We only replace "~" on Unix-like systems to avoid potential issues
-            // with paths like c:\Progra~1\ on Windows.
-            return Path.GetFullPath(IsClientLinux ? path.Replace("~", HOME_PATH) : path);
+            return Path.GetFullPath(ExpandTilde(path));
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -23,6 +23,7 @@ using System.Linq;
 #endregion
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace Duplicati.Library.Utility
@@ -1015,6 +1016,24 @@ namespace Duplicati.Library.Utility
                 ENVIRONMENT_VARIABLE_MATCHER_WINDOWS
                     .Replace(str.Replace("~", Regex.Escape(HOME_PATH)), (m) => 
                         Regex.Escape(lookup(m.Groups["name"].Value)));
+        }
+
+        /// <summary>
+        /// Get a fully-qualified path.
+        /// </summary>
+        /// <remarks>
+        /// On Unix-like systems, the '~' character is also replaced by the path to the user's home directory.
+        ///
+        /// The file or directory specified by <paramref name="path"/> does not have to exist.  If only a filename 
+        /// is provided as <paramref name="path"/>, the current working directory is prepended to the filename.
+        /// </remarks>
+        /// <param name="path">The file or directory for which to obtain absolute path information.</param>
+        /// <returns>The fully-qualified location of <paramref name="path"/>.</returns>
+        public static string GetFullPath(string path)
+        {
+            // We only replace "~" on Unix-like systems to avoid potential issues
+            // with paths like c:\Progra~1\ on Windows.
+            return Path.GetFullPath(IsClientLinux ? path.Replace("~", HOME_PATH) : path);
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1035,7 +1035,7 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <remarks>
         /// On Unix-like systems, the '~' character is also replaced by the path to the user's home directory.
-        ///
+        /// <para />
         /// The file or directory specified by <paramref name="path"/> does not have to exist.  If only a filename 
         /// is provided as <paramref name="path"/>, the current working directory is prepended to the filename.
         /// </remarks>

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -29,7 +29,7 @@ namespace Duplicati.UnitTest
         /// </summary>
         protected static readonly string BASEFOLDER =
             string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("UNITTEST_BASEFOLDER"))
-            ? Library.Utility.Utility.ExpandEnvironmentVariables(Path.Combine("~", "testdata"))
+            ? Library.Utility.Utility.GetFullPath(Path.Combine("~", "testdata"))
             : Environment.GetEnvironmentVariable("UNITTEST_BASEFOLDER");
 
         /// <summary>

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -47,9 +47,7 @@
     <Compile Include="Issue1723.cs" />
     <Compile Include="PurgeTesting.cs" />
     <Compile Include="CompressionTests.cs" />
-    <Compile Include="UtilityTests.cs">
-      <IncludeInPackage>false</IncludeInPackage>
-    </Compile>
+    <Compile Include="UtilityTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -47,6 +47,9 @@
     <Compile Include="Issue1723.cs" />
     <Compile Include="PurgeTesting.cs" />
     <Compile Include="CompressionTests.cs" />
+    <Compile Include="UtilityTests.cs">
+      <IncludeInPackage>false</IncludeInPackage>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -29,7 +29,7 @@ namespace Duplicati.UnitTest
         private static readonly string SOURCE_FOLDERS =
             Path.Combine(
                 string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("UNITTEST_BASEFOLDER"))
-                ? Library.Utility.Utility.ExpandEnvironmentVariables(Path.Combine("~", "testdata"))
+                ? Library.Utility.Utility.GetFullPath(Path.Combine("~", "testdata"))
                 : Environment.GetEnvironmentVariable("UNITTEST_BASEFOLDER")
             , "DSMCBE");
 

--- a/Duplicati/UnitTest/SVNCheckoutsTest.cs
+++ b/Duplicati/UnitTest/SVNCheckoutsTest.cs
@@ -100,9 +100,8 @@ namespace Duplicati.UnitTest
                            select Library.Utility.Utility.ExpandEnvironmentVariables(x)).ToArray();
 
                 //Expand the tilde to home folder on Linux/OSX
-                if (Utility.IsClientLinux)
-                    folders = (from x in folders
-                               select x.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.Personal))).ToArray();
+                folders = (from x in folders
+                           select Utility.ExpandTilde(x)).ToArray();
 
                 foreach (var f in folders)
                     foreach (var n in f.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -1,0 +1,59 @@
+﻿//  Copyright (C) 2017, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace Duplicati.UnitTest
+{
+    [TestFixture]
+    public class UtilityTests
+    {
+        [Test]
+        [Category("Utility")]
+        public void GetFullPath()
+        {
+            string tempDir = Path.GetTempPath();
+
+            string hasRelativeParts = Path.Combine(tempDir, "a", "b", "c", "..", "..", "d");
+            string fullyQualified = Path.Combine(tempDir, "a", "d");
+            Assert.AreEqual(fullyQualified, Utility.GetFullPath(hasRelativeParts));
+
+            string hasRedundantSeparator = Path.Combine(tempDir, "a" + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar, "b");
+            string noRedundantSeparator = Path.Combine(tempDir, "a", "b");
+            Assert.AreEqual(noRedundantSeparator, Utility.GetFullPath(hasRedundantSeparator));
+
+            string currentDirectory = Directory.GetCurrentDirectory();
+            string filename = "file.txt";
+            Assert.AreEqual(Path.Combine(currentDirectory, filename), Utility.GetFullPath(filename));
+
+            if (Utility.IsClientLinux)
+            {
+                string hasTilde = Path.Combine("~", "a");
+                string expanded = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "a");
+                Assert.AreEqual(expanded, Utility.GetFullPath(hasTilde));
+            }
+            else if (Utility.IsClientWindows)
+            {
+                string hasTilde = Path.Combine(@"c:\", "Progra~1", "file.txt");
+                Assert.AreEqual(hasTilde, Utility.GetFullPath(hasTilde));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This can be used to normalize path strings by removing redundant path separators and resolving relative path specifications to absolute ones.  This will also replace the `~` character with the path to the user's home directory, if applicable.
    
These changes fix an issue on some Linux systems, where several unit tests were failing because `BasicSetupHelper.DATAFOLDER` resolved to something like `/home/username//testdata/backup-data`.  Since paths returned by the filesystem do not contain the redundant `/`, the "Border" unit tests would fail when attempting to restore specified paths (the `LocalRestoreDatabase.PrepareRestoreFilelist` method would not find any paths matching the `//`).

This also extracts the tilde expansion to a method, and the expansion is only performed for Unix-like systems to avoid issues with paths like `c:\Progra~1\` on Windows.
