### PR TITLE
made dismiss all option only show up with 2 or more notifications

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/notificationarea.html
+++ b/Duplicati/Server/webroot/ngax/templates/notificationarea.html
@@ -35,7 +35,7 @@
             </div>
         </div>
     </li>
-    <li class="error" ng-if="Notifications.length > 0">
+    <li class="error" ng-if="Notifications.length > 1">
         <div class="content">
             <div class="buttons">
                 <a href ng-click="doDismissAll()" class="button dismiss" translate>Dismiss all</a>


### PR DESCRIPTION
I realised it looks pretty silly to have a 'dismiss all' option below a single notification and it really doesn't provide any benefit.