### PR TITLE
Make fields containing lock objects readonly

### DIFF
--- a/Duplicati/CommandLine/ConsoleOutput.cs
+++ b/Duplicati/CommandLine/ConsoleOutput.cs
@@ -24,7 +24,7 @@ namespace Duplicati.CommandLine
 {
     public class ConsoleOutput : Library.Main.IMessageSink, IDisposable
     {
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
         
         public bool QuietConsole { get; private set; }
         public bool VerboseErrors { get; private set; }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -67,7 +67,7 @@ namespace Duplicati.GUI.TrayIcon
 
         public IServerStatus Status { get { return m_status; } }
 
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
         private Queue<BackgroundRequest> m_workQueue = new Queue<BackgroundRequest>();
 
         public HttpServerConnection(Uri server, string password, bool saltedpassword, Program.PasswordSource passwordSource, Dictionary<string, string> options)

--- a/Duplicati/Library/DynamicLoader/DynamicLoader.cs
+++ b/Duplicati/Library/DynamicLoader/DynamicLoader.cs
@@ -37,7 +37,7 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// A lock used to guarantee threadsafe access to the interface lookup table
         /// </summary>
-        protected object m_lock = new object();
+        protected readonly object m_lock = new object();
 
         /// <summary>
         /// A cached list of interfaces

--- a/Duplicati/Library/Logging/Log.cs
+++ b/Duplicati/Library/Logging/Log.cs
@@ -85,7 +85,7 @@ namespace Duplicati.Library.Logging
         /// <summary>
         /// Static lock object to provide thread safe logging
         /// </summary>
-        private static object m_lock = new object();
+        private static readonly object m_lock = new object();
 
         /// <summary>
         /// Gets the lock instance used to protect the logging calls

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -244,7 +244,7 @@ namespace Duplicati.Library.Main
 
         private class DatabaseCollector
         {
-            private object m_dbqueuelock = new object();
+            private readonly object m_dbqueuelock = new object();
             private LocalDatabase m_database;
             private System.Threading.Thread m_callerThread;
             private List<IDbEntry> m_dbqueue;

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -188,7 +188,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// Lock that protects the options collection
         /// </summary>
-        protected object m_lock = new object();
+        protected readonly object m_lock = new object();
 
         protected Dictionary<string, string> m_options;
 

--- a/Duplicati/Library/Utility/BlockingQueue.cs
+++ b/Duplicati/Library/Utility/BlockingQueue.cs
@@ -115,7 +115,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The lock that protects the data structures
         /// </summary>
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
         /// <summary>
         /// The queue storing the elements produced
         /// </summary>

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -41,7 +41,7 @@ namespace Duplicati.Library.Utility
         /// Used to protect accesses to all state vars and making decisions
         /// on blocking thereon.
         /// </summary>
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
 
         /// <summary> An event to wake reader. </summary>
         private ManualResetEventSlim m_signalDataAvailable = new ManualResetEventSlim(false);

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -375,7 +375,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The lock object for protecting access to the lookup table
         /// </summary>
-        private static object _matchLock = new object();
+        private readonly static object _matchLock = new object();
 
         /// <summary>
         /// Utility function to match a filter with a default fall-through value

--- a/Duplicati/Library/Utility/TempFile.cs
+++ b/Duplicati/Library/Utility/TempFile.cs
@@ -38,7 +38,7 @@ namespace Duplicati.Library.Utility
                 
 #if DEBUG
         //In debug mode, we track the creation of temporary files, and encode the generating method into the name
-        private static object m_lock = new object();
+        private static readonly object m_lock = new object();
         private static Dictionary<string, System.Diagnostics.StackTrace> m_fileTrace = new Dictionary<string, System.Diagnostics.StackTrace>();
         
         public static System.Diagnostics.StackTrace GetStackTraceForTempFile(string filename)

--- a/Duplicati/Library/Utility/WorkerThread.cs
+++ b/Duplicati/Library/Utility/WorkerThread.cs
@@ -33,7 +33,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// Locking object for shared data
         /// </summary>
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
         /// <summary>
         /// The wait event
         /// </summary>

--- a/Duplicati/Server/EventPollNotify.cs
+++ b/Duplicati/Server/EventPollNotify.cs
@@ -13,7 +13,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The lock that grants exclusive access to control structures
         /// </summary>
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
         /// <summary>
         /// The current eventID
         /// </summary>

--- a/Duplicati/Server/LiveControls.cs
+++ b/Duplicati/Server/LiveControls.cs
@@ -102,7 +102,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The object that ensures concurrent operations
         /// </summary>
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
 
         /// <summary>
         /// Gets the current overridden thread priority

--- a/Duplicati/Server/LogWriteHandler.cs
+++ b/Duplicati/Server/LogWriteHandler.cs
@@ -143,7 +143,7 @@ namespace Duplicati.Server
             private int m_tail;
             private int m_length;
             private int m_key;
-            private object m_lock = new object();
+            private readonly object m_lock = new object();
 
             public RingBuffer(int size, IEnumerable<T> initial = null)
             {
@@ -227,7 +227,7 @@ namespace Duplicati.Server
         }
 
         private DateTime[] m_timeouts;
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
         private volatile bool m_anytimeouts = false;
         private RingBuffer<LogEntry> m_buffer;
 

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -44,7 +44,7 @@ namespace Duplicati.Server
         /// <summary>
         /// This is the lock to be used before manipulating the shared resources
         /// </summary>
-        public static object MainLock = new object();
+        public static readonly object MainLock = new object();
 
         /// <summary>
         /// This is the scheduling thread

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -264,7 +264,7 @@ namespace Duplicati.Server
             private ProgressState m_state;
             private Duplicati.Library.Main.IBackendProgress m_backendProgress;
             private Duplicati.Library.Main.IOperationProgress m_operationProgress;
-            private object m_lock = new object();
+            private readonly object m_lock = new object();
             
             public MessageSink(long taskId, string backupId)
             {

--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -53,7 +53,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The data syncronization lock
         /// </summary>
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
 
         /// <summary>
         /// An event that is raised when the schedule changes

--- a/Duplicati/Server/UpdatePollThread.cs
+++ b/Duplicati/Server/UpdatePollThread.cs
@@ -31,7 +31,7 @@ namespace Duplicati.Server
         private volatile bool m_terminated = false;
         private volatile bool m_download = false;
         private volatile bool m_forceCheck = false;
-        private object m_lock = new object();
+        private readonly object m_lock = new object();
         private AutoResetEvent m_waitSignal;
         private double m_downloadProgress;
 

--- a/Duplicati/Server/WebServer/RESTMethods/Captcha.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Captcha.cs
@@ -38,7 +38,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             }
         }
 
-        private static object m_lock = new object();
+        private static readonly object m_lock = new object();
         private static Dictionary<string, CaptchaEntry> m_captchas = new Dictionary<string, CaptchaEntry>();
 
         public static bool SolvedCaptcha(string token, string target, string answer)

--- a/Duplicati/Service/Runner.cs
+++ b/Duplicati/Service/Runner.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Service
         private Action m_onStoppedAction;
         private Action<string, bool> m_reportMessage;
 
-        private object m_writelock = new object();
+        private readonly object m_writelock = new object();
         private readonly string[] m_cmdargs;
 
 


### PR DESCRIPTION
If one of these fields is accidentally reassigned, it's possible for threads to be oblivious to an existing lock.  By making the fields `readonly`, we will be notified at compile-time if we inadvertently redefine one of these fields.