### PR TITLE
Advanced options list fixes

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
+++ b/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
@@ -1,5 +1,5 @@
 <ul class="advancedoptions">
-    <li ng-repeat="item in ngModel" class="advancedentry">
+    <li ng-repeat="item in ngModel | orderBy: 'item' as nn track by $index" class="advancedentry">
         <div>
             <label class="shortname">{{getShortName(item)}}</label>
 

--- a/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
+++ b/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
@@ -1,5 +1,5 @@
 <ul class="advancedoptions">
-    <li ng-repeat="item in ngModel | orderBy: 'item' as nn track by $index" class="advancedentry">
+    <li ng-repeat="item in ngModel | orderBy: item as nn track by $index" class="advancedentry">
         <div>
             <label class="shortname">{{getShortName(item)}}</label>
 

--- a/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
+++ b/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
@@ -3,35 +3,35 @@
         <div>
             <label class="shortname">{{getShortName(item)}}</label>
 
-            <select ng-if="getInputType(item) == 'enum'" ng-options="n for n in getEnumerations(item)" ng-model="$parent.ngModel[$index]" parse-advanced-option="getEnumerations(item)"></select>
-            <select ng-if="getInputType(item) == 'flags'" ng-options="n for n in getEnumerations(item)" ng-model="$parent.ngModel[$index]" parse-advanced-option-flags="getEnumerations(item)" multiple="multiple"></select>
-            <input ng-if="getInputType(item) == 'bool'" type="checkbox" ng-model="$parent.ngModel[$index]" parse-advanced-option-bool ></input>
-            <input ng-if="getInputType(item) == 'password'" type="password" ng-model="$parent.ngModel[$index]" parse-advanced-option ></input>
-            <input ng-if="getInputType(item) == 'text'" type="text" ng-model="$parent.ngModel[$index]" parse-advanced-option ></input>
-            <input ng-if="getInputType(item) == 'int'" type="number" ng-model="$parent.ngModel[$index]" parse-advanced-option-integer ></input>
+            <select ng-if="getInputType(item) == 'enum'" ng-options="n for n in getEnumerations(item)" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" parse-advanced-option="getEnumerations(item)"></select>
+            <select ng-if="getInputType(item) == 'flags'" ng-options="n for n in getEnumerations(item)" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" parse-advanced-option-flags="getEnumerations(item)" multiple="multiple"></select>
+            <input ng-if="getInputType(item) == 'bool'" type="checkbox" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" parse-advanced-option-bool ></input>
+            <input ng-if="getInputType(item) == 'password'" type="password" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" parse-advanced-option ></input>
+            <input ng-if="getInputType(item) == 'text'" type="text" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" parse-advanced-option ></input>
+            <input ng-if="getInputType(item) == 'int'" type="number" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" parse-advanced-option-integer ></input>
 
             <div ng-if="getInputType(item) == 'size'" class="input type multiple">
-                <input type="number" parse-advanced-option-size-number="uppercase" ng-model="$parent.ngModel[$index]" />
-                <select parse-advanced-option-size-multiplier="uppercase" ng-model="$parent.ngModel[$index]" ng-options="item.value as item.name for item in fileSizeMultipliers">
+                <input type="number" parse-advanced-option-size-number="uppercase" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" />
+                <select parse-advanced-option-size-multiplier="uppercase" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" ng-options="item.value as item.name for item in fileSizeMultipliers">
                 </select>
             </div>
 
             <div ng-if="getInputType(item) == 'speed'" class="input type multiple">
-                <input type="number" parse-advanced-option-size-number="uppercase" ng-model="$parent.ngModel[$index]" />
-                <select parse-advanced-option-size-multiplier="uppercase" ng-model="$parent.ngModel[$index]" ng-options="item.value as item.name for item in speedMultipliers">
+                <input type="number" parse-advanced-option-size-number="uppercase" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" />
+                <select parse-advanced-option-size-multiplier="uppercase" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" ng-options="item.value as item.name for item in speedMultipliers">
                 </select>
             </div>
 
             <div ng-if="getInputType(item) == 'timespan'" class="input type multiple">
-                <input parse-advanced-option-size-number type="number" ng-model="$parent.ngModel[$index]" />
-                <select parse-advanced-option-size-multiplier ng-model="$parent.ngModel[$index]" ng-options="item.value as item.name for item in timerangeMultipliers">
+                <input parse-advanced-option-size-number type="number" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" />
+                <select parse-advanced-option-size-multiplier ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" ng-options="item.value as item.name for item in timerangeMultipliers">
                     <option value="" translate>custom</option>
                 </select>
             </div>
 
             <div ng-if="getInputType(item) == 'shorttimespan'" class="input type multiple">
-                <input parse-advanced-option-size-number type="number" ng-model="$parent.ngModel[$index]" />
-                <select parse-advanced-option-size-multiplier ng-model="$parent.ngModel[$index]" ng-options="item.value as item.name for item in shorttimerangeMultipliers">
+                <input parse-advanced-option-size-number type="number" ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" />
+                <select parse-advanced-option-size-multiplier ng-model="$parent.ngModel[$parent.ngModel.indexOf(item)]" ng-options="item.value as item.name for item in shorttimerangeMultipliers">
                     <option value="" translate>custom</option>
                 </select>
             </div>


### PR DESCRIPTION
First off, I reverted the original fix 8bed599fcd7116051ed881b0a6b51a41361b9fe8, as it is directly causing #2974

Secondly, `orderBy: 'item' as nn track by $index` caused the index be cast to a string. This caused some weird sorting, which partially explained what I was seeing in #2945 with more than 10 items in the list. Simply removing the quotes around `'item'` fixed the sorting. Now entries are sorted alphabetically (because they're sorted alphabetically in the option map).

After ordering by $index there was a miss match between the model and the names/types, like I was originally describing in #2945. This is because names/types are parsed from functions looking at the `item`. Meanwhile, the model was looking at the $index, of the sorted list, in the unsorted list causing the miss match. I fixed this by looking up the index using `$parent.ngModel.indexOf(item)`. This solution looks a bit weird, but it gets the right index solving the mismatch problem.