### PR TITLE
made the side menu fixed so it follows as you scroll

### DIFF
--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -677,6 +677,7 @@ body {
                 width: 260px;
                 padding-left: 40px;
                 float: left;
+                position: fixed;
 
                 > ul {
                     > li {
@@ -883,7 +884,7 @@ body {
 
             .content {
                 float: left;
-                padding-left: 50px;
+                padding-left: 350px;
                 padding-bottom: 50px;
                 max-width: 700px;
 


### PR DESCRIPTION
We were discussing this on the forum and it's a super simply change, so here it goes.

I fixed the menu and then added padding to the content wrapper so that it's identical to how it looked previously, except now it scrolls :)

Only full sized settings were changed. It didn't seem to have any impact on the mobile layout.