### PR TITLE
Scheduler recovery from timedrift

### DIFF
--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -245,6 +245,12 @@ namespace Duplicati.Server
                         
                         try
                         {
+                            // Recover from timedrift issues by overriding the dates if the last run date is in the future.
+                            if (last > DateTime.UtcNow)
+                            {
+                                start = DateTime.UtcNow;
+                                last = DateTime.UtcNow;
+                            }
                             start = GetNextValidTime(start, last, sc.Repeat, sc.AllowedDays);
                         }
                         catch (Exception ex)


### PR DESCRIPTION
Inspired by #2904 I tried playing a bit around with handling of timedrift.

I added this little piece of code in the scheduler to try and recover from a similar scenario.

In my tests it works well (I just exported some configs and changed the dates before re-importing), and will recover from scenarios where the last backup was performed in the future.

Of course it won't help if only the start time is in the future, but there just isn't any way to tell if the start time was affected by timedrift or intentionally set a year into the future.

On import, with future timestamps:
![screen shot 2018-01-27 at 20 34 39](https://user-images.githubusercontent.com/1561484/35476144-85a98dd2-03ab-11e8-88da-d674f95e1dce.png)
And after the run (files hadn't changed, so it didn't increment the versions number):
![screen shot 2018-01-27 at 20 41 48](https://user-images.githubusercontent.com/1561484/35476145-879fa9d2-03ab-11e8-8a43-89f0e7ca1dc3.png)
For testing purposes I had the interval at 6 min.

