### PR TITLE
limited number of logs displayed on live log page

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/LogController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/LogController.js
@@ -32,7 +32,8 @@ backupApp.controller('LogController', function($scope, $routeParams, $timeout, S
 
                 resp.data.reverse();
                 $scope.LiveData.unshift.apply($scope.LiveData, resp.data);
-                $scope.LiveData.Length = Math.min(1000, $scope.LiveData.length);
+                $scope.LiveData.Length = Math.min(300, $scope.LiveData.length);
+                $scope.LiveData = $scope.LiveData.slice(0,$scope.LiveData.Length)
 
                 $scope.LiveRefreshing = false;
                 if ($scope.LiveRefreshPending)


### PR DESCRIPTION
Fixes #1617.

Now it actually has a limit and throws away old logs. Also, 1000 seemed a bit much as it would lag quite a bit when loaded on a laptop. 

300 seems to strike a good balance between not lagging too much and still being way more log lines than I ever want to read in one go.