### PR TITLE
Make constructors for abstract classes protected

### DIFF
--- a/Duplicati/Library/DynamicLoader/DynamicLoader.cs
+++ b/Duplicati/Library/DynamicLoader/DynamicLoader.cs
@@ -60,7 +60,7 @@ namespace Duplicati.Library.DynamicLoader
         /// Construcst a new instance of the dynamic loader,
         ///  does not load anything
         /// </summary>
-        public DynamicLoader()
+        protected DynamicLoader()
         {
         }
 

--- a/Duplicati/Library/Main/Database/LocalTestDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalTestDatabase.cs
@@ -174,7 +174,7 @@ namespace Duplicati.Library.Main.Database
               protected abstract string INSERTCOMMAND { get; }
               protected abstract int INSERTARGUMENTS { get; }
               
-              public Basiclist(System.Data.IDbConnection connection, string volumename)
+              protected Basiclist(System.Data.IDbConnection connection, string volumename)
               {
                 m_connection = connection;
                 m_volumename = volumename;

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -352,7 +352,7 @@ namespace Duplicati.Library.Main
         public IEnumerable<string> Warnings { get { return m_parent == null ? m_warnings : m_parent.Warnings; } }
         public IEnumerable<string> Errors { get { return m_parent == null ?  m_errors : m_parent.Errors; } }
 
-        public BasicResults()
+        protected BasicResults()
         {
             this.BeginTime = DateTime.UtcNow;
             this.m_parent = null;
@@ -367,7 +367,7 @@ namespace Duplicati.Library.Main
             m_operationProgressUpdater = new OperationProgressUpdater();
         }
 
-        public BasicResults(BasicResults p)
+        protected BasicResults(BasicResults p)
         {
             this.BeginTime = DateTime.UtcNow;
             this.m_parent = p;

--- a/Duplicati/Library/Main/Volumes/VolumeBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeBase.cs
@@ -150,7 +150,7 @@ namespace Duplicati.Library.Main.Volumes
         protected readonly string m_blockhash;
         protected readonly string m_filehash;
 
-        public VolumeBase(Options options)
+        protected VolumeBase(Options options)
         {
             m_blocksize = options.Blocksize;
             m_blockhash = options.BlockHashAlgorithm;

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -34,7 +34,7 @@ namespace Duplicati.Library.Main.Volumes
             return LoadCompressor(compressor, stream, options);
         }
 
-        public VolumeReaderBase(string compressor, string file, Options options)
+        protected VolumeReaderBase(string compressor, string file, Options options)
             : base(options)
         {
             m_compression = LoadCompressor(compressor, file, options, out m_stream);
@@ -43,7 +43,7 @@ namespace Duplicati.Library.Main.Volumes
             m_disposeCompression = true;
         }
 
-        public VolumeReaderBase(ICompression compression, Options options)
+        protected VolumeReaderBase(ICompression compression, Options options)
             : base(options)
         {
             m_compression = compression;

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -24,7 +24,7 @@ namespace Duplicati.Library.Main.Volumes
             m_volumename = name;
         }
 
-        public VolumeWriterBase(Options options)
+        protected VolumeWriterBase(Options options)
             : this(options, DateTime.UtcNow)
         {
         }
@@ -44,7 +44,7 @@ namespace Duplicati.Library.Main.Volumes
             m_volumename = GenerateFilename(this.FileType, options.Prefix, GenerateGuid(options), timestamp, options.CompressionModule, options.NoEncryption ? null : options.EncryptionModule);
         }
 
-        public VolumeWriterBase(Options options, DateTime timestamp)
+        protected VolumeWriterBase(Options options, DateTime timestamp)
             : base(options)
         {
             if (!string.IsNullOrWhiteSpace(options.AsynchronousUploadFolder))

--- a/Duplicati/Library/Snapshots/NoSnapshot.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshot.cs
@@ -41,7 +41,7 @@ namespace Duplicati.Library.Snapshots
         /// Constructs a new backup snapshot, using all the required disks
         /// </summary>
         /// <param name="sources">The folders that are about to be backed up</param>
-        public NoSnapshot(string[] sources)
+        protected NoSnapshot(string[] sources)
             : this(sources, new Dictionary<string, string>())
         {
         }
@@ -51,7 +51,7 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="sources">The folders that are about to be backed up</param>
         /// <param name="options">A set of system options</param>
-        public NoSnapshot(string[] sources, Dictionary<string, string> options)
+        protected NoSnapshot(string[] sources, Dictionary<string, string> options)
         {
             m_sources = new string[sources.Length];
             for (int i = 0; i < m_sources.Length; i++)

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -310,7 +310,7 @@ namespace Duplicati.Library.Utility
         {
             protected DirectStreamLink m_linkStream;
             protected long m_knownLength = -1;
-            public LinkedSubStream(DirectStreamLink linkStream)
+            protected LinkedSubStream(DirectStreamLink linkStream)
             { this.m_linkStream = linkStream; }
 
             public override bool CanSeek { get { return false; } }

--- a/Duplicati/Library/Utility/FileBackedList.cs
+++ b/Duplicati/Library/Utility/FileBackedList.cs
@@ -104,7 +104,7 @@ namespace Duplicati.Library.Utility
         public bool IsFileBacked { get { return !(m_stream is MemoryStream); } }
         public long SwitchToFileLimit { get; set; }
         
-        public FileBackedList()
+        protected FileBackedList()
         {
             m_file = null;
             m_stream = new MemoryStream();


### PR DESCRIPTION
While this does not affect any behavior, it more accurately describes the accessibility.  Since abstract classes can only be instantiated by an instance of a derived type, the constructors should at most have protected access.