### PR TITLE
Move RunScript module to be configured first

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -771,7 +771,19 @@ namespace Duplicati.Library.Main
             foreach (var k in qp.Keys)
                 conopts[(string)k] = qp[(string)k];
 
+            //// Since Configure in RunScript can alter the RawOptions, make sure it is first in the list for Configure
+            var LoadedModules = new List<KeyValuePair<bool, Interface.IGenericModule>>();
             foreach (var mx in m_options.LoadedModules)
+                if (mx.Value.ToString().ToLower().Contains("runscript"))
+                {
+                    LoadedModules.Insert(0, mx);
+                }
+                else
+                {
+                    LoadedModules.Add(mx);
+                }
+
+            foreach (var mx in LoadedModules)
                 if (mx.Key)
                 {
                     if (mx.Value is Library.Interface.IConnectionModule)

--- a/Duplicati/Library/Modules/Builtin/run-script-example.bat
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.bat
@@ -52,7 +52,7 @@ REM All Duplicati options can be changed by the script by writing options to
 REM stdout (with echo or similar). Anything not starting with a double dash (--)
 REM will be ignored:
 REM echo "Hello! -- test, this line is ignored"
-REM echo "--new-option=""This will be a setting"""
+REM echo --new-option=This will be a setting
 
 REM Filters are supplied in the DUPLICAT__FILTER variable.
 REM The variable contains all filters supplied with --include and --exclude,


### PR DESCRIPTION
The process for adding configuration to scripts for sending email (like username and password) was not working.  It was altering the configuration, but the configuration was not being loaded for the SendMail module.

This update just re-arranges the order that the modules are loaded in so that the RunScript module is loaded first.

This update also changes the example to not use double quotes.  The double quotes were being added as part of the configuration.