### PR TITLE
Use Equals to compare CultureInfo instances

### DIFF
--- a/Duplicati/Library/Localization/LocalizationService.cs
+++ b/Duplicati/Library/Localization/LocalizationService.cs
@@ -110,7 +110,7 @@ namespace Duplicati.Library.Localization
         /// </summary>
         public static ILocalizationService Get(CultureInfo ci)
         {
-            if (ci == CultureInfo.InvariantCulture)
+            if (ci.Equals(CultureInfo.InvariantCulture))
                 return InvariantService;
 
             ILocalizationService service;


### PR DESCRIPTION
Since the `Equals` method is overridden in the `CultureInfo` class, we should use it instead of the `==` operator to compare two instances.