### PR TITLE
Fix Appveyor build by removing inlined out variable

### DIFF
--- a/Duplicati/Library/Logging/LogEntry.cs
+++ b/Duplicati/Library/Logging/LogEntry.cs
@@ -75,7 +75,9 @@ namespace Duplicati.Library.Logging
             {
                 if (m_logContext == null)
                     return null;
-                m_logContext.TryGetValue(key, out var s);
+
+                string s;
+                m_logContext.TryGetValue(key, out s);
                 return s;
             }
 


### PR DESCRIPTION
This replaces an inlined `out` variable with the older declaration syntax.  Inlined `out` variables are a newer C# language feature that are not supported by the current Appveyor build, which is currently using MSBuild 14.0.