### PR TITLE
Add option to disable backup when on battery power

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -545,6 +545,11 @@ namespace Duplicati.CommandLine
             {
                 using (var periodicOutput = new PeriodicOutput(output, TimeSpan.FromSeconds(5)))
                 {
+                    if ((new Duplicati.Library.Main.Options(options)).DisableOnBattery && (Duplicati.Library.Utility.Power.PowerSupply.GetSource() == Duplicati.Library.Utility.Power.PowerSupply.Source.Battery))
+                    {
+                        output.MessageEvent("The \"disable-on-battery\" option only affects scheduled backups and is ignored by backups run manually or from the command line.");
+                    }
+
                     output.MessageEvent(string.Format("Backup started at {0}", DateTime.Now));
 
                     output.PhaseChanged += (phase, previousPhase) =>

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -257,7 +257,8 @@ namespace Duplicati.Library.Main
                     "compression-extension-file",
                     "full-remote-verification",
                     "disable-synthetic-filelist",
-                    "disable-file-scanner"
+                    "disable-file-scanner",
+                    "disable-on-battery"
                 };
             }
         }
@@ -541,6 +542,7 @@ namespace Duplicati.Library.Main
 
                     new CommandLineArgument("auto-vacuum", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AutoVacuumShort, Strings.Options.AutoVacuumLong, "false"),
                     new CommandLineArgument("disable-file-scanner", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisablefilescannerShort, Strings.Options.DisablefilescannerLong, "false"),
+                    new CommandLineArgument("disable-on-battery", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisableOnBatteryShort, Strings.Options.DisableOnBatteryLong, "false"),
                 });
 
                 return lst;
@@ -1881,6 +1883,15 @@ namespace Duplicati.Library.Main
         public bool DisableFileScanner
         {
             get { return Library.Utility.Utility.ParseBoolOption(m_options, "disable-file-scanner"); }
+        }
+
+        /// <summary>
+        /// Gets a flag indicating whether the backup should be disabled when on battery power.
+        /// </summary>
+        /// <value><c>true</c> if the backup should be disabled when on battery power; otherwise, <c>false</c>.</value>
+        public bool DisableOnBattery
+        {
+            get { return Library.Utility.Utility.ParseBoolOption(m_options, "disable-on-battery"); }
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -242,6 +242,8 @@ namespace Duplicati.Library.Main.Strings
         public static string AutoVacuumLong { get { return LC.L(@"Some operations that manipulate the local database leave unused entries behind. These entries are not deleted from a hard drive until a VACUUM operation is run. This operation saves disk space in the long run but needs to temporarily create a copy of all valid entries in the database. Setting this to true will allow Duplicati to perform VACUUM operations at its discretion."); } }
         public static string DisablefilescannerShort { get { return LC.L(@"Disable the read-ahead scanner"); } }
         public static string DisablefilescannerLong { get { return LC.L(@"When this flag is enabled, the scanner that computes the size of source files is disabled, and instead the reported size is read from the database. Using this flag can speed up the backup by reducing disk access, but will give a less accurate progress indicator."); } }
+        public static string DisableOnBatteryShort { get { return LC.L("Disable the backup when on battery power"); } }
+        public static string DisableOnBatteryLong { get { return LC.L("When this flag is enabled, a scheduled backup will not run if the system is detected to be running on battery power (manual or command line backups will still be run).  If the detected power source is mains (i.e., AC) or unknown, then scheduled backups will proceed as normal."); } }
 
         public static string LogfileloglevelLong { get { return LC.L(@"Specifies the amount of log information to write into the file specified by --log-file"); } }
         public static string LogfileloglevelShort { get { return LC.L(@"Log file information level"); } }

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -843,7 +843,7 @@ namespace Duplicati.Server
             options["disable-module"] = string.Join(",", mods.Union(new string[] { module }).Distinct(StringComparer.OrdinalIgnoreCase));
         }
         
-        private static Dictionary<string, string> ApplyOptions(Duplicati.Server.Serialization.Interface.IBackup backup, DuplicatiOperation mode, Dictionary<string, string> options)
+        internal static Dictionary<string, string> ApplyOptions(Duplicati.Server.Serialization.Interface.IBackup backup, DuplicatiOperation mode, Dictionary<string, string> options)
         {
             options["backup-name"] = backup.Name;
             options["dbpath"] = backup.DBPath;
@@ -891,7 +891,7 @@ namespace Duplicati.Server
             return filter;
         }
 
-        private static Dictionary<string, string> GetCommonOptions(Duplicati.Server.Serialization.Interface.IBackup backup, DuplicatiOperation mode)
+        internal static Dictionary<string, string> GetCommonOptions(Duplicati.Server.Serialization.Interface.IBackup backup, DuplicatiOperation mode)
         {
             return 
                 (from n in Program.DataConnection.Settings


### PR DESCRIPTION
This adds an option to disable the backup when on battery power.  This can be used to preserve battery life by avoiding potentially resource intensive backup operations.  Note that only scheduled backups are skipped.  Manually run backups (e.g., by clicking "Run now" in the UI) will still be run.

To be conservative, if the detected power source is `PowerSupply.Source.Unknown`, the backup will still be run.

This addresses issue #2666.