### PR TITLE
Cache IsFSCaseSensitive to speed up file counting.

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -36,6 +36,11 @@ namespace Duplicati.Library.Utility
         public static long DEFAULT_BUFFER_SIZE => SystemContextSettings.Buffersize;
 
         /// <summary>
+        /// A cache of the FileSystemCaseSensitive property, which is computed upon the first access.
+        /// </summary>
+        private static bool? CachedIsFSCaseSensitive = null;
+
+        /// <summary>
         /// Gets the hash algorithm used for calculating a hash
         /// </summary>
         public static string HashAlgorithm { get { return "SHA256"; } }
@@ -834,13 +839,19 @@ namespace Duplicati.Library.Utility
         {
             get
             {
-                var str = Environment.GetEnvironmentVariable("FILESYSTEM_CASE_SENSITIVE");
+                if (!CachedIsFSCaseSensitive.HasValue)
+                {
+                    var str = Environment.GetEnvironmentVariable("FILESYSTEM_CASE_SENSITIVE");
 
-                // TODO: This should probably be determined by filesystem rather than OS,
-                // OSX can actually have the disks formated as Case Sensitive, but insensitive is default
-                Func<bool> defaultReply = () => Utility.IsClientLinux && !Utility.IsClientOSX;
+                    // TODO: This should probably be determined by filesystem rather than OS,
+                    // OSX can actually have the disks formated as Case Sensitive, but insensitive is default
 
-                return Utility.ParseBool(str, defaultReply);
+                    Func<bool> defaultReply = () => Utility.IsClientLinux && !Utility.IsClientOSX;
+
+                    CachedIsFSCaseSensitive = Utility.ParseBool(str, defaultReply);
+                }
+
+                return CachedIsFSCaseSensitive.Value;
             }
         }
 


### PR DESCRIPTION
`IsFSCaseSensitive` used to call `GetEnvironmentVariable()` every time it
was accessed, which unnecessarily slows down the file counting procedure.
Caching the value of this environment variable speeds up things quite a
bit.