### PR TITLE
add bound to zxcvbn password check

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -41,7 +41,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         else if ((passphrase || '') == '')
             scope.PassphraseScore = '';
         else
-            scope.PassphraseScore = (zxcvbn(passphrase) || {'score': -1}).score;
+            scope.PassphraseScore = (zxcvbn(passphrase.substring(0, 100)) || {'score': -1}).score;
 
         scope.PassphraseScoreString = strengthMap[scope.PassphraseScore];
     }


### PR DESCRIPTION
Added an upper bound to the length of password sent to zxcvbn to avoid it freezing the browser for prolonged periods of time in accordance with #3185

The max of 100 characters seems to perform fairly well in my browser, but we can revise later.