### PR TITLE
Use nameof operator when constructing ArgumentNullException

### DIFF
--- a/Duplicati/Library/Backend/S3/S3IAM.cs
+++ b/Duplicati/Library/Backend/S3/S3IAM.cs
@@ -138,7 +138,7 @@ namespace Duplicati.Library.Backend
         private string GeneratePolicyDoc(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
 
             path = path.Trim().Trim('/').Trim();
 

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -417,7 +417,7 @@ namespace Duplicati.Library.Backend
             public CustomWebRequestExecutorFactory(WebRequestExecutorFactory parent)
             {
                 if (parent == null)
-                    throw new ArgumentNullException("parent");
+                    throw new ArgumentNullException(nameof(parent));
                 m_parent = parent;
             }
 

--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -160,7 +160,7 @@ namespace Duplicati.Library.DynamicLoader
         public static IList<ICommandLineArgument> GetSupportedCommands(string url)
         {
             if (string.IsNullOrEmpty(url))
-                throw new ArgumentNullException("url");
+                throw new ArgumentNullException(nameof(url));
 
             return _backendLoader.GetSupportedCommands(url);
         }

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -63,7 +63,7 @@ namespace Duplicati.Library.DynamicLoader
             public ICompression GetModule(string fileExtension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)
             {
                 if (string.IsNullOrEmpty(fileExtension))
-                    throw new ArgumentNullException("fileExtension");
+                    throw new ArgumentNullException(nameof(fileExtension));
 
                 LoadInterfaces();
 
@@ -84,7 +84,7 @@ namespace Duplicati.Library.DynamicLoader
             public IList<ICommandLineArgument> GetSupportedCommands(string key)
             {
                 if (string.IsNullOrEmpty(key))
-                    throw new ArgumentNullException("key");
+                    throw new ArgumentNullException(nameof(key));
 
                 LoadInterfaces();
 

--- a/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
@@ -62,10 +62,10 @@ namespace Duplicati.Library.DynamicLoader
             public IEncryption GetModule(string fileExtension, string passphrase, Dictionary<string, string> options)
             {
                 if (string.IsNullOrEmpty(fileExtension))
-                    throw new ArgumentNullException("fileExtension");
+                    throw new ArgumentNullException(nameof(fileExtension));
 
                 if (string.IsNullOrEmpty(passphrase))
-                    throw new ArgumentNullException("passphrase");
+                    throw new ArgumentNullException(nameof(passphrase));
 
                 LoadInterfaces();
 
@@ -86,7 +86,7 @@ namespace Duplicati.Library.DynamicLoader
             public IList<ICommandLineArgument> GetSupportedCommands(string key)
             {
                 if (string.IsNullOrEmpty(key))
-                    throw new ArgumentNullException("key");
+                    throw new ArgumentNullException(nameof(key));
 
                 LoadInterfaces();
 

--- a/Duplicati/Library/Main/Blockprocessor.cs
+++ b/Duplicati/Library/Main/Blockprocessor.cs
@@ -15,10 +15,10 @@ namespace Duplicati.Library.Main
         public Blockprocessor(Stream stream, byte[] buffer)
         {
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             if (buffer == null)
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
 
             m_stream = stream;
             m_buffer = buffer;

--- a/Duplicati/Library/Utility/AsyncHttpRequest.cs
+++ b/Duplicati/Library/Utility/AsyncHttpRequest.cs
@@ -79,7 +79,7 @@ namespace Duplicati.Library.Utility
         public AsyncHttpRequest(WebRequest request)
         {
             if (request == null)
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             m_request = request;
             m_timeout = m_request.Timeout;
             if (m_timeout != System.Threading.Timeout.Infinite)

--- a/Duplicati/Library/Utility/OverrideableStream.cs
+++ b/Duplicati/Library/Utility/OverrideableStream.cs
@@ -36,7 +36,7 @@ namespace Duplicati.Library.Utility
         public OverrideableStream(Stream basestream)
         {
             if (basestream == null)
-                throw new ArgumentNullException("basestream");
+                throw new ArgumentNullException(nameof(basestream));
             m_basestream = basestream;
         }
 

--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -130,7 +130,7 @@ namespace Duplicati.Library.Utility
         public Uri(string url)
         {
             if (string.IsNullOrEmpty(url))
-                throw new ArgumentNullException("url");
+                throw new ArgumentNullException(nameof(url));
             
             m_queryParams = null;
             this.OriginalUri = url;
@@ -356,7 +356,7 @@ namespace Duplicati.Library.Utility
         public static string UrlEncode(string value, System.Text.Encoding encoding = null, string spacevalue = "+") 
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
                 
             encoding = encoding ?? System.Text.Encoding.UTF8;
 
@@ -399,7 +399,7 @@ namespace Duplicati.Library.Utility
         public static string UrlDecode(string value, System.Text.Encoding encoding = null)
         {
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
                 
             encoding = encoding ?? System.Text.Encoding.UTF8;
                 
@@ -443,7 +443,7 @@ namespace Duplicati.Library.Utility
         public static NameValueCollection ParseQueryString(string query)
         {
             if (query == null)
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             if (query.StartsWith("?", StringComparison.Ordinal))
                 query = query.Substring(1);
             if (string.IsNullOrEmpty(query))

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -81,7 +81,7 @@ namespace Duplicati.Server.Database
             lock(m_lock)
             {
                 if (backup == null)
-                    throw new ArgumentNullException("backup");
+                    throw new ArgumentNullException(nameof(backup));
                 if (backup.ID != null)
                     throw new ArgumentException("Backup is already active, cannot make temporary");
                 
@@ -276,7 +276,7 @@ namespace Duplicati.Server.Database
         internal IBackup GetBackup(string id)
         {
             if (string.IsNullOrWhiteSpace(id))
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             
             long lid;
             if (long.TryParse(id, out lid))

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -142,7 +142,7 @@ namespace Duplicati.Server
                 : base()
             {
                 if (runner == null)
-                    throw new ArgumentNullException("runner");
+                    throw new ArgumentNullException(nameof(runner));
                 Run = runner;
                 Operation = DuplicatiOperation.CustomRunner;
                 Backup = new Database.Backup();

--- a/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
@@ -159,7 +159,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         /// <returns>A new TreeNode instance on success; null if an exception occurred during creation.</returns>
         private static Serializable.TreeNode TryCreateTreeNodeForDrive(DriveInfo driveInfo)
         {
-            if (driveInfo == null) throw new ArgumentNullException("driveInfo");
+            if (driveInfo == null) throw new ArgumentNullException(nameof(driveInfo));
 
             try
             {


### PR DESCRIPTION
This will make rename refactorings easier in the future.