### PR TITLE
Fix server setting property accessors

### DIFF
--- a/Duplicati/Server/Database/ServerSettings.cs
+++ b/Duplicati/Server/Database/ServerSettings.cs
@@ -188,10 +188,6 @@ namespace Duplicati.Server.Database
         {
             get
             {
-                var tp = m_values[CONST.IS_FIRST_RUN];
-                if (string.IsNullOrEmpty(tp))
-                    return true;
-
                 return Duplicati.Library.Utility.Utility.ParseBoolOption(m_values, CONST.IS_FIRST_RUN);
             }
             set

--- a/Duplicati/Server/Database/ServerSettings.cs
+++ b/Duplicati/Server/Database/ServerSettings.cs
@@ -198,23 +198,19 @@ namespace Duplicati.Server.Database
             }
         }
 
-		public bool HasAskedForPasswordProtection
-		{
-			get
-			{
-                var tp = m_values[CONST.HAS_ASKED_FOR_PASSWORD_PROTECTION];
-				if (string.IsNullOrEmpty(tp))
-					return true;
-
-				return Duplicati.Library.Utility.Utility.ParseBoolOption(m_values, CONST.HAS_ASKED_FOR_PASSWORD_PROTECTION);
-			}
-			set
-			{
-				lock (m_connection.m_lock)
-					m_values[CONST.HAS_ASKED_FOR_PASSWORD_PROTECTION] = value.ToString();
-				SaveSettings();
-			}
-		}
+        public bool HasAskedForPasswordProtection
+        {
+            get
+            {
+                return Duplicati.Library.Utility.Utility.ParseBoolOption(m_values, CONST.HAS_ASKED_FOR_PASSWORD_PROTECTION);
+            }
+            set
+            {
+                lock (m_connection.m_lock)
+                    m_values[CONST.HAS_ASKED_FOR_PASSWORD_PROTECTION] = value.ToString();
+                SaveSettings();
+            }
+        }
 
 		public bool UnackedError
         {

--- a/Duplicati/Server/Database/ServerSettings.cs
+++ b/Duplicati/Server/Database/ServerSettings.cs
@@ -528,10 +528,7 @@ namespace Duplicati.Server.Database
         {
             get
             {
-                if (m_values.ContainsKey(CONST.HAS_FIXED_INVALID_BACKUPID) && string.IsNullOrWhiteSpace(m_values[CONST.HAS_FIXED_INVALID_BACKUPID]))
-                    return false;
-                else
-                    return Duplicati.Library.Utility.Utility.ParseBoolOption(m_values, CONST.HAS_FIXED_INVALID_BACKUPID);
+                return Duplicati.Library.Utility.Utility.ParseBool(m_values[CONST.HAS_FIXED_INVALID_BACKUPID], false);
             }
             set
             {

--- a/Duplicati/Server/Database/ServerSettings.cs
+++ b/Duplicati/Server/Database/ServerSettings.cs
@@ -212,11 +212,11 @@ namespace Duplicati.Server.Database
             }
         }
 
-		public bool UnackedError
+        public bool UnackedError
         {
             get
             {
-                return Duplicati.Library.Utility.Utility.ParseBoolOption(m_values, CONST.UNACKED_ERROR);
+                return Duplicati.Library.Utility.Utility.ParseBool(m_values[CONST.UNACKED_ERROR], false);
             }
             set
             {
@@ -230,7 +230,7 @@ namespace Duplicati.Server.Database
         {
             get
             {
-                return Duplicati.Library.Utility.Utility.ParseBoolOption(m_values, CONST.UNACKED_WARNING);
+                return Duplicati.Library.Utility.Utility.ParseBool(m_values[CONST.UNACKED_WARNING], false);
             }
             set
             {
@@ -239,6 +239,7 @@ namespace Duplicati.Server.Database
                 SaveSettings();
             }
         }
+
         public bool ServerPortChanged
         {
             get

--- a/Duplicati/Server/Database/ServerSettings.cs
+++ b/Duplicati/Server/Database/ServerSettings.cs
@@ -244,7 +244,7 @@ namespace Duplicati.Server.Database
         {
             get
             {
-                return Duplicati.Library.Utility.Utility.ParseBoolOption(m_values, CONST.SERVER_PORT_CHANGED);
+                return Duplicati.Library.Utility.Utility.ParseBool(m_values[CONST.SERVER_PORT_CHANGED], false);
             }
             set
             {


### PR DESCRIPTION
This modifies several of the `ServerSettings` property accessors.  The `IsFirstRun` and `HasAskedForPasswordProtection` accessors were simplified by removing redundant handling of null or empty values.  By default, the `Utility.ParseBoolOption` method returns `true` for these cases.

The `UnackedError`, `UnackedWarning`, and `ServerPortChanged` accessors were modified so that null, empty or whitespace, and unparsable values return `false`, which seems more appropriate for these settings.  When we previously returned `true` for these cases, we would encounter issues such as the red tray icon for first installs (see issue #3126).
