### PR TITLE
Fixes an issue with state info spacing

### DIFF
--- a/Duplicati/Server/webroot/ngax/less/style.less
+++ b/Duplicati/Server/webroot/ngax/less/style.less
@@ -571,7 +571,6 @@ body {
                 }
 
                 .task-name {
-                    flex: 1;
                     overflow:hidden;
                     text-overflow:ellipsis;
                     cursor: help;


### PR DESCRIPTION
This fixes an issue with the spacing between the backup name and the status being too far apart. 

Issue reported by Pectojin on the forum: https://forum.duplicati.com/t/proposal-for-a-modification-to-the-state-display-bar-green-info-bar-at-the-top/3133/8