### PR TITLE
Import database path

### DIFF
--- a/Duplicati/Server/Database/Backup.cs
+++ b/Duplicati/Server/Database/Backup.cs
@@ -67,7 +67,7 @@ namespace Duplicati.Server.Database
         /// <summary>
         /// The path to the local database
         /// </summary>
-        public string DBPath { get; internal set; }
+        public string DBPath { get; set; }
                 
         /// <summary>
         /// The backup source folders and files

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -354,9 +354,9 @@ namespace Duplicati.Server.Database
                 }
         }
 
-        internal void AddOrUpdateBackupAndSchedule(IBackup item, ISchedule schedule)
+        internal void AddOrUpdateBackupAndSchedule(IBackup item, ISchedule schedule, string folder = null)
         {
-            AddOrUpdateBackup(item, true, schedule);
+            AddOrUpdateBackup(item, true, schedule, folder);
         }
 
         internal string ValidateBackup(IBackup item, ISchedule schedule)
@@ -473,14 +473,17 @@ namespace Duplicati.Server.Database
             Program.StatusEventNotifyer.SignalNewEvent();
         }
 
-        private void AddOrUpdateBackup(IBackup item, bool updateSchedule, ISchedule schedule)
+        private void AddOrUpdateBackup(IBackup item, bool updateSchedule, ISchedule schedule, string folder)
         {
             lock(m_lock)
             {
                 bool update = item.ID != null;
                 if (!update && item.DBPath == null)
                 {
-                    var folder = Program.DataFolder;
+                    if (folder == null) {
+                        folder = Program.DataFolder;    
+                    }
+
                     if (!System.IO.Directory.Exists(folder))
                         System.IO.Directory.CreateDirectory(folder);
                     
@@ -493,7 +496,7 @@ namespace Duplicati.Server.Database
                             break;
                         }
                     }
-                    
+
                     if (item.DBPath == null)
                         throw new Exception("Unable to generate a unique database file name");
                 }

--- a/Duplicati/Server/WebServer/RESTMethods/Backups.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backups.cs
@@ -95,8 +95,20 @@ namespace Duplicati.Server.WebServer.RESTMethods
                         ipx.Backup.Metadata.Clear();
                     }
 
+                    string folder = null;
+                    // Check the database path. If it's valid use the same folder for the imported job
+                    if (ipx.Backup.DBPath != null) {
+                        var pattern = @"\/\w*\.sqlite";
+                        var regex = System.Text.RegularExpressions.Regex.Match(ipx.Backup.DBPath, pattern);
+                        if (regex.Success) {
+                            // strip the filename from the database path
+                            folder = ipx.Backup.DBPath.Substring(0, regex.Index+1);
+                        }
+                    }
+
+                    // Reset DBPath and ID for new backup job
                     ipx.Backup.ID = null;
-                    ((Database.Backup)ipx.Backup).DBPath = null;
+                    ipx.Backup.DBPath = null;
 
                     if (ipx.Schedule != null)
                         ipx.Schedule.ID = -1;
@@ -124,7 +136,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                                 return;
                             }
 
-                            Program.DataConnection.AddOrUpdateBackupAndSchedule(ipx.Backup, ipx.Schedule);
+                            Program.DataConnection.AddOrUpdateBackupAndSchedule(ipx.Backup, ipx.Schedule, folder);
                         }
 
                         info.Response.ContentType = "text/html";


### PR DESCRIPTION
In relation to #3005 I thought I'd write a little code to utilize the DBPath info now that we have it.

The code relies on regex to check that the DBPath is "valid" (e.g. it ends in "/something.sqlite"). If it's *valid* it'll parse the folder and pass that along to the method that creates the job.

If the DBPath isn't valid or isn't  defined we'll fall back to using the default folder like we've done previously.