### PR TITLE
Fix for #2945

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
+++ b/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
@@ -1,5 +1,5 @@
 <ul class="advancedoptions">
-    <li ng-repeat="item in ngModel | orderBy: 'item' as nn track by $index" class="advancedentry">
+    <li ng-repeat="item in ngModel" class="advancedentry">
         <div>
             <label class="shortname">{{getShortName(item)}}</label>
 


### PR DESCRIPTION
The orderBy attribute causes the issue described in #2945 and it doesn't actually do anything. The "$index" is just the order in the config file and they're already loaded in that order before they get sorted.