### PR TITLE
Fix 2829: Reparse points aren't always symlinks

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Duplicati.Library.Main.Database;
 using Duplicati.Library.Main.Volumes;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Snapshots;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -187,7 +188,7 @@ namespace Duplicati.Library.Main.Operation
                         m_logWriter.AddVerboseMessage("Including path due to filter: {0} => {1}", path, match.ToString());
                 }
 
-                var isSymlink = (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+                var isSymlink = m_snapshot.IsSymlink(path, attributes);
                 if (isSymlink && m_symlinkPolicy == Options.SymlinkStrategy.Ignore)
                 {
                     if (m_logWriter != null)
@@ -281,8 +282,8 @@ namespace Duplicati.Library.Main.Operation
                 var fa = FileAttributes.Normal;
                 try { fa = snapshot.GetAttributes(path); }
                 catch { }
-                
-                if (followSymlinks && ((fa & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint))
+
+                if (followSymlinks && snapshot.IsSymlink(path, fa))
                     continue;
                 else if ((fa & FileAttributes.Directory) == FileAttributes.Directory)
                     continue;
@@ -970,32 +971,39 @@ namespace Duplicati.Library.Main.Operation
                                             
                 if ((attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
                 {
-                    if (m_options.SymlinkPolicy == Options.SymlinkStrategy.Ignore)
+                    // Not all reparse points are symlinks.
+                    // For example, on Windows 10 Fall Creator's Update, the OneDrive folder (and all subfolders)
+                    // are reparse points, which allows the folder to hook into the OneDrive service and download things on-demand.
+                    // If we can't find a symlink target for the current path, we won't treat it as a symlink.
+                    string symlinkTarget = snapshot.GetSymlinkTarget(path);
+                    if (!string.IsNullOrWhiteSpace(symlinkTarget))
                     {
-                        m_result.AddVerboseMessage("Ignoring symlink {0}", path);
-                        return false;
-                    }
-    
-                    if (m_options.SymlinkPolicy == Options.SymlinkStrategy.Store)
-                    {
-                        Dictionary<string, string> metadata = GenerateMetadata(snapshot, path, attributes);
-    
-                        if (!metadata.ContainsKey("CoreSymlinkTarget"))
+                        if (m_options.SymlinkPolicy == Options.SymlinkStrategy.Ignore)
                         {
-                            var p = snapshot.GetSymlinkTarget(path);
-
-                            if (string.IsNullOrWhiteSpace(p))
-                                m_result.AddVerboseMessage("Ignoring empty symlink {0}", path);
-                            else
-                                metadata["CoreSymlinkTarget"] = p;
+                            m_result.AddVerboseMessage("Ignoring symlink {0}", path);
+                            return false;
                         }
-    
-                        var metahash = Utility.WrapMetadata(metadata, m_options);
-                        AddSymlinkToOutput(backend, path, DateTime.UtcNow, metahash);
-                        
-                        m_result.AddVerboseMessage("Stored symlink {0}", path);
-                        //Do not recurse symlinks
-                        return false;
+
+                        if (m_options.SymlinkPolicy == Options.SymlinkStrategy.Store)
+                        {
+                            Dictionary<string, string> metadata = GenerateMetadata(snapshot, path, attributes);
+
+                            if (!metadata.ContainsKey("CoreSymlinkTarget"))
+                            {
+                                metadata["CoreSymlinkTarget"] = symlinkTarget;
+                            }
+
+                            var metahash = Utility.WrapMetadata(metadata, m_options);
+                            AddSymlinkToOutput(backend, path, DateTime.UtcNow, metahash);
+
+                            m_result.AddVerboseMessage("Stored symlink {0}", path);
+                            //Do not recurse symlinks
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        m_result.AddVerboseMessage("Treating empty symlink as regular path {0}", path);
                     }
                 }
     

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -827,10 +827,10 @@ namespace Duplicati.Library.Main.Operation
                         if (m_result.TaskControlRendevouz() != TaskControlState.Stop) 
                             CompactIfRequired(backend, lastVolumeSize);
 
-						using (new Logging.Timer("Async backend wait"))
+                        using (new Logging.Timer("Async backend wait"))
                             backend.WaitForComplete(m_database, m_transaction);
 
-						if (m_options.UploadVerificationFile)
+                        if (m_options.UploadVerificationFile)
                         {
                             m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_VerificationUpload);
                             FilelistProcessor.UploadVerificationFile(backend.BackendUrl, m_options, m_result.BackendWriter, m_database, m_transaction);

--- a/Duplicati/Library/Main/Operation/TestFilterHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestFilterHandler.cs
@@ -17,6 +17,7 @@
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 using System;
 using System.IO;
+using Duplicati.Library.Snapshots;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -44,7 +45,7 @@ namespace Duplicati.Library.Main.Operation
                     try { fa = snapshot.GetAttributes(path); }
                     catch { }
                     
-                    if (storeSymlinks && ((fa & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint))
+                    if (storeSymlinks && snapshot.IsSymlink(path, fa))
                     {
                         m_result.AddVerboseMessage("Storing symlink: {0}", path);
                     }

--- a/Duplicati/Library/Snapshots/ISystemIO.cs
+++ b/Duplicati/Library/Snapshots/ISystemIO.cs
@@ -50,6 +50,7 @@ namespace Duplicati.Library.Snapshots
         FileAttributes GetFileAttributes(string path);
         void SetFileAttributes(string path, FileAttributes attributes);
         void CreateSymlink(string symlinkfile, string target, bool asDir);
+        string GetSymlinkTarget(string path);
         string PathGetDirectoryName(string path);
         string PathGetFileName(string path);
         string PathGetExtension(string path);

--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -455,7 +455,7 @@ namespace Duplicati.Library.Snapshots
         public string GetSymlinkTarget(string file)
         {
             var local = ConvertToSnapshotPath(FindSnapShotByLocalPath(file), file);
-            return UnixSupport.File.GetSymlinkTarget(NoSnapshot.NormalizePath(local));
+            return _sysIO.GetSymlinkTarget(local);
         }
 
         /// <summary>

--- a/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
@@ -45,7 +45,7 @@ namespace Duplicati.Library.Snapshots
         /// <returns>The symlink target</returns>
         public override string GetSymlinkTarget(string file)
         {
-            return UnixSupport.File.GetSymlinkTarget(NormalizePath(file));
+            return _sysIO.GetSymlinkTarget(file);
         }
         
         /// <summary>

--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -46,11 +46,7 @@ namespace Duplicati.Library.Snapshots
         /// <returns>The symlink target</returns>
         public override string GetSymlinkTarget(string file)
         {
-            try { return File.GetLinkTargetInfo(SystemIOWindows.PrefixWithUNC(file)).PrintName; }
-            catch (NotAReparsePointException) { }
-            catch (UnrecognizedReparsePointException) { }
-
-            return null;
+            return m_sysIO.GetSymlinkTarget(file);
         }
 
         /// <summary>

--- a/Duplicati/Library/Snapshots/SnapshotUtility.cs
+++ b/Duplicati/Library/Snapshots/SnapshotUtility.cs
@@ -19,6 +19,7 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace Duplicati.Library.Snapshots
@@ -69,6 +70,60 @@ namespace Duplicati.Library.Snapshots
         private static ISnapshotService CreateWindowsSnapshot(string[] folders, Dictionary<string, string> options)
         {
             return new WindowsSnapshot(folders, options);
+        }
+
+        /// <summary>
+        /// Extension method for ISnapshotService which determines whether the given path is a symlink.
+        /// </summary>
+        /// <param name="snapshot">ISnapshotService implementation</param>
+        /// <param name="path">File or folder path</param>
+        /// <returns>Whether the path is a symlink</returns>
+        public static bool IsSymlink(this ISnapshotService snapshot, string path)
+        {
+            return snapshot.IsSymlink(path, snapshot.GetAttributes(path));
+        }
+
+        /// <summary>
+        /// Extension method for ISnapshotService which determines whether the given path is a symlink.
+        /// </summary>
+        /// <param name="snapshot">ISnapshotService implementation</param>
+        /// <param name="path">File or folder path</param>
+        /// <param name="attributes">File attributes</param>
+        /// <returns>Whether the path is a symlink</returns>
+        public static bool IsSymlink(this ISnapshotService snapshot, string path, FileAttributes attributes)
+        {
+            // Not all reparse points are symlinks.
+            // For example, on Windows 10 Fall Creator's Update, the OneDrive folder (and all subfolders)
+            // are reparse points, which allows the folder to hook into the OneDrive service and download things on-demand.
+            // If we can't find a symlink target for the current path, we won't treat it as a symlink.
+            return (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint && !string.IsNullOrEmpty(snapshot.GetSymlinkTarget(path));
+        }
+
+        /// <summary>
+        /// Extension method for ISystemIO which determines whether the given path is a symlink.
+        /// </summary>
+        /// <param name="systemIO">ISystemIO implementation</param>
+        /// <param name="path">File or folder path</param>
+        /// <returns>Whether the path is a symlink</returns>
+        public static bool IsSymlink(this ISystemIO systemIO, string path)
+        {
+            return systemIO.IsSymlink(path, systemIO.GetFileAttributes(path));
+        }
+
+        /// <summary>
+        /// Extension method for ISystemIO which determines whether the given path is a symlink.
+        /// </summary>
+        /// <param name="systemIO">ISystemIO implementation</param>
+        /// <param name="path">File or folder path</param>
+        /// <param name="attributes">File attributes</param>
+        /// <returns>Whether the path is a symlink</returns>
+        public static bool IsSymlink(this ISystemIO systemIO, string path, FileAttributes attributes)
+        {
+            // Not all reparse points are symlinks.
+            // For example, on Windows 10 Fall Creator's Update, the OneDrive folder (and all subfolders)
+            // are reparse points, which allows the folder to hook into the OneDrive service and download things on-demand.
+            // If we can't find a symlink target for the current path, we won't treat it as a symlink.
+            return (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint && !string.IsNullOrEmpty(systemIO.GetSymlinkTarget(path));
         }
 
         /// <summary>

--- a/Duplicati/Library/Snapshots/SystemIOLinux.cs
+++ b/Duplicati/Library/Snapshots/SystemIOLinux.cs
@@ -104,6 +104,11 @@ namespace Duplicati.Library.Snapshots
         {
             UnixSupport.File.CreateSymlink(symlinkfile, target);
         }
+
+        public string GetSymlinkTarget(string path)
+        {
+            return UnixSupport.File.GetSymlinkTarget(NoSnapshot.NormalizePath(path));
+        }
         
         public string PathGetDirectoryName(string path)
         {

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -25,6 +25,8 @@ using System.Collections.Generic;
 using System.IO;
 using Alphaleonis.Win32.Vss;
 
+using AlphaFS = Alphaleonis.Win32.Filesystem;
+
 namespace Duplicati.Library.Snapshots
 {
     /// <summary>
@@ -129,7 +131,7 @@ namespace Duplicati.Library.Snapshots
                 m_volumes = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
                 foreach (string s in m_sourcepaths)
                 {
-                    string drive = Alphaleonis.Win32.Filesystem.Path.GetPathRoot(s);
+                    string drive = AlphaFS.Path.GetPathRoot(s);
                     if (!m_volumes.ContainsKey(drive))
                     {
                         if (!m_backup.IsVolumeSupported(drive))
@@ -198,14 +200,14 @@ namespace Duplicati.Library.Snapshots
         /// <returns>A list of non-shadow paths</returns>
         private string[] ListFolders(string folder)
         {
-            string root = Utility.Utility.AppendDirSeparator(Alphaleonis.Win32.Filesystem.Path.GetPathRoot(folder));
+            string root = Utility.Utility.AppendDirSeparator(AlphaFS.Path.GetPathRoot(folder));
             string volumePath = Utility.Utility.AppendDirSeparator(GetSnapshotPath(root));
 
             string[] tmp = null;
             string spath = GetSnapshotPath(folder);
 
             if (SystemIOWindows.IsPathTooLong(spath))
-                try { tmp = Alphaleonis.Win32.Filesystem.Directory.GetDirectories(spath); }
+                try { tmp = AlphaFS.Directory.GetDirectories(spath); }
                 catch (PathTooLongException) { }
                 catch (DirectoryNotFoundException) { }
             else
@@ -216,7 +218,7 @@ namespace Duplicati.Library.Snapshots
             {
                 spath = SystemIOWindows.PrefixWithUNC(spath);
                 volumePath = SystemIOWindows.PrefixWithUNC(volumePath);
-                tmp = Alphaleonis.Win32.Filesystem.Directory.GetDirectories(spath);
+                tmp = AlphaFS.Directory.GetDirectories(spath);
             }
 
             volumePath = SystemIOWindows.PrefixWithUNC(volumePath);
@@ -235,14 +237,14 @@ namespace Duplicati.Library.Snapshots
         /// <returns>A list of non-shadow paths</returns>
         private string[] ListFiles(string folder)
         {
-            string root = Utility.Utility.AppendDirSeparator(Alphaleonis.Win32.Filesystem.Path.GetPathRoot(folder));
+            string root = Utility.Utility.AppendDirSeparator(AlphaFS.Path.GetPathRoot(folder));
             string volumePath = Utility.Utility.AppendDirSeparator(GetSnapshotPath(root));
 
             string[] tmp = null;
             string spath = GetSnapshotPath(folder);
 
             if (SystemIOWindows.IsPathTooLong(spath))
-                try { tmp = Alphaleonis.Win32.Filesystem.Directory.GetFiles(spath); }
+                try { tmp = AlphaFS.Directory.GetFiles(spath); }
                 catch (PathTooLongException) { }
                 catch (DirectoryNotFoundException) { }
             else
@@ -253,7 +255,7 @@ namespace Duplicati.Library.Snapshots
             {
                 spath = SystemIOWindows.PrefixWithUNC(spath);
                 volumePath = SystemIOWindows.PrefixWithUNC(volumePath);
-                tmp = Alphaleonis.Win32.Filesystem.Directory.GetFiles(spath);
+                tmp = AlphaFS.Directory.GetFiles(spath);
             }
 
             volumePath = SystemIOWindows.PrefixWithUNC(volumePath);
@@ -273,7 +275,7 @@ namespace Duplicati.Library.Snapshots
             if (!Path.IsPathRooted(localPath))
                 throw new InvalidOperationException();
 
-            string root = Alphaleonis.Win32.Filesystem.Path.GetPathRoot(localPath);
+            string root = AlphaFS.Path.GetPathRoot(localPath);
 
             string volumePath;
             if (!m_volumeMap.TryGetValue(root, out volumePath))
@@ -318,7 +320,7 @@ namespace Duplicati.Library.Snapshots
                 }
                 catch (PathTooLongException) { }
 
-            return Alphaleonis.Win32.Filesystem.File.GetLastWriteTimeUtc(SystemIOWindows.PrefixWithUNC(spath));
+            return AlphaFS.File.GetLastWriteTimeUtc(SystemIOWindows.PrefixWithUNC(spath));
         }
 
         /// <summary>
@@ -336,7 +338,7 @@ namespace Duplicati.Library.Snapshots
                 }
                 catch (PathTooLongException) { }
 
-            return Alphaleonis.Win32.Filesystem.File.GetCreationTimeUtc(SystemIOWindows.PrefixWithUNC(spath));
+            return AlphaFS.File.GetCreationTimeUtc(SystemIOWindows.PrefixWithUNC(spath));
         }
 
         /// <summary>
@@ -377,13 +379,7 @@ namespace Duplicati.Library.Snapshots
         public string GetSymlinkTarget(string file)
         {
             string spath = GetSnapshotPath(file);
-            try
-            {
-                return Alphaleonis.Win32.Filesystem.File.GetLinkTargetInfo(spath).PrintName;
-            }
-            catch (PathTooLongException) { }
-
-            return Alphaleonis.Win32.Filesystem.File.GetLinkTargetInfo(SystemIOWindows.PrefixWithUNC(spath)).PrintName;
+            return _ioWin.GetSymlinkTarget(spath);
         }
 
         /// <summary>

--- a/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using Duplicati.Library.Snapshots;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
@@ -215,7 +216,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 try
                 {
                     var attr = systemIO.GetFileAttributes(s);
-                    var isSymlink = (attr & FileAttributes.ReparsePoint) != 0;
+                    var isSymlink = systemIO.IsSymlink(s, attr);
                     var isFolder = (attr & FileAttributes.Directory) != 0;
                     var isFile = !isFolder;
                     var isHidden = (attr & FileAttributes.Hidden) != 0;


### PR DESCRIPTION
This fixes issue #2829 by making Duplicati not treat all reparse points as symlinks.
This is inspired largely by the new (/ returning) feature of OneDrive in Windows 10 Fall Creator's Update, which downloads files on-demand.
A side effect of that change is that the OneDrive folder (and subfolders of it) are marked as reparse points, even though they are not technically standard symlinks.
With this change, a new extension method IsSymlink is added for ISnapshotService and ISystemIO, which checks both the file attributes (for reparse point) and the symlink target path (if null, the path is not treated as a symlink).
All places that previously checked only the file attributes have been updated to use either this method (or at least the same logic, in the case of the core BackupHandler file check).
One side effect of this change is that '--symlink-policy=store' no longer ignores empty symlinks - they are now treated as regular files.
If there are empty symlinks, they will now be backed up as if they were regular files, but I don't know what the conditions are that create symlinks like that, so this might not effect anything in practice.