### PR TITLE
Fix <param> issues in XML documentation

### DIFF
--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -364,7 +364,6 @@ namespace Duplicati.Library.Backend
         /// We have to check for the exceptions thrown to know about file /folder existence.
         /// Why the funny guys at MS provided an .Exists field stays a mystery...
         /// </summary>
-        /// <param name="fileNameInfo"> the filename  </param>
         private void wrappedExecuteQueryOnConext(SP.ClientContext ctx, string serverRelPathInfo, bool isFolder)
         {
             try { ctx.ExecuteQuery(); }

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -129,7 +129,7 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// Instanciates a specific compression module, given the file extension and options
         /// </summary>
-        /// <param name="fileExtension">The file extension to create the instance for</param>
+        /// <param name="fileextension">The file extension to create the instance for</param>
         /// <param name="filename">The filename of the file used to compress/decompress contents</param>
         /// <param name="options">The options to pass to the instance constructor</param>
         /// <returns>The instanciated compression module or null if the file extension is not supported</returns>

--- a/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
@@ -132,7 +132,7 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// Instanciates a specific encryption module, given the file extension and options
         /// </summary>
-        /// <param name="fileExtension">The file extension to create the instance for</param>
+        /// <param name="fileextension">The file extension to create the instance for</param>
         /// <param name="passphrase">The passphrase used to encrypt contents</param>
         /// <param name="options">The options to pass to the instance constructor</param>
         /// <returns>The instanciated encryption module or null if the file extension is not supported</returns>

--- a/Duplicati/Library/Encryption/AESEncryption.cs
+++ b/Duplicati/Library/Encryption/AESEncryption.cs
@@ -67,7 +67,6 @@ namespace Duplicati.Library.Encryption
         /// <summary>
         /// Constructs a new AES encryption/decyption instance
         /// </summary>
-        /// <param name="key">The key used for encryption. The key gets stretched through SHA hashing to fit the key size requirements</param>
         public AESEncryption(string passphrase, Dictionary<string, string> options)
         {
             if(string.IsNullOrEmpty(passphrase))

--- a/Duplicati/Library/Encryption/GPGEncryption.cs
+++ b/Duplicati/Library/Encryption/GPGEncryption.cs
@@ -222,7 +222,6 @@ namespace Duplicati.Library.Encryption
         /// </summary>
         /// <param name="args">The commandline arguments</param>
         /// <param name="input">The input stream</param>
-        /// <param name="output">The output stream</param>
         private System.IO.Stream Execute(string args, System.IO.Stream input, bool encrypt)
         {
             System.Diagnostics.ProcessStartInfo psi = new System.Diagnostics.ProcessStartInfo();

--- a/Duplicati/Library/Interface/CommandLineArgument.cs
+++ b/Duplicati/Library/Interface/CommandLineArgument.cs
@@ -221,7 +221,6 @@ namespace Duplicati.Library.Interface
         /// <param name="longDescription">The arguments long description</param>
         /// <param name="defaultValue">The default value of the argumen</param>
         /// <param name="aliases">A list of aliases for the command</param>
-        /// <param name="values">A list of valid values for the command</param>
         public CommandLineArgument(string name, ArgumentType type, string shortDescription, string longDescription, string defaultValue, string[] aliases)
             : this(name, type, shortDescription, longDescription, defaultValue)
         {

--- a/Duplicati/Library/Interface/IGenericCallbackModule.cs
+++ b/Duplicati/Library/Interface/IGenericCallbackModule.cs
@@ -32,7 +32,6 @@ namespace Duplicati.Library.Interface
         /// <summary>
         /// Called when the operation finishes
         /// </summary>
-        /// <param name="operationname">The full name of the operation</param>
         /// <param name="result">The result object, if this derives from an exception, the operation failed</param>
         void OnFinish(object result);
     }

--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -275,7 +275,6 @@ namespace Duplicati.Library.Main.Database
         /// Adds a block to the local database, returning a value indicating if the value presents a new block
         /// </summary>
         /// <param name="key">The block key</param>
-        /// <param name="archivename">The name of the archive that holds the data</param>
         /// <returns>True if the block should be added to the current output</returns>
         public bool AddBlock (string key, long size, long volumeid, System.Data.IDbTransaction transaction = null)
         {
@@ -319,8 +318,6 @@ namespace Duplicati.Library.Main.Database
         /// </summary>
         /// <param name="filehash">The hash of the blockset</param>
         /// <param name="size">The size of the blockset</param>
-        /// <param name="fragmentoffset">The fragmentoffset for the last block</param>
-        /// <param name="fragmenthash">The hash of the fragment</param>
         /// <param name="hashes">The list of hashes</param>
         /// <param name="blocksetid">The id of the blockset, new or old</param>
         /// <returns>True if the blockset was created, false otherwise</returns>
@@ -436,7 +433,6 @@ namespace Duplicati.Library.Main.Database
         /// <param name="blocksetID">The ID of the hashkey for the file</param>
         /// <param name="metadataID">The ID for the metadata</param>
         /// <param name="transaction">The transaction to use for insertion, or null for no transaction</param>
-        /// <param name="operationId">The operationId to use, or -1 to use the current operation</param>
         public void AddFile(string filename, DateTime lastmodified, long blocksetID, long metadataID, System.Data.IDbTransaction transaction)
         {            
             var fileidobj = -1L;

--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -393,7 +393,7 @@ namespace Duplicati.Library.Main.Database
         /// <summary>
         /// Adds a metadata set to the database, and returns a value indicating if the record was new
         /// </summary>
-        /// <param name="hash">The metadata hash</param>
+        /// <param name="filehash">The metadata hash</param>
         /// <param name="metadataid">The id of the metadata set</param>
         /// <returns>True if the set was added to the database, false otherwise</returns>
         public bool AddMetadataset(string filehash, long size, int blocksize, IEnumerable<string> blockhashes, IEnumerable<string> blocklisthashes, out long metadataid, System.Data.IDbTransaction transaction = null)

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -63,8 +63,6 @@ namespace Duplicati.Library.Main.Database
         /// <summary>
         /// Creates a new database instance and starts a new operation
         /// </summary>
-        /// <param name="path">The path to the database</param>
-        /// <param name="operation">The name of the operation</param>
         public LocalDatabase(LocalDatabase db)
             : this(db.m_connection)
         {
@@ -77,7 +75,6 @@ namespace Duplicati.Library.Main.Database
         /// <summary>
         /// Creates a new database instance and starts a new operation
         /// </summary>
-        /// <param name="path">The path to the database</param>
         /// <param name="operation">The name of the operation</param>
         public LocalDatabase(System.Data.IDbConnection connection, string operation)
             : this(connection)

--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -304,7 +304,6 @@ namespace Duplicati.Library.Main.Database
         /// <summary>
         /// Builds a lookup table to enable faster response to block queries
         /// </summary>
-        /// <param name="volumename">The name of the volume to prepare for</param>
         public IBlockQuery CreateBlockQueryHelper(Options options, System.Data.IDbTransaction transaction)
         {
             return new BlockQuery(m_connection, options, transaction);

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -1362,7 +1362,7 @@ namespace Duplicati.Library.Main.Operation
         /// Adds a file to the output, 
         /// </summary>
         /// <param name="filename">The name of the file to record</param>
-        /// <param name="lastModified">The value of the lastModified timestamp</param>
+        /// <param name="lastmodified">The value of the lastModified timestamp</param>
         /// <param name="hashlist">The list of hashes that make up the file</param>
         /// <param name="size">The size of the file</param>
         /// <param name="metadata">A lookup table with various metadata values describing the file</param>

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -1339,9 +1339,6 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         /// <param name="filename">The name of the file to record</param>
         /// <param name="lastModified">The value of the lastModified timestamp</param>
-        /// <param name="hashlist">The list of hashes that make up the file</param>
-        /// <param name="size">The size of the file</param>
-        /// <param name="fragmentoffset">The offset into a fragment block where the last few bytes are stored</param>
         /// <param name="metadata">A lookup table with various metadata values describing the file</param>
         private void AddFolderToOutput(BackendManager backend, string filename, DateTime lastModified, IMetahash metadata)
         {
@@ -1354,9 +1351,6 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         /// <param name="filename">The name of the file to record</param>
         /// <param name="lastModified">The value of the lastModified timestamp</param>
-        /// <param name="hashlist">The list of hashes that make up the file</param>
-        /// <param name="size">The size of the file</param>
-        /// <param name="fragmentoffset">The offset into a fragment block where the last few bytes are stored</param>
         /// <param name="metadata">A lookup table with various metadata values describing the file</param>
         private void AddSymlinkToOutput(BackendManager backend, string filename, DateTime lastModified, IMetahash metadata)
         {
@@ -1371,7 +1365,6 @@ namespace Duplicati.Library.Main.Operation
         /// <param name="lastModified">The value of the lastModified timestamp</param>
         /// <param name="hashlist">The list of hashes that make up the file</param>
         /// <param name="size">The size of the file</param>
-        /// <param name="fragmentoffset">The offset into a fragment block where the last few bytes are stored</param>
         /// <param name="metadata">A lookup table with various metadata values describing the file</param>
         private void AddFileToOutput(BackendManager backend, string filename, long size, DateTime lastmodified, IMetahash metadata, IEnumerable<string> hashlist, string filehash, IEnumerable<string> blocklisthashes)
         {

--- a/Duplicati/Library/Snapshots/ISnapshotService.cs
+++ b/Duplicati/Library/Snapshots/ISnapshotService.cs
@@ -97,7 +97,7 @@ namespace Duplicati.Library.Snapshots
         /// Gets a unique hardlink target ID
         /// </summary>
         /// <returns>The hardlink ID</returns>
-        /// <param name="file">The file or folder to examine</param>
+        /// <param name="path">The file or folder to examine</param>
         string HardlinkTargetID(string path);
     }
 }

--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -261,7 +261,7 @@ namespace Duplicati.Library.Snapshots
         /// <summary>
         /// Constructs a new snapshot module using LVM
         /// </summary>
-        /// <param name="folders">The list of folders to create snapshots for</param>
+        /// <param name="sources">The list of folders to create snapshots for</param>
         /// <param name="options">A set of commandline options</param>
         public LinuxSnapshot(string[] sources, Dictionary<string, string> options)
         {
@@ -494,7 +494,7 @@ namespace Duplicati.Library.Snapshots
         /// Gets a unique hardlink target ID
         /// </summary>
         /// <returns>The hardlink ID</returns>
-        /// <param name="file">The file or folder to examine</param>
+        /// <param name="path">The file or folder to examine</param>
         public string HardlinkTargetID(string path)
         {
             var local = ConvertToSnapshotPath(FindSnapShotByLocalPath(path), path);

--- a/Duplicati/Library/Snapshots/NoSnapshot.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshot.cs
@@ -40,7 +40,7 @@ namespace Duplicati.Library.Snapshots
         /// <summary>
         /// Constructs a new backup snapshot, using all the required disks
         /// </summary>
-        /// <param name="sourcepaths">The folders that are about to be backed up</param>
+        /// <param name="sources">The folders that are about to be backed up</param>
         public NoSnapshot(string[] sources)
             : this(sources, new Dictionary<string, string>())
         {
@@ -49,7 +49,7 @@ namespace Duplicati.Library.Snapshots
         /// <summary>
         /// Constructs a new backup snapshot, using all the required disks
         /// </summary>
-        /// <param name="folders">The folders that are about to be backed up</param>
+        /// <param name="sources">The folders that are about to be backed up</param>
         /// <param name="options">A set of system options</param>
         public NoSnapshot(string[] sources, Dictionary<string, string> options)
         {

--- a/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
@@ -83,7 +83,7 @@ namespace Duplicati.Library.Snapshots
         /// Gets a unique hardlink target ID
         /// </summary>
         /// <returns>The hardlink ID</returns>
-        /// <param name="file">The file or folder to examine</param>
+        /// <param name="path">The file or folder to examine</param>
         public override string HardlinkTargetID(string path)
         {
             path = NormalizePath(path);

--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -167,7 +167,7 @@ namespace Duplicati.Library.Snapshots
         /// Gets a unique hardlink target ID
         /// </summary>
         /// <returns>The hardlink ID</returns>
-        /// <param name="file">The file or folder to examine</param>
+        /// <param name="path">The file or folder to examine</param>
         public override string HardlinkTargetID(string path)
         {
             return null;

--- a/Duplicati/Library/Snapshots/Win32USN.cs
+++ b/Duplicati/Library/Snapshots/Win32USN.cs
@@ -526,13 +526,13 @@ namespace Duplicati.Library.Snapshots
         /// Sends the dwIoControlCode to the device specified by hDevice.
         /// </summary>
         /// <param name="hDevice">Safe handle to the device </param>
-        /// <param name="dwIoControlCode">Device IO Control Code to send</param>
-        /// <param name="lpInBuffer">Input buffer if required</param>
+        /// <param name="IoControlCode">Device IO Control Code to send</param>
+        /// <param name="InBuffer">Input buffer if required</param>
         /// <param name="nInBufferSize">Size of input buffer</param>
-        /// <param name="lpOutBuffer">Output buffer if required</param>
+        /// <param name="OutBuffer">Output buffer if required</param>
         /// <param name="nOutBufferSize">Size of output buffer</param>
-        /// <param name="lpBytesReturned">Number of bytes returned in output buffer</param>
-        /// <param name="lpOverlapped">IntPtr to an 'OVERLAPPED' structure</param>
+        /// <param name="pBytesReturned">Number of bytes returned in output buffer</param>
+        /// <param name="overlapped">IntPtr to an 'OVERLAPPED' structure</param>
         /// <returns>'true' if successful, otherwise 'false'</returns>
         [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool DeviceIoControl(
@@ -550,13 +550,13 @@ namespace Duplicati.Library.Snapshots
         /// Sends the dwIoControlCode to the device specified by hDevice.
         /// </summary>
         /// <param name="hDevice">Safe handle to the device </param>
-        /// <param name="dwIoControlCode">Device IO Control Code to send</param>
-        /// <param name="lpInBuffer">Input buffer if required</param>
+        /// <param name="IoControlCode">Device IO Control Code to send</param>
+        /// <param name="InBuffer">Input buffer if required</param>
         /// <param name="nInBufferSize">Size of input buffer</param>
-        /// <param name="lpOutBuffer">Output buffer if required</param>
+        /// <param name="OutBuffer">Output buffer if required</param>
         /// <param name="nOutBufferSize">Size of output buffer</param>
-        /// <param name="lpBytesReturned">Number of bytes returned in output buffer</param>
-        /// <param name="lpOverlapped">IntPtr to an 'OVERLAPPED' structure</param>
+        /// <param name="pBytesReturned">Number of bytes returned in output buffer</param>
+        /// <param name="overlapped">IntPtr to an 'OVERLAPPED' structure</param>
         /// <returns>'true' if successful, otherwise 'false'</returns>
         [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool DeviceIoControl(
@@ -574,13 +574,13 @@ namespace Duplicati.Library.Snapshots
         /// Sends the dwIoControlCode to the device specified by hDevice.
         /// </summary>
         /// <param name="hDevice">Safe handle to the device </param>
-        /// <param name="dwIoControlCode">Device IO Control Code to send</param>
-        /// <param name="lpInBuffer">Input buffer if required</param>
+        /// <param name="IoControlCode">Device IO Control Code to send</param>
+        /// <param name="InBuffer">Input buffer if required</param>
         /// <param name="nInBufferSize">Size of input buffer</param>
-        /// <param name="lpOutBuffer">Output buffer if required</param>
+        /// <param name="OutBuffer">Output buffer if required</param>
         /// <param name="nOutBufferSize">Size of output buffer</param>
-        /// <param name="lpBytesReturned">Number of bytes returned in output buffer</param>
-        /// <param name="lpOverlapped">IntPtr to an 'OVERLAPPED' structure</param>
+        /// <param name="pBytesReturned">Number of bytes returned in output buffer</param>
+        /// <param name="overlapped">IntPtr to an 'OVERLAPPED' structure</param>
         /// <returns>'true' if successful, otherwise 'false'</returns>
         [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool DeviceIoControl(

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -273,7 +273,6 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// Creates a new <see cref="Duplicati.Library.Utility.FilterExpression"/> instance, representing an empty filter.
         /// </summary>
-        /// <param name="filter">The filter string that represents the filter</param>
         public FilterExpression()
             : this((IEnumerable<string>)null, true)
         {

--- a/Duplicati/Library/Utility/ThrottledStream.cs
+++ b/Duplicati/Library/Utility/ThrottledStream.cs
@@ -215,7 +215,6 @@ namespace Duplicati.Library.Utility
 		/// <summary>
 		/// Calculates the speed, and inserts appropriate delays
 		/// </summary>
-		/// <returns>The number of bytes processed while delaying</returns>
 		private void DelayIfRequired(ref long limit, int count, ref DateTime last_sample, ref long last_count, ref double current_speed)
 		{
 			var now = DateTime.Now;

--- a/Duplicati/Library/Utility/ThrottledStream.cs
+++ b/Duplicati/Library/Utility/ThrottledStream.cs
@@ -92,8 +92,6 @@ namespace Duplicati.Library.Utility
 		/// Creates a throttle around a stream.
 		/// </summary>
 		/// <param name="basestream">The stream to throttle</param>
-		/// <param name="readspeed">The maximum number of bytes pr. second to read. Specify a number less than 1 to allow unlimited speed.</param>
-		/// <param name="writespeed">The maximum number of bytes pr. second to write. Specify a number less than 1 to allow unlimited speed.</param>
         public ThrottledStream(Stream basestream, Action<ThrottledStream> updateLimits)
 			: base(basestream)
 		{
@@ -217,10 +215,6 @@ namespace Duplicati.Library.Utility
 		/// <summary>
 		/// Calculates the speed, and inserts appropriate delays
 		/// </summary>
-		/// <param name="read">True if the operation is read, false otherwise</param>
-		/// <param name="buffer">The data buffer</param>
-		/// <param name="offset">The offset into the buffer</param>
-		/// <param name="count">The number of bytes to read or write</param>
 		/// <returns>The number of bytes processed while delaying</returns>
 		private void DelayIfRequired(ref long limit, int count, ref DateTime last_sample, ref long last_count, ref double current_speed)
 		{

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -546,7 +546,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// Calculates the hash of a given stream, and returns the results as an base64 encoded string
         /// </summary>
-        /// <param name="path">The stream to calculate the hash for</param>
+        /// <param name="stream">The stream to calculate the hash for</param>
         /// <returns>The base64 encoded hash</returns>
         public static string CalculateHash(System.IO.Stream stream)
         {

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -132,7 +132,6 @@ namespace Duplicati.Library.Utility
         /// The search is recursive.
         /// </summary>
         /// <param name="basepath">The folder to look in</param>
-        /// <param name="filter">The filter to apply.</param>
         /// <returns>A list of the full filenames</returns>
         public static IEnumerable<string> EnumerateFiles(string basepath)
         {

--- a/Duplicati/Server/LiveControls.cs
+++ b/Duplicati/Server/LiveControls.cs
@@ -163,7 +163,6 @@ namespace Duplicati.Server
         /// <summary>
         /// Constructs a new instance of the LiveControl
         /// </summary>
-        /// <param name="initialTimeout">The duration that the backups should be initially suspended</param>
         public LiveControls(Database.ServerSettings settings)
         {
             m_state = LiveControlState.Running;
@@ -216,7 +215,6 @@ namespace Duplicati.Server
         /// Event that occurs when the timeout duration is exceeded
         /// </summary>
         /// <param name="sender">The sender of the event</param>
-        /// <param name="e">An unused event argument</param>
         private void  m_waitTimer_Tick(object sender)
         {
             lock (m_lock)

--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -73,9 +73,7 @@ namespace Duplicati.Server
         /// <summary>
         /// Constructs a new scheduler
         /// </summary>
-        /// <param name="connection">The database connection</param>
         /// <param name="worker">The worker thread</param>
-        /// <param name="datalock">The database lock object</param>
         public Scheduler(WorkerThread<Server.Runner.IRunnerData> worker)
         {
             m_thread = new Thread(new ThreadStart(Runner));


### PR DESCRIPTION
This fixes a few issues in the C# XML documentation.  There were several places where a `<param>` element corresponding to a non-existent parameter was removed.  We also fixed some of the parameter names to match the names used in the code.