### PR TITLE
Easier syntax for unlimited timeframes and intervals

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -919,9 +919,10 @@ namespace Duplicati.Library.Main
             {
                 foreach (var configEntry in m_options.RetentionPolicy)
                 {
-                    if (configEntry.Value >= configEntry.Key)
+                    if (!configEntry.IsKeepAllVersions() && !configEntry.IsUnlimtedTimeframe() &&
+                        configEntry.Interval >= configEntry.Timeframe)
                     {
-                        throw new Interface.UserInformationException("A time frame cannot be smaller than its interval");
+                        throw new Interface.UserInformationException("An interval cannot be bigger than the timeframe it is in");
                     }
                 }
             }


### PR DESCRIPTION
As discussed in https://forum.duplicati.com/t/new-retention-policy-deletes-old-backups-in-a-smart-way/2195/65 and before:

This allows the user to specify `U` for both the timeframe and interval to hopefully  make some edge cases easier to understand:
- `1W:U`: "For one week keep unlimited (=all) backups”. Internally it works the same as specifying 0s for the intervall, which is still valid.
- `U:1W`: "For unlimited time keep a backup at the interval of one week". This replaces the need for having to specify a very long timeframe like 99Y if you don't want old backups to get deleted. It is always applied after the last rule, so for example if there is a rule `99Y:2W`, then that one will be used before the `U:1W`.

I also refactored the handling of the retention policy option to use a list of custom objects instead of a dictionary to reduce confusion when working with them.

_Since this change doesn't render the current syntax invalid but only expands it, it should be OK to add this change after the next experimental has been released, in case you don't want to delay that one with more and more features._