### PR TITLE
Feature: Quota warning/error

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -588,37 +588,36 @@ namespace Duplicati.CommandLine
             if (output.VerboseOutput)
             {
                 Library.Utility.Utility.PrintSerializeObject(result, outwriter);
+                outwriter.WriteLine();
             }
-            else
+
+            var parsedStats = result.BackendStatistics as Duplicati.Library.Interface.IParsedBackendStatistics;
+            output.MessageEvent(string.Format("  Duration of backup: {0:hh\\:mm\\:ss}", result.Duration));
+            if (parsedStats != null)
             {
-                var parsedStats = result.BackendStatistics as Duplicati.Library.Interface.IParsedBackendStatistics;
-                output.MessageEvent(string.Format("  Duration of backup: {0:hh\\:mm\\:ss}", result.Duration));
-                if (parsedStats != null)
+                if (parsedStats.KnownFileCount > 0)
                 {
-                    if (parsedStats.KnownFileCount > 0)
-                    {
-                        output.MessageEvent(string.Format("  Remote files: {0}", parsedStats.KnownFileCount));
-                        output.MessageEvent(string.Format("  Remote size: {0}", Library.Utility.Utility.FormatSizeString(parsedStats.KnownFileSize)));
-                    }
-
-                    if (parsedStats.TotalQuotaSpace >= 0)
-                    {
-                        output.MessageEvent(string.Format("  Total remote quota: {0}", Library.Utility.Utility.FormatSizeString(parsedStats.TotalQuotaSpace)));
-                    }
-
-                    if (parsedStats.FreeQuotaSpace >= 0)
-                    {
-                        output.MessageEvent(string.Format("  Available remote quota: {0}", Library.Utility.Utility.FormatSizeString(parsedStats.FreeQuotaSpace)));
-                    }
+                    output.MessageEvent(string.Format("  Remote files: {0}", parsedStats.KnownFileCount));
+                    output.MessageEvent(string.Format("  Remote size: {0}", Library.Utility.Utility.FormatSizeString(parsedStats.KnownFileSize)));
                 }
-                
-                output.MessageEvent(string.Format("  Files added: {0}", result.AddedFiles));
-                output.MessageEvent(string.Format("  Files deleted: {0}", result.DeletedFiles));
-                output.MessageEvent(string.Format("  Files changed: {0}", result.ModifiedFiles));
 
-                output.MessageEvent(string.Format("  Data uploaded: {0}", Library.Utility.Utility.FormatSizeString(result.BackendStatistics.BytesUploaded)));
-                output.MessageEvent(string.Format("  Data downloaded: {0}", Library.Utility.Utility.FormatSizeString(result.BackendStatistics.BytesDownloaded)));
+                if (parsedStats.TotalQuotaSpace >= 0)
+                {
+                    output.MessageEvent(string.Format("  Total remote quota: {0}", Library.Utility.Utility.FormatSizeString(parsedStats.TotalQuotaSpace)));
+                }
+
+                if (parsedStats.FreeQuotaSpace >= 0)
+                {
+                    output.MessageEvent(string.Format("  Available remote quota: {0}", Library.Utility.Utility.FormatSizeString(parsedStats.FreeQuotaSpace)));
+                }
             }
+                
+            output.MessageEvent(string.Format("  Files added: {0}", result.AddedFiles));
+            output.MessageEvent(string.Format("  Files deleted: {0}", result.DeletedFiles));
+            output.MessageEvent(string.Format("  Files changed: {0}", result.ModifiedFiles));
+
+            output.MessageEvent(string.Format("  Data uploaded: {0}", Library.Utility.Utility.FormatSizeString(result.BackendStatistics.BytesUploaded)));
+            output.MessageEvent(string.Format("  Data downloaded: {0}", Library.Utility.Utility.FormatSizeString(result.BackendStatistics.BytesDownloaded)));
 
             if (result.ExaminedFiles == 0 && (filter != null || !filter.Empty))
                 output.MessageEvent("No files were processed. If this was not intentional you may want to use the \"test-filters\" command");

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -210,7 +210,8 @@ namespace Duplicati.Library.Main.Operation
                                      select n).ToList();
 
             log.KnownFileCount = remotelist.Count;
-            log.KnownFileSize = remotelist.Select(x => Math.Max(0, x.File.Size)).Sum();
+            long knownFileSize = remotelist.Select(x => Math.Max(0, x.File.Size)).Sum();
+            log.KnownFileSize = knownFileSize;
             log.UnknownFileCount = unknownlist.Count;
             log.UnknownFileSize = unknownlist.Select(x => Math.Max(0, x.Size)).Sum();
             log.BackupListCount = filesets.Count;
@@ -225,6 +226,27 @@ namespace Duplicati.Library.Main.Operation
                     {
                         log.TotalQuotaSpace = quota.TotalQuotaSpace;
                         log.FreeQuotaSpace = quota.FreeQuotaSpace;
+
+                        // Check to see if there should be a warning or error about the quota
+                        // Since this processor may be called multiple times during a backup
+                        // (both at the start and end, for example), the log keeps track of
+                        // whether a quota error or warning has been sent already.
+                        // Note that an error can still be sent later even if a warning was sent earlier.
+                        if (!log.ReportedQuotaError && quota.FreeQuotaSpace == 0)
+                        {
+                            log.ReportedQuotaError = true;
+                            log.AddError(string.Format("Backend quota has been exceeded: Using {0} of {1} ({2} available)", Library.Utility.Utility.FormatSizeString(knownFileSize), Library.Utility.Utility.FormatSizeString(quota.TotalQuotaSpace), Library.Utility.Utility.FormatSizeString(quota.FreeQuotaSpace)), null);
+                        }
+                        else if (!log.ReportedQuotaWarning && !log.ReportedQuotaError && quota.FreeQuotaSpace >= 0) // Negative value means the backend didn't return the quota info
+                        {
+                            // Warnings are sent if the available free space is less than the given percentage of the total backup size.
+                            double warningThreshold = options.QuotaWarningThreshold / (double)100;
+                            if (quota.FreeQuotaSpace < warningThreshold * knownFileSize)
+                            {
+                                log.ReportedQuotaWarning = true;
+                                log.AddWarning(string.Format("Backend quota is close to being exceeded: Using {0} of {1} ({2} available)", Library.Utility.Utility.FormatSizeString(knownFileSize), Library.Utility.Utility.FormatSizeString(quota.TotalQuotaSpace), Library.Utility.Utility.FormatSizeString(quota.FreeQuotaSpace)), null);
+                            }
+                        }
                     }
                 }
 

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -75,6 +75,11 @@ namespace Duplicati.Library.Main
         private const string DEFAULT_LOG_RETENTION = "30D";
 
         /// <summary>
+        /// The default threshold for warning about coming close to quota
+        /// </summary>
+        private const int DEFAULT_QUOTA_WARNING_THRESHOLD = 10;
+
+        /// <summary>
         /// An enumeration that describes the supported strategies for an optimization
         /// </summary>
         public enum OptimizationStrategy
@@ -460,8 +465,9 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("list-verify-uploads", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ListverifyuploadsShort, Strings.Options.ListverifyuploadsShort, "false"),
                     new CommandLineArgument("allow-sleep", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AllowsleepShort, Strings.Options.AllowsleepLong, "false"),
                     new CommandLineArgument("no-connection-reuse", CommandLineArgument.ArgumentType.Boolean, Strings.Options.NoconnectionreuseShort, Strings.Options.NoconnectionreuseLong, "false"),
-                    
+
                     new CommandLineArgument("quota-size", CommandLineArgument.ArgumentType.Size, Strings.Options.QuotasizeShort, Strings.Options.QuotasizeLong),
+                    new CommandLineArgument("quota-warning-threshold", CommandLineArgument.ArgumentType.Integer, Strings.Options.QuotaWarningThresholdShort, Strings.Options.QuotaWarningThresholdLong, DEFAULT_QUOTA_WARNING_THRESHOLD.ToString()),
 
                     new CommandLineArgument("default-filters", CommandLineArgument.ArgumentType.String, Strings.Options.DefaultFiltersShort, Strings.Options.DefaultFiltersLong(DefaultFilterSet.Windows.ToString(), DefaultFilterSet.OSX.ToString(), DefaultFilterSet.Linux.ToString(), DefaultFilterSet.All.ToString()), string.Empty, new[] { "default-filter" }),
 
@@ -1300,6 +1306,29 @@ namespace Duplicati.Library.Main
                     return -1;
                 else
                     return Library.Utility.Sizeparser.ParseSize(m_options["quota-size"], "mb");
+            }
+        }
+
+        /// <summary>
+        /// Gets the threshold at which a quota warning should be generated.
+        /// </summary>
+        /// <remarks>
+        /// This is treated as a percentage, where a warning is given when the amount of free space is less than this percentage of the backup size.
+        /// </remarks>
+        public int QuotaWarningThreshold
+        {
+            get
+            {
+                string tmp;
+                m_options.TryGetValue("quota-warning-threshold", out tmp);
+                if (string.IsNullOrEmpty(tmp))
+                {
+                    return DEFAULT_QUOTA_WARNING_THRESHOLD;
+                }
+                else
+                {
+                    return int.Parse(tmp);
+                }
             }
         }
 

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -49,6 +49,9 @@ namespace Duplicati.Library.Main
         long FreeQuotaSpace { set; }
         long AssignedQuotaSpace { set; }
 
+        bool ReportedQuotaError { get; set; }
+        bool ReportedQuotaWarning { get; set; }
+
         /// <summary>
         /// The backend sends this event when performing an action
         /// </summary>
@@ -125,6 +128,9 @@ namespace Duplicati.Library.Main
         public long TotalQuotaSpace { get; set; }
         public long FreeQuotaSpace { get; set; }
         public long AssignedQuotaSpace { get; set; }
+
+        public bool ReportedQuotaError { get; set; }
+        public bool ReportedQuotaWarning { get; set; }
 
         public override OperationMode MainOperation { get { return m_parent.MainOperation; } }
 

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -119,6 +119,8 @@ namespace Duplicati.Library.Main.Strings
         public static string UploadUnchangedBackupsShort { get { return LC.L(@"Upload empty backup files"); } }
         public static string QuotasizeLong { get { return LC.L(@"This value can be used to set a known upper limit on the amount of space a backend has. If the backend reports the size itself, this value is ignored"); } }
         public static string QuotasizeShort { get { return LC.L(@"A reported maximum storage"); } }
+        public static string QuotaWarningThresholdLong { get { return LC.L(@"Sets a threshold for when to warn about the backend quota being nearly exceeded. It is given as a percentage, and a warning is generated if the amount of available quota is less that this percentage of the total backup size. If the backend does not report the quota information, this value will be ignored"); } }
+        public static string QuotaWarningThresholdShort { get { return LC.L(@"Threshold for warning about low quota"); } }
         public static string DefaultFiltersLong(string windows, string osx, string linux, string all) { return LC.L(@"Exclude files that match the given filter sets. Which default filter sets should be used. Valid sets are ""{0}"", ""{1}"", ""{2}"", and ""{3}"". If this parameter is set with no value, the set for the current operating system will be used.", windows, osx, linux, all); }
         public static string DefaultFiltersShort { get { return LC.L(@"Default filter sets"); } }
         public static string SymlinkpolicyShort { get { return LC.L(@"Symlink handling"); } }


### PR DESCRIPTION
This change adds a warning when the amount of available quota reaches a configurable percentage of the total backup size, and an error when the available quota reaches 0. By default, the warning is sent when the available quota is less than 10% of the backup size.

It also changes/fixes console logging when using the --verbose flag, so that both the verbose and regular diagnostics info is reported (without this fix, some data which is presented in the regular diagnostics info, e.g., quota info, is not presented when using the --verbose flag).