### PR TITLE
added 'UserName' and 'StartedBy' variables to the system info page

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -156,6 +156,8 @@ namespace Duplicati.GUI.TrayIcon
                 openui = Duplicati.Server.Program.IsFirstRun || Duplicati.Server.Program.ServerPortChanged;
                 password = Duplicati.Server.Program.DataConnection.ApplicationSettings.WebserverPassword;
                 saltedpassword = true;
+                // Tell the hosted server it was started by the TrayIcon
+                Duplicati.Server.Program.Origin = "Tray icon";
 
                 var cert = Duplicati.Server.Program.DataConnection.ApplicationSettings.ServerSSLCertificate;
                 var scheme = "http";

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -122,6 +122,11 @@ namespace Duplicati.Server
         /// </summary>
         public static LogWriteHandler LogHandler = new LogWriteHandler();
 
+        /// <summary>
+        /// Used to check the origin of the web server (e.g. Tray icon or a stand alone Server) 
+        /// </summary>
+        public static string Origin = "Server";
+
         private static System.Threading.Timer PurgeTempFilesTimer = null;
 
         public static int ServerPort
@@ -136,6 +141,12 @@ namespace Duplicati.Server
         {
             get { return DataConnection.ApplicationSettings.IsFirstRun; }
             set { DataConnection.ApplicationSettings.IsFirstRun = value; }
+        }
+
+        public static string StartedBy
+        {
+            get { return Origin; }
+            set { Origin = value; }
         }
 
         public static bool ServerPortChanged

--- a/Duplicati/Server/WebServer/RESTMethods/SystemInfo.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/SystemInfo.cs
@@ -71,6 +71,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 ServerVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(),
                 ServerVersionName = Duplicati.License.VersionNumbers.Version,
                 ServerVersionType = Duplicati.Library.AutoUpdater.UpdaterManager.SelfVersion.ReleaseType,
+                StartedBy = Duplicati.Server.Program.Origin,
                 BaseVersionName = Duplicati.Library.AutoUpdater.UpdaterManager.BaseVersion.Displayname,
                 DefaultUpdateChannel = Duplicati.Library.AutoUpdater.AutoUpdateSettings.DefaultUpdateChannel,
                 DefaultUsageReportLevel = Duplicati.Library.UsageReporter.Reporter.DefaultReportLevel,
@@ -81,6 +82,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 CaseSensitiveFilesystem = Duplicati.Library.Utility.Utility.IsFSCaseSensitive,
                 MonoVersion = Duplicati.Library.Utility.Utility.IsMono ? Duplicati.Library.Utility.Utility.MonoVersion.ToString() : null,
                 MachineName = System.Environment.MachineName,
+                UserName = System.Environment.UserName,
                 NewLine = System.Environment.NewLine,
                 CLRVersion = System.Environment.Version.ToString(),
                 CLROSInfo = new


### PR DESCRIPTION
As discussed in https://forum.duplicati.com/t/solved-headless-server-access-to-all-files/2736 I wanted to add a "UserName" variable to make it easier to determine which user the server is running under.

Additionally I wanted to display how the server was started (stand alone or tray icon) to make it easier to identify issues with running standalone servers and tray icon servers at the same time.