### PR TITLE
Retention Policy

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -865,10 +865,10 @@ namespace Duplicati.Library.Main
             if (!string.IsNullOrWhiteSpace(m_options.Prefix) && m_options.Prefix.Contains("-"))
                 throw new Interface.UserInformationException("The prefix cannot contain hyphens (-)");
 
-            //Check validity of keep-staggered-versions option value
+            //Check validity of retention-policy option value
             try
             {
-                foreach (var configEntry in m_options.KeepStaggeredVersion)
+                foreach (var configEntry in m_options.RetentionPolicy)
                 {
                     if (configEntry.Value >= configEntry.Key)
                     {
@@ -878,7 +878,7 @@ namespace Duplicati.Library.Main
             }
             catch (Exception e) // simply reading the option value might also result in an exception due to incorrect formatting
             {
-                throw new Interface.UserInformationException(string.Format("An error occoured while processing the value of --{0}", "keep-staggered-versions"), e);
+                throw new Interface.UserInformationException(string.Format("An error occoured while processing the value of --{0}", "retention-policy"), e);
             }
 
             //No point in going through with this if we can't report

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -865,6 +865,22 @@ namespace Duplicati.Library.Main
             if (!string.IsNullOrWhiteSpace(m_options.Prefix) && m_options.Prefix.Contains("-"))
                 throw new Interface.UserInformationException("The prefix cannot contain hyphens (-)");
 
+            //Check validity of keep-staggered-versions option value
+            try
+            {
+                foreach (var configEntry in m_options.KeepStaggeredVersion)
+                {
+                    if (configEntry.Value >= configEntry.Key)
+                    {
+                        throw new Interface.UserInformationException("A time frame cannot be smaller than its interval");
+                    }
+                }
+            }
+            catch (Exception e) // simply reading the option value might also result in an exception due to incorrect formatting
+            {
+                throw new Interface.UserInformationException(string.Format("An error occoured while processing the value of --{0}", "keep-staggered-versions"), e);
+            }
+
             //No point in going through with this if we can't report
             if (log == null)
                 return;

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -601,7 +601,7 @@ namespace Duplicati.Library.Main.Operation
         {
             var currentIsSmall = lastVolumeSize != -1 && lastVolumeSize <= m_options.SmallFileSize;
 
-            if (m_options.KeepTime.Ticks > 0 || m_options.KeepVersions != 0 || m_options.KeepStaggeredVersion.Count > 0)
+            if (m_options.KeepTime.Ticks > 0 || m_options.KeepVersions != 0 || m_options.RetentionPolicy.Count > 0)
             {
                 m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_Delete);
                 m_result.DeleteResults = new DeleteResults(m_result);

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -601,7 +601,7 @@ namespace Duplicati.Library.Main.Operation
         {
             var currentIsSmall = lastVolumeSize != -1 && lastVolumeSize <= m_options.SmallFileSize;
 
-            if (m_options.KeepTime.Ticks > 0 || m_options.KeepVersions != 0)
+            if (m_options.KeepTime.Ticks > 0 || m_options.KeepVersions != 0 || m_options.KeepStaggeredVersion.Count > 0)
             {
                 m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_Delete);
                 m_result.DeleteResults = new DeleteResults(m_result);

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -85,7 +85,7 @@ namespace Duplicati.Library.Main.Operation
                 
                 var filesetNumbers = db.FilesetTimes.Zip(Enumerable.Range(0, db.FilesetTimes.Count()), (a, b) => new Tuple<long, DateTime>(b, a.Value)).ToList();
                 var sets = db.FilesetTimes.Select(x => x.Value).ToArray();
-                var toDelete = m_options.GetFilesetsToDelete(sets);
+                var toDelete = GetFilesetsToDelete(sets);
 
                 if (!m_options.AllowFullRemoval && sets.Length == toDelete.Length)
                 {
@@ -157,6 +157,149 @@ namespace Duplicati.Library.Main.Operation
                     select n, 
                     m_options.Dryrun);
             }
+        }
+
+        /// <summary>
+        /// Gets the filesets selected for deletion
+        /// </summary>
+        /// <returns>The filesets to delete</returns>
+        /// <param name="backups">The list of backups that can be deleted</param>
+        private DateTime[] GetFilesetsToDelete(DateTime[] backups)
+        {
+            if (backups.Length == 0)
+                return backups;
+
+            if (backups.Distinct().Count() != backups.Length)
+                throw new Exception(string.Format("List of backup timestamps contains duplicates: {0}", string.Join(", ", backups.Select(x => x.ToString()))));
+
+            List<DateTime> res = new List<DateTime>();
+
+            var versions = m_options.Version;
+            if (versions != null && versions.Length > 0)
+                foreach (var ix in versions.Distinct())
+                    if (ix >= 0 && ix < backups.Length)
+                        res.Add(backups[ix]);
+
+            var keepVersions = m_options.KeepVersions;
+            if (keepVersions > 0 && keepVersions < backups.Length)
+                res.AddRange(backups.Skip(keepVersions));
+
+            var keepTime = m_options.KeepTime;
+            if (keepTime.Ticks > 0)
+                res.AddRange(backups.SkipWhile(x => x >= keepTime));
+
+            res.AddRange(ApplyStaggeredVersioning(backups));
+
+            var filtered = res.Distinct().OrderByDescending(x => x).AsEnumerable();
+
+            var removeCount = filtered.Count();
+            if (removeCount > backups.Length)
+                throw new Exception(string.Format("Too many entries {0} vs {1}, lists: {2} vs {3}", removeCount, backups.Length, string.Join(", ", filtered.Select(x => x.ToString())), string.Join(", ", backups.Select(x => x.ToString()))));
+
+            return filtered.ToArray();
+        }
+
+        /// <summary>
+        /// Thins out the backups according to the configuration.
+        /// Backups that are not within any of the specified time frames will will NOT be deleted.
+        /// </summary>
+        /// <returns>The filesets to delete</returns>
+        /// <param name="backups">The list of backups that can be deleted</param>
+        private List<DateTime> ApplyStaggeredVersioning(DateTime[] backups)
+        {
+            // Any work to do?
+            Dictionary<TimeSpan, TimeSpan> keepStaggeredVersionOptionValue = m_options.KeepStaggeredVersion;
+            if (keepStaggeredVersionOptionValue.Count == 0 || backups.Length == 0)
+            {
+                return new List<DateTime>(); // don't delete any backups
+            }
+
+            Logging.Log.WriteMessage("[Staggered versioning]: Starting to thin out backups", Logging.LogMessageType.Information);
+
+            // Work with a copy to not modify the enumeration that the caller passed
+            List<DateTime> clonedBackups = new List<DateTime>(backups);
+
+            // Make sure the backups are in descending order (newest backup in the beginning)
+            clonedBackups = clonedBackups.OrderByDescending(x => x).ToList();
+
+            // Most current backup should never get deleted due to the thinning out, so exclude it
+            clonedBackups.RemoveAt(0);
+
+            // Calculate the date for each period based on the current DateTime
+            var timeFramesIntervales = new List<KeyValuePair<DateTime, TimeSpan>>();
+            foreach (var configEntry in keepStaggeredVersionOptionValue.ToList())
+            {
+                var period = configEntry.Key;
+                var interval = configEntry.Value;
+
+                DateTime periodEnd;
+                if (period > TimeSpan.Zero)
+                {
+                    periodEnd = DateTime.Now - period;
+                }
+                else
+                {
+                    periodEnd = DateTime.MinValue; // periods equal or below 0 mean "biggest time frame possible"
+                }
+                timeFramesIntervales.Add(new KeyValuePair<DateTime, TimeSpan>(periodEnd, interval));
+            }
+
+            timeFramesIntervales = timeFramesIntervales.OrderByDescending(x => x.Key).ToList();
+
+            Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Time frames and intervals pairs: {0}",
+                string.Join(", ", timeFramesIntervales.Select(x => x.Key + " / " + x.Value))), Logging.LogMessageType.Information);
+            Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Backups to consider: {0}",
+                string.Join(", ", clonedBackups)), Logging.LogMessageType.Information);
+
+            // For each period collect all potentiel backups in the time frame and thin out 
+            // according to the specified interval, starting with the oldest backup in the time frame
+            // If backups are not within any time frame, they will NOT be deleted here.
+            // The --keep-time and --keep-versions switched should be used to ultimately delete backups that are too old
+            List<DateTime> backupsToDelete = new List<DateTime>();
+            foreach (var timeFrameInterval in timeFramesIntervales)
+            {
+                DateTime timeFrame = timeFrameInterval.Key;
+                TimeSpan interval = timeFrameInterval.Value;
+
+                Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Next time frame and interval pair: {0} / {1}", timeFrame, interval), Logging.LogMessageType.Profiling);
+
+                List<DateTime> backupsInTimeFrame = new List<DateTime>();
+                while (clonedBackups.Count > 0 && clonedBackups[0] >= timeFrame)
+                {
+                    backupsInTimeFrame.Insert(0, clonedBackups[0]); // Insert at begining to reverse order, which is nessecary for next step
+                    clonedBackups.RemoveAt(0); // remove from here to not handle the same backup in two time frames
+                }
+
+                Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Backups in this time frame: {0}",
+                    string.Join(", ", backupsInTimeFrame)), Logging.LogMessageType.Information);
+
+                // Run through backups in this time frame
+                DateTime? lastKept = null;
+                foreach (DateTime backup in backupsInTimeFrame)
+                {
+                    // Keep this backup if
+                    // - no backup has yet been added to the time frame (keeps at least the oldest backup in a time frame)
+                    // - difference between last added backup and this backup is bigger than the specified interval
+                    if (lastKept == null || (backup - lastKept.Value) >= interval)
+                    {
+                        Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Keeping backup: {0}", backup), Logging.LogMessageType.Profiling);
+                        lastKept = backup;
+                    }
+                    else
+                    {
+                        Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Marking backup for deletion: {0}", backup), Logging.LogMessageType.Profiling);
+                        backupsToDelete.Add(backup);
+                    }
+                }
+            }
+
+            Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Backups outside of all time frames and thus not checked: {0}",
+                    string.Join(", ", clonedBackups)), Logging.LogMessageType.Profiling);
+
+            Logging.Log.WriteMessage(string.Format("[Staggered versioning]: Backups to delete: {0}",
+                string.Join(", ", backupsToDelete.OrderByDescending(x => x))), Logging.LogMessageType.Information);
+
+            return backupsToDelete;
         }
     }
 }

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -819,161 +819,20 @@ namespace Duplicati.Library.Main
                     return staggeredVersionConfig;
                 }
 
-                // Default config
-                if (v == "default")
+                var periodIntervalStrings = v.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (var periodIntervalString in periodIntervalStrings)
                 {
-                    staggeredVersionConfig.Add(TimeSpan.FromHours(24), TimeSpan.Zero); // Every version for 24 hours
-                    staggeredVersionConfig.Add(TimeSpan.FromDays(7), TimeSpan.FromHours(24)); // One version per 24 hours for 7 days
-                    staggeredVersionConfig.Add(TimeSpan.FromDays(90), TimeSpan.FromDays(7)); // One version per 7 days for 90 days
-                    staggeredVersionConfig.Add(TimeSpan.Zero, TimeSpan.FromDays(30)); // one version every 30 days for the rest of the time
-                }
-                else
-                {
-                    var periodIntervalStrings = v.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    var periodInterval = periodIntervalString.Split(':');
+                    var period = Library.Utility.Timeparser.ParseTimeSpan(periodInterval[0]);
+                    var interval = Library.Utility.Timeparser.ParseTimeSpan(periodInterval[1]);
 
-                    foreach (var periodIntervalString in periodIntervalStrings)
-                    {
-                        var periodInterval = periodIntervalString.Split(':');
-                        if (periodInterval.Length != 2)
-                        {
-                            // TODO: Log Warning?
-                            staggeredVersionConfig.Clear();
-                            break; // Invalid config entry -> Discard whole config, so this feature is disable just to be on the safe side
-                        }
-
-                        var period = Library.Utility.Timeparser.ParseTimeSpan(periodInterval[0]);
-                        var interval = Library.Utility.Timeparser.ParseTimeSpan(periodInterval[1]);
-
-                        staggeredVersionConfig.Add(period, interval);
-                    }
+                    staggeredVersionConfig.Add(period, interval);
                 }
 
                 return staggeredVersionConfig;
             }
         }
-                
-        /// <summary>
-        /// Gets the filesets selected for deletion
-        /// </summary>
-        /// <returns>The filesets to delete</returns>
-        /// <param name="backups">The list of backups that can be deleted</param>
-        public DateTime[] GetFilesetsToDelete (DateTime[] backups)
-        {
-            if (backups.Length == 0)
-                return backups;
-
-            if (backups.Distinct().Count() != backups.Length)
-                throw new Exception(string.Format("List of backup timestamps contains duplicates: {0}", string.Join(", ", backups.Select(x => x.ToString()))));
-
-            List<DateTime> res = new List<DateTime>();
-                
-            var versions = this.Version;
-            if (versions != null && versions.Length > 0) 
-                foreach (var ix in versions.Distinct())
-                    if (ix >= 0 && ix < backups.Length)
-                        res.Add(backups[ix]);
-            
-            var keepVersions = this.KeepVersions;
-            if (keepVersions > 0 && keepVersions < backups.Length)
-                res.AddRange(backups.Skip(keepVersions));
-            
-            var keepTime = this.KeepTime;
-            if (keepTime.Ticks > 0)
-                res.AddRange(backups.SkipWhile(x => x >= keepTime));
-            
-            res.AddRange(ApplyStaggeredVersioning(backups));
-
-            var filtered = res.Distinct().OrderByDescending(x => x).AsEnumerable();
-            
-            var removeCount = filtered.Count();
-            if (removeCount > backups.Length)
-                throw new Exception(string.Format("Too many entries {0} vs {1}, lists: {2} vs {3}", removeCount, backups.Length, string.Join(", ", filtered.Select(x => x.ToString())),string.Join(", ", backups.Select(x => x.ToString()))));
-
-            return filtered.ToArray();
-        }
-
-        /// <summary>
-        /// Thins out the backups according to the configuration.
-        /// Backups that are not within any of the specified time frames will will NOT be deleted.
-        /// </summary>
-        /// <returns>The filesets to delete</returns>
-        /// <param name="backups">The list of backups that can be deleted</param>
-        private List<DateTime> ApplyStaggeredVersioning(DateTime[] backups)
-        {
-            // Any work to do?
-            if (this.KeepStaggeredVersion.Count == 0 || backups.Length == 0)
-            {
-                return new List<DateTime>(); // no backups to delete
-            }
-
-            // Work with a copy to not modify the enumeration that the caller passed
-            List<DateTime> clonedBackups = new List<DateTime>(backups);
-
-            // Make sure the backups are in descending order (newest backup in the beginning)
-            clonedBackups = clonedBackups.OrderByDescending(x => x).ToList();
-
-            // Keep reference to most current backup, since it should never be deleted due to the thinning out
-            DateTime newestBackup = clonedBackups[0];
-
-            // Calculate the date for each period based on the current DateTime
-            var timeFramesIntervales = new List<KeyValuePair<DateTime, TimeSpan>>();
-            foreach (var configEntry in this.KeepStaggeredVersion.ToList())
-            {
-                var period = configEntry.Key;
-                var interval = configEntry.Value;
-
-                DateTime periodEnd;
-                if (period > TimeSpan.Zero)
-                {
-                    periodEnd = DateTime.Now - period;
-                }
-                else
-                {
-                    periodEnd = DateTime.MinValue; // periods equal or below 0 mean "biggest time frame possible"
-                }
-                timeFramesIntervales.Add(new KeyValuePair<DateTime, TimeSpan>(periodEnd, interval));
-            }
-
-            timeFramesIntervales = timeFramesIntervales.OrderByDescending(x => x.Key).ToList();
-
-            // For each period collect all potentiel backups in the time frame and thin out 
-            // according to the specified interval, starting with the oldest backup in the time frame
-            // If backups are not within any time frame, they will NOT be deleted here.
-            // The --keep-time and --keep-versions switched should be used to ultimately delete backups that are too old
-            List<DateTime> backupsToDelete = new List<DateTime>();
-            foreach (var timeFrameInterval in timeFramesIntervales)
-            {
-                List<DateTime> backupsInTimeFrame = new List<DateTime>();
-                while (clonedBackups.Count > 0 && clonedBackups[0] >= timeFrameInterval.Key)
-                {
-                    backupsInTimeFrame.Insert(0, clonedBackups[0]); // Insert at begining to reverse order, which is nessecary for next step
-                    clonedBackups.RemoveAt(0); // remove from here to not handle the same backup in two time frames
-                }
-
-                // Run through backups in this time frame
-                DateTime? lastKept = null;
-                foreach (DateTime backup in backupsInTimeFrame)
-                {
-                    // Keep this backup if
-                    // - no backup has yet been added to the time frame (keeps at least the oldest backup in a time frame)
-                    // - difference between last added backup and this backup is bigger than the specified interval
-                    if (lastKept == null || (backup - lastKept.Value) >= timeFrameInterval.Value)
-                    {
-                        lastKept = backup;
-                    }
-                    else
-                    {
-                        backupsToDelete.Add(backup);
-                    }
-                }
-            }
-
-            // If newest backup was marked for deletion in this process, remove it from being removed
-            backupsToDelete.Remove(newestBackup);
-
-            return backupsToDelete;
-        }
-        
 
         /// <summary>
         /// Gets the encryption passphrase

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -509,7 +509,7 @@ namespace Duplicati.Library.Main
 
                     new CommandLineArgument("keep-versions", CommandLineArgument.ArgumentType.Integer, Strings.Options.KeepversionsShort, Strings.Options.KeepversionsLong, DEFAULT_KEEP_VERSIONS.ToString()),
                     new CommandLineArgument("keep-time", CommandLineArgument.ArgumentType.Timespan, Strings.Options.KeeptimeShort, Strings.Options.KeeptimeLong),
-                    new CommandLineArgument("retention policy", CommandLineArgument.ArgumentType.String, Strings.Options.RetentionPolicyShort, Strings.Options.RetentionPolicyLong),
+                    new CommandLineArgument("retention-policy", CommandLineArgument.ArgumentType.String, Strings.Options.RetentionPolicyShort, Strings.Options.RetentionPolicyLong),
                     new CommandLineArgument("upload-verification-file", CommandLineArgument.ArgumentType.Boolean, Strings.Options.UploadverificationfileShort, Strings.Options.UploadverificationfileLong, "false"),
                     new CommandLineArgument("allow-passphrase-change", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AllowpassphrasechangeShort, Strings.Options.AllowpassphrasechangeLong, "false"),
                     new CommandLineArgument("no-local-blocks", CommandLineArgument.ArgumentType.Boolean, Strings.Options.NolocalblocksShort, Strings.Options.NolocalblocksLong, "false"),

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -509,7 +509,7 @@ namespace Duplicati.Library.Main
 
                     new CommandLineArgument("keep-versions", CommandLineArgument.ArgumentType.Integer, Strings.Options.KeepversionsShort, Strings.Options.KeepversionsLong, DEFAULT_KEEP_VERSIONS.ToString()),
                     new CommandLineArgument("keep-time", CommandLineArgument.ArgumentType.Timespan, Strings.Options.KeeptimeShort, Strings.Options.KeeptimeLong),
-                    new CommandLineArgument("keep-staggered-versions", CommandLineArgument.ArgumentType.String, Strings.Options.KeepstaggeredversionsShort, Strings.Options.KeepstaggeredversionsLong),
+                    new CommandLineArgument("retention policy", CommandLineArgument.ArgumentType.String, Strings.Options.RetentionPolicyShort, Strings.Options.RetentionPolicyLong),
                     new CommandLineArgument("upload-verification-file", CommandLineArgument.ArgumentType.Boolean, Strings.Options.UploadverificationfileShort, Strings.Options.UploadverificationfileLong, "false"),
                     new CommandLineArgument("allow-passphrase-change", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AllowpassphrasechangeShort, Strings.Options.AllowpassphrasechangeLong, "false"),
                     new CommandLineArgument("no-local-blocks", CommandLineArgument.ArgumentType.Boolean, Strings.Options.NolocalblocksShort, Strings.Options.NolocalblocksLong, "false"),
@@ -806,17 +806,17 @@ namespace Duplicati.Library.Main
         }
 
         /// <summary>
-        /// Gets the time frames and intervals for the staggered versioning
+        /// Gets the time frames and intervals for the retention policy
         /// </summary>        
-        public Dictionary<TimeSpan, TimeSpan> KeepStaggeredVersion
+        public Dictionary<TimeSpan, TimeSpan> RetentionPolicy
         {
             get {
-                var staggeredVersionConfig = new Dictionary<TimeSpan, TimeSpan>();
+                var retentionPolicyConfig = new Dictionary<TimeSpan, TimeSpan>();
 
                 string v;
-                m_options.TryGetValue("keep-staggered-versions", out v);
+                m_options.TryGetValue("retention-policy", out v);
                 if (string.IsNullOrEmpty(v)) { 
-                    return staggeredVersionConfig;
+                    return retentionPolicyConfig;
                 }
 
                 var periodIntervalStrings = v.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
@@ -827,10 +827,10 @@ namespace Duplicati.Library.Main
                     var period = Library.Utility.Timeparser.ParseTimeSpan(periodInterval[0]);
                     var interval = Library.Utility.Timeparser.ParseTimeSpan(periodInterval[1]);
 
-                    staggeredVersionConfig.Add(period, interval);
+                    retentionPolicyConfig.Add(period, interval);
                 }
 
-                return staggeredVersionConfig;
+                return retentionPolicyConfig;
             }
         }
 

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -181,7 +181,7 @@ namespace Duplicati.Library.Main.Strings
         public static string KeeptimeShort { get { return LC.L(@"Keep all versions within a timespan"); } }
         public static string KeeptimeLong { get { return LC.L(@"Use this option to set the timespan in which backups are kept."); } }
         public static string RetentionPolicyShort { get { return LC.L(@"Reduce number of versions by deleting old intermediate backups"); } }
-        public static string RetentionPolicyLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age by deleting most of the old backups. The expected format is a comma seperated list of collon sperated time frame and interval pairs. For example the value ""1D:-1,1M:1D,10Y:1M"" means ""For 1 day keep 1 backup per hour, for one month one backup per day and for 10 years one backup per month"); } }
+        public static string RetentionPolicyLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age by deleting most of the old backups. The expected format is a comma seperated list of collon sperated time frame and interval pairs. For example the value ""7D:0s,3M:1D,10Y:2M"" means ""For 7 day keep all backups, for 3 months keep one backup per day and for 10 years one backup every 2nd month"); } }
         public static string AllowmissingsourceShort { get { return LC.L(@"Ignore missing source elements"); } }
         public static string AllowmissingsourceLong { get { return LC.L(@"Use this option to continue even if some source entries are missing."); } }
         public static string OverwriteShort { get { return LC.L(@"Overwrite files when restoring"); } }

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -180,6 +180,8 @@ namespace Duplicati.Library.Main.Strings
         public static string KeepversionsLong { get { return LC.L(@"Use this option to set number of versions to keep, supply -1 to keep all versions"); } }
         public static string KeeptimeShort { get { return LC.L(@"Keep all versions within a timespan"); } }
         public static string KeeptimeLong { get { return LC.L(@"Use this option to set the timespan in which backups are kept."); } }
+        public static string KeepstaggeredversionsShort { get { return LC.L(@"Reduce versions kept with increasing age"); } }
+        public static string KeepstaggeredversionsLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age."); } }
         public static string AllowmissingsourceShort { get { return LC.L(@"Ignore missing source elements"); } }
         public static string AllowmissingsourceLong { get { return LC.L(@"Use this option to continue even if some source entries are missing."); } }
         public static string OverwriteShort { get { return LC.L(@"Overwrite files when restoring"); } }

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -180,8 +180,8 @@ namespace Duplicati.Library.Main.Strings
         public static string KeepversionsLong { get { return LC.L(@"Use this option to set number of versions to keep, supply -1 to keep all versions"); } }
         public static string KeeptimeShort { get { return LC.L(@"Keep all versions within a timespan"); } }
         public static string KeeptimeLong { get { return LC.L(@"Use this option to set the timespan in which backups are kept."); } }
-        public static string KeepstaggeredversionsShort { get { return LC.L(@"Reduce versions kept with increasing age"); } }
-        public static string KeepstaggeredversionsLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age."); } }
+        public static string KeepstaggeredversionsShort { get { return LC.L(@"Reduce versions kept with by deleting intermediate backups"); } }
+        public static string KeepstaggeredversionsLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age by deleting most of the old backups. The expected format is a comma seperated list of collon sperated time frame and interval pairs. For example the value ""1D:1h,1M:1D,10Y:1M"" means ""For 1 day keep 1 backup per hour, for one month one backup per day and for 10 years one backup per month"); } }
         public static string AllowmissingsourceShort { get { return LC.L(@"Ignore missing source elements"); } }
         public static string AllowmissingsourceLong { get { return LC.L(@"Use this option to continue even if some source entries are missing."); } }
         public static string OverwriteShort { get { return LC.L(@"Overwrite files when restoring"); } }

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -180,8 +180,8 @@ namespace Duplicati.Library.Main.Strings
         public static string KeepversionsLong { get { return LC.L(@"Use this option to set number of versions to keep, supply -1 to keep all versions"); } }
         public static string KeeptimeShort { get { return LC.L(@"Keep all versions within a timespan"); } }
         public static string KeeptimeLong { get { return LC.L(@"Use this option to set the timespan in which backups are kept."); } }
-        public static string KeepstaggeredversionsShort { get { return LC.L(@"Reduce versions kept with by deleting intermediate backups"); } }
-        public static string KeepstaggeredversionsLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age by deleting most of the old backups. The expected format is a comma seperated list of collon sperated time frame and interval pairs. For example the value ""1D:1h,1M:1D,10Y:1M"" means ""For 1 day keep 1 backup per hour, for one month one backup per day and for 10 years one backup per month"); } }
+        public static string RetentionPolicyShort { get { return LC.L(@"Reduce number of versions by deleting old intermediate backups"); } }
+        public static string RetentionPolicyLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age by deleting most of the old backups. The expected format is a comma seperated list of collon sperated time frame and interval pairs. For example the value ""1D:-1,1M:1D,10Y:1M"" means ""For 1 day keep 1 backup per hour, for one month one backup per day and for 10 years one backup per month"); } }
         public static string AllowmissingsourceShort { get { return LC.L(@"Ignore missing source elements"); } }
         public static string AllowmissingsourceLong { get { return LC.L(@"Use this option to continue even if some source entries are missing."); } }
         public static string OverwriteShort { get { return LC.L(@"Overwrite files when restoring"); } }


### PR DESCRIPTION
As discussed in #2084:
This adds the new option "--retention-policy" which deletes old intermediate backups as specified in the option value by the user. 
For example the value "7D:0s,3M:1D,10Y:2M" means:
- For 7 days keep all backups ("0 seconds" here basicly means the time between two backups can be infinitely small)
- For 3 months keep one backup every day (=24 hours)
- For 10 years keep one backup every two months (=60days)
- The format for the time range values is the same as in "--keep-time"

Additional notes:
- Backups outside the specified ranges are untouched and can for example be removed with the already existing "--keep-time" option
- Old backups are not modified. This means it's **not ensured** that the last version of a deleted file is always kept, as it was briefly discussed here https://github.com/duplicati/duplicati/issues/2084#issuecomment-330050927
- there is currently no nice GUI for configuring this option
  - the advanced option has to be specified as a (rather complex) string
- there is no way to specify a different retention policy algorithm as suggested here https://github.com/duplicati/duplicati/issues/2084#issuecomment-328310297