### PR TITLE
added a dismiss-all button to the notification area

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/directives/notificationArea.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/notificationArea.js
@@ -16,6 +16,19 @@ backupApp.directive('notificationArea', function() {
             );
         };
 
+        $scope.doDismissAll = function() {
+            angular.forEach($scope.Notifications, function(value, key){
+                id = value['ID'];
+                AppService.delete('/notification/' + id).then(
+                    function() { }, // Don't care, the message will be removed
+                    function(resp) {
+                        // Most likely there was a sync problem, so attempt to reload
+                        NotificationService.refresh_notifications();
+                    }
+                );
+            });
+        };
+
         $scope.doShowLog = function(backupid) {
             AppService.get('/backup/' + backupid + '/isactive').then(
                 function() {

--- a/Duplicati/Server/webroot/ngax/templates/notificationarea.html
+++ b/Duplicati/Server/webroot/ngax/templates/notificationarea.html
@@ -33,7 +33,14 @@
                     <div class="clear"></div>
                 </div>
             </div>
-
+        </div>
+    </li>
+    <li class="error" ng-if="Notifications.length > 0">
+        <div class="content">
+            <div class="buttons">
+                <a href ng-click="doDismissAll()" class="button dismiss" translate>Dismiss all</a>
+                <div class="clear"></div>
+            </div>
         </div>
     </li>
 </ul>


### PR DESCRIPTION
Made for https://forum.duplicati.com/t/would-love-a-dismiss-all-button/3129

I copied the delete call from the doDismiss function for two reasons:
1. To keep it separate in case one of them needs to be tweaked
2. To ensure it runs async, by having the for loop call the AppService method directly, which returns a promise.
![screen shot 2018-04-05 at 20 26 43](https://user-images.githubusercontent.com/1561484/38384844-80b441ce-3910-11e8-876d-8f3dc4a01de5.png)
