### PR TITLE
Convert if statements to switch statements for enums

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -550,22 +550,29 @@ namespace Duplicati.CommandLine
                 {
                     if (previousPhase == Duplicati.Library.Main.OperationPhase.Backup_PostBackupTest)
                         output.MessageEvent("Remote backup verification completed");
-                
-                    if (phase == Duplicati.Library.Main.OperationPhase.Backup_ProcessingFiles)
+
+                    switch (phase)
                     {
-                        output.MessageEvent("Scanning local files ...");
-                        periodicOutput.SetReady();
+                        case Duplicati.Library.Main.OperationPhase.Backup_ProcessingFiles:
+                            output.MessageEvent("Scanning local files ...");
+                            periodicOutput.SetReady();
+                            break;
+                        case Duplicati.Library.Main.OperationPhase.Backup_Finalize:
+                            periodicOutput.SetFinished();
+                            break;
+                        case Duplicati.Library.Main.OperationPhase.Backup_PreBackupVerify:
+                            output.MessageEvent("Checking remote backup ...");
+                            break;
+                        case Duplicati.Library.Main.OperationPhase.Backup_PostBackupVerify:
+                            output.MessageEvent("Checking remote backup ...");
+                            break;
+                        case Duplicati.Library.Main.OperationPhase.Backup_PostBackupTest:
+                            output.MessageEvent("Verifying remote backup ...");
+                            break;
+                        case Duplicati.Library.Main.OperationPhase.Backup_Compact:
+                            output.MessageEvent("Compacting remote backup ...");
+                            break;
                     }
-                    else if (phase == Duplicati.Library.Main.OperationPhase.Backup_Finalize)
-                        periodicOutput.SetFinished();
-                    else if (phase == Duplicati.Library.Main.OperationPhase.Backup_PreBackupVerify)
-                        output.MessageEvent("Checking remote backup ...");
-                    else if (phase == Duplicati.Library.Main.OperationPhase.Backup_PostBackupVerify)
-                        output.MessageEvent("Checking remote backup ...");
-                    else if (phase == Duplicati.Library.Main.OperationPhase.Backup_PostBackupTest)
-                        output.MessageEvent("Verifying remote backup ...");
-                    else if (phase == Duplicati.Library.Main.OperationPhase.Backup_Compact)
-                        output.MessageEvent("Compacting remote backup ...");
                 };
                 
                 periodicOutput.WriteOutput += (progress, files, size, counting) => {

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -471,24 +471,29 @@ namespace Duplicati.CommandLine
                     {
                         output.PhaseChanged += (phase, previousPhase) =>
                         {
-                            if (phase == Duplicati.Library.Main.OperationPhase.Restore_PreRestoreVerify)
-                                output.MessageEvent("Checking remote backup ...");
-                            else if (phase == Duplicati.Library.Main.OperationPhase.Restore_ScanForExistingFiles)
-                                output.MessageEvent("Checking existing target files ...");
-                            /*else if (phase == Duplicati.Library.Main.OperationPhase.Restore_DownloadingRemoteFiles)
-                                output.MessageEvent("Downloading remote files ..."); */
-                            else if (phase == Duplicati.Library.Main.OperationPhase.Restore_PatchWithLocalBlocks)
-                                output.MessageEvent("Updating target files with local data ...");
-                            else if (phase == Duplicati.Library.Main.OperationPhase.Restore_PostRestoreVerify)
+                            switch (phase)
                             {
-                                periodicOutput.SetFinished();
-                                periodicOutput.Join(TimeSpan.FromMilliseconds(100));
-                                output.MessageEvent("Verifying restored files ...");
+                                case Duplicati.Library.Main.OperationPhase.Restore_PreRestoreVerify:
+                                    output.MessageEvent("Checking remote backup ...");
+                                    break;
+                                case Duplicati.Library.Main.OperationPhase.Restore_ScanForExistingFiles:
+                                    output.MessageEvent("Checking existing target files ...");
+                                    break;
+                                case Duplicati.Library.Main.OperationPhase.Restore_PatchWithLocalBlocks:
+                                    output.MessageEvent("Updating target files with local data ...");
+                                    break;
+                                case Duplicati.Library.Main.OperationPhase.Restore_PostRestoreVerify:
+                                    periodicOutput.SetFinished();
+                                    periodicOutput.Join(TimeSpan.FromMilliseconds(100));
+                                    output.MessageEvent("Verifying restored files ...");
+                                    break;
+                                case Duplicati.Library.Main.OperationPhase.Restore_ScanForLocalBlocks:
+                                    output.MessageEvent("Scanning local files for needed data ...");
+                                    break;
+                                case Duplicati.Library.Main.OperationPhase.Restore_CreateTargetFolders:
+                                    periodicOutput.SetReady();
+                                    break;
                             }
-                            else if (phase == Duplicati.Library.Main.OperationPhase.Restore_ScanForLocalBlocks)
-                                output.MessageEvent("Scanning local files for needed data ...");
-                            else if (phase == Duplicati.Library.Main.OperationPhase.Restore_CreateTargetFolders)
-                                periodicOutput.SetReady();
                         };
 
                         periodicOutput.WriteOutput += (progress, files, size, counting) =>

--- a/Duplicati/CommandLine/ConsoleOutput.cs
+++ b/Duplicati/CommandLine/ConsoleOutput.cs
@@ -72,16 +72,24 @@ namespace Duplicati.CommandLine
             lock(m_lock)
                 if (type == BackendEventType.Started)
                 {
-                    if (action == BackendActionType.Put)
-                        Output.WriteLine("  Uploading file ({0}) ...", Library.Utility.Utility.FormatSizeString(size));
-                    else if (action == BackendActionType.Get)
-                        Output.WriteLine("  Downloading file ({0}) ...", size < 0 ? "unknown" : Library.Utility.Utility.FormatSizeString(size));
-                    else if (action == BackendActionType.List)
-                        Output.WriteLine("  Listing remote folder ...");
-                    else if (action == BackendActionType.CreateFolder)
-                        Output.WriteLine("  Creating remote folder ...");
-                    else if (action == BackendActionType.Delete)
-                        Output.WriteLine("  Deleting file {0}{1} ...", path, size < 0 ? "" : (" (" + Library.Utility.Utility.FormatSizeString(size) + ")"));
+                    switch (action)
+                    {
+                        case BackendActionType.Put:
+                            Output.WriteLine("  Uploading file ({0}) ...", Library.Utility.Utility.FormatSizeString(size));
+                            break;
+                        case BackendActionType.Get:
+                            Output.WriteLine("  Downloading file ({0}) ...", size < 0 ? "unknown" : Library.Utility.Utility.FormatSizeString(size));
+                            break;
+                        case BackendActionType.List:
+                            Output.WriteLine("  Listing remote folder ...");
+                            break;
+                        case BackendActionType.CreateFolder:
+                            Output.WriteLine("  Creating remote folder ...");
+                            break;
+                        case BackendActionType.Delete:
+                            Output.WriteLine("  Deleting file {0}{1} ...", path, size < 0 ? "" : (" (" + Library.Utility.Utility.FormatSizeString(size) + ")"));
+                            break;
+                    }
                 }
         }
                         

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -222,39 +222,39 @@ namespace Duplicati.Library.Main.Operation
                                             if (expectedmetablocks <= 1) expectedmetablocklisthashes = 0;
 
                                             var metadataid = long.MinValue;
-                                            if (fe.Type == FilelistEntryType.Folder)
+                                            switch (fe.Type)
                                             {
-                                                metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
-                                                restoredb.AddDirectoryEntry(filesetid, fe.Path, fe.Time, metadataid, tr);
-                                            }
-                                            else if (fe.Type == FilelistEntryType.File)
-                                            {
-                                                var expectedblocks = (fe.Size + blocksize - 1)  / blocksize;
-                                                var expectedblocklisthashes = (expectedblocks + hashes_pr_block - 1) / hashes_pr_block;
-                                                if (expectedblocks <= 1) expectedblocklisthashes = 0;
+                                                case FilelistEntryType.Folder:
+                                                    metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
+                                                    restoredb.AddDirectoryEntry(filesetid, fe.Path, fe.Time, metadataid, tr);
+                                                    break;
+                                                case FilelistEntryType.File:
+                                                    var expectedblocks = (fe.Size + blocksize - 1) / blocksize;
+                                                    var expectedblocklisthashes = (expectedblocks + hashes_pr_block - 1) / hashes_pr_block;
+                                                    if (expectedblocks <= 1) expectedblocklisthashes = 0;
 
-                                                var blocksetid = restoredb.AddBlockset(fe.Hash, fe.Size, fe.BlocklistHashes, expectedblocklisthashes, tr);
-                                                metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
-                                                restoredb.AddFileEntry(filesetid, fe.Path, fe.Time, blocksetid, metadataid, tr);
-                                                
-                                                if (fe.Size <= blocksize)
-                                                {
-                                                    if (!string.IsNullOrWhiteSpace(fe.Blockhash))
-                                                        restoredb.AddSmallBlocksetLink(fe.Hash, fe.Blockhash, fe.Blocksize, tr);
-                                                    else if (m_options.BlockHashAlgorithm == m_options.FileHashAlgorithm)
-                                                        restoredb.AddSmallBlocksetLink(fe.Hash, fe.Hash, fe.Size, tr);
-                                                    else
-                                                        m_result.AddWarning(string.Format("No block hash found for file: {0}", fe.Path), null);
-                                                }
-                                            }
-                                            else if (fe.Type == FilelistEntryType.Symlink)
-                                            {
-                                                metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
-                                                restoredb.AddSymlinkEntry(filesetid, fe.Path, fe.Time, metadataid, tr);
-                                            }
-                                            else
-                                            {
-                                                m_result.AddWarning(string.Format("Skipping file-entry with unknown type {0}: {1} ", fe.Type, fe.Path), null);
+                                                    var blocksetid = restoredb.AddBlockset(fe.Hash, fe.Size, fe.BlocklistHashes, expectedblocklisthashes, tr);
+                                                    metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
+                                                    restoredb.AddFileEntry(filesetid, fe.Path, fe.Time, blocksetid, metadataid, tr);
+
+                                                    if (fe.Size <= blocksize)
+                                                    {
+                                                        if (!string.IsNullOrWhiteSpace(fe.Blockhash))
+                                                            restoredb.AddSmallBlocksetLink(fe.Hash, fe.Blockhash, fe.Blocksize, tr);
+                                                        else if (m_options.BlockHashAlgorithm == m_options.FileHashAlgorithm)
+                                                            restoredb.AddSmallBlocksetLink(fe.Hash, fe.Hash, fe.Size, tr);
+                                                        else
+                                                            m_result.AddWarning(string.Format("No block hash found for file: {0}", fe.Path), null);
+                                                    }
+
+                                                    break;
+                                                case FilelistEntryType.Symlink:
+                                                    metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
+                                                    restoredb.AddSymlinkEntry(filesetid, fe.Path, fe.Time, metadataid, tr);
+                                                    break;
+                                                default:
+                                                    m_result.AddWarning(string.Format("Skipping file-entry with unknown type {0}: {1} ", fe.Type, fe.Path), null);
+                                                    break;
                                             }
 
                                             if (fe.Metasize <= blocksize && (fe.Type == FilelistEntryType.Folder || fe.Type == FilelistEntryType.File || fe.Type == FilelistEntryType.Symlink))

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -221,9 +221,10 @@ namespace Duplicati.Library.Main.Operation
                                             var expectedmetablocklisthashes = (expectedmetablocks + hashes_pr_block - 1) / hashes_pr_block;
                                             if (expectedmetablocks <= 1) expectedmetablocklisthashes = 0;
 
+                                            var metadataid = long.MinValue;
                                             if (fe.Type == FilelistEntryType.Folder)
                                             {
-                                                var metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
+                                                metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
                                                 restoredb.AddDirectoryEntry(filesetid, fe.Path, fe.Time, metadataid, tr);
                                             }
                                             else if (fe.Type == FilelistEntryType.File)
@@ -233,7 +234,7 @@ namespace Duplicati.Library.Main.Operation
                                                 if (expectedblocks <= 1) expectedblocklisthashes = 0;
 
                                                 var blocksetid = restoredb.AddBlockset(fe.Hash, fe.Size, fe.BlocklistHashes, expectedblocklisthashes, tr);
-                                                var metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
+                                                metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
                                                 restoredb.AddFileEntry(filesetid, fe.Path, fe.Time, blocksetid, metadataid, tr);
                                                 
                                                 if (fe.Size <= blocksize)
@@ -248,7 +249,7 @@ namespace Duplicati.Library.Main.Operation
                                             }
                                             else if (fe.Type == FilelistEntryType.Symlink)
                                             {
-                                                var metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
+                                                metadataid = restoredb.AddMetadataset(fe.Metahash, fe.Metasize, fe.MetaBlocklistHashes, expectedmetablocklisthashes, tr);
                                                 restoredb.AddSymlinkEntry(filesetid, fe.Path, fe.Time, metadataid, tr);
                                             }
                                             else

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -209,82 +209,80 @@ namespace Duplicati.Library.Main.Operation
             var parsedInfo = Volumes.VolumeBase.ParseFilename(vol.Name);
             sample_percent = Math.Min(1, Math.Max(sample_percent, 0.01));
 
-            if (parsedInfo.FileType == RemoteVolumeType.Files)
+            switch (parsedInfo.FileType)
             {
-                //Compare with db and see if all files are accounted for 
-                // with correct file hashes and blocklist hashes
-                using(var fl = db.CreateFilelist(vol.Name))
-                {
-                    using(var rd = new Volumes.FilesetVolumeReader(parsedInfo.CompressionModule, tf, options))
-                        foreach(var f in rd.Files)
-                            fl.Add(f.Path, f.Size, f.Hash, f.Metasize, f.Metahash, f.BlocklistHashes, f.Type, f.Time);
-                                    
-                    return new KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>(vol.Name, fl.Compare().ToList());
-                }       
-            }
-            else if (parsedInfo.FileType == RemoteVolumeType.Index)
-            {
-                var blocklinks = new List<Tuple<string, string, long>>();
-                IEnumerable<KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>> combined = new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>[0]; 
-                                
-                //Compare with db and see that all hashes and volumes are listed
-                using(var rd = new Volumes.IndexVolumeReader(parsedInfo.CompressionModule, tf, options, hashsize))
-                    foreach(var v in rd.Volumes)
+                case RemoteVolumeType.Files:
+                    //Compare with db and see if all files are accounted for 
+                    // with correct file hashes and blocklist hashes
+                    using (var fl = db.CreateFilelist(vol.Name))
                     {
-                        blocklinks.Add(new Tuple<string, string, long>(v.Filename, v.Hash, v.Length));
-                        using(var bl = db.CreateBlocklist(v.Filename))
-                        {
-                            foreach(var h in v.Blocks)
-                                bl.AddBlock(h.Key, h.Value);
-                                                
-                            combined = combined.Union(bl.Compare().ToArray());
-                        }
+                        using (var rd = new Volumes.FilesetVolumeReader(parsedInfo.CompressionModule, tf, options))
+                            foreach (var f in rd.Files)
+                                fl.Add(f.Path, f.Size, f.Hash, f.Metasize, f.Metahash, f.BlocklistHashes, f.Type, f.Time);
+
+                        return new KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>(vol.Name, fl.Compare().ToList());
                     }
-                                
-                using(var il = db.CreateIndexlist(vol.Name))
-                {
-                    foreach(var t in blocklinks)
-                        il.AddBlockLink(t.Item1, t.Item2, t.Item3);
-                                        
-                    combined = combined.Union(il.Compare()).ToList();
-                }
-                                
-                return new KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>(vol.Name, combined.ToList());
-            }
-            else if (parsedInfo.FileType == RemoteVolumeType.Blocks)
-            {
-                using(var bl = db.CreateBlocklist(vol.Name))
-                using(var rd = new Volumes.BlockVolumeReader(parsedInfo.CompressionModule, tf, options))
-                {                                    
-                    //Verify that all blocks are in the file
-                    foreach(var b in rd.Blocks)
-                        bl.AddBlock(b.Key, b.Value);
-    
-                    //Select random blocks and verify their hashes match the filename and size
-                    var hashsamples = new List<KeyValuePair<string, long>>(rd.Blocks);
-                    var sampleCount = Math.Min(Math.Max(0, (int)(hashsamples.Count * sample_percent)), hashsamples.Count - 1);
-                    var rnd = new Random();
-                                     
-                    while (hashsamples.Count > sampleCount)
-                        hashsamples.RemoveAt(rnd.Next(hashsamples.Count));
-    
-                    var blockbuffer = new byte[options.Blocksize];
-                    var changes = new List<KeyValuePair<Library.Interface.TestEntryStatus, string>>();
-                    foreach(var s in hashsamples)
-                    {
-                        var size = rd.ReadBlock(s.Key, blockbuffer);
-                        if (size != s.Value)
-                            changes.Add(new KeyValuePair<Library.Interface.TestEntryStatus, string>(Library.Interface.TestEntryStatus.Modified, s.Key));
-                        else
+
+                case RemoteVolumeType.Index:
+                    var blocklinks = new List<Tuple<string, string, long>>();
+                    IEnumerable<KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>> combined = new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>[0];
+
+                    //Compare with db and see that all hashes and volumes are listed
+                    using (var rd = new Volumes.IndexVolumeReader(parsedInfo.CompressionModule, tf, options, hashsize))
+                        foreach (var v in rd.Volumes)
                         {
-                            var hash = Convert.ToBase64String(blockhasher.ComputeHash(blockbuffer, 0, size));
-                            if (hash != s.Key)
+                            blocklinks.Add(new Tuple<string, string, long>(v.Filename, v.Hash, v.Length));
+                            using (var bl = db.CreateBlocklist(v.Filename))
+                            {
+                                foreach (var h in v.Blocks)
+                                    bl.AddBlock(h.Key, h.Value);
+
+                                combined = combined.Union(bl.Compare().ToArray());
+                            }
+                        }
+
+                    using (var il = db.CreateIndexlist(vol.Name))
+                    {
+                        foreach (var t in blocklinks)
+                            il.AddBlockLink(t.Item1, t.Item2, t.Item3);
+
+                        combined = combined.Union(il.Compare()).ToList();
+                    }
+
+                    return new KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>(vol.Name, combined.ToList());
+                case RemoteVolumeType.Blocks:
+                    using (var bl = db.CreateBlocklist(vol.Name))
+                    using (var rd = new Volumes.BlockVolumeReader(parsedInfo.CompressionModule, tf, options))
+                    {
+                        //Verify that all blocks are in the file
+                        foreach (var b in rd.Blocks)
+                            bl.AddBlock(b.Key, b.Value);
+
+                        //Select random blocks and verify their hashes match the filename and size
+                        var hashsamples = new List<KeyValuePair<string, long>>(rd.Blocks);
+                        var sampleCount = Math.Min(Math.Max(0, (int)(hashsamples.Count * sample_percent)), hashsamples.Count - 1);
+                        var rnd = new Random();
+
+                        while (hashsamples.Count > sampleCount)
+                            hashsamples.RemoveAt(rnd.Next(hashsamples.Count));
+
+                        var blockbuffer = new byte[options.Blocksize];
+                        var changes = new List<KeyValuePair<Library.Interface.TestEntryStatus, string>>();
+                        foreach (var s in hashsamples)
+                        {
+                            var size = rd.ReadBlock(s.Key, blockbuffer);
+                            if (size != s.Value)
                                 changes.Add(new KeyValuePair<Library.Interface.TestEntryStatus, string>(Library.Interface.TestEntryStatus.Modified, s.Key));
+                            else
+                            {
+                                var hash = Convert.ToBase64String(blockhasher.ComputeHash(blockbuffer, 0, size));
+                                if (hash != s.Key)
+                                    changes.Add(new KeyValuePair<Library.Interface.TestEntryStatus, string>(Library.Interface.TestEntryStatus.Modified, s.Key));
+                            }
                         }
+
+                        return new KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>(vol.Name, changes.Union(bl.Compare().ToList()));
                     }
-                                    
-                    return new KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>(vol.Name, changes.Union(bl.Compare().ToList()));
-                }                                
             }
 
             log.AddWarning(string.Format("Unexpected file type {0} for {1}", parsedInfo.FileType, vol.Name), null);


### PR DESCRIPTION
When the comparison is performed on an `enum`, using a `switch` statement can allow for additional compiler optimizations.