### PR TITLE
Compression classes refactoring

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Duplicati.CommandLine.BackendTester.csproj
+++ b/Duplicati/CommandLine/BackendTester/Duplicati.CommandLine.BackendTester.csproj
@@ -18,6 +18,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <UseMSBuildEngine>false</UseMSBuildEngine>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Duplicati/CommandLine/BackendTool/Duplicati.CommandLine.BackendTool.csproj
+++ b/Duplicati/CommandLine/BackendTool/Duplicati.CommandLine.BackendTool.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <UseMSBuildEngine>false</UseMSBuildEngine>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Duplicati/CommandLine/Duplicati.CommandLine.csproj
+++ b/Duplicati/CommandLine/Duplicati.CommandLine.csproj
@@ -19,6 +19,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <UseMSBuildEngine>false</UseMSBuildEngine>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Duplicati/CommandLine/RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
+++ b/Duplicati/CommandLine/RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
@@ -11,6 +11,7 @@
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseMSBuildEngine>false</UseMSBuildEngine>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Duplicati/CommandLine/RecoveryTool/Index.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Index.cs
@@ -49,7 +49,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             ixfile = Path.GetFullPath(ixfile);
             if (!File.Exists(ixfile))
             {
-                using(File.Create(ixfile))
+                using (File.Create(ixfile))
                 {
                 }
             }
@@ -67,7 +67,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             var errors = 0;
             var totalblocks = 0L;
             var files = 0;
-            foreach(var file in Directory.EnumerateFiles(folder))
+            foreach (var file in Directory.EnumerateFiles(folder))
             {
                 Console.Write("{0}: {1}", i, file);
 
@@ -95,11 +95,12 @@ namespace Duplicati.CommandLine.RecoveryTool
                     var filekey = Path.GetFileName(file);
 
                     var blocks = 0;
-                    using(var cp = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, file, options))
-                    using(var tf = new Library.Utility.TempFile())
+                    using (var stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    using (var cp = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, stream, Library.Interface.ArchiveMode.Read, options))
+                    using (var tf = new Library.Utility.TempFile())
                     {
-                        using(var sw = new StreamWriter(tf))
-                            foreach(var f in cp.ListFiles(null))
+                        using (var sw = new StreamWriter(tf))
+                            foreach (var f in cp.ListFiles(null))
                             {
                                 sw.WriteLine("{0}, {1}", Library.Utility.Utility.Base64UrlToBase64Plain(f), filekey);
                                 blocks++;
@@ -121,7 +122,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                         Console.WriteLine(" done!");
                     }
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Console.WriteLine(" error: {0}", ex);
                     errors++;
@@ -142,7 +143,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             try
             {
                 // If the file can fit into memory, this is MUCH faster
-                using(var tfout = new Library.Utility.TempFile())
+                using (var tfout = new Library.Utility.TempFile())
                 {
                     var data = File.ReadAllLines(filein);
                     Array.Sort(data, StringComparer.Ordinal);
@@ -156,8 +157,8 @@ namespace Duplicati.CommandLine.RecoveryTool
             {
             }
 
-            using(var tfin = new Library.Utility.TempFile())
-            using(var tfout = new Library.Utility.TempFile())
+            using (var tfin = new Library.Utility.TempFile())
+            using (var tfout = new Library.Utility.TempFile())
             {
                 long swaps;
 
@@ -167,8 +168,8 @@ namespace Duplicati.CommandLine.RecoveryTool
                 {
                     swaps = 0L;
 
-                    using(var sw = new System.IO.StreamWriter(tfout))
-                    using(var sr = new System.IO.StreamReader(tfin))
+                    using (var sw = new System.IO.StreamWriter(tfout))
+                    using (var sr = new System.IO.StreamReader(tfin))
                     {
                         var c1 = sr.ReadLine();
                         var c2 = sr.ReadLine();
@@ -198,7 +199,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                     File.Copy(tfout, tfin, true);
 
-                } while(swaps > 0);
+                } while (swaps > 0);
 
                 File.Copy(tfout, fileout, true);
             }
@@ -206,16 +207,16 @@ namespace Duplicati.CommandLine.RecoveryTool
 
         private static void MergeFiles(string file1, string file2, string fileout)
         {
-            using(var tf = new Library.Utility.TempFile())
+            using (var tf = new Library.Utility.TempFile())
             {
-                using(var sw = new System.IO.StreamWriter(tf))
-                using(var sr1 = new System.IO.StreamReader(file1))
-                using(var sr2 = new System.IO.StreamReader(file2))
+                using (var sw = new System.IO.StreamWriter(tf))
+                using (var sr1 = new System.IO.StreamReader(file1))
+                using (var sr2 = new System.IO.StreamReader(file2))
                 {
                     var c1 = sr1.ReadLine();
                     var c2 = sr2.ReadLine();
 
-                    while(c1 != null || c2 != null)
+                    while (c1 != null || c2 != null)
                     {
                         var cmp = StringComparer.Ordinal.Compare(c1, c2);
 

--- a/Duplicati/CommandLine/RecoveryTool/List.cs
+++ b/Duplicati/CommandLine/RecoveryTool/List.cs
@@ -44,7 +44,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             if (args.Count == 2)
             {
                 var times = ParseListFiles(folder);
-                foreach(var v in times.Zip(Enumerable.Range(0, times.Length), (a,b) => new KeyValuePair<int, DateTime>(b, a.Key)))
+                foreach (var v in times.Zip(Enumerable.Range(0, times.Length), (a, b) => new KeyValuePair<int, DateTime>(b, a.Key)))
                     Console.WriteLine("{0}: {1}", v.Key, v.Value.ToLocalTime());
             }
             else
@@ -55,7 +55,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 Library.Main.Volumes.VolumeReaderBase.UpdateOptionsFromManifest(p.CompressionModule, file, new Duplicati.Library.Main.Options(options));
 
-                foreach(var f in EnumerateFilesInDList(file, filter, options))
+                foreach (var f in EnumerateFilesInDList(file, filter, options))
                     Console.WriteLine("{0} ({1})", f.Path, Library.Utility.Utility.FormatSizeString(f.Size));
             }
 
@@ -65,9 +65,10 @@ namespace Duplicati.CommandLine.RecoveryTool
         public static IEnumerable<Duplicati.Library.Main.Volumes.IFileEntry> EnumerateFilesInDList(string file, Duplicati.Library.Utility.IFilter filter, Dictionary<string, string> options)
         {
             var p = Library.Main.Volumes.VolumeBase.ParseFilename(file);
-            using(var cm = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, file, options))
-            using(var filesetreader = new Library.Main.Volumes.FilesetVolumeReader(cm, new Duplicati.Library.Main.Options(options)))
-                foreach(var f in filesetreader.Files)
+            using (var fs = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var cm = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, fs, Library.Interface.ArchiveMode.Read, options))
+            using (var filesetreader = new Library.Main.Volumes.FilesetVolumeReader(cm, new Duplicati.Library.Main.Options(options)))
+                foreach (var f in filesetreader.Files)
                 {
                     if (f.Type != Duplicati.Library.Main.FilelistEntryType.File)
                         continue;
@@ -98,9 +99,9 @@ namespace Duplicati.CommandLine.RecoveryTool
             var parsedtime = Library.Utility.Timeparser.ParseTimeInterval(time, DateTime.Now, true);
             var el = (
                 from n in ParseListFiles(folder)
-                 let diff = Math.Abs((n.Key - parsedtime).TotalSeconds)
-                 orderby diff
-                 select n).First();
+                let diff = Math.Abs((n.Key - parsedtime).TotalSeconds)
+                orderby diff
+                select n).First();
 
             Console.WriteLine("Selected time {0}", el.Key);
 

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -100,7 +100,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
             var hashesprblock = blocksize / (blockhasher.HashSize / 8);
 
-            using(var mru = new CompressedFileMRUCache(options))
+            using (var mru = new CompressedFileMRUCache(options))
             {
                 Console.WriteLine("Building lookup table for file hashes");
                 var lookup = new HashLookupHelper(ixfile, mru, (int)blocksize, blockhasher.HashSize / 8);
@@ -111,8 +111,8 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 if (!string.IsNullOrWhiteSpace(targetpath))
                     Console.WriteLine("Computing restore path");
-                
-                foreach(var f in List.EnumerateFilesInDList(filelist, filter, options))
+
+                foreach (var f in List.EnumerateFilesInDList(filelist, filter, options))
                 {
                     if (largestprefix == null)
                     {
@@ -124,7 +124,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                         var parts = f.Path.Split(new char[] { Path.DirectorySeparatorChar });
 
                         var ni = 0;
-                        for(; ni < Math.Min(parts.Length, largestprefixparts.Length); ni++)
+                        for (; ni < Math.Min(parts.Length, largestprefixparts.Length); ni++)
                             if (!Library.Utility.Utility.ClientFilenameStringComparer.Equals(parts[ni], largestprefixparts[ni]))
                                 break;
 
@@ -155,19 +155,19 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 var i = 0L;
                 var errors = 0L;
-                foreach(var f in List.EnumerateFilesInDList(filelist, filter, options))
+                foreach (var f in List.EnumerateFilesInDList(filelist, filter, options))
                 {
                     try
                     {
                         var targetfile = MapToRestorePath(f.Path, largestprefix, targetpath);
                         if (!Directory.Exists(Path.GetDirectoryName(targetfile)))
                             Directory.CreateDirectory(Path.GetDirectoryName(targetfile));
-                            
+
                         Console.Write("{0}: {1} ({2})", i, targetfile, Library.Utility.Utility.FormatSizeString(f.Size));
 
-                        using(var tf = new Library.Utility.TempFile())
+                        using (var tf = new Library.Utility.TempFile())
                         {
-                            using(var sw = File.OpenWrite(tf))
+                            using (var sw = File.OpenWrite(tf))
                             {
                                 if (f.BlocklistHashes == null)
                                 {
@@ -176,7 +176,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                                 else
                                 {
                                     var blhi = 0L;
-                                    foreach(var blh in f.BlocklistHashes)
+                                    foreach (var blh in f.BlocklistHashes)
                                     {
                                         Console.Write(" {0}", blhi);
                                         var blockhashoffset = blhi * hashesprblock * blocksize;
@@ -184,14 +184,14 @@ namespace Duplicati.CommandLine.RecoveryTool
                                         try
                                         {
                                             var bi = 0;
-                                            foreach(var h in lookup.ReadBlocklistHashes(blh))
+                                            foreach (var h in lookup.ReadBlocklistHashes(blh))
                                             {
                                                 try
                                                 {
                                                     sw.Position = blockhashoffset + (bi * blocksize);
                                                     lookup.WriteHash(sw, h);
                                                 }
-                                                catch(Exception ex)
+                                                catch (Exception ex)
                                                 {
                                                     Console.WriteLine("Failed to read hash: {0}{1}{2}", h, Environment.NewLine, ex);
                                                 }
@@ -208,9 +208,9 @@ namespace Duplicati.CommandLine.RecoveryTool
                                     }
                                 }
                             }
-                                
+
                             string fh;
-                            using(var fs = File.OpenRead(tf))
+                            using (var fs = File.OpenRead(tf))
                                 fh = Convert.ToBase64String(filehasher.ComputeHash(fs));
 
                             if (fh == f.Hash)
@@ -288,7 +288,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                 var hashes = 0L;
                 string prev = null;
                 m_indexfile.Position = 0;
-                foreach(var n in AllFileLines())
+                foreach (var n in AllFileLines())
                 {
                     if (n.Key != prev)
                     {
@@ -308,7 +308,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                 var prevoff = 0L;
                 var hc = 0L;
                 m_indexfile.Position = 0;
-                foreach(var n in AllFileLines())
+                foreach (var n in AllFileLines())
                 {
                     if (n.Key != prev)
                     {
@@ -331,9 +331,9 @@ namespace Duplicati.CommandLine.RecoveryTool
                 var max = m_indexfile.Read(m_linebuf, 0, m_linebuf.Length);
                 if (max == 0)
                     return null;
-                
+
                 var lfi = 0;
-                for(int i = 0; i < max; i++)
+                for (int i = 0; i < max; i++)
                     if (m_linebuf[i] == m_newline[lfi])
                     {
                         if (lfi == m_newline.Length - 1)
@@ -352,12 +352,12 @@ namespace Duplicati.CommandLine.RecoveryTool
                         lfi = 0;
                     }
 
-                throw new Exception(string.Format("Unexpected long line starting at offset {0}, read {1} bytes without a newline", p, m_linebuf.Length));                
+                throw new Exception(string.Format("Unexpected long line starting at offset {0}, read {1} bytes without a newline", p, m_linebuf.Length));
             }
 
             private IEnumerable<KeyValuePair<string, string>> AllFileLines()
             {
-                while(true)
+                while (true)
                 {
                     var str = ReadNextLine();
                     if (str == null)
@@ -376,7 +376,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             public IEnumerable<string> ReadBlocklistHashes(string hash)
             {
                 var bytes = ReadHash(hash);
-                for(var i = 0; i < bytes.Length; i += m_hashsize)
+                for (var i = 0; i < bytes.Length; i += m_hashsize)
                     yield return Convert.ToBase64String(bytes, i, m_hashsize);
             }
 
@@ -392,10 +392,10 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 m_indexfile.Position = m_offsets[ix];
 
-                foreach(var v in AllFileLines())
+                foreach (var v in AllFileLines())
                 {
                     if (v.Key == hash)
-                        using(var fs = m_cache.ReadBlock(v.Value, hash))
+                        using (var fs = m_cache.ReadBlock(v.Value, hash))
                         {
                             var buf = new byte[m_blocksize];
                             var l = fs.Read(buf, 0, buf.Length);
@@ -403,8 +403,8 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                             return buf;
                         }
-                    
-                    
+
+
                     if (StringComparer.Ordinal.Compare(hash, v.Key) < 0)
                         break;
                 }
@@ -430,6 +430,7 @@ namespace Duplicati.CommandLine.RecoveryTool
         private class CompressedFileMRUCache : IDisposable
         {
             private Dictionary<string, Library.Interface.ICompression> m_lookup = new Dictionary<string, Duplicati.Library.Interface.ICompression>();
+            private Dictionary<string, Stream> m_streams = new Dictionary<string, Stream>();
             private List<string> m_mru = new List<string>();
             private Dictionary<string, string> m_options;
 
@@ -443,12 +444,13 @@ namespace Duplicati.CommandLine.RecoveryTool
             public Stream ReadBlock(string filename, string hash)
             {
                 Library.Interface.ICompression cf;
-                if (!m_lookup.TryGetValue(filename, out cf))
+                Stream stream;
+                if (!m_lookup.TryGetValue(filename, out cf) || !m_streams.TryGetValue(filename, out stream))
                 {
-                    cf = Library.DynamicLoader.CompressionLoader.GetModule(Path.GetExtension(filename).Trim('.'), filename, m_options);
-                    if (cf == null)
-                        throw new Exception(string.Format("Unable to decompress {0}, no such compression module {1}", filename, Path.GetExtension(filename).Trim('.')));
-                    m_lookup[filename] = cf;
+                    stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
+                    cf = Library.DynamicLoader.CompressionLoader.GetModule(Path.GetExtension(filename).Trim('.'), stream, Library.Interface.ArchiveMode.Read, m_options);
+                    m_lookup[filename] = cf ?? throw new Exception(string.Format("Unable to decompress {0}, no such compression module {1}", filename, Path.GetExtension(filename).Trim('.')));
+                    m_streams[filename] = stream;
                 }
 
                 if (m_mru.Count > 0 && m_mru[0] != filename)
@@ -462,6 +464,8 @@ namespace Duplicati.CommandLine.RecoveryTool
                     var f = m_mru.Last();
                     m_lookup[f].Dispose();
                     m_lookup.Remove(f);
+                    m_streams[f].Dispose();
+                    m_streams.Remove(f);
                     m_mru.Remove(f);
                 }
 
@@ -472,11 +476,16 @@ namespace Duplicati.CommandLine.RecoveryTool
 
             public void Dispose()
             {
-                foreach(var v in m_lookup.Values)
+                foreach (var v in m_lookup.Values)
+                    try { v.Dispose(); }
+                    catch { }
+
+                foreach (var v in m_streams.Values)
                     try { v.Dispose(); }
                     catch { }
 
                 m_lookup = null;
+                m_streams = null;
                 m_mru = null;
             }
 

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -449,7 +449,12 @@ namespace Duplicati.CommandLine.RecoveryTool
                 {
                     stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
                     cf = Library.DynamicLoader.CompressionLoader.GetModule(Path.GetExtension(filename).Trim('.'), stream, Library.Interface.ArchiveMode.Read, m_options);
-                    m_lookup[filename] = cf ?? throw new Exception(string.Format("Unable to decompress {0}, no such compression module {1}", filename, Path.GetExtension(filename).Trim('.')));
+                    if (cf == null)
+                    {
+                        stream.Dispose();
+                        throw new Exception(string.Format("Unable to decompress {0}, no such compression module {1}", filename, Path.GetExtension(filename).Trim('.')));
+                    }
+                    m_lookup[filename] = cf;
                     m_streams[filename] = stream;
                 }
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
@@ -28,6 +28,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <UseMSBuildEngine>false</UseMSBuildEngine>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>bin\Debug</OutputPath>

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -177,8 +177,8 @@ namespace Duplicati.GUI.TrayIcon
             m_toRumps = ch.AsWriteOnly();
 
             WriteChannel(m_rumpsProcess.StandardInput, ch.AsReadOnly());
-            ReadChannel(m_rumpsProcess.StandardOutput);
-            ReadChannel(m_rumpsProcess.StandardError);
+            var standardOutputTask = ReadChannel(m_rumpsProcess.StandardOutput);
+            var standardErrorTask = ReadChannel(m_rumpsProcess.StandardError);
 
             m_toRumps.WriteNoWait(JsonConvert.SerializeObject(new {Action = "background"}));
             //m_toRumps.WriteNoWait(JsonConvert.SerializeObject(new {Action = "setappicon", Image = GetIcon(m_lastIcon)}));

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -724,31 +724,29 @@ namespace Duplicati.Library.AutoUpdater
             var md5 = System.Security.Cryptography.MD5.Create();
             var sha256 = System.Security.Cryptography.SHA256.Create();
 
-            string computeMD5(string path)
-            {
-                using (var fs = System.IO.File.OpenRead(path))
-                    return computeStreamMD5(fs);
-            };
-
-            string computeSHA256(string path)
-            {
-                sha256.Initialize();
-                using (Stream fs = System.IO.File.OpenRead(path))
-                    return computeStreamSHA256(fs);
-            };
-
-            string computeStreamMD5(Stream stream)
+            Func<Stream, string> computeStreamMD5 = (stream) =>
             {
                 md5.Initialize();
                 return Convert.ToBase64String(md5.ComputeHash(stream));
             };
 
-            string computeStreamSHA256(Stream stream)
+            Func<Stream, string> computeStreamSHA256 = (stream) =>
             {
                 sha256.Initialize();
                 return Convert.ToBase64String(sha256.ComputeHash(stream));
             };
 
+            Func<string, string> computeMD5 = (path) =>
+            {
+                using (Stream fs = System.IO.File.OpenRead(path))
+                    return computeStreamMD5(fs);
+            };
+
+            Func<string, string> computeSHA256 = (path) =>
+            {
+                using (Stream fs = System.IO.File.OpenRead(path))
+                    return computeStreamSHA256(fs);
+            };
 
             // Build a zip
             using (var archive_temp_file = new Duplicati.Library.Utility.TempFile())

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Duplicati.Library.Interface;
 
 namespace Duplicati.Library.AutoUpdater
 {
@@ -47,8 +48,8 @@ namespace Duplicati.Library.AutoUpdater
 
         public static readonly string INSTALLDIR;
 
-        private static readonly string INSTALLED_BASE_DIR = 
-            string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME))) 
+        private static readonly string INSTALLED_BASE_DIR =
+            string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)))
             ? System.IO.Path.GetDirectoryName(Duplicati.Library.Utility.Utility.getEntryAssembly().Location)
             : Library.Utility.Utility.ExpandEnvironmentVariables(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)));
 
@@ -87,7 +88,7 @@ namespace Duplicati.Library.AutoUpdater
         /// <summary>
         /// Gets the last version found from an update
         /// </summary>
-        public static UpdateInfo LastUpdateCheckVersion { get; private set; }       
+        public static UpdateInfo LastUpdateCheckVersion { get; private set; }
 
         static UpdaterManager()
         {
@@ -118,7 +119,7 @@ namespace Duplicati.Library.AutoUpdater
                 var programfiles = System.Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
                 // The user can override updates by having a local updates folder
-                var overrides = new List<string>(new string [] {
+                var overrides = new List<string>(new string[] {
                         System.IO.Path.Combine(InstalledBaseDir, "updates"),
                     });
 
@@ -131,7 +132,7 @@ namespace Duplicati.Library.AutoUpdater
                 {
                     if (Library.Utility.Utility.IsClientOSX)
                         overrides.Add(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Application Support", APPNAME, "updates"));
-                
+
                     overrides.Add(System.IO.Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), APPNAME, "updates"));
                 }
 
@@ -173,7 +174,7 @@ namespace Duplicati.Library.AutoUpdater
                             installdir = p;
                             break;
                         }
-            
+
                 if (string.IsNullOrWhiteSpace(installdir))
                     foreach (var p in attempts)
                         if (!string.IsNullOrWhiteSpace(p) && TestDirectoryIsWriteable(p))
@@ -181,7 +182,7 @@ namespace Duplicati.Library.AutoUpdater
                             installdir = p;
                             break;
                         }
-            
+
                 INSTALLDIR = installdir;
             }
             else
@@ -222,7 +223,7 @@ namespace Duplicati.Library.AutoUpdater
                     Displayname = string.IsNullOrWhiteSpace(Duplicati.License.VersionNumbers.TAG) ? "Current" : Duplicati.License.VersionNumbers.TAG,
                     Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(),
                     ReleaseTime = new DateTime(0),
-                    ReleaseType = 
+                    ReleaseType =
 #if DEBUG
                         "Debug"
 #else
@@ -257,13 +258,13 @@ namespace Duplicati.Library.AutoUpdater
                 {
                     var selfversion = TryParseVersion(SelfVersion.Version);
 
-                    m_hasUpdateInstalled = 
+                    m_hasUpdateInstalled =
                         (from n in FindInstalledVersions()
-                            let nversion = TryParseVersion(n.Value.Version)
-                            let newerVersion = selfversion < nversion
-                            where newerVersion && VerifyUnpackedFolder(n.Key, n.Value)
-                            orderby nversion descending
-                            select n)
+                         let nversion = TryParseVersion(n.Value.Version)
+                         let newerVersion = selfversion < nversion
+                         where newerVersion && VerifyUnpackedFolder(n.Key, n.Value)
+                         orderby nversion descending
+                         select n)
                             .FirstOrDefault();
                 }
 
@@ -278,11 +279,11 @@ namespace Duplicati.Library.AutoUpdater
 
             if (!System.IO.Directory.Exists(probe))
             {
-                try 
+                try
                 {
                     System.IO.Directory.CreateDirectory(probe);
                     if (probe != path)
-                        System.IO.Directory.Delete(probe);       
+                        System.IO.Directory.Delete(probe);
                     return true;
                 }
                 catch
@@ -296,20 +297,20 @@ namespace Duplicati.Library.AutoUpdater
         public static string InstallID
         {
             get
-            { 
-                try { return System.IO.File.ReadAllText(System.IO.Path.Combine(INSTALLDIR, INSTALL_FILE)).Replace('\r', '\n').Split(new char[] { '\n' }).FirstOrDefault().Trim() ?? ""; } 
+            {
+                try { return System.IO.File.ReadAllText(System.IO.Path.Combine(INSTALLDIR, INSTALL_FILE)).Replace('\r', '\n').Split(new char[] { '\n' }).FirstOrDefault().Trim() ?? ""; }
                 catch { }
 
                 return "";
             }
         }
-            
+
         public static UpdateInfo CheckForUpdate(ReleaseType channel = ReleaseType.Unknown)
         {
             if (channel == ReleaseType.Unknown)
                 channel = AutoUpdateSettings.DefaultUpdateChannel;
 
-            foreach(var rawurl in MANIFEST_URLS)
+            foreach (var rawurl in MANIFEST_URLS)
             {
                 var url = rawurl;
 
@@ -332,17 +333,17 @@ namespace Duplicati.Library.AutoUpdater
 
                 try
                 {
-                    using(var tmpfile = new Library.Utility.TempFile())
+                    using (var tmpfile = new Library.Utility.TempFile())
                     {
                         System.Net.WebClient wc = new System.Net.WebClient();
                         wc.Headers.Add(System.Net.HttpRequestHeader.UserAgent, string.Format("{0} v{1}{2}", APPNAME, SelfVersion.Version, string.IsNullOrWhiteSpace(InstallID) ? "" : " -" + InstallID));
                         wc.Headers.Add("X-Install-ID", InstallID);
                         wc.DownloadFile(url, tmpfile);
 
-                        using(var fs = System.IO.File.OpenRead(tmpfile))
-                        using(var ss = new SignatureReadingStream(fs, SIGN_KEY))
-                        using(var tr = new System.IO.StreamReader(ss))
-                        using(var jr = new Newtonsoft.Json.JsonTextReader(tr))
+                        using (var fs = System.IO.File.OpenRead(tmpfile))
+                        using (var ss = new SignatureReadingStream(fs, SIGN_KEY))
+                        using (var tr = new System.IO.StreamReader(ss))
+                        using (var jr = new Newtonsoft.Json.JsonTextReader(tr))
                         {
                             var update = new Newtonsoft.Json.JsonSerializer().Deserialize<UpdateInfo>(jr);
 
@@ -384,10 +385,10 @@ namespace Duplicati.Library.AutoUpdater
             {
                 try
                 {
-                    using(var fs = System.IO.File.OpenRead(manifest))
-                    using(var ss = new SignatureReadingStream(fs, SIGN_KEY))
-                    using(var tr = new System.IO.StreamReader(ss))
-                    using(var jr = new Newtonsoft.Json.JsonTextReader(tr))
+                    using (var fs = System.IO.File.OpenRead(manifest))
+                    using (var ss = new SignatureReadingStream(fs, SIGN_KEY))
+                    using (var tr = new System.IO.StreamReader(ss))
+                    using (var jr = new Newtonsoft.Json.JsonTextReader(tr))
                         return new Newtonsoft.Json.JsonSerializer().Deserialize<UpdateInfo>(jr);
                 }
                 catch (Exception ex)
@@ -404,7 +405,7 @@ namespace Duplicati.Library.AutoUpdater
         {
             var res = new List<KeyValuePair<string, UpdateInfo>>();
             if (INSTALLDIR != null)
-                foreach(var folder in System.IO.Directory.GetDirectories(INSTALLDIR))
+                foreach (var folder in System.IO.Directory.GetDirectories(INSTALLDIR))
                 {
                     var r = ReadInstalledManifest(folder);
                     if (r != null)
@@ -429,20 +430,20 @@ namespace Duplicati.Library.AutoUpdater
                 var packagepath = new Library.Utility.Uri(updates[0]).Path;
                 var packagename = packagepath.Split('/').Last();
 
-                foreach(var alt_url in AutoUpdateSettings.URLs.Reverse())
+                foreach (var alt_url in AutoUpdateSettings.URLs.Reverse())
                 {
                     var alt_uri = new Library.Utility.Uri(alt_url);
                     var path_components = alt_uri.Path.Split('/');
-                    var path = string.Join("/", path_components.Take(path_components.Count() - 1).Union(new string[] { packagename}));
+                    var path = string.Join("/", path_components.Take(path_components.Count() - 1).Union(new string[] { packagename }));
 
                     var new_path = alt_uri.SetPath(path);
                     updates.Insert(0, new_path.ToString());
                 }
             }
 
-            using(var tempfile = new Library.Utility.TempFile())
+            using (var tempfile = new Library.Utility.TempFileStream())
             {
-                foreach(var url in updates)
+                foreach (var url in updates)
                 {
                     try
                     {
@@ -455,36 +456,35 @@ namespace Duplicati.Library.AutoUpdater
                         wreq.Headers.Add("X-Install-ID", InstallID);
 
                         var areq = new Duplicati.Library.Utility.AsyncHttpRequest(wreq);
-                        using(var resp = areq.GetResponse())
-                        using(var rss = areq.GetResponseStream())
-                        using(var pgs = new Duplicati.Library.Utility.ProgressReportingStream(rss, version.CompressedSize, cb))
-                        using(var fs = System.IO.File.Open(tempfile, System.IO.FileMode.Create))
-                            Duplicati.Library.Utility.Utility.CopyStream(pgs, fs);
+                        using (var resp = areq.GetResponse())
+                        using (var rss = areq.GetResponseStream())
+                        using (var pgs = new Duplicati.Library.Utility.ProgressReportingStream(rss, version.CompressedSize, cb))
+                        {
+                            Duplicati.Library.Utility.Utility.CopyStream(pgs, tempfile);
+                        }
 
                         var sha256 = System.Security.Cryptography.SHA256.Create();
-                        var md5 =  System.Security.Cryptography.MD5.Create();
+                        var md5 = System.Security.Cryptography.MD5.Create();
 
-                        using(var s = System.IO.File.OpenRead(tempfile))
-                        {
-                            if (s.Length != version.CompressedSize)
-                                throw new Exception(string.Format("Invalid file size {0}, expected {1} for {2}", s.Length, version.CompressedSize, url));
-                            
-                            var sha256hash = Convert.ToBase64String(sha256.ComputeHash(s));
-                            if (sha256hash != version.SHA256)
-                                throw new Exception(string.Format("Damaged or corrupted file, sha256 mismatch for {0}", url));
-                        }
+                        if (tempfile.Length != version.CompressedSize)
+                            throw new Exception(string.Format("Invalid file size {0}, expected {1} for {2}", tempfile.Length, version.CompressedSize, url));
 
-                        using(var s = System.IO.File.OpenRead(tempfile))
+                        tempfile.Position = 0;
+                        var sha256hash = Convert.ToBase64String(sha256.ComputeHash(tempfile));
+                        if (sha256hash != version.SHA256)
+                            throw new Exception(string.Format("Damaged or corrupted file, sha256 mismatch for {0}", url));
+
+
+                        tempfile.Position = 0;
+                        var md5hash = Convert.ToBase64String(md5.ComputeHash(tempfile));
+                        if (md5hash != version.MD5)
+                            throw new Exception(string.Format("Damaged or corrupted file, md5 mismatch for {0}", url));
+
+                        tempfile.Position = 0;
+                        using (var tempfolder = new Duplicati.Library.Utility.TempFolder())
+                        using (ICompression zip = new Duplicati.Library.Compression.FileArchiveZip(tempfile, ArchiveMode.Read, new Dictionary<string, string>()))
                         {
-                            var md5hash = Convert.ToBase64String(md5.ComputeHash(s));
-                            if (md5hash != version.MD5)
-                                throw new Exception(string.Format("Damaged or corrupted file, md5 mismatch for {0}", url));
-                        }
-                        
-                        using(var tempfolder = new Duplicati.Library.Utility.TempFolder())
-                        using(var zip = new Duplicati.Library.Compression.FileArchiveZip(tempfile, new Dictionary<string, string>()))
-                        {
-                            foreach(var file in zip.ListFilesWithSize(""))
+                            foreach (var file in zip.ListFilesWithSize(""))
                             {
                                 if (System.IO.Path.IsPathRooted(file.Key) || file.Key.Trim().StartsWith("..", StringComparison.OrdinalIgnoreCase))
                                     throw new Exception(string.Format("Out-of-place file path detected: {0}", file.Key));
@@ -494,8 +494,8 @@ namespace Duplicati.Library.AutoUpdater
                                 if (!System.IO.Directory.Exists(targetfolder))
                                     System.IO.Directory.CreateDirectory(targetfolder);
 
-                                using(var zs = zip.OpenRead(file.Key))
-                                using(var fs = System.IO.File.Create(targetpath))
+                                using (var zs = zip.OpenRead(file.Key))
+                                using (var fs = System.IO.File.Create(targetpath))
                                     zs.CopyTo(fs);
                             }
 
@@ -505,7 +505,7 @@ namespace Duplicati.Library.AutoUpdater
                                 var targetfolder = System.IO.Path.Combine(INSTALLDIR, versionstring);
                                 if (System.IO.Directory.Exists(targetfolder))
                                     System.IO.Directory.Delete(targetfolder, true);
-                                
+
                                 System.IO.Directory.CreateDirectory(targetfolder);
 
                                 var tempfolderpath = Duplicati.Library.Utility.Utility.AppendDirSeparator(tempfolder);
@@ -514,7 +514,7 @@ namespace Duplicati.Library.AutoUpdater
                                 // Would be nice, but does not work :(
                                 //System.IO.Directory.Move(tempfolder, targetfolder);
 
-                                foreach(var e in Duplicati.Library.Utility.Utility.EnumerateFileSystemEntries(tempfolder))
+                                foreach (var e in Duplicati.Library.Utility.Utility.EnumerateFileSystemEntries(tempfolder))
                                 {
                                     var relpath = e.Substring(tempfolderlength);
                                     if (string.IsNullOrWhiteSpace(relpath))
@@ -530,16 +530,16 @@ namespace Duplicati.Library.AutoUpdater
                                 // Verification will kick in when we list the installed updates
                                 //VerifyUnpackedFolder(targetfolder, version);
                                 System.IO.File.WriteAllText(System.IO.Path.Combine(INSTALLDIR, CURRENT_FILE), versionstring);
-                                 
+
                                 m_hasUpdateInstalled = null;
 
                                 var obsolete = (from n in FindInstalledVersions()
-                                    where n.Value.Version != version.Version && n.Value.Version != SelfVersion.Version
-                                    let x = TryParseVersion(n.Value.Version) 
-                                    orderby x descending
-                                    select n).Skip(1).ToArray();
+                                                where n.Value.Version != version.Version && n.Value.Version != SelfVersion.Version
+                                                let x = TryParseVersion(n.Value.Version)
+                                                orderby x descending
+                                                select n).Skip(1).ToArray();
 
-                                foreach(var f in obsolete)
+                                foreach (var f in obsolete)
                                     try { System.IO.Directory.Delete(f.Key, true); }
                                     catch { }
 
@@ -551,7 +551,7 @@ namespace Duplicati.Library.AutoUpdater
                             }
                         }
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
                         if (OnError != null)
                             OnError(ex);
@@ -572,11 +572,11 @@ namespace Duplicati.Library.AutoUpdater
                 var sha256 = System.Security.Cryptography.SHA256.Create();
                 var md5 = System.Security.Cryptography.MD5.Create();
 
-                using(var fs = System.IO.File.OpenRead(System.IO.Path.Combine(folder, UPDATE_MANIFEST_FILENAME)))
+                using (var fs = System.IO.File.OpenRead(System.IO.Path.Combine(folder, UPDATE_MANIFEST_FILENAME)))
                 {
-                    using(var ss = new SignatureReadingStream(fs, SIGN_KEY))
-                    using(var tr = new System.IO.StreamReader(ss))
-                    using(var jr = new Newtonsoft.Json.JsonTextReader(tr))
+                    using (var ss = new SignatureReadingStream(fs, SIGN_KEY))
+                    using (var tr = new System.IO.StreamReader(ss))
+                    using (var jr = new Newtonsoft.Json.JsonTextReader(tr))
                         update = new Newtonsoft.Json.JsonSerializer().Deserialize<UpdateInfo>(jr);
 
                     sha256.Initialize();
@@ -607,7 +607,7 @@ namespace Duplicati.Library.AutoUpdater
                 folder = Library.Utility.Utility.AppendDirSeparator(folder);
                 var baselen = folder.Length;
 
-                foreach(var file in Library.Utility.Utility.EnumerateFileSystemEntries(folder))
+                foreach (var file in Library.Utility.Utility.EnumerateFileSystemEntries(folder))
                 {
                     var relpath = file.Substring(baselen);
                     if (string.IsNullOrWhiteSpace(relpath))
@@ -620,7 +620,7 @@ namespace Duplicati.Library.AutoUpdater
                     if (!paths.TryGetValue(relpath, out fe))
                     {
                         var ignore = false;
-                        foreach(var c in ignores)
+                        foreach (var c in ignores)
                             if (ignore = relpath.StartsWith(c, Library.Utility.Utility.ClientFilenameStringComparision))
                                 break;
 
@@ -638,7 +638,7 @@ namespace Duplicati.Library.AutoUpdater
                     sha256.Initialize();
                     md5.Initialize();
 
-                    using(var fs = System.IO.File.OpenRead(file))
+                    using (var fs = System.IO.File.OpenRead(file))
                     {
                         if (Convert.ToBase64String(sha256.ComputeHash(fs)) != fe.SHA256)
                             throw new Exception(string.Format("Invalid sha256 hash for file: {0}", file));
@@ -690,11 +690,11 @@ namespace Duplicati.Library.AutoUpdater
 
             var manifestpath = manifest ?? System.IO.Path.Combine(inputfolder, UPDATE_MANIFEST_FILENAME);
 
-            using(var s = System.IO.File.OpenRead(manifestpath))
-            using(var sr = new System.IO.StreamReader(s))
-            using(var jr = new Newtonsoft.Json.JsonTextReader(sr))
+            using (var s = System.IO.File.OpenRead(manifestpath))
+            using (var sr = new System.IO.StreamReader(s))
+            using (var jr = new Newtonsoft.Json.JsonTextReader(sr))
                 remoteManifest = new Newtonsoft.Json.JsonSerializer().Deserialize<UpdateInfo>(jr);
-            
+
             if (remoteManifest.Files == null)
                 remoteManifest.Files = new FileEntry[0];
 
@@ -702,8 +702,8 @@ namespace Duplicati.Library.AutoUpdater
                 remoteManifest.ReleaseTime = DateTime.UtcNow;
 
             var ignoreFiles = (from n in remoteManifest.Files
-                                        where n.Ignore
-                                        select n).ToArray();
+                               where n.Ignore
+                               select n).ToArray();
 
             var ignoreMap = ignoreFiles.ToDictionary(k => k.Path, k => "", Duplicati.Library.Utility.Utility.ClientFilenameStringComparer);
 
@@ -724,60 +724,75 @@ namespace Duplicati.Library.AutoUpdater
             var md5 = System.Security.Cryptography.MD5.Create();
             var sha256 = System.Security.Cryptography.SHA256.Create();
 
-            Func<string, string> computeMD5 = (path) =>
+            string computeMD5(string path)
             {
-                md5.Initialize();
-                using(var fs = System.IO.File.OpenRead(path))
-                    return Convert.ToBase64String(md5.ComputeHash(fs));
+                using (var fs = System.IO.File.OpenRead(path))
+                    return computeStreamMD5(fs);
             };
 
-            Func<string, string> computeSHA256 = (path) =>
+            string computeSHA256(string path)
             {
                 sha256.Initialize();
-                using(var fs = System.IO.File.OpenRead(path))
-                    return Convert.ToBase64String(sha256.ComputeHash(fs));
+                using (Stream fs = System.IO.File.OpenRead(path))
+                    return computeStreamSHA256(fs);
             };
 
-            // Build a zip
-            using (var archive_temp = new Duplicati.Library.Utility.TempFile())
+            string computeStreamMD5(Stream stream)
             {
-                using (var zipfile = new Duplicati.Library.Compression.FileArchiveZip(archive_temp, new Dictionary<string, string>()))
+                md5.Initialize();
+                return Convert.ToBase64String(md5.ComputeHash(stream));
+            };
+
+            string computeStreamSHA256(Stream stream)
+            {
+                sha256.Initialize();
+                return Convert.ToBase64String(sha256.ComputeHash(stream));
+            };
+
+
+            // Build a zip
+            using (var archive_temp_file = new Duplicati.Library.Utility.TempFile())
+            {
+                using (var archive_temp = new Duplicati.Library.Utility.TempFileStream(archive_temp_file))
                 {
-                    Func<string, string, bool> addToArchive = (path, relpath) =>
+                    using (ICompression zipfile = new Duplicati.Library.Compression.FileArchiveZip(archive_temp, ArchiveMode.Write, new Dictionary<string, string>()))
                     {
-                        if (ignoreMap.ContainsKey(relpath))
-                            return false;
-                    
-                        if (path.EndsWith(dirsep, StringComparison.Ordinal))
-                            return true;
-
-                        using (var source = System.IO.File.OpenRead(path))
-                        using (var target = zipfile.CreateFile(relpath, 
-                                           Duplicati.Library.Interface.CompressionHint.Compressible,
-                                           System.IO.File.GetLastAccessTimeUtc(path)))
+                        Func<string, string, bool> addToArchive = (path, relpath) =>
                         {
-                            source.CopyTo(target);
-                            remoteManifest.UncompressedSize += source.Length;
-                        }
+                            if (ignoreMap.ContainsKey(relpath))
+                                return false;
 
-                        return true;
-                    };
-                        
-                    // Build the update manifest
-                    localManifest.Files =
-                (from fse in Duplicati.Library.Utility.Utility.EnumerateFileSystemEntries(inputfolder)
-                                let relpath = fse.Substring(baselen)
-                                where addToArchive(fse, relpath)
-                                select new FileEntry() {
-                        Path = relpath,
-                        LastWriteTime = System.IO.File.GetLastAccessTimeUtc(fse),
-                        MD5 = fse.EndsWith(dirsep, StringComparison.Ordinal) ? null : computeMD5(fse),
-                        SHA256 = fse.EndsWith(dirsep, StringComparison.Ordinal) ? null : computeSHA256(fse)
-                    })
-                .Union(ignoreFiles).ToArray();
+                            if (path.EndsWith(dirsep, StringComparison.Ordinal))
+                                return true;
 
-                    // Write a signed manifest with the files
-                
+                            using (var source = System.IO.File.OpenRead(path))
+                            using (var target = zipfile.CreateFile(relpath,
+                                               Duplicati.Library.Interface.CompressionHint.Compressible,
+                                               System.IO.File.GetLastAccessTimeUtc(path)))
+                            {
+                                source.CopyTo(target);
+                                remoteManifest.UncompressedSize += source.Length;
+                            }
+
+                            return true;
+                        };
+
+                        // Build the update manifest
+                        localManifest.Files =
+                    (from fse in Duplicati.Library.Utility.Utility.EnumerateFileSystemEntries(inputfolder)
+                     let relpath = fse.Substring(baselen)
+                     where addToArchive(fse, relpath)
+                     select new FileEntry()
+                     {
+                         Path = relpath,
+                         LastWriteTime = System.IO.File.GetLastAccessTimeUtc(fse),
+                         MD5 = fse.EndsWith(dirsep, StringComparison.Ordinal) ? null : computeMD5(fse),
+                         SHA256 = fse.EndsWith(dirsep, StringComparison.Ordinal) ? null : computeSHA256(fse)
+                     })
+                    .Union(ignoreFiles).ToArray();
+
+                        // Write a signed manifest with the files
+
                         using (var ms = new System.IO.MemoryStream())
                         using (var sw = new System.IO.StreamWriter(ms))
                         {
@@ -788,26 +803,26 @@ namespace Duplicati.Library.AutoUpdater
                             {
                                 SignatureReadingStream.CreateSignedStream(ms, ms2, key);
                                 ms2.Position = 0;
-                                using (var sigfile = zipfile.CreateFile(UPDATE_MANIFEST_FILENAME, 
+                                using (var sigfile = zipfile.CreateFile(UPDATE_MANIFEST_FILENAME,
                                     Duplicati.Library.Interface.CompressionHint.Compressible,
                                     DateTime.UtcNow))
                                     ms2.CopyTo(sigfile);
 
                             }
                         }
+                    }
+
+                    archive_temp.Position = 0;
+                    remoteManifest.CompressedSize = archive_temp.Length;
+                    remoteManifest.MD5 = computeStreamMD5(archive_temp);
+                    remoteManifest.SHA256 = computeStreamSHA256(archive_temp);
                 }
-
-                remoteManifest.CompressedSize = new System.IO.FileInfo(archive_temp).Length;
-                remoteManifest.MD5 = computeMD5(archive_temp);
-                remoteManifest.SHA256 = computeSHA256(archive_temp);
-
-                System.IO.File.Move(archive_temp, System.IO.Path.Combine(outputfolder, "package.zip"));
-
+                System.IO.File.Move(archive_temp_file, System.IO.Path.Combine(outputfolder, "package.zip"));
             }
 
             // Write a signed manifest for upload
 
-            using(var tf = new Duplicati.Library.Utility.TempFile())
+            using (var tf = new Duplicati.Library.Utility.TempFile())
             {
                 using (var ms = new System.IO.MemoryStream())
                 using (var sw = new System.IO.StreamWriter(ms))
@@ -997,7 +1012,7 @@ namespace Duplicati.Library.AutoUpdater
                         string.Format("{0}-crashlog.txt", AutoUpdateSettings.AppName)
                      );
 
-                     System.IO.File.WriteAllText(report_file, tex.ToString());
+                    System.IO.File.WriteAllText(report_file, tex.ToString());
                 }
                 catch
                 {
@@ -1090,7 +1105,7 @@ namespace Duplicati.Library.AutoUpdater
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
-                    ErrorDialog = false,                    
+                    ErrorDialog = false,
                 };
                 pi.EnvironmentVariables.Clear();
 
@@ -1200,7 +1215,7 @@ namespace Duplicati.Library.AutoUpdater
 
                 try { AppDomain.Unload(domain); }
                 catch (Exception ex)
-                { 
+                {
                     Console.WriteLine("Appdomain unload error: {0}", ex);
                 }
 
@@ -1220,7 +1235,7 @@ namespace Duplicati.Library.AutoUpdater
 
                             if (!System.IO.Path.IsPathRooted(app))
                                 app = System.IO.Path.Combine(InstalledBaseDir, app);
-                            
+
 
                             // Re-launch but give the OS a little time to fully unload all open handles, etc.                        
                             var si = new System.Diagnostics.ProcessStartInfo(app, args);

--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.Backend
                 string path = String.Format("{0}/{1}", m_path, remotename);
                 dbx.Delete(path);
             }
-            catch (DropboxException de)
+            catch (DropboxException)
             {
                 // we can catch some events here and convert them to Duplicati exceptions
                 throw;
@@ -163,7 +163,7 @@ namespace Duplicati.Library.Backend
                 string path = string.Format("{0}/{1}", m_path, remotename);
                 dbx.UploadFile(path, stream);
             }
-            catch (DropboxException de)
+            catch (DropboxException)
             {
                 // we can catch some events here and convert them to Duplicati exceptions
                 throw;
@@ -177,7 +177,7 @@ namespace Duplicati.Library.Backend
                 string path = string.Format("{0}/{1}", m_path, remotename);
                 dbx.DownloadFile(path, stream);
             }
-            catch (DropboxException de)
+            catch (DropboxException)
             {
                 // we can catch some events here and convert them to Duplicati exceptions
                 throw;

--- a/Duplicati/Library/Compression/SevenZipCompression.cs
+++ b/Duplicati/Library/Compression/SevenZipCompression.cs
@@ -2,17 +2,17 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.Library.Compression
 {
-    public class SevenZipCompression: ICompressionHinting
+    public class SevenZipCompression : ICompressionHinting
     {
         // next file starts a new stream if the previous stream is larger than this
         private const int kStreamThreshold = 1 << 20; // 1 MB
 
-        private FileStream m_file;
+        private Stream m_stream;
         private ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter m_writer;
         private ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter.PlainEncoder m_copyEncoder;
         private ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter.ThreadedEncoder m_lzma2Encoder;
@@ -33,9 +33,9 @@ namespace Duplicati.Library.Compression
             get { return m_lowOverheadMode; }
             set
             {
-                if(m_lowOverheadMode != value)
+                if (m_lowOverheadMode != value)
                 {
-                    if(m_lzma2Encoder != null)
+                    if (m_lzma2Encoder != null)
                         throw new NotSupportedException("Cannot change LowOverheadMode after writing has started.");
 
                     m_lowOverheadMode = value;
@@ -50,29 +50,46 @@ namespace Duplicati.Library.Compression
 
         /// <summary>
         /// Constructs a new zip instance.
-        /// If the file exists and has a non-zero length we read it,
-        /// otherwise we create a new archive.
+        /// Access mode is specified by mode parameter.
+        /// Note that stream would not be disposed by FileArchiveZip instance so
+        /// you may reuse it and have to dispose it yourself.
         /// </summary>
-        /// <param name="filename">The name of the file to read or write</param>
+        /// <param name="stream">The stream to read or write depending access mode</param>
+        /// <param name="mode">The archive acces mode</param>
         /// <param name="options">The options passed on the commandline</param>
-        public SevenZipCompression(string filename, Dictionary<string, string> options)
+        public SevenZipCompression(Stream stream, ArchiveMode mode, IDictionary<string, string> options)
+        {
+            InitializeCompression(options);
+            // Preventing the stream being closed by ArchiveWriter so it could be reused.
+            // Required for using with MemoryStream.
+            m_stream = new ShaderStream(stream, true);
+            if (mode == ArchiveMode.Write)
+                InitializeArchiveWriter();
+            else
+            {
+                stream.Position = 0;
+                InitializeArchiveReader();
+            }
+        }
+
+        private void InitializeCompression(IDictionary<string, string> options)
         {
             m_threadCount = DEFAULT_THREAD_COUNT;
 
             string threadCountSetting;
             int threadCountValue;
-            if(options != null
+            if (options != null
                 && options.TryGetValue(THREAD_COUNT_OPTION, out threadCountSetting)
                 && Int32.TryParse(threadCountSetting, out threadCountValue)
                 && threadCountValue > 0)
             {
                 // arbitrary limit to avoid stupid mistakes
-                if(threadCountValue > MAX_THREAD_COUNT)
+                if (threadCountValue > MAX_THREAD_COUNT)
                     threadCountValue = MAX_THREAD_COUNT;
 
                 m_threadCount = threadCountValue;
             }
-                
+
             string cplvl;
             int tmplvl;
             if (options.TryGetValue(COMPRESSION_LEVEL_OPTION, out cplvl) && int.TryParse(cplvl, out tmplvl))
@@ -85,67 +102,59 @@ namespace Duplicati.Library.Compression
 
             m_encoderProps.mLzmaProps.mLevel = tmplvl;
             m_encoderProps.mLzmaProps.mAlgo = Library.Utility.Utility.ParseBoolOption(options, COMPRESSION_FASTALGO_OPTION) ? 0 : 1;
-                
-            var file = new FileInfo(filename);
-            if(file.Exists && file.Length > 0)
-                InitializeArchiveReader(filename);
-            else
-                InitializeArchiveWriter(filename);
         }
 
-        private void InitializeArchiveReader(string file)
+        private void InitializeArchiveReader()
         {
-            m_file = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
             m_archive = new master._7zip.Legacy.CArchiveDatabaseEx();
             m_reader = new master._7zip.Legacy.ArchiveReader();
-            m_reader.Open(m_file);
+            m_reader.Open(m_stream);
             m_reader.ReadDatabase(m_archive, null);
             m_archive.Fill();
         }
 
-        private void InitializeArchiveWriter(string file)
+        private void InitializeArchiveWriter()
         {
-            m_file = new FileStream(file, FileMode.Create, FileAccess.Write, FileShare.Delete);
-            m_writer = new ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter(m_file);
+            m_writer = new ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter(m_stream);
         }
 
         public void Dispose()
         {
-            if(m_archive != null)
+            if (m_archive != null)
                 m_archive = null;
 
-            if(m_reader != null)
+            if (m_reader != null)
                 try { m_reader.Close(); }
                 finally { m_reader = null; }
 
-            if(m_writer != null)
+            if (m_writer != null)
             {
                 try
                 {
-                    if(m_copyEncoder != null)
+                    if (m_copyEncoder != null)
                         try
                         {
                             m_writer.ConnectEncoder(m_copyEncoder);
                             m_copyEncoder.Dispose();
                         }
                         finally { m_copyEncoder = null; }
-    
-                    if(m_lzma2Encoder != null)
+
+                    if (m_lzma2Encoder != null)
                         try
                         {
                             m_writer.ConnectEncoder(m_lzma2Encoder);
                             m_lzma2Encoder.Dispose();
                         }
                         finally { m_lzma2Encoder = null; }
-    
+
                     m_writer.WriteFinalHeader();
                 }
                 finally { m_writer = null; }
             }
 
-            if(m_file != null)
-                try { m_file.Dispose(); }
-                finally { m_file = null; }
+            if (m_stream != null)
+                try { m_stream.Dispose(); }
+                finally { m_stream = null; }
         }
 
         #region ICompression - Reader Methods
@@ -162,26 +171,26 @@ namespace Duplicati.Library.Compression
 
         public IEnumerable<KeyValuePair<string, long>> ListFilesWithSize(string prefix)
         {
-            if(m_reader == null)
+            if (m_reader == null)
                 throw new InvalidOperationException(Strings.SevenZipCompression.NoReaderError);
 
             StringComparison sc = Library.Utility.Utility.ClientFilenameStringComparision;
 
-            return 
+            return
                 from n in m_reader.GetFiles(m_archive)
-                    where 
-                        !n.IsDir &&
-                        (prefix == null || n.Name.StartsWith(prefix, sc))
-                        select new KeyValuePair<string, long>(n.Name, n.Size);
+                where
+                    !n.IsDir &&
+                    (prefix == null || n.Name.StartsWith(prefix, sc))
+                select new KeyValuePair<string, long>(n.Name, n.Size);
         }
-        
+
         public DateTime GetLastWriteTime(string file)
         {
             var item = m_reader.GetFiles(m_archive).FirstOrDefault(x => x.Name == file);
-            if(item == null)
+            if (item == null)
                 throw new FileNotFoundException(Strings.SevenZipCompression.FileNotFoundError, file);
 
-            if(!item.MTime.HasValue)
+            if (!item.MTime.HasValue)
                 return new DateTime(0);
 
             return item.MTime.Value;
@@ -189,14 +198,14 @@ namespace Duplicati.Library.Compression
 
         public Stream OpenRead(string file)
         {
-            if(string.IsNullOrEmpty(file))
-                throw new ArgumentNullException("file");
+            if (string.IsNullOrEmpty(file))
+                throw new ArgumentNullException(nameof(file));
 
-            if(m_reader == null)
+            if (m_reader == null)
                 throw new InvalidOperationException(Strings.SevenZipCompression.NoReaderError);
 
             var item = m_reader.GetFiles(m_archive).FirstOrDefault(x => x.Name == file);
-            if(item == null)
+            if (item == null)
                 throw new FileNotFoundException(Strings.SevenZipCompression.FileNotFoundError, file);
 
             return m_reader.OpenStream(m_archive, m_reader.GetFileIndex(m_archive, item), null);
@@ -211,7 +220,7 @@ namespace Duplicati.Library.Compression
             m_writer.ConnectEncoder(m_lzma2Encoder);
         }
 
-        private sealed class WriterEntry: ManagedLzma.LZMA.Master.SevenZip.IArchiveWriterEntry
+        private sealed class WriterEntry : ManagedLzma.LZMA.Master.SevenZip.IArchiveWriterEntry
         {
             private string mName;
             private DateTime? mTimestamp;
@@ -254,19 +263,19 @@ namespace Duplicati.Library.Compression
 
         public Stream CreateFile(string file, CompressionHint hint, DateTime lastWrite)
         {
-            if(string.IsNullOrEmpty(file))
-                throw new ArgumentNullException("file");
+            if (string.IsNullOrEmpty(file))
+                throw new ArgumentNullException(nameof(file));
 
-            if(m_writer == null)
+            if (m_writer == null)
                 throw new InvalidOperationException(Strings.SevenZipCompression.NoWriterError);
 
             var entry = new WriterEntry(file, lastWrite);
 
-            if(hint != CompressionHint.Noncompressible)
+            if (hint != CompressionHint.Noncompressible)
             {
-                if(m_lzma2Encoder == null)
+                if (m_lzma2Encoder == null)
                 {
-                    if(m_lowOverheadMode)
+                    if (m_lowOverheadMode)
                         m_lzma2Encoder = new ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter.LzmaEncoder();
                     else
                         m_lzma2Encoder = new ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter.Lzma2Encoder(m_threadCount, m_encoderProps);
@@ -279,13 +288,13 @@ namespace Duplicati.Library.Compression
             }
             else
             {
-                if(m_copyEncoder == null)
+                if (m_copyEncoder == null)
                     m_copyEncoder = new ManagedLzma.LZMA.Master.SevenZip.ArchiveWriter.PlainEncoder();
 
-                if(m_lzma2Encoder != null && m_lzma2Encoder == m_writer.CurrentEncoder)
+                if (m_lzma2Encoder != null && m_lzma2Encoder == m_writer.CurrentEncoder)
                     m_lzma2Encoder.SetOutputThreshold(kStreamThreshold); // rearm threshold so we can switch back
 
-                if(m_writer.CurrentEncoder != m_copyEncoder)
+                if (m_writer.CurrentEncoder != m_copyEncoder)
                     m_writer.ConnectEncoder(m_copyEncoder);
 
                 return m_copyEncoder.BeginWriteFile(entry);
@@ -296,10 +305,10 @@ namespace Duplicati.Library.Compression
         {
             get
             {
-                if(m_writer != null)
+                if (m_writer != null)
                     return m_writer.WrittenSize;
-                else if(m_reader != null)
-                    return m_file.Length;
+                else if (m_reader != null)
+                    return m_stream.Length;
                 else
                     throw new InvalidOperationException();
             }
@@ -309,17 +318,17 @@ namespace Duplicati.Library.Compression
         {
             get
             {
-                if(m_writer != null)
+                if (m_writer != null)
                 {
                     long remaining = m_writer.CurrentSizeLimit - m_writer.WrittenSize;
-                    if(m_copyEncoder != null && m_copyEncoder != m_writer.CurrentEncoder)
+                    if (m_copyEncoder != null && m_copyEncoder != m_writer.CurrentEncoder)
                         remaining += m_copyEncoder.UpperBound;
-                    if(m_lzma2Encoder != null && m_lzma2Encoder != m_writer.CurrentEncoder)
+                    if (m_lzma2Encoder != null && m_lzma2Encoder != m_writer.CurrentEncoder)
                         remaining += m_lzma2Encoder.UpperBound;
                     return remaining;
                 }
-                else if(m_reader != null)
-                    return m_file.Length;
+                else if (m_reader != null)
+                    return m_stream.Length;
                 else
                     throw new InvalidOperationException();
             }
@@ -392,12 +401,12 @@ namespace Duplicati.Library.Compression
                         DEFAULT_THREAD_COUNT.ToString()),
 
                     new CommandLineArgument(
-                        COMPRESSION_LEVEL_OPTION, 
-                        CommandLineArgument.ArgumentType.Enumeration, 
-                        Strings.SevenZipCompression.CompressionlevelShort, 
+                        COMPRESSION_LEVEL_OPTION,
+                        CommandLineArgument.ArgumentType.Enumeration,
+                        Strings.SevenZipCompression.CompressionlevelShort,
                         Strings.SevenZipCompression.CompressionlevelLong,
-                        DEFAULT_COMPRESSION_LEVEL.ToString(), 
-                        null, 
+                        DEFAULT_COMPRESSION_LEVEL.ToString(),
+                        null,
                         new string[] {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}),
 
                     new CommandLineArgument(

--- a/Duplicati/Library/Compression/packages.config
+++ b/Duplicati/Library/Compression/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpCompress" version="0.18.2" targetFramework="net45" />
+  <package id="SharpCompress" version="0.19.2" targetFramework="net45" />
 </packages>

--- a/Duplicati/Library/Compression/packages.config
+++ b/Duplicati/Library/Compression/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpCompress" version="0.19.2" targetFramework="net45" />
+  <package id="SharpCompress" version="0.18.2" targetFramework="net45" />
 </packages>

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -19,6 +19,7 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Duplicati.Library.Interface;
 
@@ -59,17 +60,17 @@ namespace Duplicati.Library.DynamicLoader
             /// <param name="filename">The filename used to compress/decompress contents</param>
             /// <param name="options">The options to pass to the instance constructor</param>
             /// <returns>The instanciated encryption module or null if the file extension is not supported</returns>
-            public ICompression GetModule(string fileExtension, string filename, Dictionary<string, string> options)
+            public ICompression GetModule(string fileExtension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)
             {
                 if (string.IsNullOrEmpty(fileExtension))
                     throw new ArgumentNullException("fileExtension");
 
                 LoadInterfaces();
-                
+
                 lock (m_lock)
                 {
                     if (m_interfaces.ContainsKey(fileExtension))
-                        return (ICompression)Activator.CreateInstance(m_interfaces[fileExtension].GetType(), filename, options);
+                        return (ICompression)Activator.CreateInstance(m_interfaces[fileExtension].GetType(), stream, mode, options);
                     else
                         return null;
                 }
@@ -125,17 +126,17 @@ namespace Duplicati.Library.DynamicLoader
             return _compressionLoader.GetSupportedCommands(key);
         }
 
-
         /// <summary>
         /// Instanciates a specific compression module, given the file extension and options
         /// </summary>
         /// <param name="fileextension">The file extension to create the instance for</param>
-        /// <param name="filename">The filename of the file used to compress/decompress contents</param>
+        /// <param name="stream">The stream of the file used to compress/decompress contents</param>
+        /// <param name="writing">True is the file opened for writing</param>
         /// <param name="options">The options to pass to the instance constructor</param>
         /// <returns>The instanciated compression module or null if the file extension is not supported</returns>
-        public static ICompression GetModule(string fileextension, string filename, Dictionary<string, string> options)
+        public static ICompression GetModule(string fileextension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)
         {
-            return _compressionLoader.GetModule(fileextension, filename, options);
+            return _compressionLoader.GetModule(fileextension, stream, mode, options);
         }
         #endregion
 

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -13,7 +13,7 @@ namespace Duplicati.Library.Main
     internal class BackendManager : IDisposable
     {
         public const string VOLUME_HASH = "SHA256";
-    
+
         /// <summary>
         /// Class to represent hash failures
         /// </summary>
@@ -38,7 +38,7 @@ namespace Duplicati.Library.Main
             /// <param name="innerException">The exception that caused this exception</param>
             public HashMismatchException(string message, Exception innerException) : base(message, innerException) { }
         }
-    
+
         private enum OperationType
         {
             Get,
@@ -162,20 +162,20 @@ namespace Duplicati.Library.Main
                 this.WaitForComplete();
                 if (Exception != null)
                     throw Exception;
-                    
+
                 return (TempFile)this.Result;
             }
 
             TempFile IDownloadWaitHandle.Wait(out string hash, out long size)
             {
                 this.WaitForComplete();
-                
+
                 if (Exception != null)
                     throw Exception;
-                    
+
                 hash = this.Hash;
                 size = this.Size;
-                
+
                 return (TempFile)this.Result;
             }
 
@@ -192,7 +192,7 @@ namespace Duplicati.Library.Main
                     this.Encrypted = true;
                 }
             }
-               
+
             public bool UpdateHashAndSize(Options options)
             {
                 if (Hash == null || Size < 0)
@@ -204,7 +204,7 @@ namespace Duplicati.Library.Main
 
                 return false;
             }
-            
+
             public void DeleteLocalFile(IBackendWriter stat)
             {
                 if (this.LocalTempfile != null)
@@ -212,9 +212,9 @@ namespace Duplicati.Library.Main
                     catch (Exception ex) { stat.AddWarning(string.Format("Failed to dispose temporary file: {0}", this.LocalTempfile), ex); }
                     finally { this.LocalTempfile = null; }
             }
-            
+
             public BackendActionType BackendActionType
-            { 
+            {
                 get
                 {
                     switch (this.Operation)
@@ -234,56 +234,7 @@ namespace Duplicati.Library.Main
                     }
                 }
             }
-            
-        }
 
-        /// <summary> A small utility stream that allows to keep streams open and counts the bytes sent through. </summary>
-        private class ShaderStream : System.IO.Stream
-        {
-            private readonly System.IO.Stream m_baseStream;
-            private readonly bool m_keepBaseOpen;
-            private long m_read = 0;
-            private long m_written = 0;
-
-            public ShaderStream(System.IO.Stream baseStream, bool keepBaseOpen)
-            {
-                if (baseStream == null) throw new ArgumentNullException("baseStream");
-                this.m_baseStream = baseStream;
-                this.m_keepBaseOpen = keepBaseOpen;
-            }
-
-            public long TotalBytesRead { get { return m_read; } }
-            public long TotalBytesWritten { get { return m_written; } }
-
-            public override bool CanRead { get { return m_baseStream.CanRead; } }
-            public override bool CanSeek { get { return m_baseStream.CanSeek; } }
-            public override bool CanWrite { get { return m_baseStream.CanWrite; } }
-            public override long Length { get { return m_baseStream.Length; } }
-            public override long Position
-            {
-                get { return m_baseStream.Position; }
-                set { m_baseStream.Position = value; }
-            }
-            public override void Flush() { m_baseStream.Flush(); }
-            public override long Seek(long offset, System.IO.SeekOrigin origin) { return m_baseStream.Seek(offset, origin); }
-            public override void SetLength(long value) { m_baseStream.SetLength(value); }
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                int r = m_baseStream.Read(buffer, offset, count);
-                m_read += r;
-                return r;
-            }
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                m_baseStream.Write(buffer, offset, count);
-                m_written += count;
-            }
-            protected override void Dispose(bool disposing)
-            {
-                if (disposing && !m_keepBaseOpen)
-                    m_baseStream.Close();
-                base.Dispose(disposing);
-            }
         }
 
         private class DatabaseCollector
@@ -293,16 +244,16 @@ namespace Duplicati.Library.Main
             private System.Threading.Thread m_callerThread;
             private List<IDbEntry> m_dbqueue;
             private IBackendWriter m_stats;
-            
+
             private interface IDbEntry { }
-            
+
             private class DbOperation : IDbEntry
             {
                 public string Action;
                 public string File;
                 public string Result;
             }
-            
+
             private class DbUpdate : IDbEntry
             {
                 public string Remotename;
@@ -310,53 +261,53 @@ namespace Duplicati.Library.Main
                 public long Size;
                 public string Hash;
             }
-            
+
             private class DbRename : IDbEntry
             {
                 public string Oldname;
                 public string Newname;
             }
-            
+
             public DatabaseCollector(LocalDatabase database, IBackendWriter stats)
             {
                 m_database = database;
                 m_stats = stats;
-                m_dbqueue = new List<IDbEntry>();    
+                m_dbqueue = new List<IDbEntry>();
                 if (m_database != null)
                     m_callerThread = System.Threading.Thread.CurrentThread;
             }
 
-    
+
             public void LogDbOperation(string action, string file, string result)
             {
-                lock(m_dbqueuelock)
+                lock (m_dbqueuelock)
                     m_dbqueue.Add(new DbOperation() { Action = action, File = file, Result = result });
             }
-            
+
             public void LogDbUpdate(string remotename, RemoteVolumeState state, long size, string hash)
             {
-                lock(m_dbqueuelock)
+                lock (m_dbqueuelock)
                     m_dbqueue.Add(new DbUpdate() { Remotename = remotename, State = state, Size = size, Hash = hash });
             }
 
             public void LogDbRename(string oldname, string newname)
             {
-                lock(m_dbqueuelock)
+                lock (m_dbqueuelock)
                     m_dbqueue.Add(new DbRename() { Oldname = oldname, Newname = newname });
             }
-            
+
             public bool FlushDbMessages(bool checkThread = false)
             {
                 if (m_database != null && (checkThread == false || m_callerThread == System.Threading.Thread.CurrentThread))
                     return FlushDbMessages(m_database, null);
-                
+
                 return false;
             }
-            
+
             public bool FlushDbMessages(LocalDatabase db, System.Data.IDbTransaction transaction)
             {
                 List<IDbEntry> entries;
-                lock(m_dbqueuelock)
+                lock (m_dbqueuelock)
                     if (m_dbqueue.Count == 0)
                         return false;
                     else
@@ -369,7 +320,7 @@ namespace Duplicati.Library.Main
                 HashSet<string> volsRemoved = new HashSet<string>();
 
                 //As we replace the list, we can now freely access the elements without locking
-                foreach(var e in entries)
+                foreach (var e in entries)
                     if (e is DbOperation)
                         db.LogRemoteOperation(((DbOperation)e).Action, ((DbOperation)e).File, ((DbOperation)e).Result, transaction);
                     else if (e is DbUpdate && ((DbUpdate)e).State == RemoteVolumeState.Deleted)
@@ -407,9 +358,9 @@ namespace Duplicati.Library.Main
         // Cache these
         private readonly int m_numberofretries;
         private readonly TimeSpan m_retrydelay;
-                
+
         public string BackendUrl { get { return m_backendurl; } }
-        
+
         public bool HasDied { get { return m_lastException != null; } }
         public Exception LastException { get { return m_lastException; } }
 
@@ -444,7 +395,7 @@ namespace Duplicati.Library.Main
             }
 
             if (m_taskControl != null)
-                m_taskControl.StateChangedEvent += (state) => { 
+                m_taskControl.StateChangedEvent += (state) => {
                     if (state == TaskControlState.Abort)
                         m_thread.Abort();
                 };
@@ -509,7 +460,7 @@ namespace Duplicati.Library.Main
                         {
                             if (m_taskControl != null)
                                 m_taskControl.TaskControlRendevouz();
-                            
+
                             if (m_options.NoConnectionReuse && m_backend != null)
                             {
                                 m_backend.Dispose();
@@ -521,7 +472,7 @@ namespace Duplicati.Library.Main
                             if (m_backend == null)
                                 throw new Exception("Backend failed to re-load");
 
-                            using(new Logging.Timer(string.Format("RemoteOperation{0}", item.Operation)))
+                            using (new Logging.Timer(string.Format("RemoteOperation{0}", item.Operation)))
                                 switch (item.Operation)
                                 {
                                     case OperationType.Put:
@@ -558,7 +509,7 @@ namespace Duplicati.Library.Main
                             retries++;
                             lastException = ex;
                             m_statwriter.AddRetryAttempt(string.Format("Operation {0} with file {1} attempt {2} of {3} failed with message: {4}", item.Operation, item.RemoteFilename, retries, m_numberofretries, ex.Message), ex);
-                            
+
                             // If the thread is aborted, we exit here
                             if (ex is System.Threading.ThreadAbortException)
                             {
@@ -567,33 +518,33 @@ namespace Duplicati.Library.Main
                                 item.SignalComplete();
                                 throw;
                             }
-                            
+
                             m_statwriter.SendEvent(item.BackendActionType, retries < m_numberofretries ? BackendEventType.Retrying : BackendEventType.Failed, item.RemoteFilename, item.Size);
 
                             bool recovered = false;
                             if (!uploadSuccess && ex is Duplicati.Library.Interface.FolderMissingException && m_options.AutocreateFolders)
                             {
-                                try 
-                                { 
+                                try
+                                {
                                     // If we successfully create the folder, we can re-use the connection
-                                    m_backend.CreateFolder(); 
+                                    m_backend.CreateFolder();
                                     recovered = true;
                                 }
-                                catch(Exception dex) 
-                                { 
-                                    m_statwriter.AddWarning(string.Format("Failed to create folder: {0}", ex.Message), dex); 
+                                catch (Exception dex)
+                                {
+                                    m_statwriter.AddWarning(string.Format("Failed to create folder: {0}", ex.Message), dex);
                                 }
                             }
-                            
+
                             // To work around the Apache WEBDAV issue, we rename the file here
                             if (item.Operation == OperationType.Put && retries < m_numberofretries && !item.NotTrackedInDb)
                                 RenameFileAfterError(item);
-                            
+
                             if (!recovered)
                             {
                                 try { m_backend.Dispose(); }
-                                catch(Exception dex) { m_statwriter.AddWarning(LC.L("Failed to dispose backend instance: {0}", ex.Message), dex); }
-    
+                                catch (Exception dex) { m_statwriter.AddWarning(LC.L("Failed to dispose backend instance: {0}", ex.Message), dex); }
+
                                 m_backend = null;
 
                                 if (retries < m_numberofretries && m_retrydelay.Ticks != 0)
@@ -603,13 +554,13 @@ namespace Duplicati.Library.Main
                                     {
                                         if (m_taskControl != null && m_taskControl.IsAbortRequested())
                                             break;
-                                        
+
                                         System.Threading.Thread.Sleep(500);
                                     }
                                 }
                             }
                         }
-                        
+
 
                     } while (retries < m_numberofretries);
 
@@ -624,7 +575,7 @@ namespace Duplicati.Library.Main
                                 m_statwriter.AddMessage(LC.L("Recovered from problem with attempting to delete non-existing file {0}", item.RemoteFilename));
                             }
                         }
-                        catch(Exception ex)
+                        catch (Exception ex)
                         {
                             m_statwriter.AddWarning(LC.L("Failed to recover from error deleting file {0}", item.RemoteFilename), ex);
                         }
@@ -635,17 +586,17 @@ namespace Duplicati.Library.Main
                         item.Exception = lastException;
                         if (item.Operation == OperationType.Put)
                             item.DeleteLocalFile(m_statwriter);
-                                                        
+
                         if (item.ExceptionKillsHandler)
                         {
                             m_lastException = lastException;
 
                             //TODO: If there are temp files in the queue, we must delete them
                             m_queue.SetCompleted();
-                           }
-                        
+                        }
+
                     }
-                    
+
                     item.SignalComplete();
                 }
             }
@@ -663,13 +614,13 @@ namespace Duplicati.Library.Main
             var time = p.Time.Ticks == 0 ? p.Time : p.Time.AddSeconds(1);
             var newname = VolumeBase.GenerateFilename(p.FileType, p.Prefix, guid, time, p.CompressionModule, p.EncryptionModule);
             var oldname = item.RemoteFilename;
-            
+
             m_statwriter.SendEvent(item.BackendActionType, BackendEventType.Rename, oldname, item.Size);
             m_statwriter.SendEvent(item.BackendActionType, BackendEventType.Rename, newname, item.Size);
             m_statwriter.AddMessage(string.Format("Renaming \"{0}\" to \"{1}\"", oldname, newname));
             m_db.LogDbRename(oldname, newname);
             item.RemoteFilename = newname;
-            
+
             // If there is an index file attached to the block file, 
             // it references the block filename, so we create a new index file
             // which is a copy of the current, but with the new name
@@ -681,13 +632,13 @@ namespace Duplicati.Library.Main
                     item.Indexfile.Item1.Close();
                     item.IndexfileUpdated = true;
                 }
-            
+
                 IndexVolumeWriter wr = null;
                 try
                 {
                     var hashsize = HashAlgorithmHelper.Create(m_options.BlockHashAlgorithm).HashSize / 8;
                     wr = new IndexVolumeWriter(m_options);
-                    using(var rd = new IndexVolumeReader(p.CompressionModule, item.Indexfile.Item2.LocalFilename, m_options, hashsize))
+                    using (var rd = new IndexVolumeReader(p.CompressionModule, item.Indexfile.Item2.LocalFilename, m_options, hashsize))
                         wr.CopyFrom(rd, x => x == oldname ? newname : x);
                     item.Indexfile.Item1.Dispose();
                     item.Indexfile = new Tuple<IndexVolumeWriter, FileEntryItem>(wr, item.Indexfile.Item2);
@@ -701,7 +652,7 @@ namespace Duplicati.Library.Main
                         try { wr.Dispose(); }
                         catch { }
                         finally { wr = null; }
-                        
+
                     throw;
                 }
             }
@@ -739,9 +690,9 @@ namespace Duplicati.Library.Main
         private void DoPut(FileEntryItem item)
         {
             if (m_encryption != null)
-                lock(m_encryptionLock)
+                lock (m_encryptionLock)
                     item.Encrypt(m_encryption, m_statwriter);
-                
+
             if (item.UpdateHashAndSize(m_options) && !item.NotTrackedInDb)
                 m_db.LogDbUpdate(item.RemoteFilename, RemoteVolumeState.Uploading, item.Size, item.Hash);
 
@@ -750,7 +701,7 @@ namespace Duplicati.Library.Main
                 item.Indexfile.Item1.FinishVolume(item.Hash, item.Size);
                 item.Indexfile.Item1.Close();
                 item.IndexfileUpdated = true;
-            }            
+            }
 
             m_db.LogDbOperation("put", item.RemoteFilename, JsonConvert.SerializeObject(new { Size = item.Size, Hash = item.Hash }));
             m_statwriter.SendEvent(BackendActionType.Put, BackendEventType.Started, item.RemoteFilename, item.Size);
@@ -772,7 +723,7 @@ namespace Duplicati.Library.Main
 
             if (!item.NotTrackedInDb)
                 m_db.LogDbUpdate(item.RemoteFilename, RemoteVolumeState.Uploaded, item.Size, item.Hash);
-            
+
             m_statwriter.SendEvent(BackendActionType.Put, BackendEventType.Completed, item.RemoteFilename, item.Size);
 
             if (m_options.ListVerifyUploads)
@@ -1079,7 +1030,7 @@ namespace Duplicati.Library.Main
                     item.Result = tmpfile;
                     tmpfile = null;
                 }
-                    
+
             }
             catch
             {
@@ -1147,7 +1098,7 @@ namespace Duplicati.Library.Main
                         m_statwriter.AddMessage(LC.L("Listing indicates file {0} is deleted correctly", item.RemoteFilename));
                         return;
                     }
-                    
+
                 }
 
                 result = ex.ToString();
@@ -1157,11 +1108,11 @@ namespace Duplicati.Library.Main
             {
                 m_db.LogDbOperation("delete", item.RemoteFilename, result);
             }
-            
+
             m_db.LogDbUpdate(item.RemoteFilename, RemoteVolumeState.Deleted, -1, null);
             m_statwriter.SendEvent(BackendActionType.Delete, BackendEventType.Completed, item.RemoteFilename, item.Size);
         }
-        
+
         private void DoCreateFolder(FileEntryItem item)
         {
             m_statwriter.SendEvent(BackendActionType.CreateFolder, BackendEventType.Started, null, -1);
@@ -1170,7 +1121,7 @@ namespace Duplicati.Library.Main
             try
             {
                 m_backend.CreateFolder();
-            } 
+            }
             catch (Exception ex)
             {
                 result = ex.ToString();
@@ -1180,15 +1131,15 @@ namespace Duplicati.Library.Main
             {
                 m_db.LogDbOperation("createfolder", item.RemoteFilename, result);
             }
-            
+
             m_statwriter.SendEvent(BackendActionType.CreateFolder, BackendEventType.Completed, null, -1);
         }
-        
+
         public void PutUnencrypted(string remotename, string localpath)
         {
             if (m_lastException != null)
                 throw m_lastException;
-                
+
             var req = new FileEntryItem(OperationType.Put, remotename, null);
             req.SetLocalfilename(localpath);
             req.Encrypted = true; //Prevent encryption
@@ -1208,7 +1159,7 @@ namespace Duplicati.Library.Main
             {
                 m_statwriter.BackendProgressUpdater.SetBlocking(false);
             }
-            
+
             if (m_lastException != null)
                 throw m_lastException;
         }
@@ -1217,23 +1168,23 @@ namespace Duplicati.Library.Main
         {
             if (m_lastException != null)
                 throw m_lastException;
-            
+
             item.Close();
             var req = new FileEntryItem(OperationType.Put, item.RemoteFilename, null);
             req.LocalTempfile = item.TempFile;
-                        
+
             if (m_lastException != null)
                 throw m_lastException;
 
             FileEntryItem req2 = null;
-            
+
             // As the network link is the bottleneck,
             // we encrypt the dblock volume before the
             // upload is enqueued (i.e. on the worker thread)
             if (m_encryption != null)
                 lock (m_encryptionLock)
                     req.Encrypt(m_encryption, m_statwriter);
-                    
+
             req.UpdateHashAndSize(m_options);
             m_db.LogDbUpdate(item.RemoteFilename, RemoteVolumeState.Uploading, req.Size, req.Hash);
 
@@ -1270,7 +1221,7 @@ namespace Duplicati.Library.Main
             {
                 m_statwriter.BackendProgressUpdater.SetBlocking(false);
             }
-            
+
             if (m_lastException != null)
                 throw m_lastException;
         }
@@ -1344,12 +1295,12 @@ namespace Duplicati.Library.Main
             else
                 throw new InvalidOperationException("GetAsync called after backend is shut down");
         }
-        
+
         public void GetForTesting(string remotename, long size, string hash)
         {
             if (m_lastException != null)
                 throw m_lastException;
-            
+
             if (string.IsNullOrWhiteSpace(hash))
                 throw new InvalidOperationException("Cannot test a file without the hash");
 
@@ -1372,7 +1323,7 @@ namespace Duplicati.Library.Main
 
             if (m_lastException != null)
                 throw m_lastException;
-        }        
+        }
 
         public IList<Library.Interface.IFileEntry> List()
         {
@@ -1477,7 +1428,7 @@ namespace Duplicati.Library.Main
         {
             if (m_lastException != null)
                 throw m_lastException;
-                
+
             m_db.LogDbUpdate(remotename, RemoteVolumeState.Deleting, size, null);
             var req = new FileEntryItem(OperationType.Delete, remotename, size, null);
             try
@@ -1498,12 +1449,12 @@ namespace Duplicati.Library.Main
             if (m_lastException != null)
                 throw m_lastException;
         }
-        
+
         public bool FlushDbMessages(LocalDatabase database, System.Data.IDbTransaction transaction)
         {
             return m_db.FlushDbMessages(database, transaction);
         }
-        
+
         public bool FlushDbMessages()
         {
             return m_db.FlushDbMessages(false);
@@ -1513,7 +1464,7 @@ namespace Duplicati.Library.Main
         {
             if (m_queue != null && !m_queue.Completed)
                 m_queue.SetCompleted();
-            
+
             if (m_thread != null)
             {
                 if (!m_thread.Join(TimeSpan.FromSeconds(10)))
@@ -1524,7 +1475,7 @@ namespace Duplicati.Library.Main
 
                 m_thread = null;
             }
-            
+
             //TODO: We cannot null this, because it will be recreated
             //Should we wait for queue completion or abort immediately?
             if (m_backend != null)
@@ -1532,7 +1483,7 @@ namespace Duplicati.Library.Main
                 m_backend.Dispose();
                 m_backend = null;
             }
-            
+
             try { m_db.FlushDbMessages(true); }
             catch (Exception ex) { m_statwriter.AddError(string.Format("Backend Shutdown error: {0}", ex.Message), ex); }
         }

--- a/Duplicati/Library/Main/DatabaseLocator.cs
+++ b/Duplicati/Library/Main/DatabaseLocator.cs
@@ -217,7 +217,6 @@ namespace Duplicati.Library.Main
                 return false;
 
             var file = System.IO.Path.Combine(folder, "dbconfig.json");
-            List<BackendEntry> configs;
             if (!System.IO.File.Exists(file))
                 return false;
 

--- a/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
+++ b/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
@@ -16,6 +16,7 @@
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 using System;
+using System.IO;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main.Database;
 
@@ -33,7 +34,7 @@ namespace Duplicati.Library.Main.Operation
             m_options = options;
             m_result = result;
         }
-        
+
         public void Run()
         {
             var ext = System.IO.Path.GetExtension(m_targetpath);
@@ -41,22 +42,22 @@ namespace Duplicati.Library.Main.Operation
 
             if (ext == "" || string.Compare(ext, 1, module, 0, module.Length, StringComparison.OrdinalIgnoreCase) != 0)
                 m_targetpath = m_targetpath + "." + module;
-        
+
             if (System.IO.File.Exists(m_targetpath))
                 throw new UserInformationException(string.Format("Output file already exists, not overwriting: {0}", m_targetpath));
-                
+
             if (!System.IO.File.Exists(m_options.Dbpath))
                 throw new UserInformationException(string.Format("Database file does not exist: {0}", m_options.Dbpath));
-                
+
             m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.BugReport_Running);
             m_result.OperationProgressUpdater.UpdateProgress(0);
 
             m_result.AddMessage("Scrubbing filenames from database, this may take a while, please wait");
 
-            using(var tmp = new Library.Utility.TempFile())
+            using (var tmp = new Library.Utility.TempFile())
             {
                 System.IO.File.Copy(m_options.Dbpath, tmp, true);
-                using(var db = new LocalBugReportDatabase(tmp))
+                using (var db = new LocalBugReportDatabase(tmp))
                 {
                     m_result.SetDatabase(db);
                     db.Fix();
@@ -65,20 +66,21 @@ namespace Duplicati.Library.Main.Operation
                         db.Vacuum();
                     }
                 }
-                
-                using(var cm = DynamicLoader.CompressionLoader.GetModule(module, m_targetpath, m_options.RawOptions))
+
+                using (var stream = new System.IO.FileStream(m_targetpath, FileMode.Create, FileAccess.Write, FileShare.Read))
+                using (ICompression cm = DynamicLoader.CompressionLoader.GetModule(module, stream, Interface.ArchiveMode.Write, m_options.RawOptions))
                 {
-                    using(var cs = cm.CreateFile("log-database.sqlite", Duplicati.Library.Interface.CompressionHint.Compressible, DateTime.UtcNow))
-                    using(var fs = System.IO.File.Open(tmp, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite))
+                    using (var cs = cm.CreateFile("log-database.sqlite", Duplicati.Library.Interface.CompressionHint.Compressible, DateTime.UtcNow))
+                    using (var fs = System.IO.File.Open(tmp, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite))
                         Library.Utility.Utility.CopyStream(fs, cs);
-                        
-                    using(var cs = new System.IO.StreamWriter(cm.CreateFile("system-info.txt", Duplicati.Library.Interface.CompressionHint.Compressible, DateTime.UtcNow)))
-                        foreach(var line in SystemInfoHandler.GetSystemInfo())
+
+                    using (var cs = new System.IO.StreamWriter(cm.CreateFile("system-info.txt", Duplicati.Library.Interface.CompressionHint.Compressible, DateTime.UtcNow)))
+                        foreach (var line in SystemInfoHandler.GetSystemInfo())
                             cs.WriteLine(line);
                 }
 
                 m_result.TargetPath = m_targetpath;
-            }               
+            }
         }
     }
 }

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -34,11 +34,11 @@ namespace Duplicati.Library.Main
         void AddDryrunMessage(string message);
         void WriteLogMessageDirect(string message, LogMessageType type, Exception ex);
     }
-    
+
     internal interface IBackendWriter : ILogWriter
     {
         void AddRetryAttempt(string message, Exception ex);
-        
+
         long UnknownFileSize { set; }
         long UnknownFileCount { set; }
         long KnownFileCount { set; }
@@ -57,32 +57,32 @@ namespace Duplicati.Library.Main
         /// <param name="path">Path to the resource</param>
         /// <param name="size">Size of the file or progress</param>
         void SendEvent(BackendActionType action, BackendEventType type, string path, long size);
-        
+
         /// <summary>
         /// Gets the backend progress updater.
         /// </summary>
         /// <value>The backend progress updater.</value>
         IBackendProgressUpdater BackendProgressUpdater { get; }
     }
-    
+
     internal interface ISetCommonOptions : ILogWriter
     {
-        bool VerboseOutput { set; }
+        new bool VerboseOutput { set; }
         bool VerboseErrors { set; }
-        
+
         DateTime EndTime { get; set; }
         DateTime BeginTime { set; }
-        
+
         void SetDatabase(LocalDatabase db);
-        
+
         OperationMode MainOperation { get; }
-        IMessageSink MessageSink { set; }        
+        IMessageSink MessageSink { set; }
     }
-    
+
     internal class BackendWriter : BasicResults, IBackendWriter, IBackendStatstics, IParsedBackendStatistics
     {
         public BackendWriter(BasicResults p) : base(p) { }
-        
+
         protected long m_remoteCalls = 0;
         protected long m_bytesUploaded = 0;
         protected long m_bytesDownloaded = 0;
@@ -91,22 +91,22 @@ namespace Duplicati.Library.Main
         protected long m_filesDeleted = 0;
         protected long m_foldersCreated = 0;
         protected long m_retryAttemptCount = 0;
-        
+
         public void AddNumberOfRemoteCalls(long count)
         {
             System.Threading.Interlocked.Add(ref m_remoteCalls, count);
         }
-        
+
         public void AddBytesUploaded(long count)
         {
             System.Threading.Interlocked.Add(ref m_bytesUploaded, count);
         }
-        
+
         public void AddBytesDownloaded(long count)
         {
             System.Threading.Interlocked.Add(ref m_bytesDownloaded, count);
         }
-        
+
         public long RemoteCalls { get { return m_remoteCalls; } }
         public long BytesUploaded { get { return m_bytesUploaded; } }
         public long BytesDownloaded { get { return m_bytesDownloaded; } }
@@ -125,9 +125,9 @@ namespace Duplicati.Library.Main
         public long TotalQuotaSpace { get; set; }
         public long FreeQuotaSpace { get; set; }
         public long AssignedQuotaSpace { get; set; }
-        
+
         public override OperationMode MainOperation { get { return m_parent.MainOperation; } }
-                
+
         public void SendEvent(BackendActionType action, BackendEventType type, string path, long size)
         {
             if (type == BackendEventType.Started)
@@ -160,13 +160,13 @@ namespace Duplicati.Library.Main
                         break;
                 }
             }
-            
+
             base.AddBackendEvent(action, type, path, size);
         }
-        
-        IBackendProgressUpdater IBackendWriter.BackendProgressUpdater { get { return base.BackendProgressUpdater; } }   
+
+        IBackendProgressUpdater IBackendWriter.BackendProgressUpdater { get { return base.BackendProgressUpdater; } }
     }
-    
+
     public interface ITaskControl
     {
         void Pause();
@@ -174,7 +174,7 @@ namespace Duplicati.Library.Main
         void Stop();
         void Abort();
     }
-    
+
     internal enum TaskControlState
     {
         Run,
@@ -182,7 +182,7 @@ namespace Duplicati.Library.Main
         Stop,
         Abort
     }
-    
+
     internal abstract class BasicResults : IBasicResults, ILogWriter, ISetCommonOptions, ITaskControl, Logging.ILog
     {
         protected class DbMessage
@@ -190,7 +190,7 @@ namespace Duplicati.Library.Main
             public readonly string Type;
             public readonly string Message;
             public readonly Exception Exception;
-            
+
             public DbMessage(string type, string message, Exception ex)
             {
                 this.Type = type;
@@ -198,28 +198,28 @@ namespace Duplicati.Library.Main
                 this.Exception = ex;
             }
         }
-    
+
         protected LocalDatabase m_db;
         protected readonly BasicResults m_parent;
         protected System.Threading.Thread m_callerThread;
         protected readonly object m_lock = new object();
         protected Queue<DbMessage> m_dbqueue;
-                
+
         private TaskControlState m_controlState = TaskControlState.Run;
         private System.Threading.ManualResetEvent m_pauseEvent = new System.Threading.ManualResetEvent(true);
-        
+
         private bool m_verboseOutput;
         private bool m_verboseErrors;
-        
+
         public bool VerboseOutput
-        { 
+        {
             get
-            { 
+            {
                 if (m_parent != null)
                     return m_parent.VerboseOutput;
                 else
                     return m_verboseOutput;
-            } 
+            }
             set
             {
                 if (m_parent != null)
@@ -228,15 +228,16 @@ namespace Duplicati.Library.Main
                     m_verboseOutput = value;
             }
         }
+
         public bool VerboseErrors
-        { 
+        {
             get
-            { 
+            {
                 if (m_parent != null)
                     return m_parent.VerboseErrors;
                 else
                     return m_verboseErrors;
-            } 
+            }
             set
             {
                 if (m_parent != null)
@@ -257,24 +258,24 @@ namespace Duplicati.Library.Main
                 else
                     return ParsedResultType.Success;
             }
-        }        
+        }
 
         public DateTime EndTime { get; set; }
         public DateTime BeginTime { get; set; }
         public TimeSpan Duration { get { return EndTime.Ticks == 0 ? new TimeSpan(0) : EndTime - BeginTime; } }
-        
+
         public abstract OperationMode MainOperation { get; }
-        
+
         protected Library.Utility.FileBackedStringList m_messages;
         protected Library.Utility.FileBackedStringList m_warnings;
         protected Library.Utility.FileBackedStringList m_errors;
         protected Library.Utility.FileBackedStringList m_retryAttempts;
-        
+
         protected IMessageSink m_messageSink;
         public IMessageSink MessageSink
         {
             get { return m_messageSink; }
-            set 
+            set
             {
                 m_messageSink = value;
                 if (value != null)
@@ -284,7 +285,7 @@ namespace Duplicati.Library.Main
                 }
             }
         }
-        
+
         protected internal IOperationProgressUpdaterAndReporter m_operationProgressUpdater;
         internal IOperationProgressUpdaterAndReporter OperationProgressUpdater
         {
@@ -296,7 +297,7 @@ namespace Duplicati.Library.Main
                     return m_operationProgressUpdater;
             }
         }
-        
+
         protected internal IBackendProgressUpdaterAndReporter m_backendProgressUpdater;
         internal IBackendProgressUpdaterAndReporter BackendProgressUpdater
         {
@@ -308,7 +309,7 @@ namespace Duplicati.Library.Main
                     return m_backendProgressUpdater;
             }
         }
-        
+
         public void SetDatabase(LocalDatabase db)
         {
             if (m_parent != null)
@@ -317,7 +318,7 @@ namespace Duplicati.Library.Main
             }
             else
             {
-                lock(m_lock)
+                lock (m_lock)
                 {
                     m_db = db;
                     if (m_db != null)
@@ -325,14 +326,14 @@ namespace Duplicati.Library.Main
                 }
             }
         }
-        
+
         public void FlushLog()
         {
             if (m_parent != null)
                 m_parent.FlushLog();
             else
             {
-                lock(m_lock)
+                lock (m_lock)
                 {
                     while (m_dbqueue.Count > 0)
                     {
@@ -342,7 +343,7 @@ namespace Duplicati.Library.Main
                 }
             }
         }
-         
+
         private void LogDbMessage(string type, string message, Exception ex)
         {
             if (System.Threading.Thread.CurrentThread != m_callerThread)
@@ -366,7 +367,7 @@ namespace Duplicati.Library.Main
             }
             else
             {
-                lock(Logging.Log.Lock)
+                lock (Logging.Log.Lock)
                 {
                     if (m_is_reporting)
                         return;
@@ -388,7 +389,7 @@ namespace Duplicati.Library.Main
                     }
                 }
             }
-                
+
         }
 
         public void AddDryrunMessage(string message)
@@ -397,7 +398,7 @@ namespace Duplicati.Library.Main
                 m_parent.AddDryrunMessage(message);
             else
             {
-                lock(Logging.Log.Lock)
+                lock (Logging.Log.Lock)
                 {
                     if (m_is_reporting)
                         return;
@@ -423,7 +424,7 @@ namespace Duplicati.Library.Main
                 m_parent.AddVerboseMessage(message, args);
             else
             {
-                lock(Logging.Log.Lock)
+                lock (Logging.Log.Lock)
                 {
                     if (m_is_reporting)
                         return;
@@ -445,12 +446,12 @@ namespace Duplicati.Library.Main
         }
 
         public void AddMessage(string message)
-        { 
+        {
             if (m_parent != null)
                 m_parent.AddMessage(message);
             else
             {
-                lock(Logging.Log.Lock)
+                lock (Logging.Log.Lock)
                 {
                     if (m_is_reporting)
                         return;
@@ -465,7 +466,7 @@ namespace Duplicati.Library.Main
                         if (MessageSink != null)
                             MessageSink.MessageEvent(message);
 
-                        lock(m_lock)
+                        lock (m_lock)
                             if (m_db != null && !m_db.IsDisposed)
                                 LogDbMessage("Message", message, null);
                     }
@@ -483,7 +484,7 @@ namespace Duplicati.Library.Main
                 m_parent.AddWarning(message, ex);
             else
             {
-                lock(Logging.Log.Lock)
+                lock (Logging.Log.Lock)
                 {
                     if (m_is_reporting)
                         return;
@@ -499,7 +500,7 @@ namespace Duplicati.Library.Main
                         if (MessageSink != null)
                             MessageSink.WarningEvent(message, ex);
 
-                        lock(m_lock)
+                        lock (m_lock)
                             if (m_db != null && !m_db.IsDisposed)
                                 LogDbMessage("Warning", message, ex);
                     }
@@ -517,7 +518,7 @@ namespace Duplicati.Library.Main
                 m_parent.AddRetryAttempt(message, ex);
             else
             {
-                lock(Logging.Log.Lock)
+                lock (Logging.Log.Lock)
                 {
                     if (m_is_reporting)
                         return;
@@ -533,7 +534,7 @@ namespace Duplicati.Library.Main
                         if (MessageSink != null)
                             MessageSink.RetryEvent(message, ex);
 
-                        lock(m_lock)
+                        lock (m_lock)
                             if (m_db != null && !m_db.IsDisposed)
                                 LogDbMessage("Retry", message, ex);
                     }
@@ -551,7 +552,7 @@ namespace Duplicati.Library.Main
                 m_parent.AddError(message, ex);
             else
             {
-                lock(Logging.Log.Lock)
+                lock (Logging.Log.Lock)
                 {
                     if (m_is_reporting)
                         return;
@@ -567,7 +568,7 @@ namespace Duplicati.Library.Main
                         if (MessageSink != null)
                             MessageSink.ErrorEvent(message, ex);
 
-                        lock(m_lock)
+                        lock (m_lock)
                             if (m_db != null && !m_db.IsDisposed)
                                 LogDbMessage("Error", message, ex);
                     }
@@ -578,14 +579,14 @@ namespace Duplicati.Library.Main
                 }
             }
         }
-        
+
         public IEnumerable<string> Messages { get { return m_messages; } }
         public IEnumerable<string> Warnings { get { return m_warnings; } }
         public IEnumerable<string> Errors { get { return m_errors; } }
-        
-        public BasicResults() 
-        { 
-            this.BeginTime = DateTime.UtcNow; 
+
+        public BasicResults()
+        {
+            this.BeginTime = DateTime.UtcNow;
             this.m_parent = null;
             m_messages = new Library.Utility.FileBackedStringList();
             m_warnings = new Library.Utility.FileBackedStringList();
@@ -599,27 +600,27 @@ namespace Duplicati.Library.Main
         }
 
         public BasicResults(BasicResults p)
-        { 
-            this.BeginTime = DateTime.UtcNow; 
+        {
+            this.BeginTime = DateTime.UtcNow;
             this.m_parent = p;
         }
-        
+
         protected IBackendStatstics m_backendStatistics;
         public IBackendStatstics BackendStatistics
-        { 
+        {
             get
             {
                 if (this.m_parent != null)
                     return this.m_parent.BackendStatistics;
-                    
+
                 return m_backendStatistics;
             }
         }
-        
+
         public IBackendWriter BackendWriter { get { return (IBackendWriter)this.BackendStatistics; } }
-        
+
         public event Action<TaskControlState> StateChangedEvent;
-        
+
         /// <summary>
         /// Request that this task pauses.
         /// </summary>
@@ -640,7 +641,7 @@ namespace Duplicati.Library.Main
                     StateChangedEvent(m_controlState);
             }
         }
-        
+
         /// <summary>
         /// Request that this task resumes.
         /// </summary>
@@ -661,11 +662,11 @@ namespace Duplicati.Library.Main
                     StateChangedEvent(m_controlState);
             }
         }
-        
+
         /// <summary>
         /// Request that this task stops.
         /// </summary>
-        public void Stop() 
+        public void Stop()
         {
             if (m_parent != null)
                 m_parent.Stop();
@@ -682,7 +683,7 @@ namespace Duplicati.Library.Main
                     StateChangedEvent(m_controlState);
             }
         }
-        
+
         /// <summary>
         /// Request that this task aborts.
         /// </summary>
@@ -702,7 +703,7 @@ namespace Duplicati.Library.Main
                     StateChangedEvent(m_controlState);
             }
         }
-        
+
         /// <summary>
         /// Helper method that the current running task can call to obtain the current state
         /// </summary>
@@ -746,7 +747,7 @@ namespace Duplicati.Library.Main
         public override string ToString()
         {
             return Library.Utility.Utility.PrintSerializeObject(
-                this, 
+                this,
                 filter: (prop, item) =>
                     !typeof(IBackendProgressUpdater).IsAssignableFrom(prop.PropertyType) &&
                     !typeof(IMessageSink).IsAssignableFrom(prop.PropertyType) &&
@@ -849,11 +850,11 @@ namespace Duplicati.Library.Main
                 else if ((Warnings != null && Warnings.Any()) || PartialBackup)
                     return ParsedResultType.Warning;
                 else
-                    return ParsedResultType.Success;                    
+                    return ParsedResultType.Success;
             }
         }
     }
-    
+
     internal class RestoreResults : BasicResults, Library.Interface.IRestoreResults
     {
         public long FilesRestored { get; internal set; }
@@ -864,9 +865,9 @@ namespace Duplicati.Library.Main
         public long FilesDeleted { get; internal set; }
         public long FoldersDeleted { get; internal set; }
         public long SymlinksDeleted { get; internal set; }
-        
+
         public override OperationMode MainOperation { get { return OperationMode.Restore; } }
-        
+
         public IRecreateDatabaseResults RecreateDatabaseResults { get; internal set; }
 
         public override ParsedResultType ParsedResult
@@ -908,7 +909,7 @@ namespace Duplicati.Library.Main
             this.FileSizes = fileSizes;
         }
     }
-    
+
     internal class ListResults : BasicResults, Duplicati.Library.Interface.IListResults
     {
         private IEnumerable<Duplicati.Library.Interface.IListResultFileset> m_filesets;
@@ -920,10 +921,10 @@ namespace Duplicati.Library.Main
             m_filesets = filesets;
             m_files = files;
         }
-        
+
         public IEnumerable<Duplicati.Library.Interface.IListResultFileset> Filesets { get { return m_filesets; } }
         public IEnumerable<Duplicati.Library.Interface.IListResultFile> Files { get { return m_files; } }
-        
+
         public override OperationMode MainOperation { get { return OperationMode.List; } }
     }
 
@@ -941,7 +942,7 @@ namespace Duplicati.Library.Main
             m_logs = logs;
             m_volumes = volumes;
         }
-        
+
         public IEnumerable<Duplicati.Library.Interface.IListResultFileset> Filesets { get { return m_filesets; } }
         public IEnumerable<Duplicati.Library.Interface.IListResultFile> Files { get { return m_files; } }
         public IEnumerable<Duplicati.Library.Interface.IListResultRemoteLog> LogMessages { get { return m_logs; } }
@@ -954,23 +955,23 @@ namespace Duplicati.Library.Main
     {
         public IEnumerable<Tuple<long, DateTime>> DeletedSets { get; private set; }
         public bool Dryrun { get; private set; }
-        
+
         public void SetResults(IEnumerable<Tuple<long, DateTime>> deletedSets, bool dryrun)
         {
             EndTime = DateTime.UtcNow;
             DeletedSets = deletedSets;
             Dryrun = dryrun;
         }
-        
+
         public override OperationMode MainOperation { get { return OperationMode.Delete; } }
 
         public DeleteResults() : base() { }
         public DeleteResults(BasicResults p) : base(p) { }
-        
+
         private ICompactResults m_compactResults;
 
         public ICompactResults CompactResults
-        { 
+        {
             get
             {
                 if (m_parent != null && m_parent is BackupResults)
@@ -982,33 +983,33 @@ namespace Duplicati.Library.Main
             {
                 if (m_parent != null && m_parent is BackupResults)
                     ((BackupResults)m_parent).CompactResults = value;
-                    
+
                 m_compactResults = value;
             }
         }
-    } 
-    
+    }
+
     internal class RecreateDatabaseResults : BasicResults, Library.Interface.IRecreateDatabaseResults
     {
         public override OperationMode MainOperation { get { return OperationMode.Repair; } }
-        
+
         public RecreateDatabaseResults() : base() { }
         public RecreateDatabaseResults(BasicResults p) : base(p) { }
-    }   
+    }
 
     internal class CreateLogDatabaseResults : BasicResults, Library.Interface.ICreateLogDatabaseResults
     {
         public override OperationMode MainOperation { get { return OperationMode.CreateLogDb; } }
         public string TargetPath { get; internal set; }
-    }   
-    
+    }
+
     internal class RestoreControlFilesResults : BasicResults, Library.Interface.IRestoreControlFilesResults
     {
         public IEnumerable<string> Files { get; private set; }
-        
+
         public override OperationMode MainOperation { get { return OperationMode.RestoreControlfiles; } }
         public void SetResult(IEnumerable<string> files) { this.Files = files; }
-    }   
+    }
 
     internal class ListRemoteResults : BasicResults, Library.Interface.IListRemoteResults
     {
@@ -1021,12 +1022,12 @@ namespace Duplicati.Library.Main
     internal class RepairResults : BasicResults, Library.Interface.IRepairResults
     {
         public override OperationMode MainOperation { get { return OperationMode.Repair; } }
-        
+
         public RepairResults() : base() { }
         public RepairResults(BasicResults p) : base(p) { }
         public Library.Interface.IRecreateDatabaseResults RecreateDatabaseResults { get; internal set; }
-    }   
-    
+    }
+
     internal class CompactResults : BasicResults, Library.Interface.ICompactResults
     {
         public long DeletedFileCount { get; internal set; }
@@ -1038,22 +1039,22 @@ namespace Duplicati.Library.Main
         public bool Dryrun { get; internal set; }
 
         public override OperationMode MainOperation { get { return OperationMode.Compact; } }
-        
+
         public CompactResults() : base() { }
         public CompactResults(BasicResults p) : base(p) { }
-    }   
+    }
 
     internal class ListChangesResults : BasicResults, Library.Interface.IListChangesResults
     {
         public override OperationMode MainOperation { get { return OperationMode.ListChanges; } }
-        
+
         public DateTime BaseVersionTimestamp { get; internal set; }
         public DateTime CompareVersionTimestamp { get; internal set; }
         public long BaseVersionIndex { get; internal set; }
         public long CompareVersionIndex { get; internal set; }
-        
-        public IEnumerable<Tuple<ListChangesChangeType, ListChangesElementType, string>> ChangeDetails { get; internal set; } 
-        
+
+        public IEnumerable<Tuple<ListChangesChangeType, ListChangesElementType, string>> ChangeDetails { get; internal set; }
+
         public long AddedFolders { get; internal set; }
         public long AddedSymlinks { get; internal set; }
         public long AddedFiles { get; internal set; }
@@ -1065,13 +1066,13 @@ namespace Duplicati.Library.Main
         public long ModifiedFolders { get; internal set; }
         public long ModifiedSymlinks { get; internal set; }
         public long ModifiedFiles { get; internal set; }
-        
+
         public long PreviousSize { get; internal set; }
         public long CurrentSize { get; internal set; }
 
         public long AddedSize { get; internal set; }
         public long DeletedSize { get; internal set; }
-        
+
         public void SetResult(
             DateTime baseVersionTime, long baseVersionIndex, DateTime compareVersionTime, long compareVersionIndex,
             long addedFolders, long addedSymlinks, long addedFiles,
@@ -1085,38 +1086,38 @@ namespace Duplicati.Library.Main
             this.BaseVersionIndex = baseVersionIndex;
             this.CompareVersionTimestamp = compareVersionTime;
             this.CompareVersionIndex = compareVersionIndex;
-        
-            this.AddedFolders = addedFolders;        
+
+            this.AddedFolders = addedFolders;
             this.AddedSymlinks = addedSymlinks;
             this.AddedFiles = addedFiles;
-            
+
             this.DeletedFolders = deletedFolders;
             this.DeletedSymlinks = deletedSymlinks;
             this.DeletedFiles = deletedFiles;
-            
+
             this.ModifiedFolders = modifiedFolders;
             this.ModifiedSymlinks = modifiedSymlinks;
             this.ModifiedFiles = modifiedFiles;
-            
+
             this.AddedSize = addedSize;
             this.DeletedSize = deletedSize;
-            
+
             this.PreviousSize = previousSize;
             this.CurrentSize = currentSize;
-            
+
             this.ChangeDetails = changeDetails;
         }
     }
-    
+
     internal class TestResults : BasicResults, ITestResults
     {
         public TestResults() : base() { }
         public TestResults(BasicResults p) : base(p) { }
-        
+
         public override OperationMode MainOperation { get { return OperationMode.Test; } }
         public IEnumerable<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>> Verifications { get { return m_verifications; } }
         private List<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>> m_verifications = new List<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>>();
-        
+
         public KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>> AddResult(string volume, IEnumerable<KeyValuePair<TestEntryStatus, string>> changes)
         {
             var res = new KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>(volume, changes);
@@ -1124,7 +1125,7 @@ namespace Duplicati.Library.Main
             return res;
         }
     }
-    
+
     internal class TestFilterResults : BasicResults, ITestFilterResults
     {
         public long FileCount { get; set; }

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -19,10 +19,10 @@ namespace Duplicati.Library.Main.Volumes
             if (tmp == null)
             {
                 var name = "[stream]";
-                if (stream is FileStream fs)
-                    name = fs.Name;
-                if (stream is TempFileStream tfs)
-                    name = tfs.Name;
+                if (stream is FileStream)
+                    name = ((FileStream)stream).Name;
+                if (stream is TempFileStream)
+                    name = ((TempFileStream)stream).Name;
 
                 throw new Exception(string.Format("Unable to create {0} decompressor on file {1}", compressor, name));
             }

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Duplicati.Library.Interface;
+﻿using Duplicati.Library.Interface;
+using Duplicati.Library.Utility;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Duplicati.Library.Main.Volumes
@@ -12,18 +11,37 @@ namespace Duplicati.Library.Main.Volumes
     {
         protected bool m_disposeCompression = false;
         protected ICompression m_compression;
+        protected Stream m_stream;
 
-        private static ICompression LoadCompressor(string compressor, string file, Options options)
+        private static ICompression LoadCompressor(string compressor, Stream stream, Options options)
         {
-            var tmp = DynamicLoader.CompressionLoader.GetModule(compressor, file, options.RawOptions);
+            var tmp = DynamicLoader.CompressionLoader.GetModule(compressor, stream, Interface.ArchiveMode.Read, options.RawOptions);
             if (tmp == null)
-                throw new Exception(string.Format("Unable to create {0} decompressor on file {1}", compressor, file));
+            {
+                var name = "[stream]";
+                if (stream is FileStream fs)
+                    name = fs.Name;
+                if (stream is TempFileStream tfs)
+                    name = tfs.Name;
+
+                throw new Exception(string.Format("Unable to create {0} decompressor on file {1}", compressor, name));
+            }
+
             return tmp;
         }
 
-        public VolumeReaderBase(string compressor, string file, Options options)
-            : this(LoadCompressor(compressor, file, options), options)
+        private static ICompression LoadCompressor(string compressor, string file, Options options, out Stream stream)
         {
+            stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return LoadCompressor(compressor, stream, options);
+        }
+
+        public VolumeReaderBase(string compressor, string file, Options options)
+            : base(options)
+        {
+            m_compression = LoadCompressor(compressor, file, options, out m_stream);
+            ReadManifests(options);
+
             m_disposeCompression = true;
         }
 
@@ -31,13 +49,18 @@ namespace Duplicati.Library.Main.Volumes
             : base(options)
         {
             m_compression = compression;
+            ReadManifests(options);
+        }
+
+        private void ReadManifests(Options options)
+        {
             if (!options.DontReadManifests)
             {
                 using (var s = m_compression.OpenRead(MANIFEST_FILENAME))
                 {
                     if (s == null)
                         throw new InvalidManifestException("No manifest file found in volume");
-    
+
                     using (var fs = new StreamReader(s, ENCODING))
                         ManifestData.VerifyManifest(fs.ReadToEnd(), m_blocksize, options.BlockHashAlgorithm, options.FileHashAlgorithm);
                 }
@@ -46,7 +69,8 @@ namespace Duplicati.Library.Main.Volumes
 
         public static void UpdateOptionsFromManifest(string compressor, string file, Options options)
         {
-            using(var c = LoadCompressor(compressor, file, options))
+            using (var stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var c = LoadCompressor(compressor, stream, options))
             using (var s = c.OpenRead(MANIFEST_FILENAME))
             using (var fs = new StreamReader(s, ENCODING))
             {
@@ -75,17 +99,20 @@ namespace Duplicati.Library.Main.Volumes
             {
                 m_compression.Dispose();
                 m_compression = null;
+
+                m_stream?.Dispose();
+                m_stream = null;
             }
         }
 
         public static IEnumerable<string> ReadBlocklist(ICompression compression, string filename, long hashsize)
         {
             var buffer = new byte[hashsize];
-            using(var fs = compression.OpenRead(filename))
+            using (var fs = compression.OpenRead(filename))
             {
                 int s;
                 while ((s = Library.Utility.Utility.ForceStreamRead(fs, buffer, buffer.Length)) != 0)
-                {                    
+                {
                     if (s != buffer.Length)
                         throw new InvalidDataException("Premature End-of-stream encountered while reading blocklist hashes");
 

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Duplicati.Library.Interface;
+using Duplicati.Library.Utility;
+using System;
 using System.IO;
-using Duplicati.Library.Interface;
 
 namespace Duplicati.Library.Main.Volumes
 {
@@ -11,6 +9,7 @@ namespace Duplicati.Library.Main.Volumes
     {
         protected ICompression m_compression;
         protected Library.Utility.TempFile m_localfile;
+        protected Stream m_localFileStream;
         protected string m_volumename;
         public string LocalFilename { get { return m_localfile; } }
         public string RemoteFilename { get { return m_volumename; } }
@@ -19,7 +18,7 @@ namespace Duplicati.Library.Main.Volumes
         public abstract RemoteVolumeType FileType { get; }
 
         public long VolumeID { get; set; }
-        
+
         public void SetRemoteFilename(string name)
         {
             m_volumename = name;
@@ -29,15 +28,15 @@ namespace Duplicati.Library.Main.Volumes
             : this(options, DateTime.UtcNow)
         {
         }
-        
+
         public static string GenerateGuid(Options options)
         {
             var s = Guid.NewGuid().ToString("N");
-            
+
             //We can choose shorter GUIDs here
-            
+
             return s;
-            
+
         }
 
         public void ResetRemoteFilename(Options options, DateTime timestamp)
@@ -54,14 +53,16 @@ namespace Duplicati.Library.Main.Volumes
                 m_localfile = new Library.Utility.TempFile();
 
             ResetRemoteFilename(options, timestamp);
-            m_compression = DynamicLoader.CompressionLoader.GetModule(options.CompressionModule, m_localfile, options.RawOptions);
-            
-            if(m_compression == null)
+
+            m_localFileStream = new System.IO.FileStream(m_localfile, FileMode.Create, FileAccess.Write, FileShare.Read);
+            m_compression = DynamicLoader.CompressionLoader.GetModule(options.CompressionModule, m_localFileStream, ArchiveMode.Write, options.RawOptions);
+
+            if (m_compression == null)
                 throw new UserInformationException(string.Format("Unsupported compression module: {0}", options.CompressionModule));
-            
+
             if ((this is IndexVolumeWriter || this is FilesetVolumeWriter) && m_compression is Library.Interface.ICompressionHinting)
                 ((Library.Interface.ICompressionHinting)m_compression).LowOverheadMode = true;
-                
+
             AddManifestfile();
         }
 
@@ -77,6 +78,10 @@ namespace Duplicati.Library.Main.Volumes
                 try { m_compression.Dispose(); }
                 finally { m_compression = null; }
 
+            if (m_localFileStream != null)
+                try { m_localFileStream.Dispose(); }
+                finally { m_localFileStream = null; }
+
             if (m_localfile != null)
                 try { m_localfile.Dispose(); }
                 finally { m_localfile = null; }
@@ -89,16 +94,13 @@ namespace Duplicati.Library.Main.Volumes
             if (m_compression != null)
                 try { m_compression.Dispose(); }
                 finally { m_compression = null; }
+
+            if (m_localFileStream != null)
+                try { m_localFileStream.Dispose(); }
+                finally { m_localFileStream = null; }
         }
 
         public long Filesize { get { return m_compression.Size + m_compression.FlushBufferSize; } }
 
-        public void SetTempFile(Library.Utility.TempFile tmpfile)
-        {
-            if (m_localfile != null)
-                m_localfile.Dispose();
-
-            m_localfile = tmpfile;
-        }
     }
 }

--- a/Duplicati/Library/UsageReporter/OSInfoHelper.cs
+++ b/Duplicati/Library/UsageReporter/OSInfoHelper.cs
@@ -154,7 +154,6 @@ namespace Duplicati.Library.UsageReporter
                     return RunProgramAndReadOutput("uname", "-srvmpio");
                 }
 
-                return null;
             }
         }    
     }

--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -51,6 +51,7 @@
     <Compile Include="OverrideableStream.cs" />
     <Compile Include="ProgressReportingStream.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ShaderStream.cs" />
     <Compile Include="Sizeparser.cs" />
     <Compile Include="SslCertificateValidator.cs" />
     <Compile Include="TempFile.cs" />
@@ -102,7 +103,5 @@
       <Name>Duplicati.Library.Localization</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Power\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Duplicati/Library/Utility/ShaderStream.cs
+++ b/Duplicati/Library/Utility/ShaderStream.cs
@@ -1,0 +1,73 @@
+﻿#region Disclaimer / License
+// Copyright (C) 2015, The Duplicati Team
+// http://www.duplicati.com, info@duplicati.com
+// 
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+// 
+#endregion
+using System;
+
+namespace Duplicati.Library.Utility
+{
+    /// <summary>
+    /// A small utility stream that allows to keep streams open and counts the bytes sent through. </summary>
+    /// </summary>
+    public class ShaderStream : System.IO.Stream
+    {
+        private readonly System.IO.Stream m_baseStream;
+        private readonly bool m_keepBaseOpen;
+        private long m_read = 0;
+        private long m_written = 0;
+
+        public ShaderStream(System.IO.Stream baseStream, bool keepBaseOpen)
+        {
+            this.m_baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+            this.m_keepBaseOpen = keepBaseOpen;
+        }
+
+        public long TotalBytesRead { get { return m_read; } }
+        public long TotalBytesWritten { get { return m_written; } }
+
+        public override bool CanRead { get { return m_baseStream.CanRead; } }
+        public override bool CanSeek { get { return m_baseStream.CanSeek; } }
+        public override bool CanWrite { get { return m_baseStream.CanWrite; } }
+        public override long Length { get { return m_baseStream.Length; } }
+        public override long Position
+        {
+            get { return m_baseStream.Position; }
+            set { m_baseStream.Position = value; }
+        }
+        public override void Flush() { m_baseStream.Flush(); }
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { return m_baseStream.Seek(offset, origin); }
+        public override void SetLength(long value) { m_baseStream.SetLength(value); }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int r = m_baseStream.Read(buffer, offset, count);
+            m_read += r;
+            return r;
+        }
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            m_baseStream.Write(buffer, offset, count);
+            m_written += count;
+        }
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !m_keepBaseOpen)
+                m_baseStream.Close();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Duplicati/Library/Utility/ShaderStream.cs
+++ b/Duplicati/Library/Utility/ShaderStream.cs
@@ -33,7 +33,9 @@ namespace Duplicati.Library.Utility
 
         public ShaderStream(System.IO.Stream baseStream, bool keepBaseOpen)
         {
-            this.m_baseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+            if (baseStream == null)
+                throw new ArgumentNullException(nameof(baseStream));
+            this.m_baseStream = baseStream;
             this.m_keepBaseOpen = keepBaseOpen;
         }
 

--- a/Duplicati/Library/Utility/TempFile.cs
+++ b/Duplicati/Library/Utility/TempFile.cs
@@ -72,13 +72,17 @@ namespace Duplicati.Library.Utility
                 m_fileTrace.Add(s, st);
             return s;            
         }
-        
+
 #else
         private static string GenerateUniqueName()
         {
             return APPLICATION_PREFIX + Guid.NewGuid().ToString();
         }
 #endif
+        /// <summary>
+        /// The name of the temp file
+        /// </summary>
+        public string Name => m_path;
 
         /// <summary>
         /// Gets all temporary files found in the current tempdir, that matches the application prefix

--- a/Duplicati/Library/Utility/TempFileStream.cs
+++ b/Duplicati/Library/Utility/TempFileStream.cs
@@ -49,7 +49,9 @@ namespace Duplicati.Library.Utility
 
         public TempFileStream(TempFile file)
         {
-            m_file = file ?? throw new ArgumentNullException(nameof(file));
+            if (file == null)
+                throw new ArgumentNullException(nameof(file));
+            m_file = file;
             m_stream = System.IO.File.Open(file, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
         }
 

--- a/Duplicati/Library/Utility/TempFileStream.cs
+++ b/Duplicati/Library/Utility/TempFileStream.cs
@@ -37,6 +37,11 @@ namespace Duplicati.Library.Utility
         {
         }
 
+        /// <summary>
+        /// Full name of the temp file.
+        /// </summary>
+        public string Name => m_file?.Name;
+
         public TempFileStream(string file)
             : this(TempFile.WrapExistingFile(file))
         {
@@ -44,7 +49,7 @@ namespace Duplicati.Library.Utility
 
         public TempFileStream(TempFile file)
         {
-            m_file = file;
+            m_file = file ?? throw new ArgumentNullException(nameof(file));
             m_stream = System.IO.File.Open(file, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
         }
 

--- a/Duplicati/Server/Duplicati.Server.csproj
+++ b/Duplicati/Server/Duplicati.Server.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <UseMSBuildEngine>false</UseMSBuildEngine>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
@@ -154,7 +154,7 @@ namespace Duplicati.Server.WebServer
                     else
                         throw new Exception("Unable to get XSRF token");
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     response.Status = System.Net.HttpStatusCode.InternalServerError;
                     response.Reason = "The system is incorrectly configured";
@@ -175,7 +175,7 @@ namespace Duplicati.Server.WebServer
                 {
                     username = ShellExec(AUTH_CGI, shell: false, exitcode: 0, env: tmpenv).Result;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     response.Status = System.Net.HttpStatusCode.InternalServerError;
                     response.Reason = "The system is incorrectly configured";

--- a/Duplicati/UnitTest/CompressionTests.cs
+++ b/Duplicati/UnitTest/CompressionTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Duplicati.UnitTest
@@ -25,44 +26,87 @@ namespace Duplicati.UnitTest
     [Category("Compression")]
     public class CompressionTests
     {
-        [Test]
-        public void TestZipCompressionHints()
-        {
-            TestCompressionHints("zip");
-        }
-
-        [Test]
-        public void Test7zCompressionHints()
-        {
-            TestCompressionHints("7z");
-        }
-
+        [TestCase("zip")]
+        [TestCase("7z")]
         public void TestCompressionHints(string module)
         {
             const int TESTSIZE = 1024 * 1024;
 
-            using (var tf0 = new Library.Utility.TempFile())
-            using (var tf1 = new Library.Utility.TempFile())
+            using (var tf0 = new MemoryStream())
+            using (var tf1 = new MemoryStream())
             {
                 var opts = new Dictionary<string, string>();
                 opts["zip-compression-level"] = "9";
 
-                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, tf0, opts))
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, tf0, Library.Interface.ArchiveMode.Write, opts))
                 using (var fs0 = z0.CreateFile("sample", Library.Interface.CompressionHint.Noncompressible, DateTime.Now))
                     fs0.Write(new byte[TESTSIZE], 0, TESTSIZE);
 
-                using (var z1 = Library.DynamicLoader.CompressionLoader.GetModule(module, tf1, opts))
+                using (var z1 = Library.DynamicLoader.CompressionLoader.GetModule(module, tf1, Library.Interface.ArchiveMode.Write, opts))
                 using (var fs1 = z1.CreateFile("sample", Library.Interface.CompressionHint.Compressible, DateTime.Now))
                     fs1.Write(new byte[TESTSIZE], 0, TESTSIZE);
 
 
-                if (new FileInfo(tf0).Length < TESTSIZE)
+                if (tf0.Length < TESTSIZE)
                     throw new Exception("Compression hint non-compressible is not honored");
 
-                if (new FileInfo(tf1).Length > new FileInfo(tf0).Length * 0.25)
+                if (tf1.Length > tf0.Length * 0.25)
                     throw new Exception("Compression is not applied");
             }
         }
-        
+
+        /// <summary>
+        /// Test compression reversibility
+        /// </summary>
+        /// <param name="module"></param>
+        [TestCase("zip")]
+        [TestCase("7z")]
+        public void TestCompressionReversibility(string module)
+        {
+            const int TESTSIZE = 1024 * 1024;
+            var testset1 = Enumerable.Range(0, TESTSIZE).Select(i => (byte)((i * 22695477) % 257));
+            var testset2 = Enumerable.Range(0, TESTSIZE).Select(i => (byte)((i * 48271) % 257));
+
+            using (var stream = new MemoryStream())
+            {
+                var opts = new Dictionary<string, string>();
+                opts["zip-compression-level"] = "9";
+
+                // Compress test streams
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, stream, Library.Interface.ArchiveMode.Write, opts))
+                {
+                    // Add two files to the archive
+                    using (var fs1 = z0.CreateFile("sample1", Library.Interface.CompressionHint.Compressible, DateTime.Now))
+                        fs1.Write(testset1.ToArray(), 0, TESTSIZE);
+
+                    using (var fs1 = z0.CreateFile("sample2", Library.Interface.CompressionHint.Compressible, DateTime.Now))
+                        fs1.Write(testset2.ToArray(), 0, TESTSIZE);
+                }
+
+                Console.WriteLine("Compression rate for module {0}: {1:0.00}%", module, 100.0 * stream.Length / (TESTSIZE * 2));
+                // Decompress
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, stream, Library.Interface.ArchiveMode.Read, opts))
+                {
+                    // Get files list
+                    var files = z0.ListFiles(null);
+
+                    // Read second file
+                    using (var fd = z0.OpenRead(files[1]))
+                    {
+                        bool match = testset2.All(b => b == fd.ReadByte()) && fd.ReadByte() == -1;
+                        if (!match)
+                            throw new Exception("Decompressed file sample2 contents do not match the source file.");
+                    }
+
+                    // Read first file
+                    using (var fd = z0.OpenRead(files[0]))
+                    {
+                        bool match = testset1.All(b => b == fd.ReadByte()) && fd.ReadByte() == -1;
+                        if (!match)
+                            throw new Exception("Decompressed file sample1 contents do not match the source file.");
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Compression classes refactored to accept streams instead of filenames.
The changes were made with a view for the future support of storing temporary files in memory (issue #2816)