### PR TITLE
Fix #3075

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -351,7 +351,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             return;
         }
 
-        if ($scope.KeepType == 'custom' && (opts['retention-policy'] || '').indexOf(':') <= 1) 
+        if ($scope.KeepType == 'custom' && (opts['retention-policy'] || '').indexOf(':') <= 0) 
         {
             DialogService.dialog(gettextCatalog.getString('Invalid retention time'), gettextCatalog.getString('You must enter a valid rentention policy string'));
             $scope.CurrentStep = 4;

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -316,7 +316,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         }
 
         // Retention options are mutual exclusive -> allow only one to be selected at a time
-        function resetAllRetentionOptionsExcept(optionToKeep = '') {
+        function resetAllRetentionOptionsExcept(optionToKeep) {
             ['keep-versions', 'keep-time', 'retention-policy'].forEach(function(entry) {
                 if (entry != optionToKeep) {
                     delete opts[entry];


### PR DESCRIPTION
IE doesn't support default parameters introduced with ECMAScript 2015 which was used in the code to ensure mutual exclusivity of the retention options. Removed it, as it does work without that default parameter anyway.

Also fixes the check for the retention policy string when there is only one rule with the new `U` parameter in the beginning, e.g. `U:1D`