### PR TITLE
added repair button to the 'please repair' notification

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/directives/notificationArea.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/notificationArea.js
@@ -37,6 +37,11 @@ backupApp.directive('notificationArea', function() {
             );
         };
 
+        $scope.doRepair = function(backupid) {
+        AppService.post('/backup/' + backupid + '/repair');
+        $location.path('/');
+        };
+
         $scope.doInstallUpdate = function(id) {
             AppService.post('/updates/install');
         };

--- a/Duplicati/Server/webroot/ngax/templates/notificationarea.html
+++ b/Duplicati/Server/webroot/ngax/templates/notificationarea.html
@@ -11,6 +11,8 @@
 
                 <a href ng-show="item.Action == 'backup:show-log'" ng-click="doShowLog(item.BackupID)" class="button showlog" translate>Show</a>
 
+                <a href ng-show="item.Message.indexOf('please run repair') > 0" ng-click="doRepair(item.BackupID)" class="button repairdb" translate>Repair</a>
+
                 <a href ng-show="item.Action.indexOf('bug-report:created:') == 0 &amp;&amp; item.DownloadLink == null" ng-click="doDownloadBugreport(item)" class="button downloadbugreport" translate>Download</a>
                 <div class="clear"></div>
             </div>


### PR DESCRIPTION
As discussed in https://forum.duplicati.com/t/how-to-please-run-repair/2771 it's not very obvious how to repair the database to new users. 

I Added a button to make it easy.
<img width="495" alt="screen shot 2018-03-09 at 20 14 46" src="https://user-images.githubusercontent.com/1561484/37225574-593d30f4-23d7-11e8-94f3-569f5ed3d897.png">

This also resolves #2118