### PR TITLE
Use thread-safe collection in SynologyAuthenticationHandler

### DIFF
--- a/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
@@ -64,11 +64,6 @@ namespace Duplicati.Server.WebServer
         private readonly ConcurrentDictionary<string, DateTime> m_logincache = new ConcurrentDictionary<string, DateTime>();
 
         /// <summary>
-        /// The loca guarding the login cache
-        /// </summary>
-        private object m_lock = new object();
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="T:Duplicati.Server.WebServer.SynologyAuthenticationHandler"/> class.
         /// </summary>
         public SynologyAuthenticationHandler()

--- a/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
@@ -15,6 +15,7 @@
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -60,7 +61,7 @@ namespace Duplicati.Server.WebServer
         /// <summary>
         /// A cache of previously authenticated logins
         /// </summary>
-        private readonly Dictionary<string, DateTime> m_logincache = new Dictionary<string, DateTime>();
+        private readonly ConcurrentDictionary<string, DateTime> m_logincache = new ConcurrentDictionary<string, DateTime>();
 
         /// <summary>
         /// The loca guarding the login cache


### PR DESCRIPTION
Since the `SynologyAuthenticationHandler` class inherits from `HttpModule`, we should ensure that access to its internal collections are thread-safe.

We also removed a lock object that was previously unused and is no longer needed.