### PR TITLE
Fix Travis build issues by limiting concurrent processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ env:
   general:
     - USAGEREPORTER_Duplicati_LEVEL=none
     - AUTOUPDATER_Duplicati_SKIP_UPDATE=1
-  matrix:
-  - JOB=job1
-  - JOB=job2
-  - JOB=job3
 notifications:
   webhooks:
     urls:
@@ -48,7 +44,7 @@ script:
 # build duplicati
   - ls -la ~/build/duplicati/duplicati/packages/
   - echo "travis_fold:start:build_duplicati"
-  - msbuild /p:Configuration=Release Duplicati.sln
+  - msbuild /p:Configuration=Release /maxcpucount:1 Duplicati.sln
   - echo "travis_fold:end:build_duplicati"
   - cp -r ./Duplicati/Server/webroot ./Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/webroot
 # download and extract testdata
@@ -70,28 +66,7 @@ script:
   - ls -la ~/testdata/data
   - echo "travis_fold:end:download_extract_testdata"
 # run unit tests
-  - echo "travis_fold:start:unit_tests_border"
-  - if [[ "$JOB" == "job1" ]]; then mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat==Border --workers=1; fi
-  - echo "travis_fold:end:unit_tests_border"
-  - echo "travis_fold:start:unit_tests_bulknormal"
-  - if [[ "$JOB" == "job2" ]]; then mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat==BulkNormal --workers=1; fi
-  - echo "travis_fold:end:unit_tests_bulknormal"
-  - echo "travis_fold:start:unit_tests_bulknosize"
-  - if [[ "$JOB" == "job2" ]]; then mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat==BulkNoSize --workers=1; fi
-  - echo "travis_fold:end:unit_tests_bulknosize"
-  - echo "travis_fold:start:unit_tests_svndata"
-  - if [[ "$JOB" == "job1" ]]; then mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat==SVNData --workers=1; fi
-  - echo "travis_fold:end:unit_tests_svndata"
-  - echo "travis_fold:start:unit_tests_svndatalong"
-  - if [[ "$JOB" == "job1" ]]; then mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat==SVNDataLong --workers=1; fi
-  - echo "travis_fold:end:unit_tests_svndatalong"
-  - echo "travis_fold:start:unit_tests_targeted"
-  - if [[ "$JOB" == "job1" ]]; then mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat==Targeted --workers=1; fi
-  - echo "travis_fold:end:unit_tests_targeted"
-  - echo "travis_fold:start:unit_tests_purge"
-  - if [[ "$JOB" == "job3" ]]; then mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat==Purge --workers=1; fi
-  - echo "travis_fold:end:unit_tests_purge"
+  - mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./Duplicati/UnitTest/bin/Release/Duplicati.UnitTest.dll --where:cat!=BulkData
 # start server and run gui tests
   - mono ./Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/Duplicati.Server.exe &
-  - if [[ "$JOB" == "job3" ]]; then python guiTests/guiTest.py; fi
-  
+  - python guiTests/guiTest.py


### PR DESCRIPTION
It seems that `msbuild` has issues when building with multiple concurrent processes.  Once we restricted the build by providing the `/maxcpucount:1` option and using a single job in the Travis build, we:

1. Obtained 5 consecutive successful builds.
2. We then removed the `/maxcpucount:1` option and immediately encountered a failed build.
3. Adding back the `/maxcpucount:1` option, we then obtained another 10 consecutive successful builds.

Prior to these changes, 6 out of 9 builds failed (with `msbuild` hanging) while experimenting with various options, along with numerous failures in previous pull requests, etc.

After limiting Travis to a single job, the build times remain approximately the same as before (22-24 minutes).

Note that similar to the AppVeyor configuration, we skip the "BulkData" tests.  These changes also enable the "Utility" tests, which were not explicitly included before.

See pull request #3171 for experimental details.