### PR TITLE
Add IQuotaInfo interface

### DIFF
--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -318,26 +318,12 @@ namespace Duplicati.Library.Backend
             return new System.IO.DriveInfo(root);
         }
 
-        public long TotalQuotaSpace
+        public IQuotaInfo Quota
         {
             get
             {
-                try { return GetDrive().TotalSize; }
-                catch { }
-
-                return -1;
-            }
-        }
-
-
-        public long FreeQuotaSpace
-        {
-            get
-            {
-                try { return GetDrive().AvailableFreeSpace; }
-                catch { }
-
-                return -1;
+                System.IO.DriveInfo driveInfo = this.GetDrive();
+                return new QuotaInfo(driveInfo.TotalSize, driveInfo.AvailableFreeSpace);
             }
         }
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -319,25 +319,19 @@ namespace Duplicati.Library.Backend.GoogleDrive
         #endregion
 
         #region IQuotaEnabledBackend implementation
-        public long TotalQuotaSpace
+        public IQuotaInfo Quota
         {
             get
             {
-                try { return GetAboutInfo().quotaBytesTotal ?? -1; }
-                catch { }
-
-                return -1;
-            }
-        }
-
-        public long FreeQuotaSpace
-        {
-            get
-            {
-                try { return GetAboutInfo().quotaBytesUsed ?? -1; }
-                catch { }
-
-                return -1;
+                try
+                {
+                    GoogleDriveAboutResponse about = this.GetAboutInfo();
+                    return new QuotaInfo(about.quotaBytesTotal ?? -1, about.quotaBytesUsed ?? -1);
+                }
+                catch
+                {
+                    return null;
+                }
             }
         }
         #endregion

--- a/Duplicati/Library/Backend/OneDrive/OneDrive.cs
+++ b/Duplicati/Library/Backend/OneDrive/OneDrive.cs
@@ -438,6 +438,15 @@ namespace Duplicati.Library.Backend
 
         #region IQuotaEnabledBackend Members
 
+        public IQuotaInfo Quota
+        {
+            get
+            {
+                WLID_QuotaInfo quota = this.GetQuotaInfo();
+                return new QuotaInfo(quota.Quota ?? -1, quota.Available ?? -1);
+            }
+        }
+
         public long TotalQuotaSpace
         {
             get

--- a/Duplicati/Library/Interface/Duplicati.Library.Interface.csproj
+++ b/Duplicati/Library/Interface/Duplicati.Library.Interface.csproj
@@ -54,9 +54,11 @@
     <Compile Include="IGenericSourceModule.cs" />
     <Compile Include="IGenericModule.cs" />
     <Compile Include="IQuotaEnabledBackend.cs" />
+    <Compile Include="IQuotaInfo.cs" />
     <Compile Include="IStreamingBackend.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IGenericCallbackModule.cs" />
+    <Compile Include="QuotaInfo.cs" />
     <Compile Include="ResultInterfaces.cs" />
     <Compile Include="IWebModule.cs" />
     <Compile Include="IConnectionModule.cs" />

--- a/Duplicati/Library/Interface/IQuotaEnabledBackend.cs
+++ b/Duplicati/Library/Interface/IQuotaEnabledBackend.cs
@@ -11,16 +11,10 @@ namespace Duplicati.Library.Interface
     public interface IQuotaEnabledBackend : IBackend
     {
         /// <summary>
-        /// The total number of bytes available on the backend,
-        /// may return -1 if the particular host implementation
-        /// does not support quotas, but the backend does
+        /// Gets information about the quota on this backend.
+        /// This may return null if the particular host implementation
+        /// does not support quotas, but the backend does.
         /// </summary>
-        long TotalQuotaSpace { get; }
-        /// <summary>
-        /// The total number of unused bytes on the backend,
-        /// may return -1 if the particular host implementation
-        /// does not support quotas, but the backend does
-        /// </summary>
-        long FreeQuotaSpace { get; }
+        IQuotaInfo Quota { get; }
     }
 }

--- a/Duplicati/Library/Interface/IQuotaInfo.cs
+++ b/Duplicati/Library/Interface/IQuotaInfo.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Duplicati.Library.Interface
+{
+    public interface IQuotaInfo
+    {
+        /// <summary>
+        /// The total number of bytes available on the backend,
+        /// This may return -1 if the particular host implementation
+        /// does not support quotas, but the backend does
+        /// </summary>
+        long TotalQuotaSpace { get; }
+        /// <summary>
+        /// The total number of unused bytes on the backend,
+        /// This may return -1 if the particular host implementation
+        /// does not support quotas, but the backend does
+        /// </summary>
+        long FreeQuotaSpace { get; }
+    }
+}

--- a/Duplicati/Library/Interface/QuotaInfo.cs
+++ b/Duplicati/Library/Interface/QuotaInfo.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Duplicati.Library.Interface
+{
+    public class QuotaInfo : IQuotaInfo
+    {
+        public QuotaInfo(long totalSpace, long freeSpace)
+        {
+            this.TotalQuotaSpace = totalSpace;
+            this.FreeQuotaSpace = freeSpace;
+        }
+
+        public long TotalQuotaSpace { get; private set; }
+
+        public long FreeQuotaSpace { get; private set; }
+    }
+}

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -422,12 +422,12 @@ namespace Duplicati.Library.Main.Operation
             {
                 try
                 {
-					if (m_options.NoBackendverification)
-					{
-						FilelistProcessor.VerifyLocalList(backend, m_options, m_database, m_result.BackendWriter);
-						UpdateStorageStatsFromDatabase();
-					}
-					else
+                    if (m_options.NoBackendverification)
+                    {
+                        FilelistProcessor.VerifyLocalList(backend, m_options, m_database, m_result.BackendWriter);
+                        UpdateStorageStatsFromDatabase();
+                    }
+                    else
                         FilelistProcessor.VerifyRemoteList(backend, m_options, m_database, m_result.BackendWriter, protectedfile);
                 }
                 catch (Exception ex)
@@ -640,33 +640,39 @@ namespace Duplicati.Library.Main.Operation
             }
         }
 
-		/// <summary>
-		/// Handler for computing backend statistics, without relying on a remote folder listing
-		/// </summary>
-		private void UpdateStorageStatsFromDatabase()
-		{
-			if (m_result.BackendWriter != null)
-			{
-				m_result.BackendWriter.KnownFileCount = m_database.GetRemoteVolumes().Count();
-				m_result.BackendWriter.KnownFileSize = m_database.GetRemoteVolumes().Select(x => Math.Max(0, x.Size)).Sum();
+        /// <summary>
+        /// Handler for computing backend statistics, without relying on a remote folder listing
+        /// </summary>
+        private void UpdateStorageStatsFromDatabase()
+        {
+            if (m_result.BackendWriter != null)
+            {
+                m_result.BackendWriter.KnownFileCount = m_database.GetRemoteVolumes().Count();
+                m_result.BackendWriter.KnownFileSize = m_database.GetRemoteVolumes().Select(x => Math.Max(0, x.Size)).Sum();
 
-				m_result.BackendWriter.UnknownFileCount = 0;
-				m_result.BackendWriter.UnknownFileSize = 0;
+                m_result.BackendWriter.UnknownFileCount = 0;
+                m_result.BackendWriter.UnknownFileSize = 0;
 
-				m_result.BackendWriter.BackupListCount = m_database.FilesetTimes.Count();
-				m_result.BackendWriter.LastBackupDate = m_database.FilesetTimes.FirstOrDefault().Value.ToLocalTime();
+                m_result.BackendWriter.BackupListCount = m_database.FilesetTimes.Count();
+                m_result.BackendWriter.LastBackupDate = m_database.FilesetTimes.FirstOrDefault().Value.ToLocalTime();
 
-				// TODO: If we have a BackendManager, we should query through that
-				using (var backend = DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions))
-					if (backend is Library.Interface.IQuotaEnabledBackend)
-					{
-						m_result.BackendWriter.TotalQuotaSpace = ((Library.Interface.IQuotaEnabledBackend)backend).TotalQuotaSpace;
-						m_result.BackendWriter.FreeQuotaSpace = ((Library.Interface.IQuotaEnabledBackend)backend).FreeQuotaSpace;
-				}
-			}
+                // TODO: If we have a BackendManager, we should query through that
+                using (var backend = DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions))
+                {
+                    if (backend is Library.Interface.IQuotaEnabledBackend)
+                    {
+                        Library.Interface.IQuotaInfo quota = ((Library.Interface.IQuotaEnabledBackend)backend).Quota;
+                        if (quota != null)
+                        {
+                            m_result.BackendWriter.TotalQuotaSpace = quota.TotalQuotaSpace;
+                            m_result.BackendWriter.FreeQuotaSpace = quota.FreeQuotaSpace;
+                        }
+                    }
+                }
+            }
 
-			m_result.BackendWriter.AssignedQuotaSpace = m_options.QuotaSize;
-		}
+            m_result.BackendWriter.AssignedQuotaSpace = m_options.QuotaSize;
+        }
 
         public void Run(string[] sources, Library.Utility.IFilter filter)
         {
@@ -839,13 +845,13 @@ namespace Duplicati.Library.Main.Operation
                                 
                             m_transaction = null;
 
-							if (m_result.TaskControlRendevouz() != TaskControlState.Stop)
-							{
-								if (m_options.NoBackendverification)
-									UpdateStorageStatsFromDatabase();
-								else
-									PostBackupVerification();
-							}
+                            if (m_result.TaskControlRendevouz() != TaskControlState.Stop)
+                            {
+                                if (m_options.NoBackendverification)
+                                    UpdateStorageStatsFromDatabase();
+                                else
+                                    PostBackupVerification();
+                            }
                         }
                         
                         m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_Complete);

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -223,13 +223,17 @@ namespace Duplicati.Library.Main.Operation
             log.BackupListCount = filesets.Count;
             log.LastBackupDate = filesets.Count == 0 ? new DateTime(0) : filesets[0].Time.ToLocalTime();
 
-			// TODO: We should query through the backendmanager
-			using (var bk = DynamicLoader.BackendLoader.GetBackend(backend.BackendUrl, options.RawOptions))
-				if (bk is Library.Interface.IQuotaEnabledBackend)
-	            {
-	                log.TotalQuotaSpace = ((Library.Interface.IQuotaEnabledBackend)bk).TotalQuotaSpace;
-	                log.FreeQuotaSpace = ((Library.Interface.IQuotaEnabledBackend)bk).FreeQuotaSpace;
-	            }
+            // TODO: We should query through the backendmanager
+            using (var bk = DynamicLoader.BackendLoader.GetBackend(backend.BackendUrl, options.RawOptions))
+                if (bk is Library.Interface.IQuotaEnabledBackend)
+                {
+                    Library.Interface.IQuotaInfo quota = ((Library.Interface.IQuotaEnabledBackend)bk).Quota;
+                    if (quota != null)
+                    {
+                        log.TotalQuotaSpace = quota.TotalQuotaSpace;
+                        log.FreeQuotaSpace = quota.FreeQuotaSpace;
+                    }
+                }
 
             log.AssignedQuotaSpace = options.QuotaSize;
             


### PR DESCRIPTION
It also makes quota enabled backends return an instance of this interface instead of the quota components separately.
This way, getting quota stats requires only a single remote request on backends like Google Drive and OneDrive.