### PR TITLE
GUI - Progress bar vertical alignment issue fix

### DIFF
--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -515,7 +515,7 @@ body {
                     margin-right: 10px;
                 }
 
-                span { 
+                span {
                     display: inline;
                 }
 
@@ -772,7 +772,7 @@ body {
                             > span {
                                 background: url('../img/mainmenu/over/arrow_down.png') right center no-repeat;
                             }
-                        }                        
+                        }
 
                         > a.add:hover {
                             background: @lColor url('../img/mainmenu/over/add.png') no-repeat 8px 7px;
@@ -908,8 +908,8 @@ body {
 
 			.progress-small {
                             text-align: center;
-                            height: 18px;                            
-                            background: rgba(164, 209,235, 0.50);                            
+                            height: 18px;
+                            background: rgba(164, 209,235, 0.50);
                         }
 
                         .progress-small-bg {
@@ -1193,7 +1193,7 @@ body {
 
                             .retention-options {
                                 input {
-                                    margin-bottom: 10px;                                    
+                                    margin-bottom: 10px;
                                 }
                             }
 
@@ -1400,7 +1400,7 @@ body {
                             width: @step-width;
                         }
                     }
-                }                
+                }
 
                 div.restore.restore-direct {
                     @legends-steps: 4;
@@ -1935,6 +1935,7 @@ div.modal-dialog {
         transition: width .6s ease;
         height: 100%;
         position: absolute;
+        top:0;
 
         &.active {
             -webkit-animation: progress-bar-stripes 2s linear infinite;
@@ -2059,7 +2060,7 @@ div.modal-dialog {
                 &.x-tree-icon-hypervmachine {
                     background-position: -96px 0px;
                 }
-				
+
 				&.x-tree-icon-mssql {
                     background-position: -96px -32px;
                 }
@@ -2235,7 +2236,7 @@ div.modal-dialog {
 
                 .donate {
                     display: none;
-                }                
+                }
             }
 
             .body {
@@ -2309,7 +2310,7 @@ div.modal-dialog {
 
     body {
         .container {
-            
+
             .header {
                 .logo {
                     padding-left: 10px;


### PR DESCRIPTION
The progress bar in the restore screen appears offset from the top (see images below). This corrects that issue. 

Changes made to LESS file to be compiled to CSS file

Screenshot of the problem: https://i.imgur.com/nmcHFTH.png 
Screenshot of the solution: https://i.imgur.com/H0tbPmP.png