### PR TITLE
Use double instead of long for Utility.FormatSizeString

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -586,19 +586,19 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <param name="size">The size to format</param>
         /// <returns>A human readable string representing the size</returns>
-        public static string FormatSizeString(long size)
+        public static string FormatSizeString(double size)
         {
-            long sizeAbs = Math.Abs(size);  // Allow formatting of negative sizes
+            double sizeAbs = Math.Abs(size);  // Allow formatting of negative sizes
             if (sizeAbs >= 1024 * 1024 * 1024 * 1024L)
-                return Strings.Utility.FormatStringTB((double)size / (1024 * 1024 * 1024 * 1024L));
+                return Strings.Utility.FormatStringTB(size / (1024 * 1024 * 1024 * 1024L));
             else if (sizeAbs >= 1024 * 1024 * 1024)
-                return Strings.Utility.FormatStringGB((double)size / (1024 * 1024 * 1024));
+                return Strings.Utility.FormatStringGB(size / (1024 * 1024 * 1024));
             else if (sizeAbs >= 1024 * 1024)
-                return Strings.Utility.FormatStringMB((double)size / (1024 * 1024));
+                return Strings.Utility.FormatStringMB(size / (1024 * 1024));
             else if (sizeAbs >= 1024)
-                return Strings.Utility.FormatStringKB((double)size / 1024);
+                return Strings.Utility.FormatStringKB(size / 1024);
             else
-                return Strings.Utility.FormatStringB(size);
+                return Strings.Utility.FormatStringB((long) size); // safe to cast because lower than 1024 and thus well within range of long
         }
 
         public static System.Threading.ThreadPriority ParsePriority(string value)


### PR DESCRIPTION
This _should_ fix the issue described in #2994.

Using `double` instead of `long` for `FormatSizeString` should help, since floating point numbers have a seperate sign bit, thus being able to represent the same range for positve and negative numbers. And since the method is only used for printing rounded numbers anyway, the potential loss of precisions shouldn't matter.

I couldn't test this myself though, since I cannot reproduce the error, but `Math.Abs(double.MinValue)` works fine.

This does NOT change all the calls to this method, some of which still force a cast to `long` when calling it. Should maybe done in a seperate pull request?