### PR TITLE
Provide value to format item

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Recompress.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Recompress.cs
@@ -287,7 +287,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 Console.WriteLine("Download complete, of {0} remote files, {1} were downloaded with {2} errors", remotefiles.Count(), downloaded, errors);
                 if (needspass > 0)
-                    Console.WriteLine("Additonally {0} remote files were skipped because of encryption, supply --passphrase to download those");
+                    Console.WriteLine("Additonally {0} remote files were skipped because of encryption, supply --passphrase to download those", needspass);
 
                 if (errors > 0)
                 {


### PR DESCRIPTION
This logging statement contains a format item `{0}` that was previously missing a value.