### PR TITLE
Remove ineffective statements

### DIFF
--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -112,11 +112,7 @@ namespace Duplicati.Library.Backend
         public void CreateFolder()
         {
             CreateConnection();
-            //Bugfix, some SSH servers do not like a trailing slash
-            string p = m_path;
-            if (p.EndsWith("/", StringComparison.Ordinal))
-                p.Substring(0, p.Length - 1);
-            m_con.CreateDirectory(p);
+            m_con.CreateDirectory(m_path);
         }
 
         public string DisplayName


### PR DESCRIPTION
The removed code was introduced in revision ba58651e5a ("Fix for CreateFolder with SSH"), presumably to fix an issue where some SSH backends did not like the trailing slash when creating new folders.  However, since we are not using the output argument of the call to `Substring`, these statements have no effect.
