### PR TITLE
Only try to load Windows registry filters on Windows.

### DIFF
--- a/Duplicati/Library/Utility/DefaultFilters.cs
+++ b/Duplicati/Library/Utility/DefaultFilters.cs
@@ -382,15 +382,19 @@ namespace Duplicati.Library.Utility
         /// <returns>The list of paths to exclude.</returns>
         private static string[] GetWindowsRegistryFilters()
         {
-            try
+            if (Utility.IsClientWindows)
             {
-                return GetWindowsRegistryFiltersInternal();
-            }
-            catch
-            {
+                // One Windows, filters may also be stored in the registry
+                try
+                {
+                    return GetWindowsRegistryFiltersInternal();
+                }
+                catch
+                {
+                }
             }
 
-            return new string[0];
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
The reason for this is that Windows filters may be used on other systems (e.g., to ignore Windows files when backing up a Windows drive)