### PR TITLE
Show default values for advanced options (#2810)

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/directives/advancedOptionsEditor.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/advancedOptionsEditor.js
@@ -119,6 +119,14 @@ backupApp.directive('advancedOptionsEditor', function() {
                 return item.LongDescription;
             };
 
+            $scope.getDefaultValue = function(item) {
+                var item = $scope.getEntry(item);
+                if (item == null)
+                    return null;
+
+                return item.DefaultValue;
+            };
+
             $scope.getEnumerations = function(item) {
                 var item = $scope.getEntry(item);
                 if (item == null)

--- a/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
+++ b/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
@@ -39,7 +39,7 @@
 
         <a href ng-click="deleteItem(item)" title="{{'Remove option' | translate}}">x</a>
 
-        <div class="longdescription">{{getLongDescription(item)}}</div>
+        <div class="longdescription">{{getLongDescription(item)}}<br>Default value: "{{getDefaultValue(item)}}"</div>
     </li>
 
     <li>


### PR DESCRIPTION
Added the function getDefaultValue() and printed it on a new line inside the long description. 
![screen shot 2018-01-27 at 23 43 57](https://user-images.githubusercontent.com/1561484/35477232-2c269c8c-03bf-11e8-8f38-f50bb61c90c0.png)
