### PR TITLE
Make sure HandleListExceptions(Func) calls HandleListExceptions(Action).

### DIFF
--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -173,7 +173,8 @@ namespace Duplicati.Library.Backend
         private T HandleListExceptions<T>(Func<T> func, System.Net.FtpWebRequest req)
         {
             T ret = default(T);
-            HandleListExceptions(() => ret = func(), req);
+            Action action = () => ret = func();
+            HandleListExceptions(action, req);
             return ret;
         }
 


### PR DESCRIPTION
This should fix #2813. The problem was that the lambda function () => ret = func() was being detected as a Func<T> instead of an Action, so the same method was being called instead of being redirected to the Action version (which actually has the logic to actually implement these).