### PR TITLE
Improve readability of single-statement if and foreach blocks

### DIFF
--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -142,7 +142,7 @@ namespace Duplicati.Library.Backend
                 if (wex.Response as System.Net.HttpWebResponse != null && (wex.Response as System.Net.HttpWebResponse).StatusCode == System.Net.HttpStatusCode.MethodNotAllowed)
                     throw new UserInformationException(Strings.WEBDAV.MethodNotAllowedError((wex.Response as System.Net.HttpWebResponse).StatusCode), "WebdavMethodNotAllowed", wex);
 
-                    throw;
+                throw;
             }
         }
 

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -230,8 +230,9 @@ namespace Duplicati.Library.Main.Database
                 if (versions != null && versions.Length > 0)
                 {
                     var qs = "";
-                    
-                    foreach(var v in versions)
+
+                    foreach (var v in versions)
+                    {
                         if (v >= 0 && v < filesets.Length)
                         {
                             args.Add(filesets[v].Key);
@@ -239,7 +240,7 @@ namespace Duplicati.Library.Main.Database
                         }
                         else
                             Logging.Log.WriteWarningMessage(LOGTAG, "SkipInvalidVersion", null, "Skipping invalid version: {0}", v);
-                            
+                    }
                         
                     if (qs.Length > 0)
                     {

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -179,15 +179,17 @@ namespace Duplicati.Library.Main
         private static string[] GetSupportedHashes()
         {
             var r = new List<string>();
-            foreach(var h in new string[] {"SHA1", "MD5", "SHA256", "SHA384", "SHA512"})
-            try 
+            foreach (var h in new string[] { "SHA1", "MD5", "SHA256", "SHA384", "SHA512" })
             {
-                var p = System.Security.Cryptography.HashAlgorithm.Create(h);
-                if (p != null)
-                    r.Add(h);
-            }
-            catch
-            {
+                try
+                {
+                    var p = System.Security.Cryptography.HashAlgorithm.Create(h);
+                    if (p != null)
+                        r.Add(h);
+                }
+                catch
+                {
+                }
             }
             
             return r.ToArray();

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -422,7 +422,8 @@ namespace Duplicati.Library.Utility
             var r = new List<FilterEntry>();
             string combined = null;
             bool first = false;
-            foreach(var f in items)
+            foreach (var f in items)
+            {
                 if (combined == null)
                 {
                     // Note that even though group filters may include regexes, we don't want to merge them together and compact them,
@@ -450,10 +451,11 @@ namespace Duplicati.Library.Utility
                             combined = "(" + combined + ")";
                             first = false;
                         }
-                        
+
                         combined += "|(" + f.Regexp + ")";
                     }
                 }
+            }
                 
             if (combined != null)
                 r.Add(new FilterEntry("[" + combined + "]"));


### PR DESCRIPTION
This improves the readability of some single-statement `if` and `foreach` blocks.  In the `CompactHandler`, `FilterExpression`, `LocalDatabase`, and `Option` classes, we indented and enclosed a multi-line statement  in curly braces.  The previous formatting could give the impression that the following code belonged to the preceding `foreach` statement when in fact it would only be executed once.

In the `WEBDAV` class, we fixed some indentation so that a statement would not be misleadingly aligned with the body of a braceless `if` statement.