### PR TITLE
Docker Images

### DIFF
--- a/Installer/Docker/README.md
+++ b/Installer/Docker/README.md
@@ -1,0 +1,64 @@
+# [Duplicati](https://www.duplicati.com)
+Duplicati is a free, open source, backup client that securely stores encrypted, incremental, compressed backups on cloud storage services and remote file servers. It works with:
+
+*Amazon S3, OneDrive, Google Drive, Rackspace Cloud Files, HubiC, Backblaze (B2), Amazon Cloud Drive (AmzCD), Swift / OpenStack, WebDAV, SSH (SFTP), FTP, and more!*
+
+Duplicati is licensed under LGPL and available for Windows, OSX and Linux (.NET 4.5+ or Mono required).
+
+## Available tags
+
+* `beta` - the most recent beta release
+* `experimental` - the most recent experimental release
+* `canary` - the most recent canary release
+* `latest` - an alias for `beta`
+* specific versions like `2.0.2.1_beta_2017-08-01`
+
+Images for the following OS/architecture combinations are available:
+
+* `linux-amd64`
+* `linux-arm32v7` - 32-bit ARMv7 devices like the Raspberry Pi 2
+
+The default architecture is `linux-amd64`. To pull an image for another architecture, prepend the architecture string to the image tag, e.g. `linux-arm32v7-beta`.
+
+## How to use this image
+
+```console
+$ docker run -p 8200:8200 -v /some/path:/some/path duplicati/duplicati
+```
+
+Then, open [http://localhost:8200](http://localhost:8200) on the host to access the Duplicati web interface and configure backups. Any host directory that you want to back up needs to be mounted into the container using the `-v` option.
+
+### Preserving configuration
+
+All configuration is stored in `/data` inside the container, so you can mount a volume at that path to preserve the configuration:
+
+```console
+$ docker run --name=duplicati -v duplicati-data:/data duplicati/duplicati
+```
+
+This allows you to delete and recreate the container without losing your configuration:
+
+```console
+$ docker rm duplicati
+$ docker run --name=duplicati -v duplicati-data:/data duplicati/duplicati
+```
+
+### Using Duplicati CLI
+
+Run the `duplicati-cli` command to use the Duplicati command-line interface:
+
+```console
+$ docker run --rm duplicati/duplicati duplicati-cli help
+See duplicati.commandline.exe help <topic> for more information.
+  General: example, changelog
+...
+$ docker run --rm -v /home:/backup/home duplicati/duplicati duplicati-cli backup ssh://user@host /backup/home
+```
+
+### Specifying server arguments
+
+To launch the Duplicati server with additional arguments, run the `duplicati-server` command:
+
+```console
+$ docker run duplicati/duplicati duplicati-server --log-level=debug
+```

--- a/Installer/Docker/build-images.sh
+++ b/Installer/Docker/build-images.sh
@@ -10,9 +10,9 @@ DEFAULT_ARCHITECTURE=amd64
 DEFAULT_CHANNEL=beta
 REPOSITORY=duplicati/duplicati
 
-ARCHIVE_NAME=`basename -s .zip $1`
-VERSION=`echo "${ARCHIVE_NAME}" | cut -d "-" -f 2-`
-CHANNEL=`echo "${ARCHIVE_NAME}" | cut -d "_" -f 2`
+ARCHIVE_NAME=$(basename -s .zip $1)
+VERSION=$(echo "${ARCHIVE_NAME}" | cut -d "-" -f 2-)
+CHANNEL=$(echo "${ARCHIVE_NAME}" | cut -d "_" -f 2)
 DIRNAME=duplicati
 
 if [ -d "${DIRNAME}" ]; then

--- a/Installer/Docker/build-images.sh
+++ b/Installer/Docker/build-images.sh
@@ -43,7 +43,7 @@ done
 for arch in ${ARCHITECTURES}; do
     tags="linux-${arch}-${VERSION} linux-${arch}-${CHANNEL}"
     if [ ${CHANNEL} = ${DEFAULT_CHANNEL} ]; then
-        tags="linux-${arch} ${tags}"
+        tags="linux-${arch}-latest ${tags}"
     fi
     if [ ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
         tags="${VERSION} ${CHANNEL} ${tags}"

--- a/Installer/Docker/build-images.sh
+++ b/Installer/Docker/build-images.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ ! -f "$1" ]; then
-	echo "Please provide the filename of an existing zip build as the first argument"
-	exit
+    echo "Please provide the filename of an existing zip build as the first argument"
+    exit
 fi
 
 ARCHITECTURES="amd64 arm32v7"
@@ -16,7 +16,7 @@ CHANNEL=`echo "${ARCHIVE_NAME}" | cut -d "_" -f 2`
 DIRNAME=duplicati
 
 if [ -d "${DIRNAME}" ]; then
-	rm -rf "${DIRNAME}"
+    rm -rf "${DIRNAME}"
 fi
 
 unzip -d "${DIRNAME}" "$1"
@@ -41,31 +41,31 @@ do
 done
 
 for arch in ${ARCHITECTURES}; do
-	tags="linux-${arch}-${VERSION} linux-${arch}-${CHANNEL}"
-	if [ ${CHANNEL} = ${DEFAULT_CHANNEL} ]; then
-		tags="linux-${arch} ${tags}"
-	fi
-	if [ ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
-		tags="${VERSION} ${CHANNEL} ${tags}"
-	fi
-	if [ ${CHANNEL} = ${DEFAULT_CHANNEL} -a ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
-		tags="latest ${tags}"
-	fi
+    tags="linux-${arch}-${VERSION} linux-${arch}-${CHANNEL}"
+    if [ ${CHANNEL} = ${DEFAULT_CHANNEL} ]; then
+        tags="linux-${arch} ${tags}"
+    fi
+    if [ ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
+        tags="${VERSION} ${CHANNEL} ${tags}"
+    fi
+    if [ ${CHANNEL} = ${DEFAULT_CHANNEL} -a ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
+        tags="latest ${tags}"
+    fi
 
-	args=""
-	for tag in ${tags}; do
-		args="-t ${REPOSITORY}:${tag} ${args}"
-	done
+    args=""
+    for tag in ${tags}; do
+        args="-t ${REPOSITORY}:${tag} ${args}"
+    done
 
-	docker build \
-		${args} \
-		--build-arg ARCH=${arch}/ \
-		--build-arg VERSION=${VERSION} \
-		--build-arg CHANNEL=${CHANNEL} \
-		--file context/Dockerfile \
-		.
+    docker build \
+        ${args} \
+        --build-arg ARCH=${arch}/ \
+        --build-arg VERSION=${VERSION} \
+        --build-arg CHANNEL=${CHANNEL} \
+        --file context/Dockerfile \
+        .
 
-	for tag in ${tags}; do
-		docker push ${REPOSITORY}:${tag}
-	done
+    for tag in ${tags}; do
+        docker push ${REPOSITORY}:${tag}
+    done
 done

--- a/Installer/Docker/build-images.sh
+++ b/Installer/Docker/build-images.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+if [ ! -f "$1" ]; then
+	echo "Please provide the filename of an existing zip build as the first argument"
+	exit
+fi
+
+ARCHITECTURES="amd64 arm32v7"
+DEFAULT_ARCHITECTURE=amd64
+DEFAULT_CHANNEL=beta
+REPOSITORY=duplicati/duplicati
+
+ARCHIVE_NAME=`basename -s .zip $1`
+VERSION=`echo "${ARCHIVE_NAME}" | cut -d "-" -f 2-`
+CHANNEL=`echo "${ARCHIVE_NAME}" | cut -d "_" -f 2`
+DIRNAME=duplicati
+
+if [ -d "${DIRNAME}" ]; then
+	rm -rf "${DIRNAME}"
+fi
+
+unzip -d "${DIRNAME}" "$1"
+
+for n in "../oem" "../../oem" "../../../oem"
+do
+    if [ -d $n ]; then
+        echo "Installing OEM files"
+        cp -R $n "${DIRNAME}/webroot/"
+    fi
+done
+
+for n in "oem-app-name.txt" "oem-update-url.txt" "oem-update-key.txt" "oem-update-readme.txt" "oem-update-installid.txt"
+do
+    for p in "../$n" "../../$n" "../../../$n"
+    do
+        if [ -f $p ]; then
+            echo "Installing OEM override file"
+            cp $p "${DIRNAME}"
+        fi
+    done
+done
+
+for arch in ${ARCHITECTURES}; do
+	tags="linux-${arch}-${VERSION} linux-${arch}-${CHANNEL}"
+	if [ ${CHANNEL} = ${DEFAULT_CHANNEL} ]; then
+		tags="linux-${arch} ${tags}"
+	fi
+	if [ ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
+		tags="${VERSION} ${CHANNEL} ${tags}"
+	fi
+	if [ ${CHANNEL} = ${DEFAULT_CHANNEL} -a ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
+		tags="latest ${tags}"
+	fi
+
+	args=""
+	for tag in ${tags}; do
+		args="-t ${REPOSITORY}:${tag} ${args}"
+	done
+
+	docker build \
+		${args} \
+		--build-arg ARCH=${arch}/ \
+		--build-arg VERSION=${VERSION} \
+		--build-arg CHANNEL=${CHANNEL} \
+		--file context/Dockerfile \
+		.
+
+	for tag in ${tags}; do
+		docker push ${REPOSITORY}:${tag}
+	done
+done

--- a/Installer/Docker/context/Dockerfile
+++ b/Installer/Docker/context/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
         libmono-sqlite4.0-cil \
         libmono-system-drawing4.0-cil \
         referenceassemblies-pcl && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists && \
+    cert-sync /etc/ssl/certs/ca-certificates.crt
 
 ENV TINI_VERSION v0.16.1
 RUN curl -L -o /usr/sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(dpkg --print-architecture) && \

--- a/Installer/Docker/context/Dockerfile
+++ b/Installer/Docker/context/Dockerfile
@@ -1,0 +1,33 @@
+ARG ARCH=
+FROM ${ARCH}mono:5-slim
+
+RUN apt-get update && \
+    apt-get install -y \
+        libmono-sqlite4.0-cil \
+        libmono-system-drawing4.0-cil \
+        referenceassemblies-pcl && \
+    rm -rf /var/lib/apt/lists
+
+ENV TINI_VERSION v0.16.1
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -L -o /usr/sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(dpkg --print-architecture) && \
+    chmod 0755 /usr/sbin/tini && \
+    apt-get autoremove --purge -y curl && \
+    rm -rf /var/lib/apt/lists
+ENTRYPOINT ["/usr/sbin/tini", "--"]
+
+ENV XDG_CONFIG_HOME=/data
+VOLUME /data
+
+COPY context/duplicati context/duplicati-server /usr/bin/
+RUN chmod 0755 /usr/bin/duplicati /usr/bin/duplicati-server
+
+ARG CHANNEL=
+ARG VERSION=
+ENV DUPLICATI_CHANNEL=${CHANNEL}
+ENV DUPLICATI_VERSION=${VERSION}
+COPY duplicati /opt/duplicati
+
+EXPOSE 8200
+CMD ["/usr/bin/duplicati-server", "--webservice-port=8200", "--webservice-interface=any"]

--- a/Installer/Docker/context/Dockerfile
+++ b/Installer/Docker/context/Dockerfile
@@ -2,7 +2,7 @@ ARG ARCH=
 FROM ${ARCH}mono:5-slim
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         libmono-sqlite4.0-cil \
         libmono-system-drawing4.0-cil \
         referenceassemblies-pcl && \
@@ -10,7 +10,7 @@ RUN apt-get update && \
 
 ENV TINI_VERSION v0.16.1
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y --no-install-recommends curl && \
     curl -L -o /usr/sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(dpkg --print-architecture) && \
     chmod 0755 /usr/sbin/tini && \
     apt-get autoremove --purge -y curl && \

--- a/Installer/Docker/context/Dockerfile
+++ b/Installer/Docker/context/Dockerfile
@@ -20,8 +20,8 @@ ENTRYPOINT ["/usr/sbin/tini", "--"]
 ENV XDG_CONFIG_HOME=/data
 VOLUME /data
 
-COPY context/duplicati context/duplicati-server /usr/bin/
-RUN chmod 0755 /usr/bin/duplicati /usr/bin/duplicati-server
+COPY context/duplicati-cli context/duplicati-server /usr/bin/
+RUN chmod 0755 /usr/bin/duplicati-cli /usr/bin/duplicati-server
 
 ARG CHANNEL=
 ARG VERSION=

--- a/Installer/Docker/context/Dockerfile
+++ b/Installer/Docker/context/Dockerfile
@@ -3,18 +3,15 @@ FROM ${ARCH}mono:5-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        curl \
         libmono-sqlite4.0-cil \
         libmono-system-drawing4.0-cil \
         referenceassemblies-pcl && \
     rm -rf /var/lib/apt/lists
 
 ENV TINI_VERSION v0.16.1
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -L -o /usr/sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(dpkg --print-architecture) && \
-    chmod 0755 /usr/sbin/tini && \
-    apt-get autoremove --purge -y curl && \
-    rm -rf /var/lib/apt/lists
+RUN curl -L -o /usr/sbin/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(dpkg --print-architecture) && \
+    chmod 0755 /usr/sbin/tini
 ENTRYPOINT ["/usr/sbin/tini", "--"]
 
 ENV XDG_CONFIG_HOME=/data

--- a/Installer/Docker/context/duplicati
+++ b/Installer/Docker/context/duplicati
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec mono /opt/duplicati/Duplicati.CommandLine.exe $@

--- a/Installer/Docker/context/duplicati
+++ b/Installer/Docker/context/duplicati
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mono /opt/duplicati/Duplicati.CommandLine.exe $@

--- a/Installer/Docker/context/duplicati-cli
+++ b/Installer/Docker/context/duplicati-cli
@@ -1,0 +1,4 @@
+#!/bin/bash
+EXE_FILE=/opt/duplicati/Duplicati.CommandLine.exe
+APP_NAME=Duplicati.CommandLine
+exec -a "$APP_NAME" mono "$EXE_FILE" "$@"

--- a/Installer/Docker/context/duplicati-server
+++ b/Installer/Docker/context/duplicati-server
@@ -1,2 +1,4 @@
-#!/bin/sh
-exec mono /opt/duplicati/Duplicati.Server.exe $@
+#!/bin/bash
+EXE_FILE=/opt/duplicati/Duplicati.Server.exe
+APP_NAME=DuplicatiServer
+exec -a "$APP_NAME" mono "$EXE_FILE" "$@"

--- a/Installer/Docker/context/duplicati-server
+++ b/Installer/Docker/context/duplicati-server
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec mono /opt/duplicati/Duplicati.Server.exe $@

--- a/build-installers.sh
+++ b/build-installers.sh
@@ -138,6 +138,17 @@ echo "Done building rpm package"
 
 echo ""
 echo ""
+echo "Building Docker images ..."
+
+cd Installer/Docker
+bash build-images.sh ../../$1
+cd ../..
+
+echo "Done building Docker images"
+
+
+echo ""
+echo ""
 echo "Building Windows instance in virtual machine"
 
 while true


### PR DESCRIPTION
See issue #2309. Took me long enough to get around to, for something that's pretty much just a simple Dockerfile, a shell script, and a readme. I pushed some test builds to [a test repo](https://hub.docker.com/r/fkrull/duplicati/). It also shows off the readme in its natural habitat.

Some key points:
* The images are based on the official `mono:5-slim` images.
* Image sizes range from ~250 to ~280 MB uncompressed and 85 to 95 MB compressed (i.e. download size).
* I started with amd64 and ARMv7 images, but other architectures should be easy to add if the base image supports them.
* I went with `duplicati/duplicati` as the repository name. This could be changed, but I already registered the *duplicati* organisation to reserve the namespace and I kinda don't wanna be stuck with it...
* The readme is designed to be used as the long description on Docker Hub.

## Build prerequisites
* I can't give you an exact Docker version, unfortunately. Relatively recent should be fine though.
* The Docker host system needs to have transparent support for running foreign-architecture binaries, in a way that works with Docker. According to [this page](http://www.ecliptik.com/Cross-Building-and-Running-Multi-Arch-Docker-Images/#docker-for-mac), Docker for Mac has that built in, but I don't have a Mac to test with. For Linux, there's a feature in Linux 4.8 that makes it possible to set that up using QEMU. I have [a Docker image for this purpose](https://hub.docker.com/r/fkrull/qemu-user-static/) with a readme briefly explaining the relevant feature.
* You need to log in your Docker daemon to Docker Hub using `docker login`.

## Build script
I created a build script in Installer/Docker and added it to build-installers.sh. It doesn't entirely fit with the other installers since it doesn't produce a file, but it sort of makes sense and it allowed me to test the script separately, without having to figure out how to make build-release.sh work. The script works like the others, taking the path to a release zip file. For testing, you can change to repository to push with the `REPOSITORY` variable at the top of the file.

## Tagging scheme
Each image always gets tagged with its version and its channel; as a result, e.g. `beta` always points to the latest beta release. The `latest` tag (which is what you get when you don't specify a tag) is currently an alias for `beta`, but should be moved to `stable` when/if that becomes a thing.

Multiple architectures are implemented by `<os>-<arch>` prefixes. This is similar to the scheme [Portainer uses](https://hub.docker.com/r/portainer/portainer/tags/). Currently the "unadorned" tags (without an arch prefix, e.g. `beta`) point to the amd64 images, which means that if you want an ARM image, you need to explicitly say so. The unadorned tags should be replaced by manifest lists once the Docker client gains a feature to upload those (there's [a merged PR for that](https://github.com/docker/cli/pull/138)). Then, pulling `latest` would always get the appropriate image for the architecture.

## Architectures
I started with amd64 because obviously and ARMv7 because I need that for my Raspberry Pi (more favourably, because I can test that). I managed to build an arm64 image, but it crashed when running it emulated, so I left it out. i386 would be easy, but I figured its time is past.

## Misc image design decisions
* The images contain [tini](https://github.com/krallin/tini), a "tiny but valid init". Without that to handle signals, you can't actually stop the container with Ctrl-C (and maybe SIGTERM?). Docker has a `--init` flag that also adds tini, but I didn't want to require a flag for correct operation.
* Duplicati runs as root inside the container because the permissions can easily get hairy otherwise.

---

One wall of text later, I think I covered the important points. I couldn't test the script in the context of a full release build, so I hope it'll work. @kenkendk If you tell me your Docker Hub username, I'll add you to the duplicati organisation.