### PR TITLE
Avoid signing assemblies

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Duplicati.CommandLine.BackendTester.csproj
+++ b/Duplicati/CommandLine/BackendTester/Duplicati.CommandLine.BackendTester.csproj
@@ -14,7 +14,6 @@
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation />
-    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />

--- a/Duplicati/CommandLine/BackendTool/Duplicati.CommandLine.BackendTool.csproj
+++ b/Duplicati/CommandLine/BackendTool/Duplicati.CommandLine.BackendTool.csproj
@@ -8,7 +8,6 @@
     <Prefer32Bit>False</Prefer32Bit>
     <RootNamespace>Duplicati.CommandLine.BackendTool</RootNamespace>
     <AssemblyName>Duplicati.CommandLine.BackendTool</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />

--- a/Duplicati/CommandLine/Duplicati.CommandLine.csproj
+++ b/Duplicati/CommandLine/Duplicati.CommandLine.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.CommandLine</RootNamespace>
     <AssemblyName>Duplicati.CommandLine</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <ApplicationIcon>TrayWarning.ico</ApplicationIcon>
     <FileUpgradeFlags>

--- a/Duplicati/CommandLine/RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
+++ b/Duplicati/CommandLine/RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
@@ -8,7 +8,6 @@
     <Prefer32Bit>False</Prefer32Bit>
     <RootNamespace>Duplicati.CommandLine.RecoveryTool</RootNamespace>
     <AssemblyName>Duplicati.CommandLine.RecoveryTool</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/AmazonCloudDrive/Duplicati.Library.Backend.AmazonCloudDrive.csproj
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/Duplicati.Library.Backend.AmazonCloudDrive.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.AmazonCloudDrive</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.AmazonCloudDrive</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/AzureBlob/Duplicati.Library.Backend.AzureBlob.csproj
+++ b/Duplicati/Library/Backend/AzureBlob/Duplicati.Library.Backend.AzureBlob.csproj
@@ -33,7 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Duplicati/Library/Backend/Backblaze/Duplicati.Library.Backend.Backblaze.csproj
+++ b/Duplicati/Library/Backend/Backblaze/Duplicati.Library.Backend.Backblaze.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.Backblaze</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.Backblaze</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/Box/Duplicati.Library.Backend.Box.csproj
+++ b/Duplicati/Library/Backend/Box/Duplicati.Library.Backend.Box.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.Box</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.Box</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/CloudFiles/Duplicati.Library.Backend.CloudFiles.csproj
+++ b/Duplicati/Library/Backend/CloudFiles/Duplicati.Library.Backend.CloudFiles.csproj
@@ -15,7 +15,6 @@
     <TargetFrameworkProfile />
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <UseMSBuildEngine>false</UseMSBuildEngine>
   </PropertyGroup>

--- a/Duplicati/Library/Backend/File/Duplicati.Library.Backend.File.csproj
+++ b/Duplicati/Library/Backend/File/Duplicati.Library.Backend.File.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Backend</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.File</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Library/Backend/GoogleServices/Duplicati.Library.Backend.GoogleServices.csproj
+++ b/Duplicati/Library/Backend/GoogleServices/Duplicati.Library.Backend.GoogleServices.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.GoogleServices</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.GoogleServices</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/HubiC/Duplicati.Library.Backend.HubiC.csproj
+++ b/Duplicati/Library/Backend/HubiC/Duplicati.Library.Backend.HubiC.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.HubiC</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.HubiC</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/Mega/Duplicati.Library.Backend.Mega.csproj
+++ b/Duplicati/Library/Backend/Mega/Duplicati.Library.Backend.Mega.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.Mega</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.Mega</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/OAuthHelper/Duplicati.Library.OAuthHelper.csproj
+++ b/Duplicati/Library/Backend/OAuthHelper/Duplicati.Library.OAuthHelper.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.OAuthHelper</RootNamespace>
     <AssemblyName>Duplicati.Library.OAuthHelper</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/OneDrive/Duplicati.Library.Backend.OneDrive.csproj
+++ b/Duplicati/Library/Backend/OneDrive/Duplicati.Library.Backend.OneDrive.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Backend</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.OneDrive</AssemblyName>
-    <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>

--- a/Duplicati/Library/Backend/OpenStack/Duplicati.Library.Backend.OpenStack.csproj
+++ b/Duplicati/Library/Backend/OpenStack/Duplicati.Library.Backend.OpenStack.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.OpenStack</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.OpenStack</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
+++ b/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Backend</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.S3</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
+++ b/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>Duplicati.Library.Backend</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.SSHv2</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>false</SignAssembly>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/Backend/Sia/Duplicati.Library.Backend.Sia.csproj
+++ b/Duplicati/Library/Backend/Sia/Duplicati.Library.Backend.Sia.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Backend.Sia</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.Sia</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>

--- a/Duplicati/Library/DynamicLoader/Duplicati.Library.DynamicLoader.csproj
+++ b/Duplicati/Library/DynamicLoader/Duplicati.Library.DynamicLoader.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.DynamicLoader</RootNamespace>
     <AssemblyName>Duplicati.Library.DynamicLoader</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Library/Encryption/Duplicati.Library.Encryption.csproj
+++ b/Duplicati/Library/Encryption/Duplicati.Library.Encryption.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Encryption</RootNamespace>
     <AssemblyName>Duplicati.Library.Encryption</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Library/Interface/Duplicati.Library.Interface.csproj
+++ b/Duplicati/Library/Interface/Duplicati.Library.Interface.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>Duplicati.Library.Interface</RootNamespace>
     <AssemblyName>Duplicati.Library.Interface</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Library/Localization/Duplicati.Library.Localization.csproj
+++ b/Duplicati/Library/Localization/Duplicati.Library.Localization.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.Localization</RootNamespace>
     <AssemblyName>Duplicati.Library.Localization</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Main\Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />

--- a/Duplicati/Library/Logging/Duplicati.Library.Logging.csproj
+++ b/Duplicati/Library/Logging/Duplicati.Library.Logging.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Logging</RootNamespace>
     <AssemblyName>Duplicati.Library.Logging</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Library/Main/Duplicati.Library.Main.csproj
+++ b/Duplicati/Library/Main/Duplicati.Library.Main.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Main</RootNamespace>
     <AssemblyName>Duplicati.Library.Main</AssemblyName>
-    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
+++ b/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Duplicati.Library.SQLiteHelper</RootNamespace>
     <AssemblyName>SQLiteHelper</AssemblyName>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\GUI\Duplicati.GUI.TrayIcon\Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />

--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -8,7 +8,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Utility</RootNamespace>
     <AssemblyName>Duplicati.Library.Utility</AssemblyName>
-    <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>Duplicati.License</RootNamespace>
     <AssemblyName>Duplicati.License</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Duplicati/Server/Duplicati.Server.Serialization/Duplicati.Server.Serialization.csproj
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Duplicati.Server.Serialization.csproj
@@ -33,7 +33,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>

--- a/Duplicati/Server/Duplicati.Server.csproj
+++ b/Duplicati/Server/Duplicati.Server.csproj
@@ -12,7 +12,6 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
-    <SignAssembly>false</SignAssembly>
     <UseMSBuildEngine>false</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/Duplicati/Service/Duplicati.Service.csproj
+++ b/Duplicati/Service/Duplicati.Service.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>Duplicati.Service</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
-    <SignAssembly>true</SignAssembly>
     <UseMSBuildEngine>false</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Duplicati/WindowsService/WindowsService.csproj
+++ b/Duplicati/WindowsService/WindowsService.csproj
@@ -14,7 +14,6 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
-    <SignAssembly>true</SignAssembly>
     <UseMSBuildEngine>false</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/thirdparty/UnixSupport/UnixSupport.csproj
+++ b/thirdparty/UnixSupport/UnixSupport.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>UnixSupport</RootNamespace>
     <AssemblyName>UnixSupport</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <ReleaseVersion>1.0</ReleaseVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>


### PR DESCRIPTION
Using strong-named assemblies can cause difficulties with the GNU LGPL
license, which allows for one to recombine or relink their application
with modified versions of the code.  While one solution is to share the
private key so that people can sign the assemblies themselves, this
would break the trust that is expected from signed assemblies.  For now,
the easiest fix is to simply not sign the assemblies.  Note that by
doing so, we prevent the code from being referenced from other signed
assemblies.

This also fixes an issue introduced in revision ba94d36a80 ("Added
auto-update for WindowsService and Service."), where the `WindowsService`
project (signed) referenced the `AutoUpdater` project (not signed).

We also removed instances of `<SignAssembly>false</SignAssembly>` to be
consistent with newly created `.csproj` files that do not contain the
`SignAssembly` element.

This was motivated by the discussion in issue #2814.