### PR TITLE
Include version information in Results

### DIFF
--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -217,6 +217,7 @@ namespace Duplicati.Library.Main
             }
         }
 
+        public string Version { get { return string.Format("{0} ({1})", AutoUpdater.UpdaterManager.SelfVersion.Version, AutoUpdater.UpdaterManager.SelfVersion.Displayname); } }
         public DateTime EndTime { get; set; }
         public DateTime BeginTime { get; set; }
         public TimeSpan Duration { get { return EndTime.Ticks == 0 ? new TimeSpan(0) : EndTime - BeginTime; } }


### PR DESCRIPTION
I made this change because I wanted the Duplicati version information included in email results.
Not sure if this is the best way to access the version information, but it works.