### PR TITLE
Check MSSQL 32bit instances on 64bit system

### DIFF
--- a/Duplicati/Library/Snapshots/MSSQLUtility.cs
+++ b/Duplicati/Library/Snapshots/MSSQLUtility.cs
@@ -94,14 +94,14 @@ namespace Duplicati.Library.Snapshots
             {
                 if (!string.IsNullOrWhiteSpace(installed as string))
                     arrInstalledInstances = new string[] { installed as string };
-            }         
+            }
             else if (installed is string[])
                 arrInstalledInstances = (string[])installed;
             else if (installed != null)
                 try { arrInstalledInstances = (string[])installed; }
                 catch { }
 
-            if(Environment.Is64BitOperatingSystem)
+            if(Environment.Is64BitOperatingSystem && arrInstalledInstances == null)
             {
                 var installed32on64 = Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SQL Server", "InstalledInstances", "");
                 if (installed32on64 is string)

--- a/Duplicati/Library/Snapshots/MSSQLUtility.cs
+++ b/Duplicati/Library/Snapshots/MSSQLUtility.cs
@@ -94,13 +94,28 @@ namespace Duplicati.Library.Snapshots
             {
                 if (!string.IsNullOrWhiteSpace(installed as string))
                     arrInstalledInstances = new string[] { installed as string };
-            }
+            }         
             else if (installed is string[])
                 arrInstalledInstances = (string[])installed;
             else if (installed != null)
                 try { arrInstalledInstances = (string[])installed; }
                 catch { }
 
+            if(Environment.Is64BitOperatingSystem)
+            {
+                var installed32on64 = Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SQL Server", "InstalledInstances", "");
+                if (installed32on64 is string)
+                {
+                    if (!string.IsNullOrWhiteSpace(installed32on64 as string))
+                        arrInstalledInstances = new string[] { installed32on64 as string };
+                }         
+                else if (installed32on64 is string[])
+                    arrInstalledInstances = (string[])installed32on64;
+                else if (installed32on64 != null)
+                    try { arrInstalledInstances = (string[])installed32on64; }
+                    catch { }
+             }
+            
             IsMSSQLInstalled = arrInstalledInstances == null ? false : arrInstalledInstances.Length > 0;
 
             if (!IsMSSQLInstalled)


### PR DESCRIPTION
Some programs create MSSQL 32bit instances on 64bit system. In that case Duplicati can't find them because it checks only 64bit registry. That change make possible to check also 32bit registry.