### PR TITLE
rclone backend should honor advanced options (Fixes #3142)

### DIFF
--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -104,7 +104,7 @@ namespace Duplicati.Library.Backend
 
             ProcessStartInfo psi = new ProcessStartInfo
             {
-                Arguments = arguments,
+                Arguments = String.Format("{0} {1}", arguments, opt_rclone),
                 CreateNoWindow = true,
                 FileName = command,
                 RedirectStandardError = true,


### PR DESCRIPTION
The rclone backend did not use the "rclone-options" advanced options field, which lead to problems in some configurations. This should fix the error described in #3142 with the solution of the rclone developers 
 from https://github.com/ncw/rclone/issues/747. 

So you can use "--config [configfile].conf" in the advanced rclone options.