### PR TITLE
Match web UI's default keep time with Library's

### DIFF
--- a/Duplicati/Server/newbackup.json
+++ b/Duplicati/Server/newbackup.json
@@ -4,7 +4,7 @@
             {Name: "encryption-module", Value: "aes"},
             {Name: "compression-module", Value: "zip"},
             {Name: "dblock-size", Value: "50mb"},
-            {Name: "keep-time", Value: "3M"}
+            {Name: "keep-time", Value: ""}
         ]
     },
     Schedule: {


### PR DESCRIPTION
I'd planned to open an issue to discuss why backups currently default to a 3 month retention time, hoping to convince you of the school of thought that says backup software shouldn't be deleting anything unless users explicitly tell it to. Some digging, however, suggests you already feel that way: your comment on issue #1568 implies new backups are meant to default to "unlimited" keep time, and [this line in Options.cs](https://github.com/duplicati/duplicati/blob/202a6641e568abe53d3d5a13b9d9ea4d8cfd0d89/Duplicati/Library/Main/Options.cs#L797) does in fact return 0 if users haven't specified anything.

On the other hand the web UI uses 3 months as its default, as seen in [newbackup.json](https://github.com/duplicati/duplicati/blob/43d9b51743d0135f2d789b1df58de06e14b6d646/Duplicati/Server/newbackup.json#L7). Since that file hasn't been modified since 2014, I'm assuming your later comments and current code more accurately reflect your design intent, so I took the liberty of making the change myself. Apologies if I've missed something important.