### PR TITLE
Live log height

### DIFF
--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -210,10 +210,6 @@ ul.tabs {
     }
 
     .entries.livedata {
-        li {
-            height: 1.2em;
-        }
-
         li.expanded {
             height: auto;
             overflow: auto;
@@ -1492,7 +1488,7 @@ body {
 
                     ul.entries {
                         li {
-                            padding-top: 30px;
+                            padding-top: 10px;
                         }
                     }
                 }

--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -204,7 +204,7 @@ ul.tabs {
     }
 
     .entries {
-        div.entryline {
+        div.entryline.clickable {
             cursor: pointer;
         }
     }
@@ -212,7 +212,6 @@ ul.tabs {
     .entries.livedata {
         li.expanded {
             height: auto;
-            overflow: auto;
         }
     }
 

--- a/Duplicati/Server/webroot/ngax/templates/log.html
+++ b/Duplicati/Server/webroot/ngax/templates/log.html
@@ -34,7 +34,7 @@
 
         <ul class="entries livedata">
             <li ng-repeat="item in LiveData" ng-class="{expanded: expanded}">
-                <div ng-click="expanded = !expanded" class="entryline" ng-class="{noexception: item.Exception == null}">{{item.When | parsetimestamp}}: {{item.Message}}</div>
+                <div ng-click="expanded = !expanded" class="entryline" ng-class="{noexception: item.Exception == null, clickable: item.Exception != null}">{{item.When | parsetimestamp}}: {{item.Message}}</div>
                 <div ng-show="expanded &amp;&amp; item.Exception != null" class="prewrapped-text exceptiontext">{{item.Exception}}</div>
             </li>
         </ul>


### PR DESCRIPTION
Fixes for #3032 

First I fixed the weird overlay issue where they would all stack up by removing the height style.
Then I fixed the weird overflow:auto issue where it would pop the log entry onto a new line when expanding it.

Then I realized it looked like most my entries were broken (because they had a "clickable" pointer over them but had no expansion content). This wasn't a problem before because they would visibly move (overflow to the next line) when I clicked them, even if they had no content.

I fixed this by making items with no expansion content not appear clickable.