### PR TITLE
Make string comparisons use ordinal (binary) sort rules

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -68,7 +68,7 @@ namespace Duplicati.CommandLine.BackendTester
                         var p = Library.Utility.Utility.ExpandEnvironmentVariables(_args[0]);
                         if (System.IO.File.Exists(p))
                             _args = (from x in System.IO.File.ReadLines(p)
-                                where !string.IsNullOrWhiteSpace(x) && !x.Trim().StartsWith("#")
+                                where !string.IsNullOrWhiteSpace(x) && !x.Trim().StartsWith("#", StringComparison.Ordinal)
                                 select x.Trim()
                             ).ToArray();
                     }

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -260,7 +260,7 @@ namespace Duplicati.CommandLine
                             options["version"] = v.ToString();
                         }
                     }
-                    else if (args[0].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[0].StartsWith("["))
+                    else if (args[0].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[0].StartsWith("[", StringComparison.Ordinal))
                     {
                         try
                         {
@@ -277,7 +277,7 @@ namespace Duplicati.CommandLine
                 
                 // Prefix all filenames with "*/" so we search all folders
                 for(var ix = 0; ix < args.Count; ix++) 
-                    if (args[ix].IndexOfAny(new char[] { '*', '?', System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar }) < 0 && !args[ix].StartsWith("["))
+                    if (args[ix].IndexOfAny(new char[] { '*', '?', System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar }) < 0 && !args[ix].StartsWith("[", StringComparison.Ordinal))
                         args[ix] = "*" + System.IO.Path.DirectorySeparatorChar.ToString() + args[ix];
                 
                 // Support for not adding the --auth-username if possible
@@ -360,7 +360,7 @@ namespace Duplicati.CommandLine
                         var f = res.Filesets.First();
                         outwriter.WriteLine("Listing contents {0} ({1}):", f.Version, f.Time);
                         foreach(var e in res.Files)
-                            outwriter.WriteLine("{0} {1}", e.Path, e.Path.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()) ? "" : "(" + Library.Utility.Utility.FormatSizeString(e.Sizes.First()) + ")");
+                            outwriter.WriteLine("{0} {1}", e.Path, e.Path.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ? "" : "(" + Library.Utility.Utility.FormatSizeString(e.Sizes.First()) + ")");
                     }
                     else
                     {
@@ -444,12 +444,12 @@ namespace Duplicati.CommandLine
 
             // Prefix all filenames with "*/" so we search all folders
             for (var ix = 0; ix < args.Count; ix++)
-                if (args[ix].IndexOfAny(new char[] { '*', '?', System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar }) < 0 && !args[ix].StartsWith("["))
+                if (args[ix].IndexOfAny(new char[] { '*', '?', System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar }) < 0 && !args[ix].StartsWith("[", StringComparison.Ordinal))
                     args[ix] = "*" + System.IO.Path.DirectorySeparatorChar.ToString() + args[ix];
 
             // suffix all folders with "*" so we restore all contents in the folder
             for (var ix = 0; ix < args.Count; ix++)
-                if (args[ix].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[ix].StartsWith("[") && args[ix].EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+                if (args[ix].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[ix].StartsWith("[", StringComparison.Ordinal) && args[ix].EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
                     args[ix] += "*";
             
             var output = new ConsoleOutput(outwriter, options);

--- a/Duplicati/CommandLine/Help.cs
+++ b/Duplicati/CommandLine/Help.cs
@@ -22,10 +22,10 @@ namespace Duplicati.CommandLine
                 StringBuilder sb = new StringBuilder();
                 foreach(var line in sr.ReadToEnd().Split(new string[] { "\r\n", "\n", "\r" }, StringSplitOptions.None))
                 {
-                    if (line.Trim().StartsWith("#"))
+                    if (line.Trim().StartsWith("#", StringComparison.Ordinal))
                         continue;
 
-                    if (line.Trim().StartsWith(">"))
+                    if (line.Trim().StartsWith(">", StringComparison.Ordinal))
                     {
                         if (sb.Length > 0)
                         {
@@ -410,13 +410,13 @@ namespace Duplicati.CommandLine
                 string c = s;
 
                 string leadingSpaces = "";
-                while (c.Length > 0 && c.StartsWith(" "))
+                while (c.Length > 0 && c.StartsWith(" ", StringComparison.Ordinal))
                 {
                     leadingSpaces += " ";
                     c = c.Remove(0, 1);
                 }
 
-                bool extraIndent = c.StartsWith("--");
+                bool extraIndent = c.StartsWith("--", StringComparison.Ordinal);
 
                 while (c.Length > 0)
                 {
@@ -424,7 +424,7 @@ namespace Duplicati.CommandLine
                     len -= leadingSpaces.Length;
                     if (len < c.Length)
                     {
-                        int ix = c.LastIndexOf(" ", len);
+                        int ix = c.LastIndexOf(" ", len, StringComparison.Ordinal);
                         if (ix > 0)
                             len = ix;
                     }

--- a/Duplicati/CommandLine/RecoveryTool/Index.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Index.cs
@@ -175,7 +175,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                         while (c1 != null || c2 != null)
                         {
-                            if (c1 != null && c1.StartsWith("a"))
+                            if (c1 != null && c1.StartsWith("a", StringComparison.Ordinal))
                                 Console.Write("");
                             var cmp = StringComparer.Ordinal.Compare(c1, c2);
 

--- a/Duplicati/CommandLine/RecoveryTool/Program.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Program.cs
@@ -125,7 +125,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 cargs.AddRange(
                     from c in fargs
-                    where !string.IsNullOrWhiteSpace(c) && !c.StartsWith("#") && !c.StartsWith("!") && !c.StartsWith("REM ", StringComparison.OrdinalIgnoreCase)
+                    where !string.IsNullOrWhiteSpace(c) && !c.StartsWith("#", StringComparison.Ordinal) && !c.StartsWith("!", StringComparison.Ordinal) && !c.StartsWith("REM ", StringComparison.OrdinalIgnoreCase)
                     select c
                 );
                     

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -366,7 +366,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                     if (str.Length == 0)
                         continue;
 
-                    var ix = str.IndexOf(", ");
+                    var ix = str.IndexOf(", ", StringComparison.Ordinal);
                     if (ix < 0)
                         Console.WriteLine("Failed to parse line starting at offset {0} in index file, string: {1}", m_indexfile.Position - str.Length - m_newline.Length, str);
                     yield return new KeyValuePair<string, string>(str.Substring(0, ix), str.Substring(ix + 2));

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -73,7 +73,7 @@ namespace Duplicati.GUI.TrayIcon
         public HttpServerConnection(Uri server, string password, bool saltedpassword, bool dbPasswordSourceDatabase, Dictionary<string, string> options)
         {
             m_baseUri = server.ToString();
-            if (!m_baseUri.EndsWith("/"))
+            if (!m_baseUri.EndsWith("/", StringComparison.Ordinal))
                 m_baseUri += "/";
 
             m_apiUri = m_baseUri + "api/v1";

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -243,7 +243,7 @@ namespace Duplicati.GUI.TrayIcon
                             menu.Callback();
                         }
                     }
-                    else if (!line.StartsWith("info") && !string.IsNullOrWhiteSpace(line))
+                    else if (!line.StartsWith("info", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(line))
                     {
                         Console.WriteLine("Unexpected message: {0}", line);
                     }

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -148,7 +148,7 @@ namespace Duplicati.Library.AutoUpdater
                 var attempts = new List<string>();
 
                 // We do not want to install anything in the basedir, if the application is installed in "ProgramFiles"
-                if (!string.IsNullOrWhiteSpace(programfiles) && !InstalledBaseDir.StartsWith(Library.Utility.Utility.AppendDirSeparator(programfiles)))
+                if (!string.IsNullOrWhiteSpace(programfiles) && !InstalledBaseDir.StartsWith(Library.Utility.Utility.AppendDirSeparator(programfiles), StringComparison.Ordinal))
                     attempts.Add(System.IO.Path.Combine(InstalledBaseDir, "updates"));
 
                 if (Library.Utility.Utility.IsClientOSX)
@@ -521,7 +521,7 @@ namespace Duplicati.Library.AutoUpdater
                                         continue;
 
                                     var fullpath = System.IO.Path.Combine(targetfolder, relpath);
-                                    if (relpath.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+                                    if (relpath.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
                                         System.IO.Directory.CreateDirectory(fullpath);
                                     else
                                         System.IO.File.Copy(e, fullpath);
@@ -748,7 +748,7 @@ namespace Duplicati.Library.AutoUpdater
                         if (ignoreMap.ContainsKey(relpath))
                             return false;
                     
-                        if (path.EndsWith(dirsep))
+                        if (path.EndsWith(dirsep, StringComparison.Ordinal))
                             return true;
 
                         using (var source = System.IO.File.OpenRead(path))
@@ -771,8 +771,8 @@ namespace Duplicati.Library.AutoUpdater
                                 select new FileEntry() {
                         Path = relpath,
                         LastWriteTime = System.IO.File.GetLastAccessTimeUtc(fse),
-                        MD5 = fse.EndsWith(dirsep) ? null : computeMD5(fse),
-                        SHA256 = fse.EndsWith(dirsep) ? null : computeSHA256(fse)
+                        MD5 = fse.EndsWith(dirsep, StringComparison.Ordinal) ? null : computeMD5(fse),
+                        SHA256 = fse.EndsWith(dirsep, StringComparison.Ordinal) ? null : computeSHA256(fse)
                     })
                 .Union(ignoreFiles).ToArray();
 

--- a/Duplicati/Library/Backend/AlternativeFTP/AlternativeFTPBackend.cs
+++ b/Duplicati/Library/Backend/AlternativeFTP/AlternativeFTPBackend.cs
@@ -147,7 +147,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
                 _userInfo.Domain = "";
 
             _url = u.SetScheme("ftp").SetQuery(null).SetCredentials(null, null).ToString();
-            if (!_url.EndsWith("/"))
+            if (!_url.EndsWith("/", StringComparison.Ordinal))
             {
                 _url += "/";
             }
@@ -215,7 +215,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
 
                 // Get the remote path
                 var url = new Uri(this._url);
-                remotePath = "/" + (url.AbsolutePath.EndsWith("/") ? url.AbsolutePath.Substring(0, url.AbsolutePath.Length - 1) : url.AbsolutePath);
+                remotePath = "/" + (url.AbsolutePath.EndsWith("/", StringComparison.Ordinal) ? url.AbsolutePath.Substring(0, url.AbsolutePath.Length - 1) : url.AbsolutePath);
 
                 if (!string.IsNullOrEmpty(filename))
                 {
@@ -354,7 +354,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
 
                     foreach (var fileEntry in fileEntries)
                     {
-                        if (fileEntry.Name.Equals(remotename) || fileEntry.Name.EndsWith("/" + remotename) || fileEntry.Name.EndsWith("\\" + remotename))
+                        if (fileEntry.Name.Equals(remotename) || fileEntry.Name.EndsWith("/" + remotename, StringComparison.Ordinal) || fileEntry.Name.EndsWith("\\" + remotename, StringComparison.Ordinal))
                         {
                             if (fileEntry.Size < 0 || streamLen < 0 || fileEntry.Size == streamLen)
                             {
@@ -522,7 +522,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
             var url = new Uri(_url);
 
             // Get the remote path
-            var remotePath = url.AbsolutePath.EndsWith("/") ? url.AbsolutePath.Substring(0, url.AbsolutePath.Length - 1) : url.AbsolutePath;
+            var remotePath = url.AbsolutePath.EndsWith("/", StringComparison.Ordinal) ? url.AbsolutePath.Substring(0, url.AbsolutePath.Length - 1) : url.AbsolutePath;
 
             // Try to create the directory 
             client.CreateDirectory(remotePath, true);
@@ -561,7 +561,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
                 ftpClient.ValidateCertificate += HandleValidateCertificate;
 
                 // Get the remote path
-                var remotePath = uri.AbsolutePath.EndsWith("/") ? uri.AbsolutePath.Substring(0, uri.AbsolutePath.Length - 1) : uri.AbsolutePath;
+                var remotePath = uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal) ? uri.AbsolutePath.Substring(0, uri.AbsolutePath.Length - 1) : uri.AbsolutePath;
                 ftpClient.SetWorkingDirectory(remotePath);
 
                 this.Client = ftpClient;

--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -75,7 +75,7 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
             var uri = new Utility.Uri(url);
 
             m_path = uri.HostAndPath;
-            if (!m_path.EndsWith("/"))
+            if (!m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path += "/";
 
             string authid = null;
@@ -152,7 +152,7 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
             {
                 if (m_endPointInfo == null)
                     RefreshMetadataAndContentUrl();
-                while (m_endPointInfo.ContentUrl.EndsWith("/"))
+                while (m_endPointInfo.ContentUrl.EndsWith("/", StringComparison.Ordinal))
                     m_endPointInfo.ContentUrl = m_endPointInfo.ContentUrl.Substring(0, m_endPointInfo.ContentUrl.Length - 1);
                 return m_endPointInfo.ContentUrl;
             }
@@ -164,7 +164,7 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
             {
                 if (m_endPointInfo == null)
                     RefreshMetadataAndContentUrl();
-                while (m_endPointInfo.MetadataUrl.EndsWith("/"))
+                while (m_endPointInfo.MetadataUrl.EndsWith("/", StringComparison.Ordinal))
                     m_endPointInfo.MetadataUrl = m_endPointInfo.MetadataUrl.Substring(0, m_endPointInfo.MetadataUrl.Length - 1);
                 return m_endPointInfo.MetadataUrl;
             }

--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -57,11 +57,11 @@ namespace Duplicati.Library.Backend.Backblaze
 
             m_bucketname = uri.Host;
             m_prefix = "/" + uri.Path;
-            if (!m_prefix.EndsWith("/"))
+            if (!m_prefix.EndsWith("/", StringComparison.Ordinal))
                 m_prefix += "/";
 
             // For B2 we do not use a leading slash
-            while(m_prefix.StartsWith("/"))
+            while(m_prefix.StartsWith("/", StringComparison.Ordinal))
                 m_prefix = m_prefix.Substring(1);
 
             m_urlencodedprefix = string.Join("/", m_prefix.Split(new [] { '/' }).Select(x => Library.Utility.Uri.UrlPathEncode(x)));
@@ -323,7 +323,7 @@ namespace Duplicati.Library.Backend.Backblaze
 
                 foreach(var f in resp.Files)
                 {
-                    if (!f.FileName.StartsWith(m_prefix))
+                    if (!f.FileName.StartsWith(m_prefix, StringComparison.Ordinal))
                         continue;
 
                     var name = f.FileName.Substring(m_prefix.Length);

--- a/Duplicati/Library/Backend/Backblaze/B2AuthHelper.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2AuthHelper.cs
@@ -49,7 +49,7 @@ namespace Duplicati.Library.Backend.Backblaze
 
         private string DropTrailingSlashes(string url)
         {
-            while(url.EndsWith("/"))
+            while(url.EndsWith("/", StringComparison.Ordinal))
                 url = url.Substring(0, url.Length - 1);
             return url;
         }

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -93,7 +93,7 @@ namespace Duplicati.Library.Backend.Box
             var uri = new Utility.Uri(url);
 
             m_path = uri.HostAndPath;
-            if (!m_path.EndsWith("/"))
+            if (!m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path += "/";
             
             string authid = null;

--- a/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
+++ b/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
@@ -84,10 +84,10 @@ namespace Duplicati.Library.Backend
 
                 if (!string.IsNullOrEmpty(u.UserInfo))
                 {
-                    if (u.UserInfo.IndexOf(":") >= 0)
+                    if (u.UserInfo.IndexOf(":", StringComparison.Ordinal) >= 0)
                     {
-                        m_username = u.UserInfo.Substring(0, u.UserInfo.IndexOf(":"));
-                        m_password = u.UserInfo.Substring(u.UserInfo.IndexOf(":") + 1);
+                        m_username = u.UserInfo.Substring(0, u.UserInfo.IndexOf(":", StringComparison.Ordinal));
+                        m_password = u.UserInfo.Substring(u.UserInfo.IndexOf(":", StringComparison.Ordinal) + 1);
                     }
                     else
                     {
@@ -108,9 +108,9 @@ namespace Duplicati.Library.Backend
                 m_path = uri.HostAndPath;
             }
 
-            if (m_path.EndsWith("/"))
+            if (m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path = m_path.Substring(0, m_path.Length - 1);
-            if (!m_path.StartsWith("/"))
+            if (!m_path.StartsWith("/", StringComparison.Ordinal))
                 m_path = "/" + m_path;
 
             if (!options.TryGetValue("cloudfiles-authentication-url", out m_authUrl))

--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -22,10 +22,10 @@ namespace Duplicati.Library.Backend
             var uri = new Utility.Uri(url);
 
             m_path = Library.Utility.Uri.UrlDecode(uri.HostAndPath);
-            if (m_path.Length != 0 && !m_path.StartsWith("/"))
+            if (m_path.Length != 0 && !m_path.StartsWith("/", StringComparison.Ordinal))
                 m_path = "/" + m_path;
 
-            if (m_path.EndsWith("/"))
+            if (m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path = m_path.Substring(0, m_path.Length - 1);
 
             if (options.ContainsKey(AUTHID_OPTION))

--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -83,7 +83,7 @@ namespace Duplicati.Library.Backend
                 m_userInfo.Domain = "";
 
             m_url = u.SetScheme("ftp").SetQuery(null).SetCredentials(null, null).ToString();
-            if (!m_url.EndsWith("/"))
+            if (!m_url.EndsWith("/", StringComparison.Ordinal))
                 m_url += "/";
 
             m_useSSL = Utility.Utility.ParseBoolOption(options, "use-ssl");
@@ -278,7 +278,7 @@ namespace Duplicati.Library.Backend
                 {
                     IEnumerable<IFileEntry> files = List(remotename);
                     foreach(IFileEntry fe in files)
-                        if (fe.Name.Equals(remotename) || fe.Name.EndsWith("/" + remotename) || fe.Name.EndsWith("\\" + remotename)) 
+                        if (fe.Name.Equals(remotename) || fe.Name.EndsWith("/" + remotename, StringComparison.Ordinal) || fe.Name.EndsWith("\\" + remotename, StringComparison.Ordinal)) 
                         {
                             if (fe.Size < 0 || streamLen < 0 || fe.Size == streamLen)
                                 return;
@@ -390,7 +390,7 @@ namespace Duplicati.Library.Backend
         private System.Net.FtpWebRequest CreateRequest(string remotename, bool createFolder)
         {
             string url = m_url;
-            if (createFolder && url.EndsWith("/"))
+            if (createFolder && url.EndsWith("/", StringComparison.Ordinal))
                 url = url.Substring(0, url.Length - 1);
             
             System.Net.FtpWebRequest req = (System.Net.FtpWebRequest)System.Net.FtpWebRequest.Create(url + remotename);

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -76,7 +76,7 @@ namespace Duplicati.Library.Backend
                     
                     for (int i = 0; i < paths.Count; i++)
                     {
-                        if (paths[i].StartsWith("*:"))
+                        if (paths[i].StartsWith("*:", StringComparison.Ordinal))
                         {
                             string rpl_path = paths[i].Substring(1);
                             paths.RemoveAt(i);
@@ -304,7 +304,7 @@ namespace Duplicati.Library.Backend
                 //TODO: Can trick this with symlinks, where the symlink is on one mounted volume,
                 // and the actual storage is on another
                 foreach (System.IO.DriveInfo di in System.IO.DriveInfo.GetDrives())
-                    if (path.StartsWith(Utility.Utility.AppendDirSeparator(di.Name)) && di.Name.Length > root.Length)
+                    if (path.StartsWith(Utility.Utility.AppendDirSeparator(di.Name), StringComparison.Ordinal) && di.Name.Length > root.Length)
                         root = di.Name;
             }
             else

--- a/Duplicati/Library/Backend/File/Win32.cs
+++ b/Duplicati/Library/Backend/File/Win32.cs
@@ -95,13 +95,13 @@ namespace Duplicati.Library.Backend
             //Strip it down from \\server\share\folder1\folder2\filename.extension to
             // \\server\share
             string minpath = path;
-            if (!minpath.StartsWith("\\\\"))
+            if (!minpath.StartsWith("\\\\", StringComparison.Ordinal))
                 return false;
 
-            int first = minpath.IndexOf("\\", 2);
+            int first = minpath.IndexOf("\\", 2, StringComparison.Ordinal);
             if (first <= 0)
                 return false;
-            int next = minpath.IndexOf("\\", first + 1);
+            int next = minpath.IndexOf("\\", first + 1, StringComparison.Ordinal);
             if (next >= 0)
                 minpath = minpath.Substring(0, next);
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -79,11 +79,11 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
             m_bucket = uri.Host;
             m_prefix = "/" + uri.Path;
-            if (!m_prefix.EndsWith("/"))
+            if (!m_prefix.EndsWith("/", StringComparison.Ordinal))
                 m_prefix += "/";
 
             // For GCS we do not use a leading slash
-            if (m_prefix.StartsWith("/"))
+            if (m_prefix.StartsWith("/", StringComparison.Ordinal))
                 m_prefix = m_prefix.Substring(1);
 
             string authid;

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -48,7 +48,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
             var uri = new Utility.Uri(url);
 
             m_path = uri.HostAndPath;
-            if (!m_path.EndsWith("/"))
+            if (!m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path += "/";
 
             string authid = null;

--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -115,7 +115,7 @@ namespace Duplicati.Library.Backend
             m_path = u.HostAndPath; // Host and path of "jottacloud://folder/subfolder" is "folder/subfolder", so the actual folder path within the mount point.
             if (string.IsNullOrEmpty(m_path)) // Require a folder. Actually it is possible to store files directly on the root level of the mount point, but that does not seem to be a good option.
                 throw new UserInformationException(Strings.Jottacloud.NoPathError);
-            if (!m_path.EndsWith("/"))
+            if (!m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path += "/";
             if (!string.IsNullOrEmpty(u.Username))
             {

--- a/Duplicati/Library/Backend/OneDrive/OneDrive.cs
+++ b/Duplicati/Library/Backend/OneDrive/OneDrive.cs
@@ -42,7 +42,7 @@ namespace Duplicati.Library.Backend
 
             m_rootfolder = uri.Host;
             m_prefix = "/" + uri.Path;
-            if (!m_prefix.EndsWith("/"))
+            if (!m_prefix.EndsWith("/", StringComparison.Ordinal))
                 m_prefix += "/";
 
             string authid = null;

--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -188,11 +188,11 @@ namespace Duplicati.Library.Backend.OpenStack
 
             m_container = uri.Host;
             m_prefix = "/" + uri.Path;
-            if (!m_prefix.EndsWith("/"))
+            if (!m_prefix.EndsWith("/", StringComparison.Ordinal))
                 m_prefix += "/";
 
             // For OpenStack we do not use a leading slash
-            if (m_prefix.StartsWith("/"))
+            if (m_prefix.StartsWith("/", StringComparison.Ordinal))
                 m_prefix = m_prefix.Substring(1);
 
             options.TryGetValue(USERNAME_OPTION, out m_username);
@@ -232,7 +232,7 @@ namespace Duplicati.Library.Backend.OpenStack
         private string JoinUrls(string uri, string fragment)
         {
             fragment = fragment ?? "";
-            return uri + (uri.EndsWith("/") ? "" : "/") + (fragment.StartsWith("/") ? fragment.Substring(1) : fragment);
+            return uri + (uri.EndsWith("/", StringComparison.Ordinal) ? "" : "/") + (fragment.StartsWith("/", StringComparison.Ordinal) ? fragment.Substring(1) : fragment);
         }
         private string JoinUrls(string uri, string fragment1, string fragment2)
         {
@@ -338,7 +338,7 @@ namespace Duplicati.Library.Backend.OpenStack
                 foreach (var n in items)
                 {
                     var name = n.name;
-                    if (name.StartsWith(m_prefix))
+                    if (name.StartsWith(m_prefix, StringComparison.Ordinal))
                         name = name.Substring(m_prefix.Length);
 
                     if (n.bytes == null)

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -218,25 +218,25 @@ namespace Duplicati.Library.Backend
                 {
                     m_bucket = Library.Utility.Uri.UrlDecode(u.PathAndQuery);
 
-                    if (m_bucket.StartsWith("/"))
+                    if (m_bucket.StartsWith("/", StringComparison.Ordinal))
                         m_bucket = m_bucket.Substring(1);
 
                     if (m_bucket.Contains("/"))
                     {
-                        m_prefix = m_bucket.Substring(m_bucket.IndexOf("/") + 1);
-                        m_bucket = m_bucket.Substring(0, m_bucket.IndexOf("/"));
+                        m_prefix = m_bucket.Substring(m_bucket.IndexOf("/", StringComparison.Ordinal) + 1);
+                        m_bucket = m_bucket.Substring(0, m_bucket.IndexOf("/", StringComparison.Ordinal));
                     }
                 }
                 else
                 {
                     //Subdomain type lookup
-                    if (host.ToLower().EndsWith("." + s3host))
+                    if (host.ToLower().EndsWith("." + s3host, StringComparison.Ordinal))
                     {
                         m_bucket = host.Substring(0, host.Length - ("." + s3host).Length);
                         host = s3host;
                         m_prefix = Library.Utility.Uri.UrlDecode(u.PathAndQuery);
 
-                        if (m_prefix.StartsWith("/"))
+                        if (m_prefix.StartsWith("/", StringComparison.Ordinal))
                             m_prefix = m_prefix.Substring(1);
                     }
                     else
@@ -255,7 +255,7 @@ namespace Duplicati.Library.Backend
 
             m_options = options;
             m_prefix = m_prefix.Trim();
-            if (m_prefix.Length != 0 && !m_prefix.EndsWith("/"))
+            if (m_prefix.Length != 0 && !m_prefix.EndsWith("/", StringComparison.Ordinal))
                 m_prefix += "/";
 
             // Auto-disable dns lookup for non AWS configurations
@@ -315,7 +315,7 @@ namespace Duplicati.Library.Backend
                 ((FileEntry)file).Name = file.Name.Substring(m_prefix.Length);
 
                 //Fix for a bug in Duplicati 1.0 beta 3 and earlier, where filenames are incorrectly prefixed with a slash
-                if (file.Name.StartsWith("/") && !m_prefix.StartsWith("/"))
+                if (file.Name.StartsWith("/", StringComparison.Ordinal) && !m_prefix.StartsWith("/", StringComparison.Ordinal))
                     ((FileEntry)file).Name = file.Name.Substring(1);
 
                 yield return file;
@@ -362,7 +362,7 @@ namespace Duplicati.Library.Backend
                 //This is a fix for the S3 backend prior to beta 3, where the filenames had a slash prefixed
                 try
                 {
-                    if (!remotename.StartsWith("/"))
+                    if (!remotename.StartsWith("/", StringComparison.Ordinal))
                         Connection.GetFileStream(m_bucket, GetFullKey("/" + remotename), output);
                     return;
                 }

--- a/Duplicati/Library/Backend/SSHv2/KeyUploader.cs
+++ b/Duplicati/Library/Backend/SSHv2/KeyUploader.cs
@@ -99,7 +99,7 @@ namespace Duplicati.Library.Backend
                 }
                 
                 var keys = authorized_keys == null ? new string[0] : authorized_keys.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                var cleaned_keys = keys.Select(x => x.Trim()).Where(x => x.Length > 0 && !x.StartsWith("#"));
+                var cleaned_keys = keys.Select(x => x.Trim()).Where(x => x.Length > 0 && !x.StartsWith("#", StringComparison.Ordinal));
                 
                 // Does the key already exist?
                 if (cleaned_keys.Where(x =>

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -78,10 +78,10 @@ namespace Duplicati.Library.Backend
 
             m_path = uri.Path;
 
-            if (!string.IsNullOrWhiteSpace(m_path) && !m_path.EndsWith("/"))
+            if (!string.IsNullOrWhiteSpace(m_path) && !m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path += "/";
 
-            if (!m_path.StartsWith("/"))
+            if (!m_path.StartsWith("/", StringComparison.Ordinal))
                 m_path = "/" + m_path;
 
             m_server = uri.Host;
@@ -114,7 +114,7 @@ namespace Duplicati.Library.Backend
             CreateConnection();
             //Bugfix, some SSH servers do not like a trailing slash
             string p = m_path;
-            if (p.EndsWith("/"))
+            if (p.EndsWith("/", StringComparison.Ordinal))
                 p.Substring(0, p.Length - 1);
             m_con.CreateDirectory(p);
         }
@@ -297,7 +297,7 @@ namespace Duplicati.Library.Backend
 
             string working_dir = m_con.WorkingDirectory;
 
-            if (!working_dir.EndsWith("/"))
+            if (!working_dir.EndsWith("/", StringComparison.Ordinal))
                 working_dir += "/";
 
             if (working_dir == path)

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -162,9 +162,9 @@ namespace Duplicati.Library.Backend
             m_spWebUrl = null;
 
             m_serverRelPath = u.Path;
-            if (!m_serverRelPath.StartsWith("/"))
+            if (!m_serverRelPath.StartsWith("/", StringComparison.Ordinal))
                 m_serverRelPath = "/" + m_serverRelPath;
-            if (!m_serverRelPath.EndsWith("/"))
+            if (!m_serverRelPath.EndsWith("/", StringComparison.Ordinal))
                 m_serverRelPath += "/";
             // remove marker for SP-Web
             m_serverRelPath = m_serverRelPath.Replace("//", "/");
@@ -290,7 +290,7 @@ namespace Duplicati.Library.Backend
             retCtx = null;
 
             string path = orgUrl.Path;
-            int webIndicatorPos = path.IndexOf("//");
+            int webIndicatorPos = path.IndexOf("//", StringComparison.Ordinal);
 
             // if a hint is supplied, we will of course use this first.
             if (webIndicatorPos >= 0)

--- a/Duplicati/Library/Backend/Sia/Sia.cs
+++ b/Duplicati/Library/Backend/Sia/Sia.cs
@@ -46,9 +46,9 @@ namespace Duplicati.Library.Backend.Sia
             }
             while(m_targetpath.Contains("//"))
                 m_targetpath = m_targetpath.Replace("//","/");
-            while (m_targetpath.StartsWith("/"))
+            while (m_targetpath.StartsWith("/", StringComparison.Ordinal))
                 m_targetpath = m_targetpath.Substring(1);
-            while (m_targetpath.EndsWith("/"))
+            while (m_targetpath.EndsWith("/", StringComparison.Ordinal))
                 m_targetpath = m_targetpath.Remove(m_targetpath.Length - 1);
 
             if (m_targetpath.Length == 0)
@@ -294,7 +294,7 @@ namespace Duplicati.Library.Backend.Sia
                 {
                     // Sia returns a complete file list, but we're only interested in files that are
                     // in our target path
-                    if (f.Siapath.StartsWith(m_targetpath))
+                    if (f.Siapath.StartsWith(m_targetpath, StringComparison.Ordinal))
                     {
                         FileEntry fe = new FileEntry(f.Siapath.Substring(m_targetpath.Length + 1));
                         fe.Size = f.Filesize;

--- a/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
+++ b/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
@@ -99,13 +99,13 @@ namespace Duplicati.Library.Backend
             var u = new Utility.Uri(url);
             u.RequireHost();
             
-            if (!u.Path.StartsWith("uri/URI:DIR2:") && !u.Path.StartsWith("uri/URI%3ADIR2%3A"))
+            if (!u.Path.StartsWith("uri/URI:DIR2:", StringComparison.Ordinal) && !u.Path.StartsWith("uri/URI%3ADIR2%3A", StringComparison.Ordinal))
                 throw new UserInformationException(Strings.TahoeBackend.UnrecognizedUriError);
 
             m_useSSL = Utility.Utility.ParseBoolOption(options, "use-ssl");
 
             m_url = u.SetScheme(m_useSSL ? "https" : "http").SetQuery(null).SetCredentials(null, null).ToString();
-            if (!m_url.EndsWith("/"))
+            if (!m_url.EndsWith("/", StringComparison.Ordinal))
                 m_url += "/";
         }
 

--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -91,13 +91,13 @@ namespace Duplicati.Library.Backend
             m_useSSL = Utility.Utility.ParseBoolOption(options, "use-ssl");
 
             m_url = u.SetScheme(m_useSSL ? "https" : "http").SetCredentials(null, null).SetQuery(null).ToString();
-            if (!m_url.EndsWith("/"))
+            if (!m_url.EndsWith("/", StringComparison.Ordinal))
                 m_url += "/";
 
             m_path = u.Path;
-            if (!m_path.StartsWith("/"))
+            if (!m_path.StartsWith("/", StringComparison.Ordinal))
                 m_path = "/" + m_path;
-            if (!m_path.EndsWith("/"))
+            if (!m_path.EndsWith("/", StringComparison.Ordinal))
                 m_path += "/";
 
             m_path = Library.Utility.Uri.UrlDecode(m_path);
@@ -195,19 +195,19 @@ namespace Duplicati.Library.Backend
 
                 //TODO: This list is getting ridiculous, should change to regexps
 
-                if (name.StartsWith(m_url))
+                if (name.StartsWith(m_url, StringComparison.Ordinal))
                     cmp_path = m_url;
-                else if (name.StartsWith(m_rawurl))
+                else if (name.StartsWith(m_rawurl, StringComparison.Ordinal))
                     cmp_path = m_rawurl;
-                else if (name.StartsWith(m_rawurlPort))
+                else if (name.StartsWith(m_rawurlPort, StringComparison.Ordinal))
                     cmp_path = m_rawurlPort;
-                else if (name.StartsWith(m_path))
+                else if (name.StartsWith(m_path, StringComparison.Ordinal))
                     cmp_path = m_path;
-                else if (name.StartsWith("/" + m_path))
+                else if (name.StartsWith("/" + m_path, StringComparison.Ordinal))
                     cmp_path = "/" + m_path;
-                else if (name.StartsWith(m_sanitizedUrl))
+                else if (name.StartsWith(m_sanitizedUrl, StringComparison.Ordinal))
                     cmp_path = m_sanitizedUrl;
-                else if (name.StartsWith(m_reverseProtocolUrl))
+                else if (name.StartsWith(m_reverseProtocolUrl, StringComparison.Ordinal))
                     cmp_path = m_reverseProtocolUrl;
                 else
                     continue;

--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -77,7 +77,7 @@ namespace Duplicati.Library.DynamicLoader
                     {
                         if (m_interfaces.ContainsKey(uri.Scheme))
                             return (IBackend)Activator.CreateInstance(m_interfaces[uri.Scheme].GetType(), url, newOpts);
-                        else if (uri.Scheme.EndsWith("s"))
+                        else if (uri.Scheme.EndsWith("s", StringComparison.Ordinal))
                         {
                             var tmpscheme = uri.Scheme.Substring(0, uri.Scheme.Length - 1);
                             if (m_interfaces.ContainsKey(tmpscheme))
@@ -123,7 +123,7 @@ namespace Duplicati.Library.DynamicLoader
                     IBackend b;
                     if (m_interfaces.TryGetValue(uri.Scheme, out b) && b != null)
                         return b.SupportedCommands;
-                    else if (uri.Scheme.EndsWith("s"))
+                    else if (uri.Scheme.EndsWith("s", StringComparison.Ordinal))
                     {
                         var tmpscheme = uri.Scheme.Substring(0, uri.Scheme.Length - 1);
                         if (m_interfaces.ContainsKey(tmpscheme))

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -205,7 +205,7 @@ namespace Duplicati.Library.Main
             {
                 List<string> expandedSources = new List<string>();
 
-                if (Library.Utility.Utility.IsClientWindows && (inputsources[i].StartsWith("*:") || inputsources[i].StartsWith("?:")))
+                if (Library.Utility.Utility.IsClientWindows && (inputsources[i].StartsWith("*:", StringComparison.Ordinal) || inputsources[i].StartsWith("?:", StringComparison.Ordinal)))
                 {
                     // *: drive paths are only supported on Windows clients
                     // Lazily load the drive info

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -201,7 +201,7 @@ namespace Duplicati.Library.Main.Database
                     while (rd.Read())
                     {
                         var s = rd.GetString(0);
-                        if (!s.StartsWith(prefix))
+                        if (!s.StartsWith(prefix, StringComparison.Ordinal))
                             continue;
 
                         var dirsep = Duplicati.Library.Utility.Utility.GuessDirSeparator(s);

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -523,7 +523,7 @@ namespace Duplicati.Library.Main.Operation
                 if (dryrun)
                     return;
 
-                var isDirTarget = path.EndsWith(DIRSEP);
+                var isDirTarget = path.EndsWith(DIRSEP, StringComparison.Ordinal);
                 var targetpath = isDirTarget ? path.Substring(0, path.Length - 1) : path;
 
                 // Make the symlink first, otherwise we cannot apply metadata to it
@@ -996,7 +996,7 @@ namespace Duplicati.Library.Main.Operation
                     {
                         //Select a new filename
                         var ext = m_systemIO.PathGetExtension(targetpath) ?? "";
-                        if (!string.IsNullOrEmpty(ext) && !ext.StartsWith("."))
+                        if (!string.IsNullOrEmpty(ext) && !ext.StartsWith(".", StringComparison.Ordinal))
                             ext = "." + ext;
                         
                         // First we try with a simple date append, assuming that there are not many conflicts there

--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -101,9 +101,9 @@ namespace Duplicati.Library.Modules.Builtin
             {
                 var filters = filter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries);
 
-                filtersInclude = filters.Where(x => x.StartsWith("+") && Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                filtersInclude = filters.Where(x => x.StartsWith("+", StringComparison.Ordinal) && Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
                     .Select(x => Regex.Match(x.Substring(1), m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant).Groups[1].Value).ToList();
-                filtersExclude = filters.Where(x => x.StartsWith("-") && Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                filtersExclude = filters.Where(x => x.StartsWith("-", StringComparison.Ordinal) && Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
                     .Select(x => Regex.Match(x.Substring(1), m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant).Groups[1].Value).ToList();
 
                 var remainingfilters = filters.Where(x => !Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).ToArray();
@@ -186,7 +186,7 @@ namespace Duplicati.Library.Modules.Builtin
 
             var pathsForBackup = new List<string>(paths);
             var filterhandler = new Utility.FilterExpression(
-                filter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries).Where(x => x.StartsWith("-")).Select(x => x.Substring(1)).ToList());
+                filter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries).Where(x => x.StartsWith("-", StringComparison.Ordinal)).Select(x => x.Substring(1)).ToList());
             
             foreach (var guestForBackup in guestsForBackup)
                 foreach (var pathForBackup in guestForBackup.DataPaths)

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -101,9 +101,9 @@ namespace Duplicati.Library.Modules.Builtin
             {
                 var filters = filter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries);
 
-                filtersInclude = filters.Where(x => x.StartsWith("+") && Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                filtersInclude = filters.Where(x => x.StartsWith("+", StringComparison.Ordinal) && Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
                     .Select(x => Regex.Match(x.Substring(1), m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant).Groups[1].Value).ToList();
-                filtersExclude = filters.Where(x => x.StartsWith("-") && Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                filtersExclude = filters.Where(x => x.StartsWith("-", StringComparison.Ordinal) && Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
                     .Select(x => Regex.Match(x.Substring(1), m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant).Groups[1].Value).ToList();
 
                 var remainingfilters = filters.Where(x => !Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).ToArray();
@@ -183,7 +183,7 @@ namespace Duplicati.Library.Modules.Builtin
 
             var pathsForBackup = new List<string>(paths);
             var filterhandler = new Utility.FilterExpression(
-                filter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries).Where(x => x.StartsWith("-")).Select(x => x.Substring(1)).ToList());
+                filter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries).Where(x => x.StartsWith("-", StringComparison.Ordinal)).Select(x => x.Substring(1)).ToList());
             
             foreach (var dbForBackup in dbsForBackup)
                 foreach (var pathForBackup in dbForBackup.DataPaths)

--- a/Duplicati/Library/Modules/Builtin/RunScript.cs
+++ b/Duplicati/Library/Modules/Builtin/RunScript.cs
@@ -252,7 +252,7 @@ namespace Duplicati.Library.Modules.Builtin
                     foreach(string rawline in stdout.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         string line = rawline.Trim();
-                        if (!line.StartsWith("--"))
+                        if (!line.StartsWith("--", StringComparison.Ordinal))
                             continue; //Ingore anything that does not start with --
 
                         line = line.Substring(2);
@@ -273,7 +273,7 @@ namespace Duplicati.Library.Modules.Builtin
                             key = line.Substring(0, lix).Trim();
                             value = line.Substring(lix + 1).Trim();
 
-                            if (value.Length >= 2 && value.StartsWith("\"") && value.EndsWith("\""))
+                            if (value.Length >= 2 && value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal))
                                 value = value.Substring(1, value.Length - 2);
                         }
 

--- a/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
+++ b/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
@@ -152,11 +152,11 @@ namespace Duplicati.Library.SQLiteHelper
             {
                 //The resource name will be "Duplicati.GUI.Database_schema.1.Sample upgrade.sql"
                 //The number indicates the version that will be upgraded to
-                if (s.StartsWith(prefix) && !s.Equals(prefix + SCHEMA_NAME))
+                if (s.StartsWith(prefix, StringComparison.Ordinal) && !s.Equals(prefix + SCHEMA_NAME))
                 {
                     try
                     {
-                        string version = s.Substring(prefix.Length, s.IndexOf(".", prefix.Length + 1) - prefix.Length);
+                        string version = s.Substring(prefix.Length, s.IndexOf(".", prefix.Length + 1, StringComparison.Ordinal) - prefix.Length);
                         int fileversion = int.Parse(version);
 
                         string prev;

--- a/Duplicati/Library/Snapshots/DefineDosDevice.cs
+++ b/Duplicati/Library/Snapshots/DefineDosDevice.cs
@@ -97,7 +97,7 @@ namespace Duplicati.Library.Snapshots
                 List<char> drives = new List<char>("DEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray());
                 foreach (DriveInfo di in DriveInfo.GetDrives())
                 {
-                    if ((di.RootDirectory.FullName.Length == 2 && di.RootDirectory.FullName[1] == ':') || ((di.RootDirectory.FullName.Length == 3 && di.RootDirectory.FullName.EndsWith(":\\"))))
+                    if ((di.RootDirectory.FullName.Length == 2 && di.RootDirectory.FullName[1] == ':') || ((di.RootDirectory.FullName.Length == 3 && di.RootDirectory.FullName.EndsWith(":\\", StringComparison.Ordinal))))
                     {
                         int i = drives.IndexOf(di.RootDirectory.FullName[0]);
                         if (i >= 0)
@@ -110,10 +110,10 @@ namespace Duplicati.Library.Snapshots
                 drive = drives[0].ToString() + ':';
             }
 
-            while (drive.EndsWith("\\"))
+            while (drive.EndsWith("\\", StringComparison.Ordinal))
                 drive = drive.Substring(0, drive.Length - 1);
 
-            if (!drive.EndsWith(":"))
+            if (!drive.EndsWith(":", StringComparison.Ordinal))
                 throw new ArgumentException("The drive specification must end with a colon.", nameof(drive));
 
             Win32API.DDD_Flags flags = 0;

--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -101,7 +101,7 @@ namespace Duplicati.Library.Snapshots
             /// <returns>The local path</returns>
             public string ConvertToLocalPath(string path)
             {
-                if (!path.StartsWith(m_mountPoint))
+                if (!path.StartsWith(m_mountPoint, StringComparison.Ordinal))
                     throw new InvalidOperationException();
 
                 return m_tmpDir + path.Substring(m_mountPoint.Length);
@@ -114,7 +114,7 @@ namespace Duplicati.Library.Snapshots
             /// <returns>The snapshot path</returns>
             public string ConvertToSnapshotPath(string path)
             {
-                if (!path.StartsWith(m_tmpDir))
+                if (!path.StartsWith(m_tmpDir, StringComparison.Ordinal))
                     throw new InvalidOperationException();
 
                 return m_mountPoint + path.Substring(m_tmpDir.Length);
@@ -342,7 +342,7 @@ namespace Duplicati.Library.Snapshots
             KeyValuePair<string, SnapShot>? best = null;
 
             foreach (KeyValuePair<string, SnapShot> s in m_entries)
-                if (name.StartsWith(s.Key) && (best == null || s.Key.Length > best.Value.Key.Length))
+                if (name.StartsWith(s.Key, StringComparison.Ordinal) && (best == null || s.Key.Length > best.Value.Key.Length))
                     best = s;
 
             if (best == null)

--- a/Duplicati/Library/Snapshots/Program.cs
+++ b/Duplicati/Library/Snapshots/Program.cs
@@ -31,21 +31,21 @@ namespace Duplicati.Library.Snapshots
 
             for (int i = 0; i < args.Count; i++)
             {
-                if (args[i].StartsWith("--"))
+                if (args[i].StartsWith("--", StringComparison.Ordinal))
                 {
                     string key = null;
                     string value = null;
-                    if (args[i].IndexOf("=") > 0)
+                    if (args[i].IndexOf("=", StringComparison.Ordinal) > 0)
                     {
-                        key = args[i].Substring(0, args[i].IndexOf("="));
-                        value = args[i].Substring(args[i].IndexOf("=") + 1);
+                        key = args[i].Substring(0, args[i].IndexOf("=", StringComparison.Ordinal));
+                        value = args[i].Substring(args[i].IndexOf("=", StringComparison.Ordinal) + 1);
                     }
                     else
                         key = args[i];
 
                     //Skip the leading --
                     key = key.Substring(2).ToLower();
-                    if (!string.IsNullOrEmpty(value) && value.Length > 1 && value.StartsWith("\"") && value.EndsWith("\""))
+                    if (!string.IsNullOrEmpty(value) && value.Length > 1 && value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal))
                         value = value.Substring(1, value.Length - 2);
 
                     //Last argument overwrites the current

--- a/Duplicati/Library/Snapshots/SystemIOLinux.cs
+++ b/Duplicati/Library/Snapshots/SystemIOLinux.cs
@@ -196,7 +196,7 @@ namespace Duplicati.Library.Snapshots
 
             var f = NoSnapshot.NormalizePath(file);
 
-            foreach(var x in data.Where(x => x.Key.StartsWith("unix-ext:")).Select(x => new KeyValuePair<string, byte[]>(x.Key.Substring("unix-ext:".Length), Convert.FromBase64String(x.Value))))
+            foreach(var x in data.Where(x => x.Key.StartsWith("unix-ext:", StringComparison.Ordinal)).Select(x => new KeyValuePair<string, byte[]>(x.Key.Substring("unix-ext:".Length), Convert.FromBase64String(x.Value))))
                 UnixSupport.File.SetExtendedAttribute(f, x.Key, x.Value);
 
             if (restorePermissions && data.ContainsKey("unix:uid-gid-perm"))

--- a/Duplicati/Library/Snapshots/SystemIOWindows.cs
+++ b/Duplicati/Library/Snapshots/SystemIOWindows.cs
@@ -33,7 +33,7 @@ namespace Duplicati.Library.Snapshots
 
         public static bool IsPathTooLong(string path)
         {
-            if (path.StartsWith(UNCPREFIX) || path.StartsWith(UNCPREFIX_SERVER) || path.Length > 260)
+            if (path.StartsWith(UNCPREFIX, StringComparison.Ordinal) || path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal) || path.Length > 260)
                 return true;
 
             return false;
@@ -41,13 +41,13 @@ namespace Duplicati.Library.Snapshots
 
         public static string PrefixWithUNC(string path)
         {
-            if (path.StartsWith(UNCPREFIX_SERVER))
+            if (path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal))
                 return path;
 
-            if (path.StartsWith(UNCPREFIX))
+            if (path.StartsWith(UNCPREFIX, StringComparison.Ordinal))
                 return path;
 
-            if (path.StartsWith(PATHPREFIX_SERVER))
+            if (path.StartsWith(PATHPREFIX_SERVER, StringComparison.Ordinal))
                 return UNCPREFIX_SERVER + path.Remove(0, PATHPREFIX_SERVER.Length);
             
             return UNCPREFIX + path;
@@ -55,7 +55,7 @@ namespace Duplicati.Library.Snapshots
 
         public static string StripUNCPrefix(string path)
         {
-            if (path.StartsWith(UNCPREFIX))
+            if (path.StartsWith(UNCPREFIX, StringComparison.Ordinal))
                 return path.Substring(UNCPREFIX.Length);
             else
                 return path;
@@ -510,7 +510,7 @@ namespace Duplicati.Library.Snapshots
 
         public Dictionary<string, string> GetMetadata(string path, bool isSymlink, bool followSymlink)
         {
-            var isDirTarget = path.EndsWith(DIRSEP);
+            var isDirTarget = path.EndsWith(DIRSEP, StringComparison.Ordinal);
             var targetpath = isDirTarget ? path.Substring(0, path.Length - 1) : path;
             var dict = new Dictionary<string, string>();
 
@@ -532,7 +532,7 @@ namespace Duplicati.Library.Snapshots
             
         public void SetMetadata(string path, Dictionary<string, string> data, bool restorePermissions)
         {
-            var isDirTarget = path.EndsWith(DIRSEP);
+            var isDirTarget = path.EndsWith(DIRSEP, StringComparison.Ordinal);
             var targetpath = isDirTarget ? path.Substring(0, path.Length - 1) : path;
 
             System.Security.AccessControl.FileSystemSecurity rules;

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -281,7 +281,7 @@ namespace Duplicati.Library.Snapshots
 
             localPath = localPath.Replace(root, String.Empty);
 
-            if (!volumePath.EndsWith(SLASH) && !localPath.StartsWith(SLASH))
+            if (!volumePath.EndsWith(SLASH, StringComparison.Ordinal) && !localPath.StartsWith(SLASH, StringComparison.Ordinal))
                 localPath = localPath.Insert(0, SLASH);
             localPath = localPath.Insert(0, volumePath);
 

--- a/Duplicati/Library/UsageReporter/OSInfoHelper.cs
+++ b/Duplicati/Library/UsageReporter/OSInfoHelper.cs
@@ -78,9 +78,9 @@ namespace Duplicati.Library.UsageReporter
                     if (m != null)
                     {
                         var lines = m.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-                        var product = lines.Where(x => x.Trim().StartsWith("ProductName:")).Select(x => x.Trim().Substring("ProductName:".Length).Trim()).FirstOrDefault();
-                        var version = lines.Where(x => x.Trim().StartsWith("ProductVersion:")).Select(x => x.Trim().Substring("ProductVersion:".Length).Trim()).FirstOrDefault();
-                        var build = lines.Where(x => x.Trim().StartsWith("BuildVersion:")).Select(x => x.Trim().Substring("BuildVersion:".Length).Trim()).FirstOrDefault();
+                        var product = lines.Where(x => x.Trim().StartsWith("ProductName:", StringComparison.Ordinal)).Select(x => x.Trim().Substring("ProductName:".Length).Trim()).FirstOrDefault();
+                        var version = lines.Where(x => x.Trim().StartsWith("ProductVersion:", StringComparison.Ordinal)).Select(x => x.Trim().Substring("ProductVersion:".Length).Trim()).FirstOrDefault();
+                        var build = lines.Where(x => x.Trim().StartsWith("BuildVersion:", StringComparison.Ordinal)).Select(x => x.Trim().Substring("BuildVersion:".Length).Trim()).FirstOrDefault();
                         if (!string.IsNullOrWhiteSpace(product))
                             return string.Format("{0} {1} {2}", product, version, build);
                     }
@@ -145,7 +145,7 @@ namespace Duplicati.Library.UsageReporter
                     if (m != null)
                     {
                         var lines = m.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-                        var line = lines.Where(x => x.Trim().StartsWith("Description:")).Select(x => x.Trim().Substring("Description:".Length).Trim()).FirstOrDefault();
+                        var line = lines.Where(x => x.Trim().StartsWith("Description:", StringComparison.Ordinal)).Select(x => x.Trim().Substring("Description:".Length).Trim()).FirstOrDefault();
                         if (!string.IsNullOrWhiteSpace(line))
                             return line;
                     }

--- a/Duplicati/Library/Utility/CommandLineParser.cs
+++ b/Duplicati/Library/Utility/CommandLineParser.cs
@@ -41,21 +41,21 @@ namespace Duplicati.Library.Utility
 
             for (int i = 0; i < args.Count; i++)
             {
-                if (args[i].StartsWith("--"))
+                if (args[i].StartsWith("--", StringComparison.Ordinal))
                 {
                     string key = null;
                     string value = null;
-                    if (args[i].IndexOf("=") > 0)
+                    if (args[i].IndexOf("=", StringComparison.Ordinal) > 0)
                     {
-                        key = args[i].Substring(0, args[i].IndexOf("="));
-                        value = args[i].Substring(args[i].IndexOf("=") + 1);
+                        key = args[i].Substring(0, args[i].IndexOf("=", StringComparison.Ordinal));
+                        value = args[i].Substring(args[i].IndexOf("=", StringComparison.Ordinal) + 1);
                     }
                     else
                         key = args[i];
 
                     //Skip the leading --
                     key = key.Substring(2).ToLower();
-                    if (!string.IsNullOrEmpty(value) && value.Length > 1 && value.StartsWith("\"") && value.EndsWith("\""))
+                    if (!string.IsNullOrEmpty(value) && value.Length > 1 && value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal))
                         value = value.Substring(1, value.Length - 2);
 
                     //Last argument overwrites the current

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -320,7 +320,7 @@ namespace Duplicati.Library.Utility
             if (string.IsNullOrWhiteSpace(filter))
                 return null;
             
-            if (filter.Length < 2 || (filter.StartsWith("[") && filter.EndsWith("]")))
+            if (filter.Length < 2 || (filter.StartsWith("[", StringComparison.Ordinal) && filter.EndsWith("]", StringComparison.Ordinal)))
                 return new string[] { filter };
             else
                 return filter.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
@@ -602,9 +602,9 @@ namespace Duplicati.Library.Utility
             foreach(var n in filters) 
             {
                 bool include;
-                if (n.StartsWith("+"))
+                if (n.StartsWith("+", StringComparison.Ordinal))
                     include = true;
-                else if (n.StartsWith("-"))
+                else if (n.StartsWith("-", StringComparison.Ordinal))
                     include = false;
                 else
                     continue;

--- a/Duplicati/Library/Utility/Sizeparser.cs
+++ b/Duplicati/Library/Utility/Sizeparser.cs
@@ -32,7 +32,7 @@ namespace Duplicati.Library.Utility
 
             size = size.ToLower().Trim();
 
-            if (size.EndsWith("tb") || size.EndsWith("gb") || size.EndsWith("mb") || size.EndsWith("kb") || size.EndsWith("b"))
+            if (size.EndsWith("tb", StringComparison.Ordinal) || size.EndsWith("gb", StringComparison.Ordinal) || size.EndsWith("mb", StringComparison.Ordinal) || size.EndsWith("kb", StringComparison.Ordinal) || size.EndsWith("b", StringComparison.Ordinal))
                 return ParseSize(size);
             else
                 return ParseSize(size + " " + defaultSuffix);
@@ -49,27 +49,27 @@ namespace Duplicati.Library.Utility
             
             long factor = 1;
 
-            if (size.EndsWith("tb"))
+            if (size.EndsWith("tb", StringComparison.Ordinal))
             {
                 factor = 1024L * 1024 * 1024 * 1024;
                 size = size.Substring(0, size.Length - 2).Trim();
             }
-            else if (size.EndsWith("gb"))
+            else if (size.EndsWith("gb", StringComparison.Ordinal))
             {
                 factor = 1024 * 1024 * 1024;
                 size = size.Substring(0, size.Length - 2).Trim();
             }
-            else if (size.EndsWith("mb"))
+            else if (size.EndsWith("mb", StringComparison.Ordinal))
             {
                 factor = 1024 * 1024;
                 size = size.Substring(0, size.Length - 2).Trim();
             }
-            else if (size.EndsWith("kb"))
+            else if (size.EndsWith("kb", StringComparison.Ordinal))
             {
                 factor = 1024;
                 size = size.Substring(0, size.Length - 2).Trim();
             }
-            else if (size.EndsWith("b"))
+            else if (size.EndsWith("b", StringComparison.Ordinal))
                 size = size.Substring(0, size.Length - 1).Trim();
 
             long r;

--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -165,11 +165,11 @@ namespace Duplicati.Library.Utility
             var h = m.Groups["hostname"].Success ? m.Groups["hostname"].Value : "";
 
             var p = m.Groups["path"].Success ? m.Groups["path"].Value : "";
-            if (m.Groups["hostname"].Success && p.StartsWith("/"))
+            if (m.Groups["hostname"].Success && p.StartsWith("/", StringComparison.Ordinal))
                 p = p.Substring(1);
 
             // file://c:\test support
-            if (h.Length == 1 && p.StartsWith(":"))
+            if (h.Length == 1 && p.StartsWith(":", StringComparison.Ordinal))
             {
                 h = h + p;
                 p = "";
@@ -260,7 +260,7 @@ namespace Duplicati.Library.Utility
             
             if (!string.IsNullOrEmpty(path))
             {
-                if (!string.IsNullOrEmpty(host) && !path.StartsWith("/"))
+                if (!string.IsNullOrEmpty(host) && !path.StartsWith("/", StringComparison.Ordinal))
                     s += "/";
                 s += path;
             }
@@ -444,7 +444,7 @@ namespace Duplicati.Library.Utility
         {
             if (query == null)
                 throw new ArgumentNullException("query");
-            if (query.StartsWith("?"))
+            if (query.StartsWith("?", StringComparison.Ordinal))
                 query = query.Substring(1);
             if (string.IsNullOrEmpty(query))
                 return new NameValueCollection(StringComparer.OrdinalIgnoreCase);

--- a/Duplicati/Library/Utility/UrlUtillity.cs
+++ b/Duplicati/Library/Utility/UrlUtillity.cs
@@ -47,7 +47,7 @@ namespace Duplicati.Library.Utility
         /// <param name="url">The url to open, must start with http:// or https://</param>
         public static void OpenURL(string url, string browserprogram = null)
         {
-            if (!url.StartsWith("http://") && !url.StartsWith("https://"))
+            if (!url.StartsWith("http://", StringComparison.Ordinal) && !url.StartsWith("https://", StringComparison.Ordinal))
                 throw new Exception("Malformed URL");
 
             if (string.IsNullOrWhiteSpace(browserprogram))
@@ -107,7 +107,7 @@ namespace Duplicati.Library.Utility
 
             try
             {
-                if (!url.StartsWith("http://") && !url.StartsWith("https://"))
+                if (!url.StartsWith("http://", StringComparison.Ordinal) && !url.StartsWith("https://", StringComparison.Ordinal))
                     throw new Exception("Malformed URL");
 
                 if (string.IsNullOrEmpty(browserprogram))

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -170,7 +170,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full filenames</returns>
         public static IEnumerable<string> EnumerateFiles(string basepath, IFilter filter)
         {
-            return EnumerateFileSystemEntries(basepath, filter).Where(x => !x.EndsWith(DirectorySeparatorString));
+            return EnumerateFileSystemEntries(basepath, filter).Where(x => !x.EndsWith(DirectorySeparatorString, StringComparison.Ordinal));
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full paths</returns>
         public static IEnumerable<string> EnumerateFolders(string basepath, IFilter filter)
         {
-            return EnumerateFileSystemEntries(basepath, filter).Where(x => x.EndsWith(DirectorySeparatorString));
+            return EnumerateFileSystemEntries(basepath, filter).Where(x => x.EndsWith(DirectorySeparatorString, StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/Duplicati/License/LicenseEntry.cs
+++ b/Duplicati/License/LicenseEntry.cs
@@ -57,7 +57,7 @@ namespace Duplicati.License
             if (!string.IsNullOrEmpty(urlfile) && System.IO.File.Exists(urlfile))
                 Url = System.IO.File.ReadAllText(urlfile).Trim();
             License = System.IO.File.ReadAllText(licensefile);
-            if (License.IndexOf("\r\n") < 0)
+            if (License.IndexOf("\r\n", StringComparison.Ordinal) < 0)
                 License = License.Replace("\n", "\r\n").Replace("\r", "\r\n");
             if (Environment.NewLine != "\r\n")
                 License = License.Replace("\r\n", Environment.NewLine);

--- a/Duplicati/Server/Database/Backup.cs
+++ b/Duplicati/Server/Database/Backup.cs
@@ -92,7 +92,7 @@ namespace Duplicati.Server.Database
         /// <summary>
         /// Gets a value indicating if this instance is not persisted to the database
         /// </summary>        
-        public bool IsTemporary { get { return ID == null ? false : ID.IndexOf("-") > 0; } }
+        public bool IsTemporary { get { return ID == null ? false : ID.IndexOf("-", StringComparison.Ordinal) > 0; } }
 
     }
 }

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -248,7 +248,7 @@ namespace Duplicati.Server.Database
             if (tags == null || tags.Length == 0)
                 return new long[0];
                 
-            if (tags.Length == 1 && tags[0].StartsWith("ID="))
+            if (tags.Length == 1 && tags[0].StartsWith("ID=", StringComparison.Ordinal))
                 return new long[] { long.Parse(tags[0].Substring("ID=".Length)) };
                 
             lock(m_lock)
@@ -510,7 +510,7 @@ namespace Duplicati.Server.Database
                             @"INSERT INTO ""Backup"" (""Name"", ""Tags"", ""TargetURL"", ""DBPath"") VALUES (?,?,?,?)",
                         (n) => {
                         
-                            if (n.TargetURL.IndexOf(Duplicati.Server.WebServer.Server.PASSWORD_PLACEHOLDER) >= 0)
+                            if (n.TargetURL.IndexOf(Duplicati.Server.WebServer.Server.PASSWORD_PLACEHOLDER, StringComparison.Ordinal) >= 0)
                                 throw new Exception("Attempted to save a backup with the password placeholder");
                             if (update && long.Parse(n.ID) <= 0)
                                 throw new Exception("Invalid update, cannot update application settings through update method");

--- a/Duplicati/Server/Database/ServerSettings.cs
+++ b/Duplicati/Server/Database/ServerSettings.cs
@@ -89,7 +89,7 @@ namespace Duplicati.Server.Database
                     m_values.Clear();
 
                 foreach(var k in newsettings)
-                    if (!clearExisting && newsettings[k.Key] == null && k.Key.StartsWith("--"))
+                    if (!clearExisting && newsettings[k.Key] == null && k.Key.StartsWith("--", StringComparison.Ordinal))
                         m_values.Remove(k.Key);
                     else
                         m_values[k.Key] = newsettings[k.Key];

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -833,12 +833,12 @@ namespace Duplicati.Server
             
             // Apply normal options
             foreach(var o in backup.Settings)
-                if (!o.Name.StartsWith("--") && TestIfOptionApplies(backup, mode, o.Filter))
+                if (!o.Name.StartsWith("--", StringComparison.Ordinal) && TestIfOptionApplies(backup, mode, o.Filter))
                     options[o.Name] = o.Value;
 
             // Apply override options
             foreach(var o in backup.Settings)
-                if (o.Name.StartsWith("--") && TestIfOptionApplies(backup, mode, o.Filter))
+                if (o.Name.StartsWith("--", StringComparison.Ordinal) && TestIfOptionApplies(backup, mode, o.Filter))
                     options[o.Name.Substring(2)] = o.Value;
             
             
@@ -855,8 +855,8 @@ namespace Duplicati.Server
             {
                 var nf =
                     (from n in f2
-                    let exp = 
-                        n.Expression.StartsWith("[") && n.Expression.EndsWith("]")
+                    let exp =
+                        n.Expression.StartsWith("[", StringComparison.Ordinal) && n.Expression.EndsWith("]", StringComparison.Ordinal)
                         ? SpecialFolders.ExpandEnvironmentVariablesRegexp(n.Expression)
                         : SpecialFolders.ExpandEnvironmentVariables(n.Expression)
                     orderby n.Order

--- a/Duplicati/Server/Serializable/ServerStatus.cs
+++ b/Duplicati/Server/Serializable/ServerStatus.cs
@@ -84,7 +84,7 @@ namespace Duplicati.Server.Serializable
                 return (
                     from n in Program.Scheduler.Schedule
                                 let backupid = (from t in n.Value.Tags
-                                                where t != null && t.StartsWith("ID=")
+                                                where t != null && t.StartsWith("ID=", StringComparison.Ordinal)
                                                 select t.Substring("ID=".Length)).FirstOrDefault()
                                 where !string.IsNullOrWhiteSpace(backupid)
                                 select new Tuple<string, DateTime>(backupid, n.Key)

--- a/Duplicati/Server/SpecialFolders.cs
+++ b/Duplicati/Server/SpecialFolders.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Server
         public static string ExpandEnvironmentVariables(string path)
         {
             foreach(var n in Nodes)
-                if (path.StartsWith(n.id))
+                if (path.StartsWith(n.id, StringComparison.Ordinal))
                     path = path.Replace(n.id, n.resolvedpath);
             return Library.Utility.Utility.ExpandEnvironmentVariables(path);
         }
@@ -162,7 +162,7 @@ namespace Duplicati.Server
                 try
                 {
                     var nx = x;
-                    if (nx.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+                    if (nx.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
                         nx = nx.Substring(0, nx.Length - 1);
                     var n = systemIO.PathGetFileName(nx);
                     if (!string.IsNullOrWhiteSpace(n))
@@ -172,8 +172,8 @@ namespace Duplicati.Server
                 {
                 }
 
-                if (x.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()) && x.Length > 1)
-                    return new KeyValuePair<string, string>(x, x.Substring(0, x.Length - 1).Substring(x.Substring(0, x.Length - 1).LastIndexOf("/") + 1));
+                if (x.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) && x.Length > 1)
+                    return new KeyValuePair<string, string>(x, x.Substring(0, x.Length - 1).Substring(x.Substring(0, x.Length - 1).LastIndexOf("/", StringComparison.Ordinal) + 1));
                 else
                     return new KeyValuePair<string, string>(x, x);
 

--- a/Duplicati/Server/WebServer/AuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/AuthenticationHandler.cs
@@ -250,7 +250,7 @@ namespace Duplicati.Server.WebServer
                         var expires = DateTime.UtcNow.AddHours(1);
                         m_prng.GetBytes(buf);
                         var token = Duplicati.Library.Utility.Utility.Base64UrlEncode(buf);
-                        while (token.Length > 0 && token.EndsWith("="))
+                        while (token.Length > 0 && token.EndsWith("=", StringComparison.Ordinal))
                             token = token.Substring(0, token.Length - 1);
 
                         m_activeTokens.AddOrUpdate(token, key => expires, (key, existingValue) =>

--- a/Duplicati/Server/WebServer/IndexHtmlHandler.cs
+++ b/Duplicati/Server/WebServer/IndexHtmlHandler.cs
@@ -40,7 +40,7 @@ namespace Duplicati.Server.WebServer
 
             if (System.IO.Directory.Exists(path) && (System.IO.File.Exists(html) || System.IO.File.Exists(htm)))
             {
-                if (!request.Uri.AbsolutePath.EndsWith("/"))
+                if (!request.Uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal))
                 {
                     response.Redirect(request.Uri.AbsolutePath + "/");
                     return true;
@@ -68,7 +68,7 @@ namespace Duplicati.Server.WebServer
             if (ForbiddenChars.Where(x => uri.AbsolutePath.Contains(x)).Any())
                 throw new BadRequestException("Illegal path");
             var uripath = Uri.UnescapeDataString(uri.AbsolutePath);
-            while(uripath.Length > 0 && (uripath.StartsWith("/") || uripath.StartsWith(DirSep)))
+            while(uripath.Length > 0 && (uripath.StartsWith("/", StringComparison.Ordinal) || uripath.StartsWith(DirSep, StringComparison.Ordinal)))
                 uripath = uripath.Substring(1);
             return System.IO.Path.Combine(m_webroot, uripath.Replace('/', System.IO.Path.DirectorySeparatorChar));
         }

--- a/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
@@ -48,9 +48,9 @@ namespace Duplicati.Server.WebServer.RESTMethods
             string specialpath = null;
             string specialtoken = null;
 
-            if (path.StartsWith("%"))
+            if (path.StartsWith("%", StringComparison.Ordinal))
             {
-                var ix = path.IndexOf("%", 1);
+                var ix = path.IndexOf("%", 1, StringComparison.Ordinal);
                 if (ix > 0)
                 {
                     var tk = path.Substring(0, ix + 1);
@@ -65,7 +65,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             path = SpecialFolders.ExpandEnvironmentVariables(path);
 
-            if (Duplicati.Library.Utility.Utility.IsClientLinux && !path.StartsWith("/"))
+            if (Duplicati.Library.Utility.Utility.IsClientLinux && !path.StartsWith("/", StringComparison.Ordinal))
             {
                 info.ReportClientError("The path parameter must start with a forward-slash");
                 return;

--- a/Duplicati/UnitTest/SVNCheckoutsTest.cs
+++ b/Duplicati/UnitTest/SVNCheckoutsTest.cs
@@ -269,7 +269,7 @@ namespace Duplicati.UnitTest
 
                                             //Remove all folders from list
                                             for (int j = 0; j < sourcefiles.Count; j++)
-                                                if (sourcefiles[j].EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+                                                if (sourcefiles[j].EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
                                                 {
                                                     sourcefiles.RemoveAt(j);
                                                     j--;
@@ -361,7 +361,7 @@ namespace Duplicati.UnitTest
                             continue;
                         if (s == logfilename)
                             continue;                        
-                        if (s.StartsWith(Utility.AppendDirSeparator(tf)))
+                        if (s.StartsWith(Utility.AppendDirSeparator(tf), StringComparison.Ordinal))
                             continue;
 
                         Log.WriteMessage(string.Format("Found left-over temp file: {0}", s.Substring(tempdir.Length)), LogMessageType.Warning);
@@ -375,7 +375,7 @@ namespace Duplicati.UnitTest
                     }
 
                     foreach (string s in Utility.EnumerateFolders(tempdir))
-                        if (!s.StartsWith(Utility.AppendDirSeparator(tf)) && Utility.AppendDirSeparator(s) != Utility.AppendDirSeparator(tf) && Utility.AppendDirSeparator(s) != Utility.AppendDirSeparator(tempdir))
+                        if (!s.StartsWith(Utility.AppendDirSeparator(tf), StringComparison.Ordinal) && Utility.AppendDirSeparator(s) != Utility.AppendDirSeparator(tf) && Utility.AppendDirSeparator(s) != Utility.AppendDirSeparator(tempdir))
                         {
                             Log.WriteMessage(string.Format("Found left-over temp folder: {0}", s.Substring(tempdir.Length)), LogMessageType.Warning);
                             BasicSetupHelper.ProgressWriteLine("Found left-over temp folder: {0}", s.Substring(tempdir.Length));


### PR DESCRIPTION
This makes many string comparisons use the `StringComparison.Ordinal` comparison, which performs a byte comparison in a culture-insensitive manner.  These string comparisons should not be culture-aware.