### PR TITLE
Fix incorrect format item in format string

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/List.cs
+++ b/Duplicati/CommandLine/RecoveryTool/List.cs
@@ -90,7 +90,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             {
                 var items = ParseListFiles(folder);
                 if (index < 0 || index >= items.Length)
-                    throw new Duplicati.Library.Interface.UserInformationException(string.Format("Valid range for version is 0 to {1}", items.Length - 1));
+                    throw new Duplicati.Library.Interface.UserInformationException(string.Format("Valid range for version is 0 to {0}", items.Length - 1));
 
                 return items[index].Value;
             }


### PR DESCRIPTION
This fixes an index error in a `String.Format` format item.