### PR TITLE
added the blueray container .m2ts to the no_compression list

### DIFF
--- a/Duplicati/Library/Main/default_compressed_extensions.txt
+++ b/Duplicati/Library/Main/default_compressed_extensions.txt
@@ -82,6 +82,7 @@
 .webm #WebM Video File
 .wmv #Windows Media Video File
 .wtv #Windows Recorded TV Show
+.m2ts # Blu-ray Disc MPEG-2 Transport Stream
 
 
 # Compressed image files


### PR DESCRIPTION
On the [forum](https://forum.duplicati.com/t/extremely-slow-backup-over-lan/2386/18) rb28z2 discovered that the blueray m2ts container format is not on the no_compression list.

This type of file contains compressed video and likely compresses no better than mkv or m4v files.