### PR TITLE
Fix code references in XML documentation

### DIFF
--- a/Duplicati/Library/Main/Database/HashLookupHelper.cs
+++ b/Duplicati/Library/Main/Database/HashLookupHelper.cs
@@ -35,7 +35,7 @@ namespace Duplicati.Library.Main
         private readonly ulong m_entries;
         
         /// <summary>
-        /// Initializes a new instance of the <see cref="Duplicati.Library.Main.HashLookupHelper"/> class.
+        /// Initializes a new instance of the <see cref="Duplicati.Library.Main.HashLookupHelper{T}"/> class.
         /// </summary>
         /// <param name="maxmemory">The maximum amount of bytes to use for the lookup table</param>
         public HashLookupHelper (ulong maxmemory)

--- a/Duplicati/Library/Main/Database/PathLookupHelper.cs
+++ b/Duplicati/Library/Main/Database/PathLookupHelper.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Library.Main.Database
         private readonly List<KeyValuePair<string, FolderEntry>> m_lookup;
         
         /// <summary>
-        /// Initializes a new instance of the <see cref="Duplicati.Library.Main.Database.PathLookupHelper`1"/> class.
+        /// Initializes a new instance of the <see cref="Duplicati.Library.Main.Database.PathLookupHelper{T}"/> class.
         /// </summary>
         /// <param name="useHotPath">If set to <c>true</c> use hotpath optimization</param>
         public PathLookupHelper(bool useHotPath = true)

--- a/Duplicati/Library/Utility/BlockingQueue.cs
+++ b/Duplicati/Library/Utility/BlockingQueue.cs
@@ -24,7 +24,7 @@ using System.Text;
 namespace Duplicati.Library.Utility
 {
     /// <summary>
-    /// Class for wrapping a <see cref="Duplicati.Library.Utility.BlockingQueue"/> as an <see cref="System.Collections.Generic.IEnumerable"/>
+    /// Class for wrapping a <see cref="Duplicati.Library.Utility.BlockingQueue{T}"/> as an <see cref="System.Collections.Generic.IEnumerable{T}"/>
     /// </summary>
     public class BlockingQueueAsEnumerable<T> : IEnumerable<T>
     {
@@ -138,19 +138,19 @@ namespace Duplicati.Library.Utility
         private long m_maxCapacity = 100;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.BlockingQueue"/> class with the default capacity
+        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.BlockingQueue{T}"/> class with the default capacity
         /// </summary>
         public BlockingQueue()
         {
         }
 
         /// <summary>
-        /// Gets a value indicating whether this <see cref="Duplicati.Library.Utility.BlockingQueue"/> is completed
+        /// Gets a value indicating whether this <see cref="Duplicati.Library.Utility.BlockingQueue{T}"/> is completed
         /// </summary>
         public bool Completed { get { return m_completed; } }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.BlockingQueue"/> class
+        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.BlockingQueue{T}"/> class
         /// </summary>
         /// <param name='maxCapacity'>The maximum capacity of the queue, the producers will be blocked if more elements are put into the queue</param>
         public BlockingQueue(long maxCapacity)

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -288,7 +288,7 @@ namespace Duplicati.Library.Utility
         }
     
         /// <summary>
-        /// Creates a new <see cref="Duplicati.Library.Main.FilterExpression"/> instance.
+        /// Creates a new <see cref="Duplicati.Library.Utility.FilterExpression"/> instance.
         /// </summary>
         /// <param name="filter">The filter string that represents the filter</param>
         public FilterExpression(IEnumerable<string> filter, bool result = true)

--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -124,7 +124,7 @@ namespace Duplicati.Library.Utility
         }
         
         /// <summary>
-        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.Utility.Uri"/> struct.
+        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.Uri"/> struct.
         /// </summary>
         /// <param name="url">The URL to parse</param>
         public Uri(string url)


### PR DESCRIPTION
This fixes a few code references in the XML documentation.  There were some cases where generic classes weren't referenced correctly (see https://msdn.microsoft.com/en-us/library/acd0tfbe(VS.85).aspx), as well as some incorrect namespaces.