### PR TITLE
Improve construction of ArgumentExceptions

### DIFF
--- a/Duplicati/Library/Compression/FileArchiveZip.cs
+++ b/Duplicati/Library/Compression/FileArchiveZip.cs
@@ -207,7 +207,7 @@ namespace Duplicati.Library.Compression
         public FileArchiveZip(string filename, Dictionary<string, string> options)
         {
             if (string.IsNullOrEmpty(filename) && filename.Trim().Length == 0)
-                throw new ArgumentException("Invalid filename.", "filename");
+                throw new ArgumentException("Invalid filename.", nameof(filename));
 
             if (File.Exists(filename) && new FileInfo(filename).Length > 0)
             {

--- a/Duplicati/Library/Compression/FileArchiveZip.cs
+++ b/Duplicati/Library/Compression/FileArchiveZip.cs
@@ -207,7 +207,7 @@ namespace Duplicati.Library.Compression
         public FileArchiveZip(string filename, Dictionary<string, string> options)
         {
             if (string.IsNullOrEmpty(filename) && filename.Trim().Length == 0)
-                throw new ArgumentException("filename");
+                throw new ArgumentException("Invalid filename.", "filename");
 
             if (File.Exists(filename) && new FileInfo(filename).Length > 0)
             {

--- a/Duplicati/Library/Encryption/AESEncryption.cs
+++ b/Duplicati/Library/Encryption/AESEncryption.cs
@@ -71,7 +71,7 @@ namespace Duplicati.Library.Encryption
         public AESEncryption(string passphrase, Dictionary<string, string> options)
         {
             if(string.IsNullOrEmpty(passphrase))
-                throw new ArgumentException(Strings.AESEncryption.EmptyKeyError, "passphrase");
+                throw new ArgumentException(Strings.AESEncryption.EmptyKeyError, nameof(passphrase));
 
             m_key = passphrase;
 

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -223,7 +223,7 @@ namespace Duplicati.Library.Main.Database
                     if (filter == null || filter.Empty)
                         pathprefix = "";
                     else if (filter as Library.Utility.FilterExpression == null || ((Library.Utility.FilterExpression)filter).Type != Duplicati.Library.Utility.FilterType.Simple || ((Library.Utility.FilterExpression)filter).GetSimpleList().Length != 1)
-                        throw new ArgumentException("Filter for list-folder-contents must be a path prefix with no wildcards", "filter");
+                        throw new ArgumentException("Filter for list-folder-contents must be a path prefix with no wildcards", nameof(filter));
                     else
                         pathprefix = ((Library.Utility.FilterExpression)filter).GetSimpleList().First();
 

--- a/Duplicati/Library/Main/Database/PathLookupHelper.cs
+++ b/Duplicati/Library/Main/Database/PathLookupHelper.cs
@@ -165,7 +165,7 @@ namespace Duplicati.Library.Main.Database
             public bool TryGetChild(string name, out FolderEntry v)
             {
                 if (string.IsNullOrEmpty(name))
-                    throw new ArgumentException("Invalid pathname.", "name");
+                    throw new ArgumentException("Invalid pathname.", nameof(name));
                     
                 if (m_folders == null)
                 {

--- a/Duplicati/Library/Main/Database/PathLookupHelper.cs
+++ b/Duplicati/Library/Main/Database/PathLookupHelper.cs
@@ -165,7 +165,7 @@ namespace Duplicati.Library.Main.Database
             public bool TryGetChild(string name, out FolderEntry v)
             {
                 if (string.IsNullOrEmpty(name))
-                    throw new ArgumentException("name");
+                    throw new ArgumentException("Invalid pathname.", "name");
                     
                 if (m_folders == null)
                 {

--- a/Duplicati/Library/Snapshots/DefineDosDevice.cs
+++ b/Duplicati/Library/Snapshots/DefineDosDevice.cs
@@ -114,7 +114,7 @@ namespace Duplicati.Library.Snapshots
                 drive = drive.Substring(0, drive.Length - 1);
 
             if (!drive.EndsWith(":"))
-                throw new ArgumentException("drive");
+                throw new ArgumentException("The drive specification must end with a colon.", "drive");
 
             Win32API.DDD_Flags flags = 0;
             if (!notifyShell)

--- a/Duplicati/Library/Snapshots/DefineDosDevice.cs
+++ b/Duplicati/Library/Snapshots/DefineDosDevice.cs
@@ -114,7 +114,7 @@ namespace Duplicati.Library.Snapshots
                 drive = drive.Substring(0, drive.Length - 1);
 
             if (!drive.EndsWith(":"))
-                throw new ArgumentException("The drive specification must end with a colon.", "drive");
+                throw new ArgumentException("The drive specification must end with a colon.", nameof(drive));
 
             Win32API.DDD_Flags flags = 0;
             if (!notifyShell)

--- a/Duplicati/Library/Utility/BlockingQueue.cs
+++ b/Duplicati/Library/Utility/BlockingQueue.cs
@@ -157,7 +157,7 @@ namespace Duplicati.Library.Utility
             : this()
         {
             if (maxCapacity <= 0)
-                throw new ArgumentException("maxCapacity", "maxCapacity must be a positive number");
+                throw new ArgumentException("maxCapacity must be a positive number", "maxCapacity");
 
             m_maxCapacity = maxCapacity;
         }

--- a/Duplicati/Library/Utility/BlockingQueue.cs
+++ b/Duplicati/Library/Utility/BlockingQueue.cs
@@ -157,7 +157,7 @@ namespace Duplicati.Library.Utility
             : this()
         {
             if (maxCapacity <= 0)
-                throw new ArgumentException("maxCapacity must be a positive number", nameof(maxCapacity));
+                throw new ArgumentException("The maximum capacity must be a positive number", nameof(maxCapacity));
 
             m_maxCapacity = maxCapacity;
         }

--- a/Duplicati/Library/Utility/BlockingQueue.cs
+++ b/Duplicati/Library/Utility/BlockingQueue.cs
@@ -157,7 +157,7 @@ namespace Duplicati.Library.Utility
             : this()
         {
             if (maxCapacity <= 0)
-                throw new ArgumentException("maxCapacity must be a positive number", "maxCapacity");
+                throw new ArgumentException("maxCapacity must be a positive number", nameof(maxCapacity));
 
             m_maxCapacity = maxCapacity;
         }

--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -158,7 +158,7 @@ namespace Duplicati.Library.Utility
                     catch
                     {
                     }
-                throw new ArgumentException(Strings.Uri.UriParseError(url), "url");
+                throw new ArgumentException(Strings.Uri.UriParseError(url), nameof(url));
             }
                 
             this.Scheme = m.Groups["scheme"].Value;


### PR DESCRIPTION
This makes some trivial modifications to several usages of `ArgumentException`:
1. The argument order was fixed in one case in `BlockingQueue.cs`.
2. The `nameof` operator is used instead of a string literal to provide the second argument (parameter name) to the constructor.  This makes it easier to rename the parameter in the future while keeping the exception messages consistent.
3. There were a few cases where only the parameter name was provided to the constructor.  We added some simple messages to clarify the exception.