### PR TITLE
Mark fields that shouldn't be reassigned as readonly

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -27,12 +27,12 @@ namespace Duplicati.CommandLine
         private class PeriodicOutput : IDisposable
         {
             public event Action<float, long, long, bool> WriteOutput;
-            
-            private System.Threading.ManualResetEvent m_readyEvent;
-            private System.Threading.ManualResetEvent m_finishEvent;
-            private ConsoleOutput m_output;
+
+            private readonly System.Threading.ManualResetEvent m_readyEvent;
+            private readonly System.Threading.ManualResetEvent m_finishEvent;
+            private readonly ConsoleOutput m_output;
             private System.Threading.Thread m_thread;
-            private TimeSpan m_updateFrequency;
+            private readonly TimeSpan m_updateFrequency;
             
             public PeriodicOutput(ConsoleOutput messageSink, TimeSpan updateFrequency)
             {

--- a/Duplicati/CommandLine/Help.cs
+++ b/Duplicati/CommandLine/Help.cs
@@ -442,7 +442,7 @@ namespace Duplicati.CommandLine
 
         private class Matcher
         {
-            Dictionary<string, Library.Interface.ICommandLineArgument> args = new Dictionary<string, Library.Interface.ICommandLineArgument>(StringComparer.OrdinalIgnoreCase);
+            readonly Dictionary<string, Library.Interface.ICommandLineArgument> args = new Dictionary<string, Library.Interface.ICommandLineArgument>(StringComparer.OrdinalIgnoreCase);
 
             public Matcher()
             {

--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -29,7 +29,7 @@ namespace Duplicati.CommandLine
 {
     public class Program
     {
-        private static string LOGTAG = Library.Logging.Log.LogTagFromType<Program>();
+        private static readonly string LOGTAG = Library.Logging.Log.LogTagFromType<Program>();
 
         public static bool FROM_COMMANDLINE = false;
 

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -268,14 +268,14 @@ namespace Duplicati.CommandLine.RecoveryTool
         {
             private const int LOOKUP_TABLE_SIZE = 2048;
 
-            private CompressedFileMRUCache m_cache;
-            private int m_hashsize;
-            private int m_blocksize;
+            private readonly CompressedFileMRUCache m_cache;
+            private readonly int m_hashsize;
+            private readonly int m_blocksize;
             private Stream m_indexfile;
-            private List<string> m_lookup = new List<string>();
-            private List<long> m_offsets = new List<long>();
-            private byte[] m_linebuf = new byte[128];
-            private byte[] m_newline = Environment.NewLine.Select(x => (byte)x).ToArray();
+            private readonly List<string> m_lookup = new List<string>();
+            private readonly List<long> m_offsets = new List<long>();
+            private readonly byte[] m_linebuf = new byte[128];
+            private readonly byte[] m_newline = Environment.NewLine.Select(x => (byte)x).ToArray();
 
             public HashLookupHelper(string indexfile, CompressedFileMRUCache cache, int blocksize, int hashsize)
             {
@@ -432,7 +432,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             private Dictionary<string, Library.Interface.ICompression> m_lookup = new Dictionary<string, Duplicati.Library.Interface.ICompression>();
             private Dictionary<string, Stream> m_streams = new Dictionary<string, Stream>();
             private List<string> m_mru = new List<string>();
-            private Dictionary<string, string> m_options;
+            private readonly Dictionary<string, string> m_options;
 
             private const int MAX_OPEN_ARCHIVES = 20;
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -28,8 +28,8 @@ namespace Duplicati.GUI.TrayIcon
     {        
         private class MenuItemWrapper : Duplicati.GUI.TrayIcon.IMenuItem
         {
-            private NSMenuItem m_item;
-            private Action m_callback;
+            private readonly NSMenuItem m_item;
+            private readonly Action m_callback;
             
             public NSMenuItem MenuItem { get { return m_item; } }
             
@@ -93,11 +93,11 @@ namespace Duplicati.GUI.TrayIcon
         private static readonly string ICON_ERROR = ICON_PATH + "normal-error.png";
         
         private NSStatusItem m_statusItem;
-        private Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, NSImage> m_images = new Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, NSImage>();
+        private readonly Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, NSImage> m_images = new Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, NSImage>();
         private NSApplication m_app;
 
         // We need to keep the items around, otherwise the GC will destroy them and crash the app
-        private List<Duplicati.GUI.TrayIcon.IMenuItem> m_keeper = new List<Duplicati.GUI.TrayIcon.IMenuItem>();
+        private readonly List<Duplicati.GUI.TrayIcon.IMenuItem> m_keeper = new List<Duplicati.GUI.TrayIcon.IMenuItem>();
 
         public override void Init(string[] args)
         {

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HostedInstanceKeeper.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HostedInstanceKeeper.cs
@@ -10,7 +10,7 @@ namespace Duplicati.GUI.TrayIcon
     /// </summary>
     internal class HostedInstanceKeeper : IDisposable
     {
-        private System.Threading.Thread m_runner;
+        private readonly System.Threading.Thread m_runner;
         private System.Exception m_runnerException = null;
         public event Action InstanceShutdown;
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -38,10 +38,10 @@ namespace Duplicati.GUI.TrayIcon
             }
         }
 
-        private string m_apiUri;
-        private string m_baseUri;
+        private readonly string m_apiUri;
+        private readonly string m_baseUri;
         private string m_password;
-        private bool m_saltedpassword;
+        private readonly bool m_saltedpassword;
         private string m_authtoken;
         private string m_xsrftoken;
         private static readonly System.Text.Encoding ENCODING = System.Text.Encoding.GetEncoding("utf-8");
@@ -59,7 +59,7 @@ namespace Duplicati.GUI.TrayIcon
         private volatile bool m_shutdown = false;
         private volatile System.Threading.Thread m_requestThread;
         private volatile System.Threading.Thread m_pollThread;
-        private System.Threading.AutoResetEvent m_waitLock;
+        private readonly System.Threading.AutoResetEvent m_waitLock;
 
         private readonly Dictionary<string, string> m_updateRequest;
         private readonly Dictionary<string, string> m_options;
@@ -69,7 +69,7 @@ namespace Duplicati.GUI.TrayIcon
         public IServerStatus Status { get { return m_status; } }
 
         private readonly object m_lock = new object();
-        private Queue<BackgroundRequest> m_workQueue = new Queue<BackgroundRequest>();
+        private readonly Queue<BackgroundRequest> m_workQueue = new Queue<BackgroundRequest>();
 
         public HttpServerConnection(Uri server, string password, bool saltedpassword, Program.PasswordSource passwordSource, Dictionary<string, string> options)
         {

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -29,7 +29,7 @@ namespace Duplicati.GUI.TrayIcon
         private class MenuItemWrapper : Duplicati.GUI.TrayIcon.IMenuItem
         {
 
-            private RumpsRunner m_parent;
+            private readonly RumpsRunner m_parent;
 
             private string m_text;
             private MenuIcons m_icon;
@@ -115,7 +115,7 @@ namespace Duplicati.GUI.TrayIcon
         private static readonly string ICON_RUNNING = ICON_PATH + "normal-running.png";
         private static readonly string ICON_ERROR = ICON_PATH + "normal-error.png";
 
-        private Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, string> m_images = new Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, string>();
+        private readonly Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, string> m_images = new Dictionary<Duplicati.GUI.TrayIcon.TrayIcons, string>();
 
         private System.Diagnostics.Process m_rumpsProcess;
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
@@ -27,8 +27,8 @@ namespace Duplicati.GUI.TrayIcon.Windows
     {
         private class MenuItemWrapper : IMenuItem
         {
-            private ToolStripItem m_menu;
-            private Action m_callback;
+            private readonly ToolStripItem m_menu;
+            private readonly Action m_callback;
 
             public ToolStripItem MenuItem { get { return m_menu; } }
             

--- a/Duplicati/Library/AutoUpdater/SignatureReadingStream.cs
+++ b/Duplicati/Library/AutoUpdater/SignatureReadingStream.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Library.AutoUpdater
         /// <summary>
         /// The stream to read from
         /// </summary>
-        private System.IO.Stream m_stream;
+        private readonly System.IO.Stream m_stream;
 
         protected SignatureReadingStream()
         {

--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -45,14 +45,14 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
         private EndpointInfo m_endPointInfo;
         private ResourceModel m_curdir;
 
-        private string m_path;
-        private string[] m_labels;
+        private readonly string m_path;
+        private readonly string[] m_labels;
 
-        private OAuthHelper m_oauth;
+        private readonly OAuthHelper m_oauth;
         private Dictionary<string, string> m_filecache;
-        private string m_userid;
+        private readonly string m_userid;
         private DateTime m_waitUntil;
-        private TimeSpan m_delayTimeSpan;
+        private readonly TimeSpan m_delayTimeSpan;
 
         private enum RemoteOperation
         {

--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -35,12 +35,12 @@ namespace Duplicati.Library.Backend.Backblaze
 
         private const int DEFAULT_PAGE_SIZE = 500;
 
-        private string m_bucketname;
-        private string m_prefix;
-        private string m_urlencodedprefix;
-        private string m_bucketType;
-        private int m_pagesize;
-        private B2AuthHelper m_helper;
+        private readonly string m_bucketname;
+        private readonly string m_prefix;
+        private readonly string m_urlencodedprefix;
+        private readonly string m_bucketType;
+        private readonly int m_pagesize;
+        private readonly B2AuthHelper m_helper;
         private UploadUrlResponse m_uploadUrl;
 
         private Dictionary<string, List<FileEntity>> m_filecache;

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -35,9 +35,9 @@ namespace Duplicati.Library.Backend.Box
 
         private const int PAGE_SIZE = 200;
 
-        private BoxHelper m_oauth;
-        private string m_path;
-        private bool m_deleteFromTrash;
+        private readonly BoxHelper m_oauth;
+        private readonly string m_path;
+        private readonly bool m_deleteFromTrash;
 
         private string m_currentfolder;
         private Dictionary<string, string> m_filecache;

--- a/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
+++ b/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
@@ -39,13 +39,13 @@ namespace Duplicati.Library.Backend
 
 
         private const int ITEM_LIST_LIMIT = 1000;
-        private string m_username;
-        private string m_password;
-        private string m_path;
+        private readonly string m_username;
+        private readonly string m_password;
+        private readonly string m_path;
 
         private string m_storageUrl = null;
         private string m_authToken = null;
-        private string m_authUrl;
+        private readonly string m_authUrl;
 
         private readonly byte[] m_copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
 

--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -10,8 +10,9 @@ namespace Duplicati.Library.Backend
         private const string AUTHID_OPTION = "authid";
         private const int MAX_FILE_LIST = 10000;
 
-        private string m_path,m_accesToken;
-        private DropboxHelper dbx;
+        private readonly string m_accesToken;
+        private readonly string m_path;
+        private readonly DropboxHelper dbx;
 
         public Dropbox()
         {

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -32,12 +32,12 @@ namespace Duplicati.Library.Backend
         private const string OPTION_MOVE_FILE = "use-move-for-put";
         private const string OPTION_FORCE_REAUTH = "force-smb-authentication";
 
-        private string m_path;
+        private readonly string m_path;
         private string m_username;
         private string m_password;
-        private bool m_moveFile;
+        private readonly bool m_moveFile;
         private bool m_hasAutenticated;
-        private bool m_forceReauth;
+        private readonly bool m_forceReauth;
 
         private readonly byte[] m_copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -61,13 +61,13 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
             new KeyValuePair<string, string>("Nearline", "NEARLINE"),
         };
 
-        private string m_bucket;
-        private string m_prefix;
-        private string m_project;
-        private OAuthHelper m_oauth;
+        private readonly string m_bucket;
+        private readonly string m_prefix;
+        private readonly string m_project;
+        private readonly OAuthHelper m_oauth;
 
-        private string m_location;
-        private string m_storage_class;
+        private readonly string m_location;
+        private readonly string m_storage_class;
         public GoogleCloudStorage()
         {
         }

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -41,7 +41,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
 
         private readonly OAuthHelper m_oauth;
         private string m_currentFolderId;
-        private Dictionary<string, GoogleDriveFolderItem[]> m_filecache;
+        private readonly Dictionary<string, GoogleDriveFolderItem[]> m_filecache;
 
         public GoogleDrive()
         {

--- a/Duplicati/Library/Backend/HubiC/HubiCBackend.cs
+++ b/Duplicati/Library/Backend/HubiC/HubiCBackend.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Library.Backend.HubiC
 
         private class OpenStackHelper : OpenStackStorage
         {
-            private OAuthHelper m_helper;
+            private readonly OAuthHelper m_helper;
             private HubiCAuthResponse m_token;
 
             public OpenStackHelper(string authid, string url)

--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -44,7 +44,7 @@ namespace Duplicati.Library.Backend
         private readonly string m_url_device;
         private readonly string m_url;
         private readonly string m_url_upload;
-        private System.Net.NetworkCredential m_userInfo;
+        private readonly System.Net.NetworkCredential m_userInfo;
         private readonly byte[] m_copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
 
         public Jottacloud()

--- a/Duplicati/Library/Backend/Mega/MegaBackend.cs
+++ b/Duplicati/Library/Backend/Mega/MegaBackend.cs
@@ -24,11 +24,11 @@ namespace Duplicati.Library.Backend.Mega
 {
     public class MegaBackend: IBackend, IStreamingBackend
     {
-        private string m_username = null;
-        private string m_password = null;
+        private readonly string m_username = null;
+        private readonly string m_password = null;
         private Dictionary<string, List<INode>> m_filecache;
         private INode m_currentFolder = null;
-        private string m_prefix = null;
+        private readonly string m_prefix = null;
 
         private MegaApiClient m_client;
 

--- a/Duplicati/Library/Backend/OneDrive/OneDrive.cs
+++ b/Duplicati/Library/Backend/OneDrive/OneDrive.cs
@@ -28,14 +28,14 @@ namespace Duplicati.Library.Backend
 
         private static readonly string USER_AGENT = string.Format("Duplicati v{0}", System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
 
-        private string m_rootfolder;
-        private string m_prefix;
+        private readonly string m_rootfolder;
+        private readonly string m_prefix;
         private string m_userid;
         private WLID_FolderItem m_folderid;
 
-        private OAuthHelper m_oauth;
+        private readonly OAuthHelper m_oauth;
 
-        private Dictionary<string, string> m_fileidCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> m_fileidCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         private readonly byte[] m_copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
 

--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -40,11 +40,11 @@ namespace Duplicati.Library.Backend
         private const string RCLONE_ERROR_DIRECTORY_NOT_FOUND = "directory not found";
         private const string RCLONE_ERROR_CONFIG_NOT_FOUND = "didn't find section in config file";
 
-        private string local_repo;
-        private string remote_repo;
-        private string remote_path;
-        private string opt_rclone;
-        private string rclone_executable;
+        private readonly string local_repo;
+        private readonly string remote_repo;
+        private readonly string remote_path;
+        private readonly string opt_rclone;
+        private readonly string rclone_executable;
 
         public Rclone()
         {

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -126,8 +126,8 @@ namespace Duplicati.Library.Backend
             }
         }
 
-        private string m_bucket;
-        private string m_prefix;
+        private readonly string m_bucket;
+        private readonly string m_prefix;
 
         public const string DEFAULT_S3_HOST  = "s3.amazonaws.com";
         public const string S3_EU_REGION_NAME = "eu-west-1";

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -37,18 +37,18 @@ namespace Duplicati.Library.Backend
         public const string SSH_TIMEOUT_OPTION = "ssh-operation-timeout";
         public const string SSH_KEEPALIVE_OPTION = "ssh-keepalive";
 
-        Dictionary<string, string> m_options;
+        readonly Dictionary<string, string> m_options;
 
-        private string m_server;
-        private string m_path;
-        private string m_username;
-        private string m_password;
-        private string m_fingerprint;
-        private bool m_fingerprintallowall;
-        private TimeSpan m_operationtimeout;
-        private TimeSpan m_keepaliveinterval;
+        private readonly string m_server;
+        private readonly string m_path;
+        private readonly string m_username;
+        private readonly string m_password;
+        private readonly string m_fingerprint;
+        private readonly bool m_fingerprintallowall;
+        private readonly TimeSpan m_operationtimeout;
+        private readonly TimeSpan m_keepaliveinterval;
 
-        private int m_port = 22;
+        private readonly int m_port = 22;
 
         private SftpClient m_con;
 

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -54,15 +54,15 @@ namespace Duplicati.Library.Backend
         #region [Variables and constants declarations]
 
         /// <summary> Auth-stripped HTTPS-URI as passed to constructor. </summary>
-        private Utility.Uri m_orgUrl;
+        private readonly Utility.Uri m_orgUrl;
         /// <summary> Server relative path to backup folder. </summary>
-        private string m_serverRelPath;
+        private readonly string m_serverRelPath;
         /// <summary> User's credentials to create client context </summary>
         private System.Net.ICredentials m_userInfo;
         /// <summary> Flag indicating to move files to recycler on deletion. </summary>
-        private bool m_deleteToRecycler = false;
+        private readonly bool m_deleteToRecycler = false;
         /// <summary> Flag indicating to use UploadBinaryDirect. </summary>
-        private bool m_useBinaryDirectMode = false;
+        private readonly bool m_useBinaryDirectMode = false;
 
         /// <summary> URL to SharePoint web. Will be determined from m_orgUri on first use. </summary>
         private string m_spWebUrl;
@@ -70,10 +70,10 @@ namespace Duplicati.Library.Backend
         private SP.ClientContext m_spContext;
 
         /// <summary> The chunk size for uploading files. </summary>
-        private int m_fileChunkSize = 4 << 20; // Default: 4MB
+        private readonly int m_fileChunkSize = 4 << 20; // Default: 4MB
 
         /// <summary> The chunk size for uploading files. </summary>
-        private int m_useContextTimeoutMs = -1; // default: do not touch original setting
+        private readonly int m_useContextTimeoutMs = -1; // default: do not touch original setting
 
         #endregion
 

--- a/Duplicati/Library/Backend/Sia/Sia.cs
+++ b/Duplicati/Library/Backend/Sia/Sia.cs
@@ -15,11 +15,11 @@ namespace Duplicati.Library.Backend.Sia
         private const string SIA_TARGETPATH = "sia-targetpath";
         private const string SIA_REDUNDANCY = "sia-redundancy";
 
-        private string m_apihost;
-        private int m_apiport;
-        private string m_targetpath;
-        private float m_redundancy;
-        private System.Net.NetworkCredential m_user;
+        private readonly string m_apihost;
+        private readonly int m_apiport;
+        private readonly string m_targetpath;
+        private readonly float m_redundancy;
+        private readonly System.Net.NetworkCredential m_user;
 
         public Sia() {
 

--- a/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
+++ b/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
@@ -29,8 +29,8 @@ namespace Duplicati.Library.Backend
 {
     public class TahoeBackend : IBackend, IStreamingBackend
     {
-        private string m_url;
-        private bool m_useSSL = false;
+        private readonly string m_url;
+        private readonly bool m_useSSL = false;
         private readonly byte[] m_copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
 
         private class TahoeEl

--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -26,18 +26,18 @@ namespace Duplicati.Library.Backend
 {
     public class WEBDAV : IBackend, IStreamingBackend
     {
-        private System.Net.NetworkCredential m_userInfo;
-        private string m_url;
-        private string m_path;
-        private string m_sanitizedUrl;
-        private string m_reverseProtocolUrl;
-        private string m_rawurl;
-        private string m_rawurlPort;
-        private string m_dnsName;
-        private bool m_useIntegratedAuthentication = false;
-        private bool m_forceDigestAuthentication = false;
-        private bool m_useSSL = false;
-        private string m_debugPropfindFile = null;
+        private readonly System.Net.NetworkCredential m_userInfo;
+        private readonly string m_url;
+        private readonly string m_path;
+        private readonly string m_sanitizedUrl;
+        private readonly string m_reverseProtocolUrl;
+        private readonly string m_rawurl;
+        private readonly string m_rawurlPort;
+        private readonly string m_dnsName;
+        private readonly bool m_useIntegratedAuthentication = false;
+        private readonly bool m_forceDigestAuthentication = false;
+        private readonly bool m_useSSL = false;
+        private readonly string m_debugPropfindFile = null;
         private readonly byte[] m_copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
 
         /// <summary>

--- a/Duplicati/Library/Compression/FileArchiveZip.cs
+++ b/Duplicati/Library/Compression/FileArchiveZip.cs
@@ -92,7 +92,7 @@ namespace Duplicati.Library.Compression
         /// <summary>
         /// This property indicates reading or writing access mode of the file archive.
         /// </summary>
-        ArchiveMode m_mode;
+        readonly ArchiveMode m_mode;
 
         /// <summary>
         /// Gets the number of bytes expected to be written after the stream is disposed
@@ -126,17 +126,17 @@ namespace Duplicati.Library.Compression
         /// <summary>
         /// The compression level applied when the hint does not indicate incompressible
         /// </summary>
-        private SharpCompress.Compressors.Deflate.CompressionLevel m_defaultCompressionLevel;
+        private readonly SharpCompress.Compressors.Deflate.CompressionLevel m_defaultCompressionLevel;
 
         /// <summary>
         /// The compression level applied when the hint does not indicate incompressible
         /// </summary>
-        private CompressionType m_compressionType;
+        private readonly CompressionType m_compressionType;
 
         /// <summary>
         /// A flag indicating if zip64 is in use
         /// </summary>
-        private bool m_usingZip64;
+        private readonly bool m_usingZip64;
 
         /// <summary>
         /// Default constructor, used to read file extension and supported commands

--- a/Duplicati/Library/Compression/SevenZipCompression.cs
+++ b/Duplicati/Library/Compression/SevenZipCompression.cs
@@ -222,8 +222,8 @@ namespace Duplicati.Library.Compression
 
         private sealed class WriterEntry : ManagedLzma.LZMA.Master.SevenZip.IArchiveWriterEntry
         {
-            private string mName;
-            private DateTime? mTimestamp;
+            private readonly string mName;
+            private readonly DateTime? mTimestamp;
 
             internal WriterEntry(string name, DateTime? timestamp)
             {

--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -138,10 +138,10 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// The static instance used to access backend information
         /// </summary>
-        private static BackendLoaderSub _backendLoader = new BackendLoaderSub();
+        private static readonly BackendLoaderSub _backendLoader = new BackendLoaderSub();
 
         #region Public static API
-        
+
         /// <summary>
         /// Gets a list of loaded backends, the instances can be used to extract interface information, not used to interact with the backend.
         /// </summary>

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -103,7 +103,7 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// The static instance used to access compression module information
         /// </summary>
-        private static CompressionLoaderSub _compressionLoader = new CompressionLoaderSub();
+        private static readonly CompressionLoaderSub _compressionLoader = new CompressionLoaderSub();
 
         #region Public static API
 

--- a/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
@@ -104,7 +104,7 @@ namespace Duplicati.Library.DynamicLoader
         /// <summary>
         /// The static instance used to access encryption module information
         /// </summary>
-        private static EncryptionLoaderSub _encryptionLoader = new EncryptionLoaderSub();
+        private static readonly EncryptionLoaderSub _encryptionLoader = new EncryptionLoaderSub();
 
         #region Public static API
 

--- a/Duplicati/Library/Encryption/GPGEncryption.cs
+++ b/Duplicati/Library/Encryption/GPGEncryption.cs
@@ -94,17 +94,17 @@ namespace Duplicati.Library.Encryption
         /// <summary>
         /// The PGP program to use, should be with absolute path
         /// </summary>
-        private string m_programpath = "gpg";
+        private readonly string m_programpath = "gpg";
 
         /// <summary>
         /// Commandline switches for encryption
         /// </summary>
-        private string m_encryption_args;
+        private readonly string m_encryption_args;
 
         /// <summary>
         /// Commandline switches for decryption
         /// </summary>
-        private string m_decryption_args;
+        private readonly string m_decryption_args;
 
         /// <summary>
         /// The key used for cryptographic operations

--- a/Duplicati/Library/Localization/LocalizationContext.cs
+++ b/Duplicati/Library/Localization/LocalizationContext.cs
@@ -25,7 +25,7 @@ namespace Duplicati.Library.Localization
         /// <summary>
         /// The previous context
         /// </summary>
-        private object m_prev;
+        private readonly object m_prev;
 
         /// <summary>
         /// Flag to prevent double dispose

--- a/Duplicati/Library/Localization/MoLocalizationService.cs
+++ b/Duplicati/Library/Localization/MoLocalizationService.cs
@@ -33,7 +33,7 @@ namespace Duplicati.Library.Localization
         /// <summary>
         /// The catalog containing the translations
         /// </summary>
-        private ICatalog catalog = new Catalog();
+        private readonly ICatalog catalog = new Catalog();
 
         /// <summary>
         /// The environment variable used to locate MO files

--- a/Duplicati/Library/Localization/Short.cs
+++ b/Duplicati/Library/Localization/Short.cs
@@ -27,7 +27,7 @@ namespace Duplicati.Library.Localization.Short
         /// <summary>
         /// The instance for translation
         /// </summary>
-        private static ILocalizationService LS = LocalizationService.Invariant;
+        private static readonly ILocalizationService LS = LocalizationService.Invariant;
 
         /// <summary>
         /// Localizes the string similar to how string.Format works
@@ -172,7 +172,7 @@ namespace Duplicati.Library.Localization.Short
         /// <summary>
         /// The instance for translation
         /// </summary>
-        private static ILocalizationService LS = LocalizationService.Installed;
+        private static readonly ILocalizationService LS = LocalizationService.Installed;
 
         /// <summary>
         /// Localizes the string similar to how string.Format works

--- a/Duplicati/Library/Logging/Timer.cs
+++ b/Duplicati/Library/Logging/Timer.cs
@@ -33,7 +33,7 @@ namespace Duplicati.Library.Logging
         /// </summary>
         private static readonly string LOGTAG = "Timer";
 
-        private DateTime m_begin;
+        private readonly DateTime m_begin;
         private string m_operation;
         private readonly string m_logtag;
         private readonly string m_logid;

--- a/Duplicati/Library/Main/AsyncDownloader.cs
+++ b/Duplicati/Library/Main/AsyncDownloader.cs
@@ -17,7 +17,7 @@ namespace Duplicati.Library.Main
         {
             private class AsyncDownloadedFile : IAsyncDownloadedFile
             {
-                private Exception m_exception;
+                private readonly Exception m_exception;
                 private Library.Utility.TempFile m_file;
                 
                 public string Name { get; private set; }
@@ -53,9 +53,9 @@ namespace Duplicati.Library.Main
                 }
             }
         
-            private IList<IRemoteVolume> m_volumes;
+            private readonly IList<IRemoteVolume> m_volumes;
             private BackendManager.IDownloadWaitHandle m_handle;
-            private BackendManager m_backend;
+            private readonly BackendManager m_backend;
             private int m_index;
             private AsyncDownloadedFile m_current;
 
@@ -129,8 +129,8 @@ namespace Duplicati.Library.Main
             }
         }
 
-        private IList<IRemoteVolume> m_volumes;
-        private BackendManager m_backend;
+        private readonly IList<IRemoteVolume> m_volumes;
+        private readonly BackendManager m_backend;
 
         public AsyncDownloader(IList<IRemoteVolume> volumes, BackendManager backend)
         {

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -126,7 +126,7 @@ namespace Duplicati.Library.Main
             /// <summary>
             /// The event that is signaled once the operation is complete or has failed
             /// </summary>
-            private System.Threading.ManualResetEvent DoneEvent;
+            private readonly System.Threading.ManualResetEvent DoneEvent;
 
             public FileEntryItem(OperationType operation, string remotefilename, Tuple<IndexVolumeWriter, FileEntryItem> indexfile = null)
             {
@@ -245,10 +245,10 @@ namespace Duplicati.Library.Main
         private class DatabaseCollector
         {
             private readonly object m_dbqueuelock = new object();
-            private LocalDatabase m_database;
-            private System.Threading.Thread m_callerThread;
+            private readonly LocalDatabase m_database;
+            private readonly System.Threading.Thread m_callerThread;
             private List<IDbEntry> m_dbqueue;
-            private IBackendWriter m_stats;
+            private readonly IBackendWriter m_stats;
 
             private interface IDbEntry { }
 
@@ -349,15 +349,15 @@ namespace Duplicati.Library.Main
         }
 
         private readonly BlockingQueue<FileEntryItem> m_queue;
-        private Options m_options;
+        private readonly Options m_options;
         private volatile Exception m_lastException;
-        private Library.Interface.IEncryption m_encryption;
+        private readonly Library.Interface.IEncryption m_encryption;
         private readonly object m_encryptionLock = new object();
         private Library.Interface.IBackend m_backend;
-        private string m_backendurl;
-        private IBackendWriter m_statwriter;
+        private readonly string m_backendurl;
+        private readonly IBackendWriter m_statwriter;
         private System.Threading.Thread m_thread;
-        private BasicResults m_taskControl;
+        private readonly BasicResults m_taskControl;
         private readonly DatabaseCollector m_db;
 
         // Cache these

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -40,7 +40,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// The parsed type-safe version of the commandline options
         /// </summary>
-        private Options m_options;
+        private readonly Options m_options;
         /// <summary>
         /// The destination for all output messages during execution
         /// </summary>
@@ -59,7 +59,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// Holds various keys that need to be reset after running the task
         /// </summary>
-        private Dictionary<string, string> m_resetKeys = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> m_resetKeys = new Dictionary<string, string>();
 
         /// <summary>
         /// The thread priority to reset to

--- a/Duplicati/Library/Main/ControllerMultiLogTarget.cs
+++ b/Duplicati/Library/Main/ControllerMultiLogTarget.cs
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// The list of log targets to handle
         /// </summary>
-        private List<Tuple<ILogDestination, LogMessageType, Library.Utility.IFilter>> m_targets = new List<Tuple<ILogDestination, LogMessageType, Library.Utility.IFilter>>();
+        private readonly List<Tuple<ILogDestination, LogMessageType, Library.Utility.IFilter>> m_targets = new List<Tuple<ILogDestination, LogMessageType, Library.Utility.IFilter>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Duplicati.Library.Main.ControllerMultiLogTarget"/> class.

--- a/Duplicati/Library/Main/Database/HashLookupHelper.cs
+++ b/Duplicati/Library/Main/Database/HashLookupHelper.cs
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// The lookup table
         /// </summary>
-        private SortedList<string, T>[] m_lookup;
+        private readonly SortedList<string, T>[] m_lookup;
         /// <summary>
         /// The number of entries in the table
         /// </summary>

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -561,8 +561,8 @@ namespace Duplicati.Library.Main.Database
 
         protected class TemporaryTransactionWrapper : IDisposable
         {
-            private System.Data.IDbTransaction m_parent;
-            private bool m_isTemporary;
+            private readonly System.Data.IDbTransaction m_parent;
+            private readonly bool m_isTemporary;
 
             public TemporaryTransactionWrapper(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction)
             {
@@ -604,7 +604,7 @@ namespace Duplicati.Library.Main.Database
         
         private class LocalFileEntry : ILocalFileEntry
         {
-            private System.Data.IDataReader m_reader;
+            private readonly System.Data.IDataReader m_reader;
             public LocalFileEntry(System.Data.IDataReader reader)
             {
                 m_reader = reader;
@@ -849,8 +849,8 @@ ON
         {
             private class BlocklistHashEnumerator : IEnumerator<string>
             {
-                private System.Data.IDataReader m_reader;
-                private BlocklistHashEnumerable m_parent;
+                private readonly System.Data.IDataReader m_reader;
+                private readonly BlocklistHashEnumerable m_parent;
                 private string m_path = null;
                 private bool m_first = true;
                 private string m_current = null;
@@ -912,7 +912,7 @@ ON
                 }
             }
 
-            private System.Data.IDataReader m_reader;
+            private readonly System.Data.IDataReader m_reader;
 
             public BlocklistHashEnumerable(System.Data.IDataReader reader)
             {
@@ -1142,8 +1142,8 @@ ORDER BY
         public class FilteredFilenameTable : IDisposable
         {
             public string Tablename { get; private set; }
-            private System.Data.IDbConnection m_connection;
-            
+            private readonly System.Data.IDbConnection m_connection;
+
             public FilteredFilenameTable(System.Data.IDbConnection connection, Library.Utility.IFilter filter, System.Data.IDbTransaction transaction)
             {
                 m_connection = connection;

--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -170,20 +170,20 @@ namespace Duplicati.Library.Main.Database
         
         private class CompactReport : ICompactReport
         {
-            private IEnumerable<VolumeUsage> m_report;
-            private IEnumerable<VolumeUsage> m_cleandelete;
-            private IEnumerable<VolumeUsage> m_wastevolumes;
-            private IEnumerable<VolumeUsage> m_smallvolumes;
+            private readonly IEnumerable<VolumeUsage> m_report;
+            private readonly IEnumerable<VolumeUsage> m_cleandelete;
+            private readonly IEnumerable<VolumeUsage> m_wastevolumes;
+            private readonly IEnumerable<VolumeUsage> m_smallvolumes;
+
+            private readonly long m_deletablevolumes;
+            private readonly long m_wastedspace;
+            private readonly long m_smallspace;
+            private readonly long m_fullsize;
+            private readonly long m_smallvolumecount;
             
-            private long m_deletablevolumes;
-            private long m_wastedspace;
-            private long m_smallspace;
-            private long m_fullsize;
-            private long m_smallvolumecount;
-            
-            private long m_wastethreshold;
-            private long m_volsize;
-            private long m_maxsmallfilecount;
+            private readonly long m_wastethreshold;
+            private readonly long m_volsize;
+            private readonly long m_maxsmallfilecount;
             
             public CompactReport(long volsize, long wastethreshold, long smallfilesize, long maxsmallfilecount, IEnumerable<VolumeUsage> report)
             {

--- a/Duplicati/Library/Main/Database/LocalListChangesDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListChangesDatabase.cs
@@ -89,7 +89,7 @@ namespace Duplicati.Library.Main.Database
         
         private class StorageHelper : IStorageHelper
         {
-            private System.Data.IDbConnection m_connection;
+            private readonly System.Data.IDbConnection m_connection;
             private System.Data.IDbTransaction m_transaction;
             
             private System.Data.IDbCommand m_insertPreviousElementCommand;

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -56,9 +56,9 @@ namespace Duplicati.Library.Main.Database
         
         private class FileSets : IFileSets
         {
-            private System.Data.IDbConnection m_connection;
+            private readonly System.Data.IDbConnection m_connection;
             private string m_tablename;
-            private KeyValuePair<long, DateTime>[] m_filesets;
+            private readonly KeyValuePair<long, DateTime>[] m_filesets;
             
             public FileSets(LocalListDatabase owner, DateTime time, long[] versions)
             {
@@ -94,7 +94,7 @@ namespace Duplicati.Library.Main.Database
             
             private class Fileversion : IFileversion
             {
-                private System.Data.IDataReader m_reader;
+                private readonly System.Data.IDataReader m_reader;
                 public string Path { get; private set; }
                 public bool More { get; private set; }
                 

--- a/Duplicati/Library/Main/Database/LocalPurgeDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalPurgeDatabase.cs
@@ -74,7 +74,7 @@ namespace Duplicati.Library.Main.Database
             private readonly System.Data.IDbConnection m_connection;
             private readonly System.Data.IDbTransaction m_transaction;
             private readonly string m_tablename;
-            private LocalPurgeDatabase m_parentdb;
+            private readonly LocalPurgeDatabase m_parentdb;
 
             public long ParentID { get; private set; }
             public long RemovedFileCount { get; private set; }

--- a/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
@@ -49,23 +49,23 @@ namespace Duplicati.Library.Main.Database
             }
         }
         
-        private System.Data.IDbCommand m_insertFileCommand;
-        private System.Data.IDbCommand m_insertFilesetEntryCommand;
-        private System.Data.IDbCommand m_insertMetadatasetCommand;
-        private System.Data.IDbCommand m_insertBlocksetCommand;
-        private System.Data.IDbCommand m_insertBlocklistHashCommand;
-        private System.Data.IDbCommand m_updateBlockVolumeCommand;
-        private System.Data.IDbCommand m_insertBlockset;
-        private System.Data.IDbCommand m_insertSmallBlockset;
-        private System.Data.IDbCommand m_findBlocksetCommand;
-        private System.Data.IDbCommand m_findMetadatasetCommand;
-        private System.Data.IDbCommand m_findFilesetCommand;
-        private System.Data.IDbCommand m_findblocklisthashCommand;
-        private System.Data.IDbCommand m_findHashBlockCommand;
-        private System.Data.IDbCommand m_insertBlockCommand;
-        private System.Data.IDbCommand m_insertDuplicateBlockCommand;
+        private readonly System.Data.IDbCommand m_insertFileCommand;
+        private readonly System.Data.IDbCommand m_insertFilesetEntryCommand;
+        private readonly System.Data.IDbCommand m_insertMetadatasetCommand;
+        private readonly System.Data.IDbCommand m_insertBlocksetCommand;
+        private readonly System.Data.IDbCommand m_insertBlocklistHashCommand;
+        private readonly System.Data.IDbCommand m_updateBlockVolumeCommand;
+        private readonly System.Data.IDbCommand m_insertBlockset;
+        private readonly System.Data.IDbCommand m_insertSmallBlockset;
+        private readonly System.Data.IDbCommand m_findBlocksetCommand;
+        private readonly System.Data.IDbCommand m_findMetadatasetCommand;
+        private readonly System.Data.IDbCommand m_findFilesetCommand;
+        private readonly System.Data.IDbCommand m_findblocklisthashCommand;
+        private readonly System.Data.IDbCommand m_findHashBlockCommand;
+        private readonly System.Data.IDbCommand m_insertBlockCommand;
+        private readonly System.Data.IDbCommand m_insertDuplicateBlockCommand;
         
-        private PathLookupHelper<PathEntryKeeper> m_filesetLookup;
+        private readonly PathLookupHelper<PathEntryKeeper> m_filesetLookup;
         
         private string m_tempblocklist;
         private string m_tempsmalllist;

--- a/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
@@ -71,8 +71,8 @@ namespace Duplicati.Library.Main.Database
                     
                 }
             }
-        
-            private System.Data.IDataReader m_rd;
+
+            private readonly System.Data.IDataReader m_rd;
             public bool Done { get; private set; }
             
             public BlockWithSources(System.Data.IDataReader rd)
@@ -135,11 +135,11 @@ namespace Duplicati.Library.Main.Database
         
         private class MissingBlockList : IMissingBlockList
         {
-            private System.Data.IDbConnection m_connection;
-            private TemporaryTransactionWrapper m_transaction;
+            private readonly System.Data.IDbConnection m_connection;
+            private readonly TemporaryTransactionWrapper m_transaction;
             private System.Data.IDbCommand m_insertCommand;
             private string m_tablename;
-            private string m_volumename;
+            private readonly string m_volumename;
             
             public MissingBlockList(string volumename, System.Data.IDbConnection connection, System.Data.IDbTransaction transaction)
             {

--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -536,7 +536,7 @@ namespace Duplicati.Library.Main.Database
 
         private class ExistingFile : IExistingFile
         {
-            private System.Data.IDataReader m_reader;
+            private readonly System.Data.IDataReader m_reader;
 
             public ExistingFile(System.Data.IDataReader rd) { m_reader = rd; HasMore = true; }
 
@@ -549,7 +549,7 @@ namespace Duplicati.Library.Main.Database
 
             private class ExistingFileBlock : IExistingFileBlock
             {
-                private System.Data.IDataReader m_reader;
+                private readonly System.Data.IDataReader m_reader;
 
                 public ExistingFileBlock(System.Data.IDataReader rd) { m_reader = rd; }
 
@@ -606,7 +606,7 @@ namespace Duplicati.Library.Main.Database
             {
                 private class BlockSource : IBlockSource
                 {
-                    private System.Data.IDataReader m_reader;
+                    private readonly System.Data.IDataReader m_reader;
                     public BlockSource(System.Data.IDataReader rd) { m_reader = rd; }
 
                     public string Path { get { return m_reader.ConvertValueToString(6); } }
@@ -615,7 +615,7 @@ namespace Duplicati.Library.Main.Database
                     public bool IsMetadata { get { return false; } }
                 }
 
-                private System.Data.IDataReader m_reader;
+                private readonly System.Data.IDataReader m_reader;
                 public BlockDescriptor(System.Data.IDataReader rd) { m_reader = rd; HasMore = true; }
 
                 private string TargetPath { get { return m_reader.ConvertValueToString(0); } }
@@ -645,7 +645,7 @@ namespace Duplicati.Library.Main.Database
                 }
             }
 
-            private System.Data.IDataReader m_reader;
+            private readonly System.Data.IDataReader m_reader;
             public LocalBlockSource(System.Data.IDataReader rd) { m_reader = rd; HasMore = true; }
 
             public string TargetPath { get { return m_reader.ConvertValueToString(0); } }
@@ -756,12 +756,12 @@ namespace Duplicati.Library.Main.Database
 
         private class FilesAndMetadata : IFilesAndMetadata
         {
-            private string m_tmptable;
-            private string m_filetablename;
-            private string m_blocktablename;
-            private long m_blocksize;
+            private readonly string m_tmptable;
+            private readonly string m_filetablename;
+            private readonly string m_blocktablename;
+            private readonly long m_blocksize;
 
-            private System.Data.IDbConnection m_connection;
+            private readonly System.Data.IDbConnection m_connection;
 
             public FilesAndMetadata(System.Data.IDbConnection connection, string filetablename, string blocktablename, long blocksize, BlockVolumeReader curvolume)
             {
@@ -805,7 +805,7 @@ namespace Duplicati.Library.Main.Database
             {
                 private class PatchBlock : IPatchBlock
                 {
-                    private System.Data.IDataReader m_reader;
+                    private readonly System.Data.IDataReader m_reader;
                     public PatchBlock(System.Data.IDataReader rd) { m_reader = rd; }
 
                     public long Offset { get { return m_reader.ConvertValueToInt64(2); } }
@@ -813,7 +813,7 @@ namespace Duplicati.Library.Main.Database
                     public string Key { get { return m_reader.ConvertValueToString(4); } }
                 }
 
-                private System.Data.IDataReader m_reader;
+                private readonly System.Data.IDataReader m_reader;
                 public VolumePatch(System.Data.IDataReader rd) { m_reader = rd; HasMore = true; }
 
                 public string Path { get { return m_reader.ConvertValueToString(0); } }
@@ -1017,8 +1017,8 @@ namespace Duplicati.Library.Main.Database
             private System.Data.IDbCommand m_statUpdateCommand;
             private bool m_hasUpdates = false;
 
-            private string m_blocktablename;
-            private string m_filetablename;
+            private readonly string m_blocktablename;
+            private readonly string m_filetablename;
 
             public System.Data.IDbTransaction Transaction { get { return m_insertblockCommand.Transaction; } }
 
@@ -1212,17 +1212,17 @@ namespace Duplicati.Library.Main.Database
         {
             private class BlockEntry : IBlockEntry
             {
-                private System.Data.IDataReader m_rd;
-                private long m_blocksize;
+                private readonly System.Data.IDataReader m_rd;
+                private readonly long m_blocksize;
                 public BlockEntry(System.Data.IDataReader rd, long blocksize) { m_rd = rd; m_blocksize = blocksize; }
                 public long Offset { get { return m_rd.GetInt64(3) * m_blocksize; } }
                 public long Index { get { return m_rd.GetInt64(3); } }
                 public long Size { get { return m_rd.GetInt64(5); } }
                 public string Hash { get { return m_rd.GetString(4); } }
             }
-        
-            private System.Data.IDataReader m_rd;
-            private long m_blocksize;
+
+            private readonly System.Data.IDataReader m_rd;
+            private readonly long m_blocksize;
             public FastSource(System.Data.IDataReader rd, long blocksize) { m_rd = rd; m_blocksize = blocksize; MoreData = true; }
             public bool MoreData { get; private set; }
             public string TargetPath { get { return m_rd.GetValue(0).ToString(); } }

--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Library.Main.Operation.Backup
     internal class FlushRequest : IUploadRequest
     {
         public Task<long> LastWriteSizeAync { get { return m_tcs.Task; } }
-        private TaskCompletionSource<long> m_tcs = new TaskCompletionSource<long>();
+        private readonly TaskCompletionSource<long> m_tcs = new TaskCompletionSource<long>();
         public void SetFlushed(long size)
         {
             m_tcs.TrySetResult(size);

--- a/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
@@ -33,7 +33,7 @@ namespace Duplicati.Library.Main.Operation.Backup
     /// </summary>
     internal class BackupDatabase : DatabaseCommon
     {
-        private LocalBackupDatabase m_database;
+        private readonly LocalBackupDatabase m_database;
 
         public class FileEntryData
         {

--- a/Duplicati/Library/Main/Operation/Backup/BackupStatsCollector.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackupStatsCollector.cs
@@ -26,7 +26,7 @@ namespace Duplicati.Library.Main.Operation.Backup
     /// </summary>
     internal class BackupStatsCollector : StatsCollector
     {
-        private BackupResults m_res;
+        private readonly BackupResults m_res;
 
         public BackupStatsCollector(BackupResults res)
             : base(res.BackendWriter)

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -48,7 +48,7 @@ namespace Duplicati.Library.Main.Operation
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<BackupHandler>();
 
         private readonly Options m_options;
-        private string m_backendurl;
+        private readonly string m_backendurl;
 
         private LocalBackupDatabase m_database;
         private System.Data.IDbTransaction m_transaction;
@@ -56,7 +56,7 @@ namespace Duplicati.Library.Main.Operation
         private Library.Utility.IFilter m_filter;
         private Library.Utility.IFilter m_sourceFilter;
 
-        private BackupResults m_result;
+        private readonly BackupResults m_result;
 
         public BackupHandler(string backendurl, Options options, BackupResults results)
         {

--- a/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
+++ b/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
@@ -156,13 +156,13 @@ namespace Duplicati.Library.Main.Operation.Common
         }
 
 
-        private DatabaseCommon m_database;
+        private readonly DatabaseCommon m_database;
         private IBackend m_backend;
-        private Options m_options;
-        private string m_backendurl;
+        private readonly Options m_options;
+        private readonly string m_backendurl;
         private bool m_uploadSuccess;
-        private StatsCollector m_stats;
-        private ITaskReader m_taskreader;
+        private readonly StatsCollector m_stats;
+        private readonly ITaskReader m_taskreader;
 
         public BackendHandler(Options options, string backendUrl, DatabaseCommon database, StatsCollector stats, ITaskReader taskreader)
             : base()

--- a/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
+++ b/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
@@ -29,8 +29,8 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<CreateBugReportHandler>();
         private string m_targetpath;
-        private Options m_options;
-        private CreateLogDatabaseResults m_result;
+        private readonly Options m_options;
+        private readonly CreateLogDatabaseResults m_result;
 
         public CreateBugReportHandler(string targetpath, Options options, CreateLogDatabaseResults result)
         {

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -34,7 +34,7 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         private static readonly string LOGTAG_RETENTION = LOGTAG + ":RetentionPolicy";
 
-        private DeleteResults m_result;
+        private readonly DeleteResults m_result;
         protected string m_backendurl;
         protected Options m_options;
     

--- a/Duplicati/Library/Main/Operation/ListAffected.cs
+++ b/Duplicati/Library/Main/Operation/ListAffected.cs
@@ -24,8 +24,8 @@ namespace Duplicati.Library.Main.Operation
 {
     internal class ListAffected
     {
-        private Options m_options;
-        private ListAffectedResults m_result;
+        private readonly Options m_options;
+        private readonly ListAffectedResults m_result;
 
         public ListAffected(Options options, ListAffectedResults result)
         {

--- a/Duplicati/Library/Main/Operation/ListChangesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListChangesHandler.cs
@@ -29,9 +29,9 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(ListChangesHandler));
 
-        private string m_backendurl;
-        private Options m_options;
-        private ListChangesResults m_result;
+        private readonly string m_backendurl;
+        private readonly Options m_options;
+        private readonly ListChangesResults m_result;
 
         public ListChangesHandler(string backend, Options options, ListChangesResults result)
         {

--- a/Duplicati/Library/Main/Operation/ListControlFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListControlFilesHandler.cs
@@ -23,9 +23,9 @@ namespace Duplicati.Library.Main.Operation
 {
     internal class ListControlFilesHandler
     {
-        private Options m_options;
-        private string m_backendurl;
-        private ListResults m_result;
+        private readonly Options m_options;
+        private readonly string m_backendurl;
+        private readonly ListResults m_result;
         
         public ListControlFilesHandler(string backendurl, Options options, ListResults result)
         {

--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -13,9 +13,9 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<ListFilesHandler>();
 
-        private string m_backendurl;
-        private Options m_options;
-        private ListResults m_result;
+        private readonly string m_backendurl;
+        private readonly Options m_options;
+        private readonly ListResults m_result;
 
         public ListFilesHandler(string backend, Options options, ListResults result)
         {

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -14,9 +14,9 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<RecreateDatabaseHandler>();
 
-        private string m_backendurl;
-        private Options m_options;
-        private RecreateDatabaseResults m_result;
+        private readonly string m_backendurl;
+        private readonly Options m_options;
+        private readonly RecreateDatabaseResults m_result;
 
         public delegate IEnumerable<KeyValuePair<long, IParsedVolume>> NumberedFilterFilelistDelegate(IEnumerable<IParsedVolume> filelist);
         public delegate void BlockVolumePostProcessor(string volumename,BlockVolumeReader reader);

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -14,9 +14,9 @@ namespace Duplicati.Library.Main.Operation
         /// The tag used for logging
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<RepairHandler>();
-        private string m_backendurl;
-        private Options m_options;
-        private RepairResults m_result;
+        private readonly string m_backendurl;
+        private readonly Options m_options;
+        private readonly RepairResults m_result;
 
         public RepairHandler(string backend, Options options, RepairResults result)
         {

--- a/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
@@ -7,9 +7,9 @@ namespace Duplicati.Library.Main.Operation
 {
     internal class RestoreControlFilesHandler
     {
-        private Options m_options;
-        private string m_backendurl;
-        private RestoreControlFilesResults m_result;
+        private readonly Options m_options;
+        private readonly string m_backendurl;
+        private readonly RestoreControlFilesResults m_result;
 
         public RestoreControlFilesHandler(string backendurl, Options options, RestoreControlFilesResults result)
         {

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -15,10 +15,10 @@ namespace Duplicati.Library.Main.Operation
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<RestoreHandler>();
 
-        private string m_backendurl;
-        private Options m_options;
+        private readonly string m_backendurl;
+        private readonly Options m_options;
         private byte[] m_blockbuffer;
-        private RestoreResults m_result;
+        private readonly RestoreResults m_result;
         private static readonly Snapshots.ISystemIO m_systemIO = Duplicati.Library.Utility.Utility.IsClientLinux ? (Snapshots.ISystemIO)new Snapshots.SystemIOLinux() : (Snapshots.ISystemIO)new Snapshots.SystemIOWindows();
         private static readonly string DIRSEP = System.IO.Path.DirectorySeparatorChar.ToString();
 

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -31,8 +31,8 @@ namespace Duplicati.Library.Main.Operation
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<TestHandler>();
 
         private readonly Options m_options;
-        private string m_backendurl;
-        private TestResults m_results;
+        private readonly string m_backendurl;
+        private readonly TestResults m_results;
         
         public TestHandler(string backendurl, Options options, TestResults results)
         {

--- a/Duplicati/Library/Main/Operation/VacuumHandler.cs
+++ b/Duplicati/Library/Main/Operation/VacuumHandler.cs
@@ -8,8 +8,8 @@ namespace Duplicati.Library.Main.Operation
 {
     internal class VacuumHandler
     {
-        private Options m_options;
-        private VacuumResult m_result;
+        private readonly Options m_options;
+        private readonly VacuumResult m_result;
 
         public VacuumHandler(Options options, VacuumResult result)
         {

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -202,7 +202,7 @@ namespace Duplicati.Library.Main
         protected Queue<DbMessage> m_dbqueue;
 
         private TaskControlState m_controlState = TaskControlState.Run;
-        private System.Threading.ManualResetEvent m_pauseEvent = new System.Threading.ManualResetEvent(true);
+        private readonly System.Threading.ManualResetEvent m_pauseEvent = new System.Threading.ManualResetEvent(true);
 
         public virtual ParsedResultType ParsedResult
         {
@@ -863,7 +863,7 @@ namespace Duplicati.Library.Main
 
         public override OperationMode MainOperation { get { return OperationMode.Test; } }
         public IEnumerable<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>> Verifications { get { return m_verifications; } }
-        private List<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>> m_verifications = new List<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>>();
+        private readonly List<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>> m_verifications = new List<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>>();
 
         public KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>> AddResult(string volume, IEnumerable<KeyValuePair<TestEntryStatus, string>> changes)
         {

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeReader.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeReader.cs
@@ -20,7 +20,7 @@ namespace Duplicati.Library.Main.Volumes
                     {
                         private class BlocklistHashEnumerator : IEnumerator<string>
                         {
-                            private JsonReader m_reader;
+                            private readonly JsonReader m_reader;
                             private string m_current;
                             private bool m_firstReset = true;
                             private bool m_done = false;
@@ -73,7 +73,7 @@ namespace Duplicati.Library.Main.Volumes
                             }
                         }
 
-                        private JsonReader m_reader;
+                        private readonly JsonReader m_reader;
                         public BlocklistHashEnumerable(JsonReader reader)
                         {
                             m_reader = reader;
@@ -103,7 +103,7 @@ namespace Duplicati.Library.Main.Volumes
                     public long Blocksize { get; private set; }
                     public IEnumerable<string> BlocklistHashes { get; private set; }
                     public IEnumerable<string> MetaBlocklistHashes { get; private set; }
-                    private JsonReader m_reader;
+                    private readonly JsonReader m_reader;
 
                     public FileEntry(JsonReader reader)
                     {
@@ -221,7 +221,7 @@ namespace Duplicati.Library.Main.Volumes
                     }
                 }
 
-                private ICompression m_compression;
+                private readonly ICompression m_compression;
                 private FileEntry m_current;
                 private StreamReader m_stream;
                 private JsonReader m_reader;
@@ -302,7 +302,7 @@ namespace Duplicati.Library.Main.Volumes
                 }
             }
 
-            private ICompression m_compression;
+            private readonly ICompression m_compression;
             public FileEntryEnumerable(ICompression compression)
             {
                 m_compression = compression;
@@ -323,7 +323,7 @@ namespace Duplicati.Library.Main.Volumes
         {
             private class ControlFileEnumerator : IEnumerator<KeyValuePair<string, Stream>>
             {
-                private ICompression m_compression;
+                private readonly ICompression m_compression;
                 private string[] m_files;
                 private long m_index;
                 private KeyValuePair<string, Stream>? m_current;
@@ -365,7 +365,7 @@ namespace Duplicati.Library.Main.Volumes
                 }
             }
 
-            private ICompression m_compression;
+            private readonly ICompression m_compression;
             public ControlFileEnumerable(ICompression compression)
             {
                 m_compression = compression;

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -11,7 +11,7 @@ namespace Duplicati.Library.Main.Volumes
     public class FilesetVolumeWriter : VolumeWriterBase
     {
         private StreamWriter m_streamwriter;
-        private JsonWriter m_writer;
+        private readonly JsonWriter m_writer;
         private long m_filecount;
         private long m_foldercount;
 

--- a/Duplicati/Library/Main/Volumes/IndexVolumeReader.cs
+++ b/Duplicati/Library/Main/Volumes/IndexVolumeReader.cs
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Main.Volumes
 
         private class IndexBlockVolumeEnumerable : IEnumerable<IIndexBlockVolume>
         {
-            private ICompression m_compression;
+            private readonly ICompression m_compression;
 
             public IndexBlockVolumeEnumerable(ICompression compression)
             {
@@ -41,8 +41,8 @@ namespace Duplicati.Library.Main.Volumes
                 {
                     private class BlockEnumerator : IEnumerator<KeyValuePair<string, long>>
                     {
-                        private ICompression m_compression;
-                        private string m_filename;
+                        private readonly ICompression m_compression;
+                        private readonly string m_filename;
                         private KeyValuePair<string, long>? m_current;
                         private System.IO.StreamReader m_stream;
                         private JsonReader m_reader;
@@ -139,8 +139,8 @@ namespace Duplicati.Library.Main.Volumes
                         }
                     }
 
-                    private ICompression m_compression;
-                    private string m_filename;
+                    private readonly ICompression m_compression;
+                    private readonly string m_filename;
                     private BlockEnumerator m_enumerator;
 
                     public BlockEnumerable(ICompression compression, string filename)
@@ -173,8 +173,8 @@ namespace Duplicati.Library.Main.Volumes
 
                 private class IndexBlockVolume : IIndexBlockVolume
                 {
-                    private ICompression m_compression;
-                    private string m_filename;
+                    private readonly ICompression m_compression;
+                    private readonly string m_filename;
                     private long? m_length;
                     private string m_hash;
                     private BlockEnumerable m_blocks;
@@ -231,7 +231,7 @@ namespace Duplicati.Library.Main.Volumes
                     }
                 }
 
-                private ICompression m_compression;
+                private readonly ICompression m_compression;
                 private IndexBlockVolume m_current;
                 private string[] m_files;
                 private long m_index;
@@ -284,8 +284,8 @@ namespace Duplicati.Library.Main.Volumes
 
         private class IndexBlocklistEnumerable : IEnumerable<IIndexBlocklist>
         {
-            private ICompression m_compression;
-            private long m_hashsize;
+            private readonly ICompression m_compression;
+            private readonly long m_hashsize;
 
             public IndexBlocklistEnumerable(ICompression compression, long hashsize)
             {
@@ -297,10 +297,10 @@ namespace Duplicati.Library.Main.Volumes
             {
                 private class IndexBlocklist : IIndexBlocklist
                 {
-                    private ICompression m_compression;
-                    private string m_filename;
-                    private long m_size;
-                    private long m_hashsize;
+                    private readonly ICompression m_compression;
+                    private readonly string m_filename;
+                    private readonly long m_size;
+                    private readonly long m_hashsize;
 
                     public IndexBlocklist(ICompression compression, string filename, long size, long hashsize)
                     {
@@ -333,11 +333,11 @@ namespace Duplicati.Library.Main.Volumes
                     }
                 }
 
-                private ICompression m_compression;
+                private readonly ICompression m_compression;
                 private long m_index;
                 private KeyValuePair<string, long>[] m_files;
                 private IndexBlocklist m_current;
-                private long m_hashsize;
+                private readonly long m_hashsize;
 
                 public IndexBlocklistEnumerator(ICompression compression, long hashsize)
                 {
@@ -386,7 +386,7 @@ namespace Duplicati.Library.Main.Volumes
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return this.GetEnumerator(); }
         }
 
-        private long m_hashsize;
+        private readonly long m_hashsize;
 
         public IndexVolumeReader(ICompression compression, Options options, long hashsize)
             : base(compression, options)

--- a/Duplicati/Library/Snapshots/DefineDosDevice.cs
+++ b/Duplicati/Library/Snapshots/DefineDosDevice.cs
@@ -59,11 +59,11 @@ namespace Duplicati.Library.Snapshots
         /// <summary>
         /// The path that is mapped to the drive
         /// </summary>
-        private string m_targetPath;
+        private readonly string m_targetPath;
         /// <summary>
         /// A value indicating if the shell should be notified of changes
         /// </summary>
-        private bool m_shellBroadcast;
+        private readonly bool m_shellBroadcast;
 
         /// <summary>
         /// Gets the drive that this mapping represents

--- a/Duplicati/Library/Snapshots/HyperVUtility.cs
+++ b/Duplicati/Library/Snapshots/HyperVUtility.cs
@@ -89,7 +89,7 @@ namespace Duplicati.Library.Snapshots
         /// Enumerated Hyper-V guests
         /// </summary>
         public List<HyperVGuest> Guests { get { return m_Guests; } }
-        private List<HyperVGuest> m_Guests;
+        private readonly List<HyperVGuest> m_Guests;
 
         public HyperVUtility()
         {

--- a/Duplicati/Library/Snapshots/MSSQLUtility.cs
+++ b/Duplicati/Library/Snapshots/MSSQLUtility.cs
@@ -79,7 +79,7 @@ namespace Duplicati.Library.Snapshots
         /// Enumerated MS SQL DBs
         /// </summary>
         public List<MSSQLDB> DBs { get { return m_DBs; } }
-        private List<MSSQLDB> m_DBs;
+        private readonly List<MSSQLDB> m_DBs;
 
         public MSSQLUtility()
         {

--- a/Duplicati/Library/Snapshots/USNJournal.cs
+++ b/Duplicati/Library/Snapshots/USNJournal.cs
@@ -242,7 +242,7 @@ namespace Duplicati.Library.Snapshots
             {
                 private readonly IReadOnlyCollection<byte> m_entryData;
                 private readonly IntPtr m_bufferPointer;
-                private GCHandle m_bufferHandle;
+                private readonly GCHandle m_bufferHandle;
                 private long m_offset;
 
                 public RecordEnumeratorImpl(IReadOnlyCollection<byte> entryData)

--- a/Duplicati/Library/Utility/AsyncHttpRequest.cs
+++ b/Duplicati/Library/Utility/AsyncHttpRequest.cs
@@ -17,7 +17,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The <see cref="System.Net.HttpWebRequest"/> method being wrapped
         /// </summary>
-        private WebRequest m_request;
+        private readonly WebRequest m_request;
         /// <summary>
         /// The current internal state of the object
         /// </summary>
@@ -37,7 +37,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The activity timeout value
         /// </summary>
-        private int m_activity_timeout = (int)TimeSpan.FromSeconds(30).TotalMilliseconds;
+        private readonly int m_activity_timeout = (int)TimeSpan.FromSeconds(30).TotalMilliseconds;
 
         /// <summary>
         /// List of valid states
@@ -186,13 +186,13 @@ namespace Duplicati.Library.Utility
         /// </summary>
         private class AsyncWrapper
         {
-            private IAsyncResult m_async = null;
+            private readonly IAsyncResult m_async = null;
             private Stream m_stream = null;
             private WebResponse m_response = null;
-            private AsyncHttpRequest m_owner;
+            private readonly AsyncHttpRequest m_owner;
             private Exception m_exception = null;
-            private ManualResetEvent m_event = new ManualResetEvent(false);
-            private bool m_isRequest;
+            private readonly ManualResetEvent m_event = new ManualResetEvent(false);
+            private readonly bool m_isRequest;
             private bool m_timedout = false;
 
             public AsyncWrapper(AsyncHttpRequest owner, bool isRequest)

--- a/Duplicati/Library/Utility/BlockingQueue.cs
+++ b/Duplicati/Library/Utility/BlockingQueue.cs
@@ -56,8 +56,8 @@ namespace Duplicati.Library.Utility
 
         private class BlockingQueueEnumerator : IEnumerator<T>
         {
-            private BlockingQueue<T> m_queue;
-            private bool m_first = true;
+            private readonly BlockingQueue<T> m_queue;
+            private readonly bool m_first = true;
             private T m_current;
 
             public BlockingQueueEnumerator(BlockingQueue<T> queue)
@@ -119,7 +119,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The queue storing the elements produced
         /// </summary>
-        private Queue<T> m_queue = new Queue<T>();
+        private readonly Queue<T> m_queue = new Queue<T>();
         /// <summary>
         /// A flag indicating if the queue is now empty forever
         /// </summary>
@@ -127,15 +127,15 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The event that signals that items have been produced (consumers wait for this)
         /// </summary>
-        private System.Threading.ManualResetEvent m_itemsProduced = new System.Threading.ManualResetEvent(false);
+        private readonly System.Threading.ManualResetEvent m_itemsProduced = new System.Threading.ManualResetEvent(false);
         /// <summary>
         /// The event that signals that items have been consumed (producers wait for this)
         /// </summary>
-        private System.Threading.ManualResetEvent m_itemsConsumed = new System.Threading.ManualResetEvent(false);
+        private readonly System.Threading.ManualResetEvent m_itemsConsumed = new System.Threading.ManualResetEvent(false);
         /// <summary>
         /// The maximum capacity of the queue, the producers will be blocked if more elements are put into the queue
         /// </summary>
-        private long m_maxCapacity = 100;
+        private readonly long m_maxCapacity = 100;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.BlockingQueue{T}"/> class with the default capacity

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -44,9 +44,9 @@ namespace Duplicati.Library.Utility
         private readonly object m_lock = new object();
 
         /// <summary> An event to wake reader. </summary>
-        private ManualResetEventSlim m_signalDataAvailable = new ManualResetEventSlim(false);
+        private readonly ManualResetEventSlim m_signalDataAvailable = new ManualResetEventSlim(false);
         /// <summary> An event to wake writer. </summary>
-        private ManualResetEventSlim m_signalBufferAvailable = new ManualResetEventSlim(true);
+        private readonly ManualResetEventSlim m_signalBufferAvailable = new ManualResetEventSlim(true);
         /// <summary> Track closes and enable threadsafe self dispose. </summary>
         private int m_autoDisposeCounter = 2;
 
@@ -60,10 +60,10 @@ namespace Duplicati.Library.Utility
         private volatile bool m_readerClosed = false;
 
         /// <summary> The buffer for piping. </summary>
-        private byte[] m_buf;
+        private readonly byte[] m_buf;
 
         /// <summary> A stream to pass writes to. For stream stacking. </summary>
-        private Stream m_passWriteThrough;
+        private readonly Stream m_passWriteThrough;
 
         /// <summary> Allows to set a length for SubStreams Length property. </summary>
         private long m_knownLength = -1;
@@ -78,14 +78,14 @@ namespace Duplicati.Library.Utility
         /// Forces to wait until reader has consumed all bytes from buffer
         /// on a Flush operation. Set via constructor.
         /// </summary>
-        private bool m_blockOnFlush = true;
+        private readonly bool m_blockOnFlush = true;
 
         /// <summary>
         /// Forces to wait until reader has closed its stream
         /// on writer's Close operation. This may be used to 
         /// synchronize worker threads. Set via constructor.
         /// </summary>
-        private bool m_blockOnClose = true;
+        private readonly bool m_blockOnClose = true;
 
         /// <summary> The helper stream for reader from pipe. </summary>
         private LinkedReaderStream m_readerStream;

--- a/Duplicati/Library/Utility/FileBackedList.cs
+++ b/Duplicati/Library/Utility/FileBackedList.cs
@@ -33,11 +33,11 @@ namespace Duplicati.Library.Utility
         private class StreamEnumerator : IEnumerator<T>, System.Collections.IEnumerator
         {
             private Stream m_stream;
-            private Func<Stream, long, T> m_deserialize;
+            private readonly Func<Stream, long, T> m_deserialize;
             private long m_position;
             private readonly byte[] m_sizebuffer;
-            private long m_expectedCount;
-            private FileBackedList<T> m_parent;
+            private readonly long m_expectedCount;
+            private readonly FileBackedList<T> m_parent;
             private T m_current;
 
             public StreamEnumerator(Stream stream, Func<Stream, long, T> deserialize, FileBackedList<T> parent)

--- a/Duplicati/Library/Utility/FilterCollector.cs
+++ b/Duplicati/Library/Utility/FilterCollector.cs
@@ -22,7 +22,7 @@ namespace Duplicati.Library.Utility
 {
     public class FilterCollector
     {
-        private List<Library.Utility.IFilter> m_filters = new List<Library.Utility.IFilter>();
+        private readonly List<Library.Utility.IFilter> m_filters = new List<Library.Utility.IFilter>();
         private Library.Utility.IFilter Filter
         {
             get

--- a/Duplicati/Library/Utility/ProgressReportingStream.cs
+++ b/Duplicati/Library/Utility/ProgressReportingStream.cs
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Utility
     /// </summary>
     public class ProgressReportingStream : OverrideableStream
     {
-        private Action<long> m_progress;
+        private readonly Action<long> m_progress;
         private long m_streamOffset;
 
         public ProgressReportingStream(System.IO.Stream basestream, long expectedSize, Action<long> progress)

--- a/Duplicati/Library/Utility/SslCertificateValidator.cs
+++ b/Duplicati/Library/Utility/SslCertificateValidator.cs
@@ -30,8 +30,8 @@ namespace Duplicati.Library.Utility
         [Serializable]
         public class InvalidCertificateException : Exception
         {
-            private string m_certificate = null;
-            private SslPolicyErrors m_errors = SslPolicyErrors.None;
+            private readonly string m_certificate = null;
+            private readonly SslPolicyErrors m_errors = SslPolicyErrors.None;
 
             public string Certificate { get { return m_certificate; } }
             public SslPolicyErrors SslError { get { return m_errors; } }
@@ -50,8 +50,8 @@ namespace Duplicati.Library.Utility
             m_validHashes = validHashes;
         }
 
-        private bool m_acceptAll = false;
-        private string[] m_validHashes = null;
+        private readonly bool m_acceptAll = false;
+        private readonly string[] m_validHashes = null;
         private Exception m_uncastException = null;
 
         public bool ValidateServerCertficate(object sender, X509Certificate cert, X509Chain chain, SslPolicyErrors sslPolicyErrors)

--- a/Duplicati/Library/Utility/WorkerThread.cs
+++ b/Duplicati/Library/Utility/WorkerThread.cs
@@ -37,7 +37,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The wait event
         /// </summary>
-        private AutoResetEvent m_event;
+        private readonly AutoResetEvent m_event;
         /// <summary>
         /// The internal list of tasks to perform
         /// </summary>
@@ -63,7 +63,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// A callback that performs the actual work on the item
         /// </summary>
-        private Action<Tx> m_delegate;
+        private readonly Action<Tx> m_delegate;
 
         /// <summary>
         /// An event that is raised when the runner state changes

--- a/Duplicati/License/LicenseReader.cs
+++ b/Duplicati/License/LicenseReader.cs
@@ -31,16 +31,16 @@ namespace Duplicati.License
         /// <summary>
         /// The regular expression used to find url files
         /// </summary>
-        private static System.Text.RegularExpressions.Regex URL_FILENAME = new System.Text.RegularExpressions.Regex("(homepage.txt)|(download.txt)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        private static readonly System.Text.RegularExpressions.Regex URL_FILENAME = new System.Text.RegularExpressions.Regex("(homepage.txt)|(download.txt)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         /// <summary>
         /// The regular expression used to find license files
         /// </summary>
-        private static System.Text.RegularExpressions.Regex LICENSE_FILENAME = new System.Text.RegularExpressions.Regex("license.txt", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        private static readonly System.Text.RegularExpressions.Regex LICENSE_FILENAME = new System.Text.RegularExpressions.Regex("license.txt", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         /// <summary>
         /// The regular expression used to find licensedata files
         /// </summary>
-        private static System.Text.RegularExpressions.Regex LICENSEDATA_FILENAME = new System.Text.RegularExpressions.Regex("licensedata.json", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-        
+        private static readonly System.Text.RegularExpressions.Regex LICENSEDATA_FILENAME = new System.Text.RegularExpressions.Regex("licensedata.json", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
         /// <summary>
         /// Reads all license files in the given base folder
         /// </summary>

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -25,12 +25,12 @@ namespace Duplicati.Server.Database
 {
     public class Connection : IDisposable
     {
-        private System.Data.IDbConnection m_connection;
+        private readonly System.Data.IDbConnection m_connection;
         private System.Data.IDbCommand m_errorcmd;
         public readonly object m_lock = new object();
         public const int ANY_BACKUP_ID = -1;
         public const int SERVER_SETTINGS_ID = -2;
-        private Dictionary<string, Backup> m_temporaryBackups = new Dictionary<string, Backup>();
+        private readonly Dictionary<string, Backup> m_temporaryBackups = new Dictionary<string, Backup>();
 
         public Connection(System.Data.IDbConnection connection)
         {

--- a/Duplicati/Server/Database/ServerSettings.cs
+++ b/Duplicati/Server/Database/ServerSettings.cs
@@ -53,9 +53,9 @@ namespace Duplicati.Server.Database
             public const string USAGE_REPORTER_LEVEL = "usage-reporter-level";
 			public const string HAS_ASKED_FOR_PASSWORD_PROTECTION = "has-asked-for-password-protection";
 		}
-        
-        private Dictionary<string, string> m_values;
-        private Database.Connection m_connection;
+
+        private readonly Dictionary<string, string> m_values;
+        private readonly Database.Connection m_connection;
         private Library.AutoUpdater.UpdateInfo m_latestUpdate;
 
         internal ServerSettings(Connection con)

--- a/Duplicati/Server/EventPollNotify.cs
+++ b/Duplicati/Server/EventPollNotify.cs
@@ -21,7 +21,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The list of subscribed waiting threads
         /// </summary>
-        private Queue<System.Threading.ManualResetEvent> m_waitQueue = new Queue<System.Threading.ManualResetEvent>();
+        private readonly Queue<System.Threading.ManualResetEvent> m_waitQueue = new Queue<System.Threading.ManualResetEvent>();
 
         /// <summary>
         /// An eventhandler for subscribing to event updates without blocking

--- a/Duplicati/Server/LiveControls.cs
+++ b/Duplicati/Server/LiveControls.cs
@@ -158,7 +158,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The timer that is activated after a pause period.
         /// </summary>
-        private System.Threading.Timer m_waitTimer;
+        private readonly System.Threading.Timer m_waitTimer;
 
         /// <summary>
         /// The time that the current pause is expected to expire

--- a/Duplicati/Server/LogWriteHandler.cs
+++ b/Duplicati/Server/LogWriteHandler.cs
@@ -226,7 +226,7 @@ namespace Duplicati.Server
             public int Size { get { return m_buffer.Length; } }
         }
 
-        private DateTime[] m_timeouts;
+        private readonly DateTime[] m_timeouts;
         private readonly object m_lock = new object();
         private volatile bool m_anytimeouts = false;
         private RingBuffer<LogEntry> m_buffer;

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -261,7 +261,7 @@ namespace Duplicati.Server
                 #endregion
             }
                         
-            private ProgressState m_state;
+            private readonly ProgressState m_state;
             private Duplicati.Library.Main.IBackendProgress m_backendProgress;
             private Duplicati.Library.Main.IOperationProgress m_operationProgress;
             private readonly object m_lock = new object();

--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The thread that runs the scheduler
         /// </summary>
-        private Thread m_thread;
+        private readonly Thread m_thread;
         /// <summary>
         /// A termination flag
         /// </summary>
@@ -47,11 +47,11 @@ namespace Duplicati.Server
         /// <summary>
         /// The worker thread that is invoked to do work
         /// </summary>
-        private WorkerThread<Runner.IRunnerData> m_worker;
+        private readonly WorkerThread<Runner.IRunnerData> m_worker;
         /// <summary>
         /// The wait event
         /// </summary>
-        private AutoResetEvent m_event;
+        private readonly AutoResetEvent m_event;
         /// <summary>
         /// The data syncronization lock
         /// </summary>
@@ -70,7 +70,7 @@ namespace Duplicati.Server
         /// <summary>
         /// List of update tasks, used to set the timestamp on the schedule once completed
         /// </summary>
-        private Dictionary<Server.Runner.IRunnerData, Tuple<ISchedule, DateTime, DateTime>> m_updateTasks;
+        private readonly Dictionary<Server.Runner.IRunnerData, Tuple<ISchedule, DateTime, DateTime>> m_updateTasks;
 
         /// <summary>
         /// Constructs a new scheduler

--- a/Duplicati/Server/SingleInstance.cs
+++ b/Duplicati/Server/SingleInstance.cs
@@ -100,12 +100,12 @@ namespace Duplicati.Server
         /// <summary>
         /// The folder where control files are placed
         /// </summary>
-        private string m_controldir;
-        
+        private readonly string m_controldir;
+
         /// <summary>
         /// The full path to the locking file
         /// </summary>
-        private string m_lockfilename;
+        private readonly string m_lockfilename;
 
         /// <summary>
         /// The watcher that allows interprocess communication

--- a/Duplicati/Server/UpdatePollThread.cs
+++ b/Duplicati/Server/UpdatePollThread.cs
@@ -27,12 +27,12 @@ namespace Duplicati.Server
     /// </summary>
     public class UpdatePollThread
     {
-        private Thread m_thread;
+        private readonly Thread m_thread;
         private volatile bool m_terminated = false;
         private volatile bool m_download = false;
         private volatile bool m_forceCheck = false;
         private readonly object m_lock = new object();
-        private AutoResetEvent m_waitSignal;
+        private readonly AutoResetEvent m_waitSignal;
         private double m_downloadProgress;
 
         public bool IsUpdateRequested { get; private set; } = false;

--- a/Duplicati/Server/WebServer/AuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/AuthenticationHandler.cs
@@ -41,11 +41,11 @@ namespace Duplicati.Server.WebServer
         private const int XSRF_TIMEOUT_MINUTES = 10;
         private const int AUTH_TIMEOUT_MINUTES = 10;
 
-        private ConcurrentDictionary<string, DateTime> m_activeTokens = new ConcurrentDictionary<string, DateTime>();
-        private ConcurrentDictionary<string, Tuple<DateTime, string>> m_activeNonces = new ConcurrentDictionary<string, Tuple<DateTime, string>>();
-        private ConcurrentDictionary<string, DateTime> m_activexsrf = new ConcurrentDictionary<string, DateTime>();
+        private readonly ConcurrentDictionary<string, DateTime> m_activeTokens = new ConcurrentDictionary<string, DateTime>();
+        private readonly ConcurrentDictionary<string, Tuple<DateTime, string>> m_activeNonces = new ConcurrentDictionary<string, Tuple<DateTime, string>>();
+        private readonly ConcurrentDictionary<string, DateTime> m_activexsrf = new ConcurrentDictionary<string, DateTime>();
 
-        System.Security.Cryptography.RandomNumberGenerator m_prng = System.Security.Cryptography.RNGCryptoServiceProvider.Create();
+        readonly System.Security.Cryptography.RandomNumberGenerator m_prng = System.Security.Cryptography.RNGCryptoServiceProvider.Create();
 
         private string FindXSRFToken(HttpServer.IHttpRequest request)
         {

--- a/Duplicati/Server/WebServer/BodyWriter.cs
+++ b/Duplicati/Server/WebServer/BodyWriter.cs
@@ -22,8 +22,8 @@ namespace Duplicati.Server.WebServer
 {
     public class BodyWriter : System.IO.StreamWriter, IDisposable
     {
-        private HttpServer.IHttpResponse m_resp;
-        private string m_jsonp;
+        private readonly HttpServer.IHttpResponse m_resp;
+        private readonly string m_jsonp;
         private static object SUCCESS_RESPONSE = new { Status = "OK" };
 
         // We override the format provider so all JSON output uses US format

--- a/Duplicati/Server/WebServer/IndexHtmlHandler.cs
+++ b/Duplicati/Server/WebServer/IndexHtmlHandler.cs
@@ -25,7 +25,7 @@ namespace Duplicati.Server.WebServer
 {
     internal class IndexHtmlHandler : HttpModule
     {
-        private string m_webroot;
+        private readonly string m_webroot;
 
         private static readonly string[] ForbiddenChars = new string[] {"\\", "..", ":"}.Union(from n in System.IO.Path.GetInvalidPathChars() select n.ToString()).Distinct().ToArray();
         private static readonly string DirSep = System.IO.Path.DirectorySeparatorChar.ToString();

--- a/Duplicati/Server/WebServer/RESTMethods/Captcha.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Captcha.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         }
 
         private static readonly object m_lock = new object();
-        private static Dictionary<string, CaptchaEntry> m_captchas = new Dictionary<string, CaptchaEntry>();
+        private static readonly Dictionary<string, CaptchaEntry> m_captchas = new Dictionary<string, CaptchaEntry>();
 
         public static bool SolvedCaptcha(string token, string target, string answer)
         {

--- a/Duplicati/Server/WebServer/Server.cs
+++ b/Duplicati/Server/WebServer/Server.cs
@@ -56,7 +56,7 @@ namespace Duplicati.Server.WebServer
         /// <summary>
         /// The single webserver instance
         /// </summary>
-        private HttpServer.HttpServer m_server;
+        private readonly HttpServer.HttpServer m_server;
         
         /// <summary>
         /// The webserver listening port

--- a/Duplicati/Service/Runner.cs
+++ b/Duplicati/Service/Runner.cs
@@ -22,13 +22,13 @@ namespace Duplicati.Service
 {
     public class Runner : IDisposable
     {
-        private System.Threading.Thread m_thread;
+        private readonly System.Threading.Thread m_thread;
         private volatile bool m_terminate = false;
         private volatile bool m_softstop = false;
         private System.Diagnostics.Process m_process;
-        private Action m_onStartedAction;
-        private Action m_onStoppedAction;
-        private Action<string, bool> m_reportMessage;
+        private readonly Action m_onStartedAction;
+        private readonly Action m_onStoppedAction;
+        private readonly Action<string, bool> m_reportMessage;
 
         private readonly object m_writelock = new object();
         private readonly string[] m_cmdargs;

--- a/Duplicati/WindowsService/ServiceControl.cs
+++ b/Duplicati/WindowsService/ServiceControl.cs
@@ -16,7 +16,7 @@ namespace Duplicati.WindowsService
         public const string DISPLAY_NAME = "Duplicati service";
         public const string DESCRIPTION = "Runs Duplicati as a service";
 
-        private System.Diagnostics.EventLog m_eventLog;
+        private readonly System.Diagnostics.EventLog m_eventLog;
 
         private readonly object m_lock = new object();
         private Runner m_runner = null;

--- a/thirdparty/DnsLite/DnsLite.cs
+++ b/thirdparty/DnsLite/DnsLite.cs
@@ -27,7 +27,7 @@ namespace DnsLib
         private string name;
         private ArrayList dnsServers;
         private static int DNS_PORT = 53;
-        Encoding ASCII = Encoding.ASCII;
+        readonly Encoding ASCII = Encoding.ASCII;
         public DnsLite()
         {
             id = DateTime.Now.Millisecond * 60;


### PR DESCRIPTION
This makes it explicit at compile-time that these fields should not be reassigned.