### PR TITLE
Strip backup import metadata

### DIFF
--- a/Duplicati/Server/WebServer/RESTMethods/Backups.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backups.cs
@@ -55,6 +55,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             {
                 var input = info.Request.Form;
                 var cmdline = Library.Utility.Utility.ParseBool(input["cmdline"].Value, false);
+                var import_metadata = Library.Utility.Utility.ParseBool(input["import_metadata"].Value, false);
                 var direct = Library.Utility.Utility.ParseBool(input["direct"].Value, false);
                 output_template = output_template.Replace("CBM", input["callback"].Value);
                 if (cmdline)
@@ -89,6 +90,9 @@ namespace Duplicati.Server.WebServer.RESTMethods
                             using(var sr = new System.IO.StreamReader(fs))
                                 ipx = Serializer.Deserialize<Serializable.ImportExportStructure>(sr);
                         }
+                    }
+                    if (!import_metadata) {
+                        ipx.Backup.Metadata.Clear();
                     }
 
                     ipx.Backup.ID = null;

--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -1820,6 +1820,15 @@ div.modal-dialog {
     }
 }
 
+.importpage {
+    form.styled {
+        input {
+            margin-top: 11px;
+            margin-bottom: 11px;
+        }
+    }
+}
+
 .restorewizard,
 .addwizard {
     form.styled {

--- a/Duplicati/Server/webroot/ngax/templates/import.html
+++ b/Duplicati/Server/webroot/ngax/templates/import.html
@@ -1,5 +1,5 @@
 <div ng-controller="ImportController" class="importpage">
-    
+
     <h1 ng-hide="restoremode" translate>Import backup configuration</h1>
     <h1 ng-show="restoremode" translate>Restore from backup configuration</h1>
 
@@ -16,6 +16,11 @@
         </div>
 
         <div class="input checkbox" ng-hide="restoremode">
+            <label for="import_metadata" translate>Import metadata</label>
+            <input type="checkbox" name="import_metadata" id="import_metadata" value="true" />
+        </div>
+
+        <div class="input checkbox" ng-hide="restoremode">
             <label for="direct" translate>Save immediately</label>
             <input type="checkbox" name="direct" id="direct" value="true" />
         </div>
@@ -25,7 +30,7 @@
         <div class="buttons" ng-hide="Connecting">
             <a href ng-click="doSubmit()" translate>Import</a>
         </div>
-    
+
         <div class="buttons" ng-show="Connecting">
             <a href translate>Importing ...</a>
         </div>


### PR DESCRIPTION
This was made in connection with a discussion on #2807

Seeing as it's not uncommon for people to use backup configs as templates for multiple machines or different jobs it seems logical to give the user the option to not import metadata (which contains wrong information in those cases).

I added the feature with a default towards stripping metadata unless the user intentionally asks to import it.
![screen shot 2018-01-28 at 01 28 21](https://user-images.githubusercontent.com/1561484/35477851-bc93117a-03cd-11e8-815a-2a8b3a03aadf.png)
Same config imported with and without metadata:
![screen shot 2018-01-28 at 01 27 48](https://user-images.githubusercontent.com/1561484/35477852-bcb2aa4e-03cd-11e8-8eed-5111cf0e5fd9.png)

