### PR TITLE
GUI - State Display Bar Improvements

### DIFF
--- a/Duplicati/Server/webroot/ngax/index.html
+++ b/Duplicati/Server/webroot/ngax/index.html
@@ -54,11 +54,11 @@
     <script type="text/javascript" src="scripts/libs/clipboard.min.js"></script>
     <script type="text/javascript" src="scripts/libs/ngclipboard.min.js"></script>
 
-    <script type="text/javascript" src="scripts/libs/angular-gettext.min.js"></script>    
+    <script type="text/javascript" src="scripts/libs/angular-gettext.min.js"></script>
 
     <script type="text/javascript" src="scripts/app.js"></script>
     <script type="text/javascript" src="scripts/menu.js"></script>
-    
+
     <script type="text/javascript" src="scripts/angular-gettext-cli_compiled_js_output.js"></script>
 
     <script type="text/javascript" src="scripts/services/AppUtils.js"></script>
@@ -123,25 +123,25 @@
 
 </head>
 <body class="theme-{{active_theme}}">
-     
+
     <div class="container">
         <div class="header">
             <div class="logo">
                 <a href="#/">
                     <img class="mainlogo" ng-src="{{brandingService.appLogoPath}}"/>
                 </a>
-                
+
                 <div class="logotext">
                     <a href="#/" class="home">{{brandingService.appName}}</a>
                     <div class="build-suffix" ng-hide="systemInfo.ServerVersionType == 'stable' || systemInfo.ServerVersionType == ''">{{systemInfo.ServerVersionType}}</div>
-                    <div class="powered-by">{{brandingService.appSubtitle}}</div>                
-                </div>          
+                    <div class="powered-by">{{brandingService.appSubtitle}}</div>
+                </div>
             </div>
 
             <div class="donate" ng-hide="systemInfo.SuppressDonationMessages">
                 <external-link link="'https://www.duplicati.com/donate'">{{'Donate' | translate }}</external-link>
             </div>
-            
+
 
             <a href class="menubutton hidden" data-target="mainmenu" translate>Menu</a>
 
@@ -156,18 +156,26 @@
                         <div ng-hide="state.activeTask == null">
                             <span ng-hide="activeBackup == null">
                                 <span ng-hide="StopReqId == activeTaskID">
-                                    <strong>{{activeBackup.Backup.Name}}:</strong> {{StateText}}
+                                    <div class="task-state-info">
+                                      <div class="task-name" title="{{activeBackup.Backup.Name}}">
+                                        <strong>{{activeBackup.Backup.Name}}</strong>
+                                      </div>
+                                      <strong>: </strong>
+                                      <div>
+                                        {{StateText}}
+                                      </div>
+                                    </div>
                                 </span>
                                 <span ng-show="StopReqId == activeTaskID">
                                     <strong translate>Stopping after upload:</strong> {{activeBackup.Backup.Name}}
                                 </span>
                             </span>
                             <span ng-show="activeBackup == null">
-                                <strong ng-hide="StopReqId == activeTaskID" translate>Running task:</strong> 
-                                <strong ng-show="StopReqId == activeTaskID" translate>Stopping task:</strong> 
+                                <strong ng-hide="StopReqId == activeTaskID" translate>Running task:</strong>
+                                <strong ng-show="StopReqId == activeTaskID" translate>Stopping task:</strong>
                                 {{StateText}}
                             </span>
-                            
+
                         </div>
 
                         <div ng-show="state.activeTask == null &amp;&amp; nextTask != null">
@@ -192,7 +200,7 @@
                     <div class="pause" ng-class="{'active': state.programState != 'Running'}" ng-click="pauseOptions()" title="{{state.programState == 'Running' ? 'Click to see the pause options' : 'Click to resume'}}"></div>
                     <div class="throttle {{throttle_active ? 'active' : 'inactive'}}" ng-click="throttleOptions()" title="{{'Click to set throttle options' | translate}}" alt="{{'Click to set throttle options' | translate}}"></div>
                 </div>
-            </div>            
+            </div>
         </div>
 
         <div class="body">
@@ -221,11 +229,11 @@
                     </li>
                 </ul>
             </div>
-            
+
             <div ng-view class="content">
             </div>
         </div>
-        
+
         <div class="footer">
             <div class="about-footer">
                 <ul>
@@ -241,7 +249,7 @@
                         <external-link link="'https://www.duplicati.com/donate'">{{'Donate' | translate}}</external-link>
                     </li>
                 </ul>
-            </div>            
+            </div>
             <div class="social">
                 {{'Visit us on' | translate}}<div class="external-link-image"></div>
                 <ul>
@@ -286,7 +294,7 @@
                         <li ng-repeat="btn in state.CurrentItem.buttons track by $index" style="display: inline-block"><a href class="button" ng-click="onButtonClick($index)">{{btn}}</a></li>
                     </ul>
                 </div>
-            </div>            
+            </div>
         </div>
     </div>
 

--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -496,7 +496,7 @@ body {
             .state {
                 float: left;
                 color: darken(@hColor, 10%);
-                width: 580px;
+                width: 595px;
                 padding: 13px 15px;
                 margin: 10px 20px;
                 border: 1px darken(@hColor, 10%) solid;
@@ -568,6 +568,17 @@ body {
                     left: 0px;
                     background: fade(@hColor, 25%);
                     z-index: 5;
+                }
+
+                .task-name {
+                    flex: 1;
+                    overflow:hidden;
+                    text-overflow:ellipsis;
+                    cursor: help;
+                }
+
+                .task-state-info {
+                    display: flex;
                 }
             }
 


### PR DESCRIPTION
This is to address a few issues with the state display bar including an issue that makes it difficult to see the current status due to the length of the backup name as backup names lengths are not limited.

Note: The CSS file must be recompiled with updated LESS file

This will:
1) Truncate the length of the name (in the state bar) to keep the state fully visible
2) Show the full name (as a title) if the user hovers over the name

This addresses issue: #3106
and implementation was discussed here: 
https://forum.duplicati.com/t/proposal-for-a-modification-to-the-state-display-bar-green-info-bar-at-the-top/3133/6