### PR TITLE
Use built-in method to determine if process is 64-bit

### DIFF
--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -110,7 +110,7 @@ namespace Duplicati.Library.SQLiteHelper
                     if (!Duplicati.Library.Utility.Utility.IsMono)
                     {
                         //If we run with MS.Net we can use the mixed mode assemblies
-                        if (Library.Utility.Utility.Is64BitProcess)
+                        if (Environment.Is64BitProcess)
                         {
                             if (System.IO.File.Exists(System.IO.Path.Combine(System.IO.Path.Combine(basePath, "win64"), filename)))
                                 assemblyPath = System.IO.Path.Combine(basePath, "win64");

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -35,11 +35,6 @@ namespace Duplicati.Library.Utility
         public static long DEFAULT_BUFFER_SIZE => SystemContextSettings.Buffersize;
 
         /// <summary>
-        /// A value indicating if the current process is running in 64bit mode
-        /// </summary>
-        public static readonly bool Is64BitProcess = IntPtr.Size == 8;
-
-        /// <summary>
         /// Gets the hash algorithm used for calculating a hash
         /// </summary>
         public static string HashAlgorithm { get { return "SHA256"; } }


### PR DESCRIPTION
We can use a built-in method to determine whether the current process is a 64-bit process or not.  This method was introduced in .NET 4.0.