### PR TITLE
Manual backups should skip queue

### DIFF
--- a/Duplicati/Library/Utility/WorkerThread.cs
+++ b/Duplicati/Library/Utility/WorkerThread.cs
@@ -163,6 +163,40 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// An overloaded AddTask method that allows a task to skip to the front of a queue
+        /// It does this by creating a new queue, adding the new task first, and then adding
+        /// all the old tasks to the new queue. It's cleaner to use a linked list,
+        /// but the performance difference is negligible on such a small queue.
+        /// </summary>
+        /// <param name="task">Task.</param>
+        /// <param name="skipQueue">If set to <c>true</c> skip queue.</param>
+        public void AddTask(Tx task, bool skipQueue)
+        {
+            if (!skipQueue) {
+                // Fall back to default AddTask method
+                AddTask(task);
+                return;
+            }
+
+            lock (m_lock)
+            {
+                Queue<Tx> newQueue = new Queue<Tx>();
+                newQueue.Enqueue(task);
+                while (m_tasks.Count > 0)
+                {
+                    Tx n = m_tasks.Dequeue();
+                    newQueue.Enqueue(n);
+                }
+                m_tasks = newQueue;
+                m_event.Set();
+            }
+
+            if (WorkQueueChanged != null)
+                WorkQueueChanged(this);
+        }
+
+
+        /// <summary>
         /// Removes a task from the queue, does not remove the task if it is currently running
         /// </summary>
         /// <param name="task">The task to remove</param>

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -293,7 +293,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             }
             else
             {
-                Program.WorkThread.AddTask(Runner.CreateTask(DuplicatiOperation.Backup, backup));
+                Program.WorkThread.AddTask(Runner.CreateTask(DuplicatiOperation.Backup, backup), true);
                 Program.StatusEventNotifyer.SignalNewEvent();
             }
 


### PR DESCRIPTION
This commit was made in relation to this thread on the forum:
https://forum.duplicati.com/t/server-not-yet-started-manual-backup-should-be-1-in-queue/2313

Added an overloaded AddTask method that allows tasks to skip the queue and updated the api call `backup/<id>/run` to skip the queue to correspond with the expectation of the 'Run now' button in the UI