### PR TITLE
added clarification to  error to help users resolve the problem

### DIFF
--- a/Duplicati/Server/WebServer/AuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/AuthenticationHandler.cs
@@ -286,7 +286,7 @@ namespace Duplicati.Server.WebServer
                 else
                 {
                     response.Status = System.Net.HttpStatusCode.BadRequest;
-                    response.Reason = "Missing XSRF Token";
+                    response.Reason = "Missing XSRF Token. Please reload the page";
 
                     return true;
                 }


### PR DESCRIPTION
In accordance with discussion in #3047, I'd like to expand a little on the `Missing XSRF Token` error to improve user experience.