### PR TITLE
Replace string concatenation with StringBuilder

### DIFF
--- a/Duplicati/CommandLine/Help.cs
+++ b/Duplicati/CommandLine/Help.cs
@@ -409,10 +409,10 @@ namespace Duplicati.CommandLine
 
                 string c = s;
 
-                string leadingSpaces = "";
+                StringBuilder leadingSpaces = new StringBuilder();
                 while (c.Length > 0 && c.StartsWith(" ", StringComparison.Ordinal))
                 {
-                    leadingSpaces += " ";
+                    leadingSpaces.Append(" ");
                     c = c.Remove(0, 1);
                 }
 
@@ -434,7 +434,7 @@ namespace Duplicati.CommandLine
                     if (extraIndent)
                     {
                         extraIndent = false;
-                        leadingSpaces += "  ";
+                        leadingSpaces.Append("  ");
                     }
                 }
             }

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -666,12 +666,14 @@ namespace Duplicati.Library.Backend
                 string[] folderNames = m_serverRelPath.Substring(0, m_serverRelPath.Length - 1).Split('/');
                 folderNames = Array.ConvertAll(folderNames, fold => System.Net.WebUtility.UrlDecode(fold));
                 var spfolders = new SP.Folder[folderNames.Length];
-                string folderRelPath = "";
+                StringBuilder relativePathBuilder = new StringBuilder();
                 int fi = 0;
                 for (; fi < folderNames.Length; fi++)
                 {
-                    folderRelPath += System.Web.HttpUtility.UrlPathEncode(folderNames[fi]) + "/";
+                    relativePathBuilder.Append(System.Web.HttpUtility.UrlPathEncode(folderNames[fi])).Append("/");
                     if (fi < pathLengthToWeb) continue;
+
+                    string folderRelPath = relativePathBuilder.ToString();
                     var folder = ctx.Web.GetFolderByServerRelativeUrl(folderRelPath);
                     spfolders[fi] = folder;
                     ctx.Load(folder, f => f.Exists);

--- a/Duplicati/Library/Main/DatabaseLocator.cs
+++ b/Duplicati/Library/Main/DatabaseLocator.cs
@@ -202,12 +202,13 @@ namespace Duplicati.Library.Main
         
         public static string GenerateRandomName()
         {
-            var backupname = "";
             var rnd = new Random();
-            for(var i = 0; i < 10; i++)
-                backupname += (char)rnd.Next('A', 'Z' + 1);
-                
-            return backupname;
+
+            System.Text.StringBuilder backupName = new System.Text.StringBuilder();
+            for (var i = 0; i < 10; i++)
+                backupName.Append(rnd.Next('A', 'Z' + 1));
+
+            return backupName.ToString();
         }
 
         public static bool IsDatabasePathInUse(string path)

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -420,11 +420,11 @@ namespace Duplicati.Library.Utility
         private static List<FilterEntry> Compact(IEnumerable<FilterEntry> items)
         {
             var r = new List<FilterEntry>();
-            string combined = null;
+            System.Text.StringBuilder combined = new System.Text.StringBuilder();
             bool first = false;
             foreach (var f in items)
             {
-                if (combined == null)
+                if (combined.Length == 0)
                 {
                     // Note that even though group filters may include regexes, we don't want to merge them together and compact them,
                     // since that would make their names much more difficult to interpret on the command line.
@@ -432,7 +432,7 @@ namespace Duplicati.Library.Utility
                         r.Add(f);
                     else if (f.Type != FilterType.Empty)
                     {
-                        combined = f.Regexp.ToString();
+                        combined.Append(f.Regexp.ToString());
                         first = true;
                     }
                 }
@@ -440,25 +440,25 @@ namespace Duplicati.Library.Utility
                 {
                     if (f.Type == FilterType.Simple || f.Type == FilterType.Wildcard || f.Type == FilterType.Group)
                     {
-                        r.Add(new FilterEntry("[" + combined + "]"));
+                        r.Add(new FilterEntry("[" + combined.Append("]")));
                         r.Add(f);
-                        combined = null;
+                        combined.Clear();
                     }
                     else if (f.Type != FilterType.Empty)
                     {
                         if (first)
                         {
-                            combined = "(" + combined + ")";
+                            combined.Insert(0, "(").Append(")");
                             first = false;
                         }
 
-                        combined += "|(" + f.Regexp + ")";
+                        combined.Append("|(" + f.Regexp + ")");
                     }
                 }
             }
-                
-            if (combined != null)
-                r.Add(new FilterEntry("[" + combined + "]"));
+
+            if (combined.Length > 0)
+                r.Add(new FilterEntry("[" + combined.Append("]")));
 
             return r;                    
         }


### PR DESCRIPTION
When appending to a string in a loop, using a `StringBuilder` should in general yield better performance.