### PR TITLE
Fix arguments to ArgumentOutOfRangeException constructor

### DIFF
--- a/Duplicati/Library/Main/Operation/RestoreHandlerMetadataStorage.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandlerMetadataStorage.cs
@@ -38,7 +38,7 @@ namespace Duplicati.Library.Main.Operation
             var datalen = data.Length;
 
             if (datalen > Int32.MaxValue)
-                throw new ArgumentOutOfRangeException("Metadata is larger than int32");
+                throw new ArgumentOutOfRangeException(nameof(datalen), "Metadata is larger than int32");
 
             var pathbytes = System.Text.Encoding.UTF8.GetBytes(path);
             var pathlen = BitConverter.GetBytes(pathbytes.LongLength);
@@ -97,7 +97,7 @@ namespace Duplicati.Library.Main.Operation
                         CheckedRead(bf, 0, bf.Length);
                         var datalen = BitConverter.ToInt64(bf, 0);
                         if (datalen > Int32.MaxValue)
-                            throw new ArgumentOutOfRangeException("Metadata is larger than int32");
+                            throw new ArgumentOutOfRangeException(nameof(datalen), "Metadata is larger than int32");
 
                         var databuf = datalen > buf.Length ? new byte[datalen] : buf;
                         CheckedRead(databuf, 0, (int)datalen);

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1351,11 +1351,11 @@ namespace Duplicati.Library.Main
                 if (!m_options.TryGetValue("blocksize", out tmp))
                     tmp = DEFAULT_BLOCKSIZE;
 
-                long t = Library.Utility.Sizeparser.ParseSize(tmp, "kb");
-                if (t > int.MaxValue || t < 1024)
+                long blocksize = Library.Utility.Sizeparser.ParseSize(tmp, "kb");
+                if (blocksize > int.MaxValue || blocksize < 1024)
                     throw new ArgumentOutOfRangeException("blocksize", string.Format("The blocksize cannot be less than {0}, nor larger than {1}", 1024, int.MaxValue));
                 
-                return (int)t;
+                return (int)blocksize;
             }
         }
 

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1353,7 +1353,7 @@ namespace Duplicati.Library.Main
 
                 long blocksize = Library.Utility.Sizeparser.ParseSize(tmp, "kb");
                 if (blocksize > int.MaxValue || blocksize < 1024)
-                    throw new ArgumentOutOfRangeException("blocksize", string.Format("The blocksize cannot be less than {0}, nor larger than {1}", 1024, int.MaxValue));
+                    throw new ArgumentOutOfRangeException(nameof(blocksize), string.Format("The blocksize cannot be less than {0}, nor larger than {1}", 1024, int.MaxValue));
                 
                 return (int)blocksize;
             }

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -103,7 +103,7 @@ namespace Duplicati.Library.Utility
             m_passWriteThrough = passWriteThrough;
             m_blockOnFlush = blockOnFlush;
             m_blockOnClose = blockOnClose;
-            if (bufsize <= 0) throw new ArgumentOutOfRangeException("bufsize");
+            if (bufsize <= 0) throw new ArgumentOutOfRangeException(nameof(bufsize));
             m_buf = new byte[bufsize];
             m_readerStream = new LinkedReaderStream(this);
             m_writerStream = new LinkedWriterStream(this);

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -103,7 +103,7 @@ namespace Duplicati.Library.Utility
             m_passWriteThrough = passWriteThrough;
             m_blockOnFlush = blockOnFlush;
             m_blockOnClose = blockOnClose;
-            if (bufsize <= 0) throw new ArgumentOutOfRangeException(nameof(bufsize));
+            if (bufsize <= 0) throw new ArgumentOutOfRangeException(nameof(bufsize), "The size of the buffer must be positive.");
             m_buf = new byte[bufsize];
             m_readerStream = new LinkedReaderStream(this);
             m_writerStream = new LinkedWriterStream(this);

--- a/Duplicati/Server/LogWriteHandler.cs
+++ b/Duplicati/Server/LogWriteHandler.cs
@@ -116,7 +116,7 @@ namespace Duplicati.Server
                 lock(m_lock)
                 {
                     if (m_length == 0)
-                        throw new ArgumentOutOfRangeException("Buffer is empty");
+                        throw new ArgumentOutOfRangeException(nameof(m_length), "Buffer is empty");
                     
                     m_key++;
                     var ix = m_tail;


### PR DESCRIPTION
This fixes a few instances where incorrect arguments were provided to the `ArgumentOutOfRangeException` [constructor](https://msdn.microsoft.com/en-us/library/system.argumentoutofrangeexception.argumentoutofrangeexception(v=vs.110).aspx).  When providing an error message, the name of the parameter must be provided as well.  I also took the opportunity to replace some string literals with the use of the `nameof` operator to make rename refactorings easier in the future.