### PR TITLE
Add overload for Utility.ParseBool with lazy default value

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -637,15 +637,17 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Parses a string into a boolean value
+        /// Parses a string into a boolean value.
         /// </summary>
-        /// <param name="value">The value to parse</param>
-        /// <param name="default">The default value, in case the string is not a valid boolean value</param>
-        /// <returns>The parsed value or the default value</returns>
-        public static bool ParseBool(string value, bool @default)
+        /// <param name="value">The value to parse.</param>
+        /// <param name="defaultFunc">A delegate that returns the default value if <paramref name="value"/> is not a valid boolean value.</param>
+        /// <returns>The parsed value, or the value returned by <paramref name="defaultFunc"/>.</returns>
+        public static bool ParseBool(string value, Func<bool> defaultFunc)
         {
-            if (value == null)
-                value = "";
+            if (String.IsNullOrWhiteSpace(value))
+            {
+                return defaultFunc();
+            }
 
             switch (value.Trim().ToLower())
             {
@@ -660,8 +662,19 @@ namespace Duplicati.Library.Utility
                 case "no":
                     return false;
                 default:
-                    return @default;
+                    return defaultFunc();
             }
+        }
+
+        /// <summary>
+        /// Parses a string into a boolean value.
+        /// </summary>
+        /// <param name="value">The value to parse.</param>
+        /// <param name="default">The default value, in case <paramref name="value"/> is not a valid boolean value.</param>
+        /// <returns>The parsed value, or the default value.</returns>
+        public static bool ParseBool(string value, bool @default)
+        {
+            return Utility.ParseBool(value, () => @default);
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -839,18 +839,11 @@ namespace Duplicati.Library.Utility
             {
                 var str = Environment.GetEnvironmentVariable("FILESYSTEM_CASE_SENSITIVE");
 
-                if (!string.IsNullOrWhiteSpace(str))
-                {
-                    str = str.Trim();
-                    if (new[] { "yes", "1", "on", "true" }.Contains(str, StringComparer.OrdinalIgnoreCase))
-                        return true;
-                    if (new[] { "no", "0", "off", "false" }.Contains(str, StringComparer.OrdinalIgnoreCase))
-                        return false;
-                }
-
-                //TODO: This should probably be determined by filesystem rather than OS,
+                // TODO: This should probably be determined by filesystem rather than OS,
                 // OSX can actually have the disks formated as Case Sensitive, but insensitive is default
-                return IsClientLinux && !IsClientOSX;
+                Func<bool> defaultReply = () => Utility.IsClientLinux && !Utility.IsClientOSX;
+
+                return Utility.ParseBool(str, defaultReply);
             }
         }
 

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -60,9 +60,7 @@ namespace Duplicati.UnitTest
         /// this can be used to diagnose errors on a CI build instance by setting
         /// the environment variable DEBUG_OUTPUT=1 and running the job
         /// </summary>
-        public static readonly bool DEBUG_OUTPUT =
-            new[] { "1", "true", "on", "yes" }
-            .Contains(Environment.GetEnvironmentVariable("DEBUG_OUTPUT") ?? "", StringComparer.OrdinalIgnoreCase);
+        public static readonly bool DEBUG_OUTPUT = Library.Utility.Utility.ParseBool(Environment.GetEnvironmentVariable("DEBUG_OUTPUT"), false);
 
         /// <summary>
         /// Writes a message to TestContext.Progress and Console.Out

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -57,5 +57,42 @@ namespace Duplicati.UnitTest
             Assert.IsNotNull(actualUniqueItems);
             Assert.IsNotNull(actualDuplicateItems);
         }
+
+        [Test]
+        [Category("Utility")]
+        public void ParseBool()
+        {
+            string[] expectTrue = { "1", "on", "true", "yes" };
+            string[] expectFalse = { "0", "off", "false", "no" };
+            string[] expectDefault = { null, "", "maybe" };
+            Func<bool> returnsTrue = () => true;
+            Func<bool> returnsFalse = () => false;
+
+            foreach (string value in expectTrue)
+            {
+                string message = $"{value} should be parsed to true.";
+
+                Assert.IsTrue(Utility.ParseBool(value, false), message);
+                Assert.IsTrue(Utility.ParseBool(value.ToUpper(), false), message);
+                Assert.IsTrue(Utility.ParseBool($" {value} ", false), message);
+            }
+
+            foreach (string value in expectFalse)
+            {
+                string message = $"{value} should be parsed to false.";
+
+                Assert.IsFalse(Utility.ParseBool(value, true), message);
+                Assert.IsFalse(Utility.ParseBool(value.ToUpper(), true), message);
+                Assert.IsFalse(Utility.ParseBool($" {value} ", true), message);
+            }
+
+            foreach (string value in expectDefault)
+            {
+                Assert.IsTrue(Utility.ParseBool(value, true));
+                Assert.IsTrue(Utility.ParseBool(value, returnsTrue));
+                Assert.IsFalse(Utility.ParseBool(value, false));
+                Assert.IsFalse(Utility.ParseBool(value, returnsFalse));
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds an overload for the `Utility.ParseBool` method that accepts a `Func<bool>` to determine the default value.  The `Func` is not evaluated unless the default value is required, which is useful in cases where the default value may be expensive to compute (e.g., in `Utility.IsFSCaseSensitive`).

We also make use of the `Utility.ParseBool` method where applicable to reduce some duplication in the code, and added a few tests to verify the behavior.
