### PR TITLE
Dispose enumerators after manually iterating over elements

### DIFF
--- a/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
@@ -558,17 +558,19 @@ ORDER BY
 "
                 ,blocksize, blockhashlength);
 
-                var en = blocklist.GetEnumerator();
-                foreach(var r in cmd.ExecuteReaderEnumerable(query, hash, length))
+                using (var en = blocklist.GetEnumerator())
                 {
-                    if (!en.MoveNext())
-                        throw new Exception(string.Format("Too few entries in source blocklist with hash {0}", hash));
-                    if (en.Current != r.GetString(0))
-                        throw new Exception(string.Format("Mismatch in blocklist with hash {0}", hash));
-                }
+                    foreach (var r in cmd.ExecuteReaderEnumerable(query, hash, length))
+                    {
+                        if (!en.MoveNext())
+                            throw new Exception(string.Format("Too few entries in source blocklist with hash {0}", hash));
+                        if (en.Current != r.GetString(0))
+                            throw new Exception(string.Format("Mismatch in blocklist with hash {0}", hash));
+                    }
 
-                if (en.MoveNext())
-                    throw new Exception(string.Format("Too many source blocklist entries in {0}", hash));
+                    if (en.MoveNext())
+                        throw new Exception(string.Format("Too many source blocklist entries in {0}", hash));
+                }
             }
         }
     }

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -83,15 +83,17 @@ namespace Duplicati.Library.Main.Volumes
             if (blocklisthashes != null)
             {
                 //Slightly akward, but we avoid writing if there are no entries 
-                var en = blocklisthashes.GetEnumerator();
-                if (en.MoveNext() && !string.IsNullOrEmpty(en.Current))
+                using (var en = blocklisthashes.GetEnumerator())
                 {
-                    m_writer.WritePropertyName("blocklists");
-                    m_writer.WriteStartArray();
-                    m_writer.WriteValue(en.Current);
-                    while (en.MoveNext())
+                    if (en.MoveNext() && !string.IsNullOrEmpty(en.Current))
+                    {
+                        m_writer.WritePropertyName("blocklists");
+                        m_writer.WriteStartArray();
                         m_writer.WriteValue(en.Current);
-                    m_writer.WriteEndArray();
+                        while (en.MoveNext())
+                            m_writer.WriteValue(en.Current);
+                        m_writer.WriteEndArray();
+                    }
                 }
             }
             else if (!string.IsNullOrWhiteSpace(blockhash))


### PR DESCRIPTION
Since the `IEnumerator<T>` interface implements `IDisposable`, we should make sure to dispose of the enumerator whenever we manually iterate over the elements.