### PR TITLE
disabled default filters until we decide on how to use them

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -196,7 +196,7 @@
                             </ul>
                             <a href ng-click="Backup.Filters.push('-*')" translate>Add filter</a>
                         </div>
-
+                        <!-- Disabled for https://github.com/duplicati/duplicati/issues/3056
                         <div class="input checkbox multiple">
                             <strong translate>Default Filters</strong>
                             
@@ -209,7 +209,7 @@
                                        ng-click="toggleDefaultFilters(filterSet.value)" />
                                 <label for="filterSet_{{filterSet.value}}">{{filterSet.name}}</label>
                             </div>
-                        </div>
+                        </div>-->
                     </div>
                 </div>
                 <div class="box exclude">


### PR DESCRIPTION
Fix for #3056

Hides the UI since c9be6516904f7e196a22fc2d7e009e90095b5383 disables the backend functionality
