### PR TITLE
Using separate interfaces to read and write to archives.

### DIFF
--- a/Duplicati/CommandLine/Help.cs
+++ b/Duplicati/CommandLine/Help.cs
@@ -169,7 +169,7 @@ namespace Duplicati.CommandLine
                     lines.Add("");
                     lines.Add("");
                     lines.Add(Strings.Program.SupportedCompressionModulesHeader);
-                    foreach (Duplicati.Library.Interface.ICompression mod in Library.DynamicLoader.CompressionLoader.Modules)
+                    foreach (Duplicati.Library.Interface.ICompressionInfo mod in Library.DynamicLoader.CompressionLoader.Modules)
                         PrintCompressionModule(mod, lines);
 
                     lines.Add("");
@@ -347,7 +347,7 @@ namespace Duplicati.CommandLine
             lines.Add("");
         }
 
-        private static void PrintCompressionModule(Duplicati.Library.Interface.ICompression mod, List<string> lines)
+        private static void PrintCompressionModule(Duplicati.Library.Interface.ICompressionInfo mod, List<string> lines)
         {
             lines.Add(mod.DisplayName + " (." + mod.FilenameExtension + "):");
             lines.Add(" " + mod.Description);

--- a/Duplicati/CommandLine/RecoveryTool/Index.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Index.cs
@@ -96,7 +96,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                     var blocks = 0;
                     using (var stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
-                    using (var cp = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, stream, Library.Interface.ArchiveMode.Read, options))
+                    using (var cp = Library.DynamicLoader.CompressionLoader.GetArchiveReader(p.CompressionModule, stream, options))
                     using (var tf = new Library.Utility.TempFile())
                     {
                         using (var sw = new StreamWriter(tf))

--- a/Duplicati/CommandLine/RecoveryTool/List.cs
+++ b/Duplicati/CommandLine/RecoveryTool/List.cs
@@ -66,7 +66,7 @@ namespace Duplicati.CommandLine.RecoveryTool
         {
             var p = Library.Main.Volumes.VolumeBase.ParseFilename(file);
             using (var fs = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var cm = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, fs, Library.Interface.ArchiveMode.Read, options))
+            using (var cm = Library.DynamicLoader.CompressionLoader.GetArchiveReader(p.CompressionModule, fs, options))
             using (var filesetreader = new Library.Main.Volumes.FilesetVolumeReader(cm, new Duplicati.Library.Main.Options(options)))
                 foreach (var f in filesetreader.Files)
                 {

--- a/Duplicati/CommandLine/RecoveryTool/Recompress.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Recompress.cs
@@ -183,9 +183,9 @@ namespace Duplicati.CommandLine.RecoveryTool
                                 localFileSource = localFileSource + ".same";
                             }
                             using (var localFileSourceStream = new System.IO.FileStream(localFileSource, FileMode.Open, FileAccess.Read, FileShare.Read))
-                            using (var cmOld = Library.DynamicLoader.CompressionLoader.GetModule(remoteFile.CompressionModule, localFileSourceStream, ArchiveMode.Read, options))
+                            using (var cmOld = Library.DynamicLoader.CompressionLoader.GetArchiveReader(remoteFile.CompressionModule, localFileSourceStream, options))
                             using (var localFileTargetStream = new FileStream(localFileTarget, FileMode.Create, FileAccess.Write, FileShare.Delete))
-                            using (var cmNew = Library.DynamicLoader.CompressionLoader.GetModule(target_compr_module, localFileTargetStream, ArchiveMode.Write, options))
+                            using (var cmNew = Library.DynamicLoader.CompressionLoader.GetArchiveWriter(target_compr_module, localFileTargetStream, options))
                                 foreach (var cmfile in cmOld.ListFiles(""))
                                 {
                                     string cmfileNew = cmfile;

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -429,7 +429,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
         private class CompressedFileMRUCache : IDisposable
         {
-            private Dictionary<string, Library.Interface.ICompression> m_lookup = new Dictionary<string, Duplicati.Library.Interface.ICompression>();
+            private Dictionary<string, Library.Interface.IArchiveReader> m_lookup = new Dictionary<string, Duplicati.Library.Interface.IArchiveReader>();
             private Dictionary<string, Stream> m_streams = new Dictionary<string, Stream>();
             private List<string> m_mru = new List<string>();
             private Dictionary<string, string> m_options;
@@ -443,12 +443,12 @@ namespace Duplicati.CommandLine.RecoveryTool
 
             public Stream ReadBlock(string filename, string hash)
             {
-                Library.Interface.ICompression cf;
+                Library.Interface.IArchiveReader cf;
                 Stream stream;
                 if (!m_lookup.TryGetValue(filename, out cf) || !m_streams.TryGetValue(filename, out stream))
                 {
                     stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
-                    cf = Library.DynamicLoader.CompressionLoader.GetModule(Path.GetExtension(filename).Trim('.'), stream, Library.Interface.ArchiveMode.Read, m_options);
+                    cf = Library.DynamicLoader.CompressionLoader.GetArchiveReader(Path.GetExtension(filename).Trim('.'), stream, m_options);
                     if (cf == null)
                     {
                         stream.Dispose();

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -756,7 +756,7 @@ namespace Duplicati.Library.AutoUpdater
             {
                 using (var archive_temp = System.IO.File.Open(archive_temp_file, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
                 {
-                    using (ICompression zipfile = new Duplicati.Library.Compression.FileArchiveZip(archive_temp, ArchiveMode.Write, new Dictionary<string, string>()))
+                    using (IArchiveWriter zipfile = new Duplicati.Library.Compression.FileArchiveZip(archive_temp, ArchiveMode.Write, new Dictionary<string, string>()))
                     {
                         Func<string, string, bool> addToArchive = (path, relpath) =>
                         {

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -33,14 +33,14 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// Implementation overrides specific to compression
         /// </summary>
-        private class CompressionLoaderSub : DynamicLoader<ICompression>
+        private class CompressionLoaderSub : DynamicLoader<ICompressionInfo>
         {
             /// <summary>
             /// Returns the filename extension, which is also the key
             /// </summary>
             /// <param name="item">The item to load the key for</param>
             /// <returns>The file extension used by the module</returns>
-            protected override string GetInterfaceKey(ICompression item)
+            protected override string GetInterfaceKey(ICompressionInfo item)
             {
                 return item.FilenameExtension;
             }
@@ -90,7 +90,7 @@ namespace Duplicati.Library.DynamicLoader
 
                 lock (m_lock)
                 {
-                    ICompression b;
+                    ICompressionInfo b;
                     if (m_interfaces.TryGetValue(key, out b) && b != null)
                         return b.SupportedCommands;
                     else
@@ -109,7 +109,7 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// Gets a list of loaded compression modules, the instances can be used to extract interface information, not used to interact with the module.
         /// </summary>
-        public static ICompression[] Modules { get { return _compressionLoader.Interfaces; } }
+        public static ICompressionInfo[] Modules { get { return _compressionLoader.Interfaces; } }
 
         /// <summary>
         /// Gets a list of keys supported
@@ -127,17 +127,29 @@ namespace Duplicati.Library.DynamicLoader
         }
 
         /// <summary>
-        /// Instanciates a specific compression module, given the file extension and options
+        /// Instanciates a specific compression module for writing, given the file extension and options
         /// </summary>
         /// <param name="fileextension">The file extension to create the instance for</param>
         /// <param name="stream">The stream of the file used to compress/decompress contents</param>
-        /// <param name="writing">True is the file opened for writing</param>
         /// <param name="options">The options to pass to the instance constructor</param>
-        /// <returns>The instanciated compression module or null if the file extension is not supported</returns>
-        public static ICompression GetModule(string fileextension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)
+        /// <returns>The instanciated compression module writer or null if the file extension is not supported</returns>
+        public static IArchiveWriter GetArchiveWriter(string fileextension, Stream stream, Dictionary<string, string> options)
         {
-            return _compressionLoader.GetModule(fileextension, stream, mode, options);
+            return _compressionLoader.GetModule(fileextension, stream, ArchiveMode.Write, options);
         }
+
+        /// <summary>
+        /// Instanciates a specific compression module for reading, given the file extension and options
+        /// </summary>
+        /// <param name="fileextension">The file extension to create the instance for</param>
+        /// <param name="stream">The stream of the file used to compress/decompress contents</param>
+        /// <param name="options">The options to pass to the instance constructor</param>
+        /// <returns>The instanciated compression module reader or null if the file extension is not supported</returns>
+        public static IArchiveReader GetArchiveReader(string fileextension, Stream stream, Dictionary<string, string> options)
+        {
+            return _compressionLoader.GetModule(fileextension, stream, ArchiveMode.Read, options);
+        }
+
         #endregion
 
     }

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -33,14 +33,14 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// Implementation overrides specific to compression
         /// </summary>
-        private class CompressionLoaderSub : DynamicLoader<ICompressionInfo>
+        private class CompressionLoaderSub : DynamicLoader<ICompression>
         {
             /// <summary>
             /// Returns the filename extension, which is also the key
             /// </summary>
             /// <param name="item">The item to load the key for</param>
             /// <returns>The file extension used by the module</returns>
-            protected override string GetInterfaceKey(ICompressionInfo item)
+            protected override string GetInterfaceKey(ICompression item)
             {
                 return item.FilenameExtension;
             }
@@ -90,7 +90,7 @@ namespace Duplicati.Library.DynamicLoader
 
                 lock (m_lock)
                 {
-                    ICompressionInfo b;
+                    ICompression b;
                     if (m_interfaces.TryGetValue(key, out b) && b != null)
                         return b.SupportedCommands;
                     else

--- a/Duplicati/Library/Interface/ICompression.cs
+++ b/Duplicati/Library/Interface/ICompression.cs
@@ -19,8 +19,6 @@
 #endregion
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 
 namespace Duplicati.Library.Interface
 {
@@ -75,7 +73,10 @@ namespace Duplicati.Library.Interface
         bool LowOverheadMode { get; set; }
     }
 
-    public interface IArchiveReader
+    /// <summary>
+    /// The interface for reading from an archive.
+    /// </summary>
+    public interface IArchiveReader : ICompressionInfo
     {
         /// <summary>
         /// Returns all files in the archive, matching the prefix, if any.
@@ -113,7 +114,10 @@ namespace Duplicati.Library.Interface
         bool FileExists(string file);
     }
 
-    public interface IArchiveWriter
+    /// <summary>
+    /// The interface for writing to an archive.
+    /// </summary>
+    public interface IArchiveWriter : ICompressionInfo
     {
         /// <summary>
         /// Creates a file in the archive.
@@ -131,17 +135,10 @@ namespace Duplicati.Library.Interface
     }
 
     /// <summary>
-    /// An interface for accessing files in an archive, such as a folder or compressed file.
-    /// All modules that implements compression must implement this interface.
-    /// The classes that implements this interface MUST also 
-    /// implement a default constructor and a construtor that
-    /// has the signature new(string file, Dictionary&lt;string, string&gt; options).
-    /// The default constructor is used to construct an instance
-    /// so the DisplayName and other values can be read.
-    /// The other constructor is used to do the actual work.
-    /// The input file may not exist or have zero length, in which case it should be created.
+    /// An interface for accessing compression module properties.
+    /// Most of the values (except Size) SHOULD be accessible for an instance built with a default constructor.
     /// </summary>
-    public interface ICompression : IDisposable, IArchiveReader, IArchiveWriter
+    public interface ICompressionInfo : IDisposable
     {
         /// <summary>
         /// The total size of the archive.
@@ -167,5 +164,20 @@ namespace Duplicati.Library.Interface
         /// Gets a list of supported commandline arguments
         /// </summary>
         IList<ICommandLineArgument> SupportedCommands { get; }
+    }
+
+    /// <summary>
+    /// An interface for accessing files in an archive, such as a folder or compressed file.
+    /// All modules that implements compression must implement this interface.
+    /// The classes that implements this interface MUST also 
+    /// implement a default constructor and a construtor that
+    /// has the signature new(Stream file, ArchiveMode mode, Dictionary&lt;string, string&gt; options).
+    /// The default constructor is used to construct an instance
+    /// so the DisplayName and other values can be read via IArchiveBase interface.
+    /// The other constructor is used to do the actual work.
+    /// The stream should be writable if mode is ArchiveMode.Writer and readable if mode is ArchiveMode.Reader.
+    /// </summary>
+    public interface ICompression : ICompressionInfo, IArchiveReader, IArchiveWriter
+    {
     }
 }

--- a/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
+++ b/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
@@ -68,7 +68,7 @@ namespace Duplicati.Library.Main.Operation
                 }
 
                 using (var stream = new System.IO.FileStream(m_targetpath, FileMode.Create, FileAccess.Write, FileShare.Read))
-                using (ICompression cm = DynamicLoader.CompressionLoader.GetModule(module, stream, Interface.ArchiveMode.Write, m_options.RawOptions))
+                using (var cm = DynamicLoader.CompressionLoader.GetArchiveWriter(module, stream, m_options.RawOptions))
                 {
                     using (var cs = cm.CreateFile("log-database.sqlite", Duplicati.Library.Interface.CompressionHint.Compressible, DateTime.UtcNow))
                     using (var fs = System.IO.File.Open(tmp, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite))

--- a/Duplicati/Library/Main/Volumes/BlockVolumeReader.cs
+++ b/Duplicati/Library/Main/Volumes/BlockVolumeReader.cs
@@ -9,16 +9,16 @@ namespace Duplicati.Library.Main.Volumes
 {
     public class BlockVolumeReader : VolumeReaderBase
     {
-        public BlockVolumeReader(ICompression compression, Options options)
+        public BlockVolumeReader(IArchiveReader compression, Options options)
             : base(compression, options)
         {
         }
-
+        
         public BlockVolumeReader(string compressor, string file, Options options)
             : base(compressor, file, options)
         {
         }
-
+        
         public int ReadBlock(string hash, byte[] blockbuffer)
         {
             using (var fs = m_compression.OpenRead(Library.Utility.Utility.Base64PlainToBase64Url(hash)))

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeReader.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeReader.cs
@@ -221,14 +221,14 @@ namespace Duplicati.Library.Main.Volumes
                     }
                 }
 
-                private ICompression m_compression;
+                private IArchiveReader m_compression;
                 private FileEntry m_current;
                 private StreamReader m_stream;
                 private JsonReader m_reader;
                 private bool m_done;
                 private bool m_first;
 
-                public FileEntryEnumerator(ICompression compression)
+                public FileEntryEnumerator(IArchiveReader compression)
                 {
                     m_compression = compression;
                     this.Reset();
@@ -302,8 +302,8 @@ namespace Duplicati.Library.Main.Volumes
                 }
             }
 
-            private ICompression m_compression;
-            public FileEntryEnumerable(ICompression compression)
+            private IArchiveReader m_compression;
+            public FileEntryEnumerable(IArchiveReader compression)
             {
                 m_compression = compression;
             }
@@ -323,12 +323,12 @@ namespace Duplicati.Library.Main.Volumes
         {
             private class ControlFileEnumerator : IEnumerator<KeyValuePair<string, Stream>>
             {
-                private ICompression m_compression;
+                private IArchiveReader m_compression;
                 private string[] m_files;
                 private long m_index;
                 private KeyValuePair<string, Stream>? m_current;
 
-                public ControlFileEnumerator(ICompression compression)
+                public ControlFileEnumerator(IArchiveReader compression)
                 {
                     m_compression = compression;
                     this.Reset();
@@ -365,8 +365,8 @@ namespace Duplicati.Library.Main.Volumes
                 }
             }
 
-            private ICompression m_compression;
-            public ControlFileEnumerable(ICompression compression)
+            private IArchiveReader m_compression;
+            public ControlFileEnumerable(IArchiveReader compression)
             {
                 m_compression = compression;
             }
@@ -375,7 +375,7 @@ namespace Duplicati.Library.Main.Volumes
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return this.GetEnumerator(); }
         }
 
-        public FilesetVolumeReader(ICompression compression, Options options)
+        public FilesetVolumeReader(IArchiveReader compression, Options options)
             : base(compression, options)
         {
         }

--- a/Duplicati/Library/Main/Volumes/IndexVolumeReader.cs
+++ b/Duplicati/Library/Main/Volumes/IndexVolumeReader.cs
@@ -28,9 +28,9 @@ namespace Duplicati.Library.Main.Volumes
 
         private class IndexBlockVolumeEnumerable : IEnumerable<IIndexBlockVolume>
         {
-            private ICompression m_compression;
+            private IArchiveReader m_compression;
 
-            public IndexBlockVolumeEnumerable(ICompression compression)
+            public IndexBlockVolumeEnumerable(IArchiveReader compression)
             {
                 m_compression = compression;
             }
@@ -41,7 +41,7 @@ namespace Duplicati.Library.Main.Volumes
                 {
                     private class BlockEnumerator : IEnumerator<KeyValuePair<string, long>>
                     {
-                        private ICompression m_compression;
+                        private IArchiveReader m_compression;
                         private string m_filename;
                         private KeyValuePair<string, long>? m_current;
                         private System.IO.StreamReader m_stream;
@@ -49,7 +49,7 @@ namespace Duplicati.Library.Main.Volumes
                         private bool m_done;
                         private KeyValuePair<string, long>? m_volumeProps = null;
 
-                        public BlockEnumerator(ICompression compression, string filename)
+                        public BlockEnumerator(IArchiveReader compression, string filename)
                         {
                             m_compression = compression;
                             m_filename = filename;
@@ -139,11 +139,11 @@ namespace Duplicati.Library.Main.Volumes
                         }
                     }
 
-                    private ICompression m_compression;
+                    private IArchiveReader m_compression;
                     private string m_filename;
                     private BlockEnumerator m_enumerator;
 
-                    public BlockEnumerable(ICompression compression, string filename)
+                    public BlockEnumerable(IArchiveReader compression, string filename)
                     {
                         m_compression = compression;
                         m_filename = filename;
@@ -173,13 +173,13 @@ namespace Duplicati.Library.Main.Volumes
 
                 private class IndexBlockVolume : IIndexBlockVolume
                 {
-                    private ICompression m_compression;
+                    private IArchiveReader m_compression;
                     private string m_filename;
                     private long? m_length;
                     private string m_hash;
                     private BlockEnumerable m_blocks;
 
-                    public IndexBlockVolume(ICompression compression, string filename)
+                    public IndexBlockVolume(IArchiveReader compression, string filename)
                     {
                         m_compression = compression;
                         m_filename = filename;
@@ -231,12 +231,12 @@ namespace Duplicati.Library.Main.Volumes
                     }
                 }
 
-                private ICompression m_compression;
+                private IArchiveReader m_compression;
                 private IndexBlockVolume m_current;
                 private string[] m_files;
                 private long m_index;
 
-                public IndexBlockVolumeEnumerator(ICompression compression)
+                public IndexBlockVolumeEnumerator(IArchiveReader compression)
                 {
                     m_compression = compression;
                     this.Reset();
@@ -284,10 +284,10 @@ namespace Duplicati.Library.Main.Volumes
 
         private class IndexBlocklistEnumerable : IEnumerable<IIndexBlocklist>
         {
-            private ICompression m_compression;
+            private IArchiveReader m_compression;
             private long m_hashsize;
 
-            public IndexBlocklistEnumerable(ICompression compression, long hashsize)
+            public IndexBlocklistEnumerable(IArchiveReader compression, long hashsize)
             {
                 m_compression = compression;
                 m_hashsize = hashsize;
@@ -297,12 +297,12 @@ namespace Duplicati.Library.Main.Volumes
             {
                 private class IndexBlocklist : IIndexBlocklist
                 {
-                    private ICompression m_compression;
+                    private IArchiveReader m_compression;
                     private string m_filename;
                     private long m_size;
                     private long m_hashsize;
 
-                    public IndexBlocklist(ICompression compression, string filename, long size, long hashsize)
+                    public IndexBlocklist(IArchiveReader compression, string filename, long size, long hashsize)
                     {
                         m_compression = compression;
                         m_filename = filename;
@@ -333,13 +333,13 @@ namespace Duplicati.Library.Main.Volumes
                     }
                 }
 
-                private ICompression m_compression;
+                private IArchiveReader m_compression;
                 private long m_index;
                 private KeyValuePair<string, long>[] m_files;
                 private IndexBlocklist m_current;
                 private long m_hashsize;
 
-                public IndexBlocklistEnumerator(ICompression compression, long hashsize)
+                public IndexBlocklistEnumerator(IArchiveReader compression, long hashsize)
                 {
                     m_compression = compression;
                     m_hashsize = hashsize;

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -10,12 +10,12 @@ namespace Duplicati.Library.Main.Volumes
     public abstract class VolumeReaderBase : VolumeBase, IDisposable
     {
         protected bool m_disposeCompression = false;
-        protected ICompression m_compression;
+        protected IArchiveReader m_compression;
         protected Stream m_stream;
 
-        private static ICompression LoadCompressor(string compressor, Stream stream, Options options)
+        private static IArchiveReader LoadCompressor(string compressor, Stream stream, Options options)
         {
-            var tmp = DynamicLoader.CompressionLoader.GetModule(compressor, stream, Interface.ArchiveMode.Read, options.RawOptions);
+            var tmp = DynamicLoader.CompressionLoader.GetArchiveReader(compressor, stream, options.RawOptions);
             if (tmp == null)
             {
                 var name = "[stream]";
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Main.Volumes
             return tmp;
         }
 
-        private static ICompression LoadCompressor(string compressor, string file, Options options, out Stream stream)
+        private static IArchiveReader LoadCompressor(string compressor, string file, Options options, out Stream stream)
         {
             stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
             return LoadCompressor(compressor, stream, options);
@@ -43,7 +43,7 @@ namespace Duplicati.Library.Main.Volumes
             m_disposeCompression = true;
         }
 
-        public VolumeReaderBase(ICompression compression, Options options)
+        public VolumeReaderBase(IArchiveReader compression, Options options)
             : base(options)
         {
             m_compression = compression;
@@ -103,7 +103,7 @@ namespace Duplicati.Library.Main.Volumes
             }
         }
 
-        public static IEnumerable<string> ReadBlocklist(ICompression compression, string filename, long hashsize)
+        public static IEnumerable<string> ReadBlocklist(IArchiveReader compression, string filename, long hashsize)
         {
             var buffer = new byte[hashsize];
             using (var fs = compression.OpenRead(filename))

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -7,7 +7,7 @@ namespace Duplicati.Library.Main.Volumes
 {
     public abstract class VolumeWriterBase : VolumeBase, IDisposable
     {
-        protected ICompression m_compression;
+        protected IArchiveWriter m_compression;
         protected Library.Utility.TempFile m_localfile;
         protected Stream m_localFileStream;
         protected string m_volumename;
@@ -55,7 +55,7 @@ namespace Duplicati.Library.Main.Volumes
             ResetRemoteFilename(options, timestamp);
 
             m_localFileStream = new System.IO.FileStream(m_localfile, FileMode.Create, FileAccess.Write, FileShare.Read);
-            m_compression = DynamicLoader.CompressionLoader.GetModule(options.CompressionModule, m_localFileStream, ArchiveMode.Write, options.RawOptions);
+            m_compression = DynamicLoader.CompressionLoader.GetArchiveWriter(options.CompressionModule, m_localFileStream, options.RawOptions);
 
             if (m_compression == null)
                 throw new UserInformationException(string.Format("Unsupported compression module: {0}", options.CompressionModule));

--- a/Duplicati/Server/Serializable/ServerSettings.cs
+++ b/Duplicati/Server/Serializable/ServerSettings.cs
@@ -46,7 +46,7 @@ namespace Duplicati.Server.Serializable
             /// <summary>
             /// Constructor for compression module interface
             /// </summary>
-            public DynamicModule(Duplicati.Library.Interface.ICompression module)
+            public DynamicModule(Duplicati.Library.Interface.ICompressionInfo module)
             {
                 this.Key = module.FilenameExtension;
                 this.Description = module.Description;

--- a/Duplicati/UnitTest/CompressionTests.cs
+++ b/Duplicati/UnitTest/CompressionTests.cs
@@ -38,11 +38,11 @@ namespace Duplicati.UnitTest
                 var opts = new Dictionary<string, string>();
                 opts["zip-compression-level"] = "9";
 
-                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, tf0, Library.Interface.ArchiveMode.Write, opts))
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetArchiveWriter(module, tf0, opts))
                 using (var fs0 = z0.CreateFile("sample", Library.Interface.CompressionHint.Noncompressible, DateTime.Now))
                     fs0.Write(new byte[TESTSIZE], 0, TESTSIZE);
 
-                using (var z1 = Library.DynamicLoader.CompressionLoader.GetModule(module, tf1, Library.Interface.ArchiveMode.Write, opts))
+                using (var z1 = Library.DynamicLoader.CompressionLoader.GetArchiveWriter(module, tf1, opts))
                 using (var fs1 = z1.CreateFile("sample", Library.Interface.CompressionHint.Compressible, DateTime.Now))
                     fs1.Write(new byte[TESTSIZE], 0, TESTSIZE);
 
@@ -73,7 +73,7 @@ namespace Duplicati.UnitTest
                 opts["zip-compression-level"] = "9";
 
                 // Compress test streams
-                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, stream, Library.Interface.ArchiveMode.Write, opts))
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetArchiveWriter(module, stream, opts))
                 {
                     // Add two files to the archive
                     using (var fs1 = z0.CreateFile("sample1", Library.Interface.CompressionHint.Compressible, DateTime.Now))
@@ -85,7 +85,7 @@ namespace Duplicati.UnitTest
 
                 Console.WriteLine("Compression rate for module {0}: {1:0.00}%", module, 100.0 * stream.Length / (TESTSIZE * 2));
                 // Decompress
-                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, stream, Library.Interface.ArchiveMode.Read, opts))
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetArchiveReader(module, stream, opts))
                 {
                     // Get files list
                     var files = z0.ListFiles(null);


### PR DESCRIPTION
Using parted IArchiveReader and IArchiveWriter interfaces to access archives instead of the single ICompression interface.