### PR TITLE
Add preliminary support for detecting power supply source

### DIFF
--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -76,6 +76,7 @@
     <Compile Include="HostKeyException.cs" />
     <Compile Include="CallContextSettings.cs" />
     <Compile Include="HashAlgorithmHelper.cs" />
+    <Compile Include="Power\PowerSupply.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -95,5 +96,8 @@
       <Project>{B68F2214-951F-4F78-8488-66E1ED3F50BF}</Project>
       <Name>Duplicati.Library.Localization</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Power\" />
   </ItemGroup>
 </Project>

--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -78,6 +78,7 @@
     <Compile Include="HashAlgorithmHelper.cs" />
     <Compile Include="Power\PowerSupply.cs" />
     <Compile Include="Power\IPowerSupplyState.cs" />
+    <Compile Include="Power\DefaultPowerSupplyState.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -77,6 +77,7 @@
     <Compile Include="CallContextSettings.cs" />
     <Compile Include="HashAlgorithmHelper.cs" />
     <Compile Include="Power\PowerSupply.cs" />
+    <Compile Include="Power\IPowerSupplyState.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Power\PowerSupply.cs" />
     <Compile Include="Power\IPowerSupplyState.cs" />
     <Compile Include="Power\DefaultPowerSupplyState.cs" />
+    <Compile Include="Power\LinuxPowerSupplyState.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -43,6 +43,7 @@
     <Reference Include="FasterHashing">
       <HintPath>..\..\..\packages\FasterHashing.1.2.1\lib\net45\FasterHashing.dll</HintPath>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncHttpRequest.cs" />
@@ -80,6 +81,7 @@
     <Compile Include="Power\IPowerSupplyState.cs" />
     <Compile Include="Power\DefaultPowerSupplyState.cs" />
     <Compile Include="Power\LinuxPowerSupplyState.cs" />
+    <Compile Include="Power\WindowsPowerSupplyState.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Duplicati/Library/Utility/Power/DefaultPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/DefaultPowerSupplyState.cs
@@ -1,0 +1,27 @@
+﻿//  Copyright (C) 2017, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+namespace Duplicati.Library.Utility.Power
+{
+    public class DefaultPowerSupplyState : IPowerSupplyState
+    {
+        public PowerSupply.Source GetSource()
+        {
+            return PowerSupply.Source.Unknown;
+        }
+    }
+}

--- a/Duplicati/Library/Utility/Power/IPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/IPowerSupplyState.cs
@@ -1,0 +1,24 @@
+﻿//  Copyright (C) 2017, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+namespace Duplicati.Library.Utility.Power
+{
+    public interface IPowerSupplyState
+    {
+        PowerSupply.Source GetSource();
+    }
+}

--- a/Duplicati/Library/Utility/Power/LinuxPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/LinuxPowerSupplyState.cs
@@ -1,0 +1,107 @@
+﻿//  Copyright (C) 2017, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Duplicati.Library.Utility.Power
+{
+    public class LinuxPowerSupplyState : IPowerSupplyState
+    {
+        private readonly string sysfsPath = Path.Combine("/", "sys", "class", "power_supply");
+
+        public PowerSupply.Source GetSource()
+        {
+            if (this.IsAC())
+            {
+                return PowerSupply.Source.AC;
+            }
+            if (this.IsBattery())
+            {
+                return PowerSupply.Source.Battery;
+            }
+
+            return PowerSupply.Source.Unknown;
+        }
+
+        private bool IsAC()
+        {
+            // If any of the power supply devices of type "Mains" are online, then we are on 
+            // AC power.  If none of the power supply devices are of type "Mains", then we 
+            // are also on AC power.  See https://bugzilla.redhat.com/show_bug.cgi?id=644629.
+            bool reply = false;
+            bool haveMains = false;
+
+            try
+            {
+                foreach (string source in Directory.GetDirectories(this.sysfsPath))
+                {
+                    if (!reply)
+                    {
+                        string sourceType = File.ReadLines(Path.Combine(source, "type")).FirstOrDefault();
+                        if (String.Equals(sourceType, "Mains", StringComparison.Ordinal))
+                        {
+                            haveMains = true;
+
+                            string isOnline = File.ReadLines(Path.Combine(source, "online")).FirstOrDefault();
+                            reply = String.Equals(isOnline, "1", StringComparison.Ordinal);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            return reply |= !haveMains;
+        }
+
+        private bool IsBattery()
+        {
+            // If there is at least one power supply device of type "Mains", and all "Mains"
+            // devices are offline, then we are on battery power.
+            bool allOffline = true;
+            bool haveMains = false;
+
+            try
+            {
+                foreach (string source in Directory.GetDirectories(this.sysfsPath))
+                {
+                    if (allOffline)
+                    {
+                        string sourceType = File.ReadLines(Path.Combine(source, "type")).FirstOrDefault();
+                        if (String.Equals(sourceType, "Mains", StringComparison.Ordinal))
+                        {
+                            haveMains = true;
+
+                            string isOnline = File.ReadLines(Path.Combine(source, "online")).FirstOrDefault();
+                            allOffline &= String.Equals(isOnline, "0", StringComparison.Ordinal);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            return haveMains && allOffline;
+        }
+    }
+}

--- a/Duplicati/Library/Utility/Power/PowerSupply.cs
+++ b/Duplicati/Library/Utility/Power/PowerSupply.cs
@@ -1,0 +1,29 @@
+﻿//  Copyright (C) 2017, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+namespace Duplicati.Library.Utility.Power
+{
+    public static class PowerSupply
+    {
+        public enum Source
+        {
+            AC,
+            Battery,
+            Unknown
+        }
+    }
+}

--- a/Duplicati/Library/Utility/Power/PowerSupply.cs
+++ b/Duplicati/Library/Utility/Power/PowerSupply.cs
@@ -25,5 +25,26 @@ namespace Duplicati.Library.Utility.Power
             Battery,
             Unknown
         }
+
+        public static Source GetSource()
+        {
+            IPowerSupplyState state;
+
+            // Since IsClientLinux returns true when on Mac OS X, we need to check IsClientOSX first.
+            if (Utility.IsClientOSX)
+            {
+                state = new DefaultPowerSupplyState();
+            }
+            else if (Utility.IsClientLinux)
+            {
+                state = new LinuxPowerSupplyState();
+            }
+            else
+            {
+                state = new DefaultPowerSupplyState();
+            }
+
+            return state.GetSource();
+        }
     }
 }

--- a/Duplicati/Library/Utility/Power/WindowsPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/WindowsPowerSupplyState.cs
@@ -15,40 +15,32 @@
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
+using System.Windows.Forms;
+
 namespace Duplicati.Library.Utility.Power
 {
-    public static class PowerSupply
+    public class WindowsPowerSupplyState : IPowerSupplyState
     {
-        public enum Source
+        public PowerSupply.Source GetSource()
         {
-            AC,
-            Battery,
-            Unknown
-        }
+            try
+            {
+                PowerLineStatus status = System.Windows.Forms.SystemInformation.PowerStatus.PowerLineStatus;
+                if (status == PowerLineStatus.Online)
+                {
+                    return PowerSupply.Source.AC;
+                }
+                if (status == PowerLineStatus.Offline)
+                {
+                    return PowerSupply.Source.Battery;
+                }
 
-        public static Source GetSource()
-        {
-            IPowerSupplyState state;
-
-            // Since IsClientLinux returns true when on Mac OS X, we need to check IsClientOSX first.
-            if (Utility.IsClientOSX)
-            {
-                state = new DefaultPowerSupplyState();
+                return PowerSupply.Source.Unknown;
             }
-            else if (Utility.IsClientLinux)
+            catch
             {
-                state = new LinuxPowerSupplyState();
+                return PowerSupply.Source.Unknown;
             }
-            else if (Utility.IsClientWindows)
-            {
-                state = new WindowsPowerSupplyState();
-            }
-            else
-            {
-                state = new DefaultPowerSupplyState();
-            }
-
-            return state.GetSource();
         }
     }
 }


### PR DESCRIPTION
This adds preliminary support for detecting the current power supply source.  This can be useful if we want to later add the ability to disable the backup (or other tasks) when on battery power (see issue #2666).

Currently, the detection is only implemented for Windows (still needs testing) and Linux kernels 2.6.23 and newer.  On Linux, by accessing the information directly via `sysfs`, we should be able to avoid assumptions on the existence of particular user space functions.  If for some reason the required entries are not available (e.g., on custom-built kernels), then the implementation returns `Unknown` as the power supply source.

For Mac OS, the implementation currently returns `Unknown` as the power supply source.