### PR TITLE
Changed OSX Mono download URL

### DIFF
--- a/Installer/OSX/run-with-mono.sh
+++ b/Installer/OSX/run-with-mono.sh
@@ -26,7 +26,7 @@ REQUIRED_MINOR=0
 
 VERSION_TITLE="Cannot launch $APP_NAME"
 VERSION_MSG="$APP_NAME requires the Mono Framework version $REQUIRED_MAJOR.$REQUIRED_MINOR or later."
-DOWNLOAD_URL="http://www.go-mono.com/mono-downloads/download.html"
+DOWNLOAD_URL="http://www.mono-project.com/download/stable/#download-mac"
 
 # Try to find system default Mono if an override was not supplied
 if [ "z${MONO_BIN}" == "z" ]; then


### PR DESCRIPTION
Suggest changing Mono OSX download URL from go-mono.com to mono-project.com, as go-mono.com seems to have connection errors.