### PR TITLE
Fix Appveyor builds by removing use of C# 7 language features

### DIFF
--- a/Duplicati/CommandLine/ConsoleLogTarget.cs
+++ b/Duplicati/CommandLine/ConsoleLogTarget.cs
@@ -64,7 +64,9 @@ namespace Duplicati.CommandLine
         /// <param name="entry">The entry to write.</param>
         public void WriteMessage(LogEntry entry)
         {
-            var found = m_filter.Matches(entry.Tag, out var result, out var match);
+            bool result;
+            Duplicati.Library.Utility.IFilter match;
+            var found = m_filter.Matches(entry.Tag, out result, out match);
             // If there is a filter match, use that
             if (found)
             {

--- a/Duplicati/Library/Logging/LambdaSupport.cs
+++ b/Duplicati/Library/Logging/LambdaSupport.cs
@@ -33,7 +33,11 @@ namespace Duplicati.Library.Logging
         /// <param name="entry">The method to call for logging.</param>
         public FunctionLogDestination(Action<LogEntry> entry)
         {
-            m_entry = entry ?? throw new ArgumentNullException(nameof(entry));
+            if (Object.ReferenceEquals(entry, null))
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+            m_entry = entry;
         }
 
         /// <summary>
@@ -62,7 +66,11 @@ namespace Duplicati.Library.Logging
         /// <param name="handler">The method to call for filtering.</param>
         public FunctionFilter(Func<LogEntry, bool> handler)
         {
-            m_handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            if (Object.ReferenceEquals(handler, null))
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+            m_handler = handler;
         }
 
         /// <summary>

--- a/Duplicati/Library/Logging/LogEntry.cs
+++ b/Duplicati/Library/Logging/LogEntry.cs
@@ -75,7 +75,9 @@ namespace Duplicati.Library.Logging
             {
                 if (m_logContext == null)
                     return null;
-                m_logContext.TryGetValue(key, out var s);
+
+                string s;
+                m_logContext.TryGetValue(key, out s);
                 return s;
             }
 

--- a/Duplicati/Library/Main/ControllerMultiLogTarget.cs
+++ b/Duplicati/Library/Main/ControllerMultiLogTarget.cs
@@ -79,7 +79,9 @@ namespace Duplicati.Library.Main
         {
             foreach (var e in m_targets)
             {
-                var found = e.Item3.Matches(entry.Tag, out var result, out var match);
+                bool result;
+                Duplicati.Library.Utility.IFilter match;
+                var found = e.Item3.Matches(entry.Tag, out result, out match);
 
                 // If there is a filter match, use that
                 if (found)

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1295,7 +1295,8 @@ namespace Duplicati.Library.Main
         {
             get
             {
-                m_options.TryGetValue("log-file-log-filter", out var value);
+                string value;
+                m_options.TryGetValue("log-file-log-filter", out value);
                 return ParseLogFilter(value);
             }
         }
@@ -1308,7 +1309,8 @@ namespace Duplicati.Library.Main
         {
             get
             {
-                m_options.TryGetValue("console-log-filter", out var value);
+                string value;
+                m_options.TryGetValue("console-log-filter", out value);
                 return ParseLogFilter(value);
             }
         }


### PR DESCRIPTION
This should fix the Appveyor builds by removing the use of C# 7 language features.  The current Appveyor build uses MSBuild 14.0, which does not support these newer C# 7 language features.