### PR TITLE
Avoid unnecessary enumeration

### DIFF
--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -214,7 +214,7 @@ namespace Duplicati.Library.Modules.Builtin
             if (paths == null || !Utility.Utility.IsClientWindows)
                 return false;
 
-            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Where(x => x.Equals(m_HyperVPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).Count() > 0;
+            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Where(x => x.Equals(m_HyperVPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).Any();
         }
 
         #endregion

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -211,7 +211,7 @@ namespace Duplicati.Library.Modules.Builtin
             if (paths == null || !Utility.Utility.IsClientWindows)
                 return false;
 
-            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Where(x => x.Equals(m_MSSQLPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).Count() > 0;
+            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Where(x => x.Equals(m_MSSQLPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).Any();
         }
 
         #endregion


### PR DESCRIPTION
Instead of enumerating an entire sequence and checking that the number of elements is positive, we can simply check to see if the sequence contains at least one element.