### PR TITLE
Simplify construction of query parameter string

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -69,12 +69,7 @@ namespace Duplicati.Library.Main.Database
             {
                 cmd.Transaction = transaction;
 
-                var q = "";
-                foreach(var n in toDelete)
-                    if (q.Length == 0)
-                        q = "?";
-                    else
-                        q += ",?";
+                string q = String.Join(",", Enumerable.Repeat("?", toDelete.Length));
                         
                 //First we remove unwanted entries
                 var deleted = cmd.ExecuteNonQuery(@"DELETE FROM ""Fileset"" WHERE ""Timestamp"" IN (" + q + @") ", toDelete.Select(x => NormalizeDateTimeToEpochSeconds(x)).Cast<object>().ToArray());


### PR DESCRIPTION
This replaces a `foreach` loop with a call to `String.Join` when building the comma-separated part of a query parameter string.