### PR TITLE
Fix XML parameter documentation

### DIFF
--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -57,7 +57,6 @@ namespace Duplicati.Library.DynamicLoader
             /// Instanciates a specific compression module, given the file extension and options
             /// </summary>
             /// <param name="fileExtension">The file extension to create the instance for</param>
-            /// <param name="filename">The filename used to compress/decompress contents</param>
             /// <param name="options">The options to pass to the instance constructor</param>
             /// <returns>The instanciated encryption module or null if the file extension is not supported</returns>
             public ICompression GetModule(string fileExtension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)
@@ -131,7 +130,6 @@ namespace Duplicati.Library.DynamicLoader
         /// </summary>
         /// <param name="fileextension">The file extension to create the instance for</param>
         /// <param name="stream">The stream of the file used to compress/decompress contents</param>
-        /// <param name="writing">True is the file opened for writing</param>
         /// <param name="options">The options to pass to the instance constructor</param>
         /// <returns>The instanciated compression module or null if the file extension is not supported</returns>
         public static ICompression GetModule(string fileextension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -57,6 +57,8 @@ namespace Duplicati.Library.DynamicLoader
             /// Instanciates a specific compression module, given the file extension and options
             /// </summary>
             /// <param name="fileExtension">The file extension to create the instance for</param>
+            /// <param name="stream">The stream of the file used to compress/decompress contents</param>
+            /// <param name="mode">The mode for compression/decompression</param>
             /// <param name="options">The options to pass to the instance constructor</param>
             /// <returns>The instanciated encryption module or null if the file extension is not supported</returns>
             public ICompression GetModule(string fileExtension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)
@@ -130,6 +132,7 @@ namespace Duplicati.Library.DynamicLoader
         /// </summary>
         /// <param name="fileextension">The file extension to create the instance for</param>
         /// <param name="stream">The stream of the file used to compress/decompress contents</param>
+        /// <param name="mode">The mode for compression/decompression</param>
         /// <param name="options">The options to pass to the instance constructor</param>
         /// <returns>The instanciated compression module or null if the file extension is not supported</returns>
         public static ICompression GetModule(string fileextension, Stream stream, ArchiveMode mode, Dictionary<string, string> options)


### PR DESCRIPTION
This fixes a few issues in the C# XML documentation. There were several places where a `<param>` element corresponding to a non-existent parameter was removed.  We also added some documentation for parameters that were missing.