### PR TITLE
Fix `SpecialFolder` default filters

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -346,7 +346,7 @@ namespace Duplicati.Library.Utility
                     yield return windir;
 
                     // Also exclude "C:\Windows.old\"
-                    yield return windir.TrimEnd('\\', '/') + ".old" + System.IO.Path.DirectorySeparatorChar;
+                    yield return Utility.AppendDirSeparator(windir.TrimEnd('\\', '/') + ".old");
                 }
             }
 
@@ -564,18 +564,14 @@ namespace Duplicati.Library.Utility
             string folderPath = Environment.GetFolderPath(specialFolder);
             if (!string.IsNullOrEmpty(folderPath))
             {
+                // Note that this also replaces alternate directory separators with regular ones
                 string filter = FilterGroups.CreateWildcardFilter(folderPath);
 
                 // Duplicati matches filters against folder paths exactly.
                 // Meaning a filter for 'C:\Windows' won't match 'C:\Windows\'.
                 // So this makes sure special folder's filter's have a trailing directory separator.
                 // (Alternatively, this could append '*' to all folder filters.)
-                if (filter[filter.Length - 1] != System.IO.Path.DirectorySeparatorChar)
-                {
-                    filter += System.IO.Path.DirectorySeparatorChar;
-                }
-
-                return filter;
+                return Utility.AppendDirSeparator(filter);
             }
             else
             {

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -561,7 +561,7 @@ namespace Duplicati.Library.Utility
         /// <returns>Special folder filter</returns>
         private static string CreateSpecialFolderFilter(Environment.SpecialFolder specialFolder)
         {
-            string folderPath = FilterGroups.CreateSpecialFolderFilter(specialFolder);
+            string folderPath = Environment.GetFolderPath(specialFolder);
             if (!string.IsNullOrEmpty(folderPath))
             {
                 string filter = FilterGroups.CreateWildcardFilter(folderPath);

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -75,7 +75,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// In addition to the default names from the enums, these alternate / shorter names are also available.
         /// </summary>
-        private static Dictionary<string, FilterGroup> filterGroupAliases = new Dictionary<string, FilterGroup>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, FilterGroup> filterGroupAliases = new Dictionary<string, FilterGroup>(StringComparer.OrdinalIgnoreCase)
             {
                 { "System", FilterGroup.SystemFiles },
                 { "Sys", FilterGroup.SystemFiles },
@@ -106,6 +106,16 @@ namespace Duplicati.Library.Utility
                 { "Include", FilterGroup.DefaultIncludes },
                 { "Inc", FilterGroup.DefaultIncludes },
             };
+
+        /// <summary>
+        /// Regex escaped string for the AltDirectorySeparatorChar
+        /// </summary>
+        private static readonly string RegexEscapedAltDirectorySeparatorChar = System.Text.RegularExpressions.Regex.Escape(System.IO.Path.AltDirectorySeparatorChar.ToString());
+
+        /// <summary>
+        /// Regex escaped string for the DirectorySeparatorChar
+        /// </summary>
+        private static readonly string RegexEscapedDirectorySeparatorChar = System.Text.RegularExpressions.Regex.Escape(System.IO.Path.DirectorySeparatorChar.ToString());
 
         /// <summary>
         /// Gets the list of alternate aliases which can refer to this group.
@@ -600,9 +610,7 @@ namespace Duplicati.Library.Utility
         {
             // Create a filter with the given name.
             // However, in order to match paths correctly, the directory separators need to be normalized to match the system default.
-            string escapedAlt = System.Text.RegularExpressions.Regex.Escape(System.IO.Path.AltDirectorySeparatorChar.ToString());
-            string escaped = System.Text.RegularExpressions.Regex.Escape(System.IO.Path.DirectorySeparatorChar.ToString());
-            return "[" + filter.Replace(escapedAlt, escaped) + "]";
+            return "[" + filter.Replace(FilterGroups.RegexEscapedAltDirectorySeparatorChar, FilterGroups.RegexEscapedDirectorySeparatorChar) + "]";
         }
 
         /// <summary>


### PR DESCRIPTION
The way Duplicati matches folders against filters, folder filters need to either end with a wildcard or a slash in order to match.

However, the 'control_dir_v2', 'Windows.old', and the various Environment.SpecialFolders filters did not have trailing slashes, leading to these filters not actually applying when they should.
This change fix the few specific filters that need this specification, and adds a new utiltiy method to produce filters for SpecialFolders in a way that makes sure they end with a trailing slash.