### PR TITLE
Feature/issue 3008 retention optimizations

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -886,9 +886,31 @@ namespace Duplicati.Library.Main
         /// <param name="log">The log instance</param>
         private void ValidateOptions(ILogWriter log)
         {
-            if (m_options.KeepTime.Ticks > 0 && m_options.KeepVersions > 0)
-                throw new Interface.UserInformationException(string.Format("Setting both --{0} and --{1} is not permitted", "keep-versions", "keep-time"));
+            // Check if only one of the retention options is set
+            var selectedRetentionOptions = new List<String>();
 
+            if (m_options.KeepTime.Ticks > 0)
+            {
+                selectedRetentionOptions.Add("keep-time");
+            }
+
+            if (m_options.KeepVersions > 0)
+            {
+                selectedRetentionOptions.Add("keep-versions");
+            }
+
+            if (m_options.RetentionPolicy.Count() > 0)
+            {
+                selectedRetentionOptions.Add("retention-policy");
+            }
+
+            if (selectedRetentionOptions.Count() > 1)
+            {
+                throw new Interface.UserInformationException(string.Format("Setting multiple retention options ({0}) is not permitted",
+                    String.Join(", ", selectedRetentionOptions.Select(x => "--" + x))));
+            }
+
+            // Check Prefix
             if (!string.IsNullOrWhiteSpace(m_options.Prefix) && m_options.Prefix.Contains("-"))
                 throw new Interface.UserInformationException("The prefix cannot contain hyphens (-)");
 

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -228,8 +228,11 @@ namespace Duplicati.Library.Main.Operation
             // Make sure the backups are in descending order (newest backup in the beginning)
             clonedBackupList = clonedBackupList.OrderByDescending(x => x).ToList();
 
-            // Most current backup should never get deleted in this process, so exclude it
+            // Most recent backup usually should never get deleted in this process, so exclude it for now,
+            // but keep a reference to potentiall delete it when allow-full-removal is set
+            var mostRecentBackup = clonedBackupList.ElementAt(0);
             clonedBackupList.RemoveAt(0);
+            var deleteMostRecentBackup = m_options.AllowFullRemoval;
 
             Logging.Log.WriteMessage(string.Format("[Retention Policy]: Time frames and intervals pairs: {0}",
                 string.Join(", ", retentionPolicyOptionValue.Select(x => x.Key + " / " + x.Value))), Logging.LogMessageType.Information);
@@ -279,12 +282,23 @@ namespace Duplicati.Library.Main.Operation
                         backupsToDelete.Add(backup);
                     }
                 }
+
+                // Check if most recent backup is outside of this time frame (meaning older/smaller)
+                deleteMostRecentBackup &= (mostRecentBackup < timeFrame);
             }
 
             // Delete all remaining backups
             backupsToDelete.AddRange(clonedBackupList);
             Logging.Log.WriteMessage(string.Format("[Retention Policy]: Backups outside of all time frames and thus getting deleted: {0}",
                     string.Join(", ", clonedBackupList)), Logging.LogMessageType.Information);
+
+            // Delete most recent backup if allow-full-removal is set and the most current backup is outside of any time frame
+            if (deleteMostRecentBackup)
+            {
+                backupsToDelete.Add(mostRecentBackup);
+                Logging.Log.WriteMessage(string.Format("[Retention Policy]: Deleting most recent backup: {0}",
+                    mostRecentBackup), Logging.LogMessageType.Information);
+            }
 
             Logging.Log.WriteMessage(string.Format("[Retention Policy]: All backups to delete: {0}",
                 string.Join(", ", backupsToDelete.OrderByDescending(x => x))), Logging.LogMessageType.Information);

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -240,8 +240,6 @@ namespace Duplicati.Library.Main.Operation
             // Collect all potential backups in each time frame and thin out according to the specified interval,
             // starting with the oldest backup in that time frame.
             // The order in which the time frames values are checked has to be from the smallest to the largest.
-            // If backups are not within any time frame, they will NOT be deleted here.
-            // The --keep-time and --keep-versions switched should be used to ultimately delete backups that are too old
             List<DateTime> backupsToDelete = new List<DateTime>();
             var now = DateTime.Now;
             foreach (var singleRetentionPolicyOptionValue in retentionPolicyOptionValue.OrderBy(x => x.Key))
@@ -277,16 +275,18 @@ namespace Duplicati.Library.Main.Operation
                     }
                     else
                     {
-                        Logging.Log.WriteMessage(string.Format("[Retention Policy]: Marking backup for deletion: {0}", backup), Logging.LogMessageType.Profiling);
+                        Logging.Log.WriteMessage(string.Format("[Retention Policy]: Deleting backup: {0}", backup), Logging.LogMessageType.Profiling);
                         backupsToDelete.Add(backup);
                     }
                 }
             }
 
-            Logging.Log.WriteMessage(string.Format("[Retention Policy]: Backups outside of all time frames and thus not checked: {0}",
-                    string.Join(", ", clonedBackupList)), Logging.LogMessageType.Profiling);
+            // Delete all remaining backups
+            backupsToDelete.AddRange(clonedBackupList);
+            Logging.Log.WriteMessage(string.Format("[Retention Policy]: Backups outside of all time frames and thus getting deleted: {0}",
+                    string.Join(", ", clonedBackupList)), Logging.LogMessageType.Information);
 
-            Logging.Log.WriteMessage(string.Format("[Retention Policy]: Backups to delete: {0}",
+            Logging.Log.WriteMessage(string.Format("[Retention Policy]: All backups to delete: {0}",
                 string.Join(", ", backupsToDelete.OrderByDescending(x => x))), Logging.LogMessageType.Information);
 
             return backupsToDelete;

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -183,7 +183,7 @@ namespace Duplicati.Library.Main.Strings
         public static string KeeptimeShort { get { return LC.L(@"Keep all versions within a timespan"); } }
         public static string KeeptimeLong { get { return LC.L(@"Use this option to set the timespan in which backups are kept."); } }
         public static string RetentionPolicyShort { get { return LC.L(@"Reduce number of versions by deleting old intermediate backups"); } }
-        public static string RetentionPolicyLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age by deleting most of the old backups. The expected format is a comma seperated list of collon sperated time frame and interval pairs. For example the value ""7D:0s,3M:1D,10Y:2M"" means ""For 7 day keep all backups, for 3 months keep one backup per day and for 10 years one backup every 2nd month"); } }
+        public static string RetentionPolicyLong { get { return LC.L(@"Use this option to reduce the number of versions that are kept with increasing version age by deleting most of the old backups. The expected format is a comma separated list of colon separated time frame and interval pairs. For example the value ""7D:0s,3M:1D,10Y:2M"" means ""For 7 day keep all backups, for 3 months keep one backup every day, for 10 years one backup every 2nd month and delete every backup older than this."""); } }
         public static string AllowmissingsourceShort { get { return LC.L(@"Ignore missing source elements"); } }
         public static string AllowmissingsourceLong { get { return LC.L(@"Use this option to continue even if some source entries are missing."); } }
         public static string OverwriteShort { get { return LC.L(@"Overwrite files when restoring"); } }


### PR DESCRIPTION
As discussed in #3008:
- `--retention-policy` now deletes backups that are outside of any time frame. No need to specify `--keep-time` as well. Help text was changed accordingly.
- `--retention-policy` is now mutual exclusive to the other retention options `--keep-time` and `--keep-version`. Help text was changed accordingly.
- `--retention-policy` now complies with `--allow-full-removal`, deleting even the most recent backup, if it's outside of any time frame