### PR TITLE
Refactoring of parsing for command line options.

### DIFF
--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -113,13 +113,13 @@ namespace Duplicati.CommandLine
 
         public static IEnumerable<string> SupportedCommands { get { return CommandMap.Keys; } }
 
-        public static int ShowChangeLog(TextWriter outwriter) {
+        private static int ShowChangeLog(TextWriter outwriter) {
             var path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "changelog.txt");
             outwriter.WriteLine(System.IO.File.ReadAllText(path));
             return 0;
         }
 
-        public static void CheckForUpdates(TextWriter outwriter){
+        private static void CheckForUpdates(TextWriter outwriter){
             var update = Library.AutoUpdater.UpdaterManager.LastUpdateCheckVersion;
             if (update == null)
                 update = Library.AutoUpdater.UpdaterManager.CheckForUpdate();
@@ -141,7 +141,7 @@ namespace Duplicati.CommandLine
             }
         }
 
-        public static int ParseCommandLine(TextWriter outwriter, TextWriter errwriter, Action<Library.Main.Controller> setup, ref bool verboseErrors, string[] args) {
+        private static int ParseCommandLine(TextWriter outwriter, TextWriter errwriter, Action<Library.Main.Controller> setup, ref bool verboseErrors, string[] args) {
             List<string> cargs = new List<string>(args);
 
             var tmpparsed = Library.Utility.FilterCollector.ExtractOptions(cargs);

--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -141,7 +141,7 @@ namespace Duplicati.CommandLine
             }
         }
 
-        private static int ParseCommandLine(TextWriter outwriter, TextWriter errwriter, Action<Library.Main.Controller> setup, ref bool verboseErrors, string[] args) {
+        private static int ParseCommandLine(TextWriter outwriter, Action<Library.Main.Controller> setup, ref bool verboseErrors, string[] args) {
             List<string> cargs = new List<string>(args);
 
             var tmpparsed = Library.Utility.FilterCollector.ExtractOptions(cargs);
@@ -241,7 +241,7 @@ namespace Duplicati.CommandLine
             bool verboseErrors = false;
             try
             {
-                return ParseCommandLine(outwriter, errwriter, setup, ref verboseErrors, args);
+                return ParseCommandLine(outwriter, setup, ref verboseErrors, args);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
I reordered some parts of the commandline options parsing part, splitting basically one large function in somewhat smaller functions. I reduced some isHelp checks by moving that up front. I don't think I violated any logic changes here, but please check. 