### PR TITLE
Live logs cut off (#2812)

### DIFF
--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -212,7 +212,6 @@ ul.tabs {
     .entries.livedata {
         li {
             height: 1.2em;
-            overflow: hidden;
         }
 
         li.expanded {
@@ -1492,7 +1491,7 @@ body {
 
                     ul.entries {
                         li {
-                            padding-top: 15px;
+                            padding-top: 30px;
                         }
                     }
                 }


### PR DESCRIPTION
Fixed a problem where live logs were cut off if the backup used a prefix #2812 

It's caused by the `overflow: hidden` attribute and `padding-top: 30px` just looks better once the lines start wrapping down on 2nd line.