### PR TITLE
Add method to get unique items and duplicates from collection

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -288,13 +288,11 @@ namespace Duplicati.Library.Main
                 }
 
                 //Sanity check for duplicate files/folders
-                var pathDuplicates = sources.GroupBy(x => x, Library.Utility.Utility.ClientFilenameStringComparer)
-                      .Where(g => g.Count() > 1).Select(y => y.Key).ToList();
+                ISet<string> pathDuplicates;
+                sources = Library.Utility.Utility.GetUniqueItems(sources, Library.Utility.Utility.ClientFilenameStringComparer, out pathDuplicates).OrderBy(a => a).ToList();
 
                 foreach (var pathDuplicate in pathDuplicates)
                     result.AddVerboseMessage(string.Format("Removing duplicate source: {0}", pathDuplicate));
-
-                sources = sources.Distinct(Library.Utility.Utility.ClientFilenameStringComparer).OrderBy(a => a).ToList();
 
                 //Sanity check for multiple inclusions of the same folder
                 for (int i = 0; i < sources.Count; i++)

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -101,13 +101,8 @@ namespace Duplicati.Library.Main.Operation
                 throw new Duplicati.Library.Interface.UserInformationException(s);
             }
 
-            var lookup = new HashSet<string>();
-            var doubles = new HashSet<string>();
-            foreach(var v in tp.ParsedVolumes)
-            {
-                if (!lookup.Add(v.File.Name))
-                    doubles.Add(v.File.Name);
-            }
+            ISet<string> doubles;
+            Library.Utility.Utility.GetUniqueItems(tp.ParsedVolumes.Select(x => x.File.Name), out doubles);
 
             if (doubles.Count > 0)
             {

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -108,14 +108,11 @@ namespace Duplicati.Library.Snapshots
                 }
 
                 //Sanity check for duplicate files/folders
-                var pathDuplicates = m_sourcepaths.GroupBy(x => x, Utility.Utility.ClientFilenameStringComparer)
-                      .Where(g => g.Count() > 1).Select(y => y.Key).ToList();
+                ISet<string> pathDuplicates;
+                m_sourcepaths = Utility.Utility.GetUniqueItems(m_sourcepaths, Utility.Utility.ClientFilenameStringComparer, out pathDuplicates).OrderBy(a => a).ToList();
 
                 foreach(var pathDuplicate in pathDuplicates)
                     Logging.Log.WriteMessage(string.Format("Removing duplicate source: {0}", pathDuplicate), Logging.LogMessageType.Information);
-
-                if(pathDuplicates.Count > 0)
-                    m_sourcepaths = m_sourcepaths.Distinct(Utility.Utility.ClientFilenameStringComparer).OrderBy(a => a).ToList();
 
                 //Sanity check for multiple inclusions of the same files/folders
                 var pathIncludedPaths = m_sourcepaths.Where(x => m_sourcepaths.Where(y => y != x).Any(z => x.StartsWith(z, Utility.Utility.ClientFilenameStringComparision))).ToList();

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -109,7 +109,7 @@ namespace Duplicati.Library.Snapshots
 
                 //Sanity check for duplicate files/folders
                 ISet<string> pathDuplicates;
-                m_sourcepaths = Utility.Utility.GetUniqueItems(m_sourcepaths, Utility.Utility.ClientFilenameStringComparer, out pathDuplicates).OrderBy(a => a).ToList();
+                m_sourcepaths = Utility.Utility.GetUniqueItems(m_sourcepaths, Utility.Utility.ClientFilenameStringComparer, out pathDuplicates).ToList();
 
                 foreach(var pathDuplicate in pathDuplicates)
                     Logging.Log.WriteMessage(string.Format("Removing duplicate source: {0}", pathDuplicate), Logging.LogMessageType.Information);

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1075,6 +1075,25 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// Gets the unique items from a collection.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in <paramref name="collection"/>.</typeparam>
+        /// <param name="collection">The collection to remove duplicate items from.</param>
+        /// <param name="duplicateItems">The duplicate items in <paramref name="collection"/>.</param>
+        /// <returns>The unique items from <paramref name="collection"/>.</returns>
+        public static ISet<T> GetUniqueItems<T>(IEnumerable<T> collection, out ISet<T> duplicateItems)
+        {
+            HashSet<T> uniqueItems = new HashSet<T>();
+            duplicateItems = new HashSet<T>();
+
+            foreach (T item in collection)
+                if (!uniqueItems.Add(item))
+                    duplicateItems.Add(item);
+
+            return uniqueItems;
+        }
+
+        /// <summary>
         /// Helper method that replaces one file with another
         /// </summary>
         /// <param name="target">The file to replace</param>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1083,8 +1083,21 @@ namespace Duplicati.Library.Utility
         /// <returns>The unique items from <paramref name="collection"/>.</returns>
         public static ISet<T> GetUniqueItems<T>(IEnumerable<T> collection, out ISet<T> duplicateItems)
         {
-            HashSet<T> uniqueItems = new HashSet<T>();
-            duplicateItems = new HashSet<T>();
+            return Utility.GetUniqueItems(collection, EqualityComparer<T>.Default, out duplicateItems);
+        }
+
+        /// <summary>
+        /// Gets the unique items from a collection.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in <paramref name="collection"/>.</typeparam>
+        /// <param name="collection">The collection to remove duplicate items from.</param>
+        /// <param name="comparer">The <see cref="System.Collections.Generic.IEqualityComparer{T}"/> implementation to use when comparing values in the collection.</param>
+        /// <param name="duplicateItems">The duplicate items in <paramref name="collection"/>.</param>
+        /// <returns>The unique items from <paramref name="collection"/>.</returns>
+        public static ISet<T> GetUniqueItems<T>(IEnumerable<T> collection, IEqualityComparer<T> comparer, out ISet<T> duplicateItems)
+        {
+            HashSet<T> uniqueItems = new HashSet<T>(comparer);
+            duplicateItems = new HashSet<T>(comparer);
 
             foreach (T item in collection)
                 if (!uniqueItems.Add(item))

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Issue1723.cs" />
     <Compile Include="PurgeTesting.cs" />
     <Compile Include="CompressionTests.cs" />
+    <Compile Include="UtilityTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -32,12 +32,14 @@ namespace Duplicati.UnitTest
             string[] uniqueItems = { "A", "a", "b", "c" };
             string[] duplicateItems = { "A", "c" };
 
+            // Test with default comparer.
             ISet<string> actualDuplicateItems;
             ISet<string> actualUniqueItems = Utility.GetUniqueItems(collection, out actualDuplicateItems);
 
             CollectionAssert.AreEquivalent(uniqueItems, actualUniqueItems);
             CollectionAssert.AreEquivalent(duplicateItems, actualDuplicateItems);
 
+            // Test with custom comparer.
             IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
             uniqueItems = new string[] {"a", "b", "c"};
             duplicateItems = new string[] { "a", "c" };
@@ -48,6 +50,7 @@ namespace Duplicati.UnitTest
             Assert.That(actualUniqueItems, Is.EquivalentTo(uniqueItems).Using(comparer));
             Assert.That(actualDuplicateItems, Is.EquivalentTo(duplicateItems).Using(comparer));
 
+            // Test with empty collection.
             actualDuplicateItems = null;
             actualUniqueItems = Utility.GetUniqueItems(new string[0], out actualDuplicateItems);
 

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -28,12 +28,12 @@ namespace Duplicati.UnitTest
         [Category("Utility")]
         public void GetUniqueItems()
         {
-            int[] collection = { 1, 1, 1, 2, 3, 3 };
-            int[] uniqueItems = { 1, 2, 3 };
-            int[] duplicateItems = { 1, 3 };
+            string[] collection = { "A", "a", "A", "b", "c", "c" };
+            string[] uniqueItems = { "A", "a", "b", "c" };
+            string[] duplicateItems = { "A", "c" };
 
-            ISet<int> actualDuplicateItems;
-            ISet<int> actualUniqueItems = Utility.GetUniqueItems(collection, out actualDuplicateItems);
+            ISet<string> actualDuplicateItems;
+            ISet<string> actualUniqueItems = Utility.GetUniqueItems(collection, out actualDuplicateItems);
 
             CollectionAssert.AreEquivalent(uniqueItems, actualUniqueItems);
             CollectionAssert.AreEquivalent(duplicateItems, actualDuplicateItems);

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -1,0 +1,42 @@
+﻿//  Copyright (C) 2017, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace Duplicati.UnitTest
+{
+    [TestFixture]
+    public class UtilityTests
+    {
+        [Test]
+        [Category("Utility")]
+        public void GetUniqueItems()
+        {
+            int[] collection = { 1, 1, 1, 2, 3, 3 };
+            int[] uniqueItems = { 1, 2, 3 };
+            int[] duplicateItems = { 1, 3 };
+
+            ISet<int> actualDuplicateItems;
+            ISet<int> actualUniqueItems = Utility.GetUniqueItems(collection, out actualDuplicateItems);
+
+            CollectionAssert.AreEquivalent(uniqueItems, actualUniqueItems);
+            CollectionAssert.AreEquivalent(duplicateItems, actualDuplicateItems);
+        }
+    }
+}

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -37,6 +37,16 @@ namespace Duplicati.UnitTest
 
             CollectionAssert.AreEquivalent(uniqueItems, actualUniqueItems);
             CollectionAssert.AreEquivalent(duplicateItems, actualDuplicateItems);
+
+            IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
+            uniqueItems = new string[] {"a", "b", "c"};
+            duplicateItems = new string[] { "a", "c" };
+
+            actualDuplicateItems = null;
+            actualUniqueItems = Utility.GetUniqueItems(collection, comparer, out actualDuplicateItems);
+
+            Assert.That(actualUniqueItems, Is.EquivalentTo(uniqueItems).Using(comparer));
+            Assert.That(actualDuplicateItems, Is.EquivalentTo(duplicateItems).Using(comparer));
         }
     }
 }

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -47,6 +47,12 @@ namespace Duplicati.UnitTest
 
             Assert.That(actualUniqueItems, Is.EquivalentTo(uniqueItems).Using(comparer));
             Assert.That(actualDuplicateItems, Is.EquivalentTo(duplicateItems).Using(comparer));
+
+            actualDuplicateItems = null;
+            actualUniqueItems = Utility.GetUniqueItems(new string[0], out actualDuplicateItems);
+
+            Assert.IsNotNull(actualUniqueItems);
+            Assert.IsNotNull(actualDuplicateItems);
         }
     }
 }


### PR DESCRIPTION
This adds a method to get the unique elements as well as the duplicates from a collection.  The method does so by enumerating the collection just once, and should be more efficient than implementations using LINQ.

This also adds a few unit tests to verify the behavior, and replaces several cases that can benefit from the new implementation.