### PR TITLE
Remove unnecessary calls to String.Format

### DIFF
--- a/Duplicati/Library/Backend/Sia/Sia.cs
+++ b/Duplicati/Library/Backend/Sia/Sia.cs
@@ -135,7 +135,7 @@ namespace Duplicati.Library.Backend.Sia
         private SiaFileList GetFiles()
         {
             var fl = new SiaFileList();
-            string endpoint = string.Format("/renter/files");
+            string endpoint = "/renter/files";
 
             try
             {
@@ -189,7 +189,7 @@ namespace Duplicati.Library.Backend.Sia
         private SiaDownloadList GetDownloads()
         {
             var fl = new SiaDownloadList();
-            string endpoint = string.Format("/renter/downloads");
+            string endpoint = "/renter/downloads";
 
             try
             {

--- a/Duplicati/Library/Logging/Log.cs
+++ b/Duplicati/Library/Logging/Log.cs
@@ -427,7 +427,7 @@ namespace Duplicati.Library.Logging
                     
                     LogScope sc;
                     if (!m_log_instances.TryGetValue(cur, out sc))
-                        throw new Exception(string.Format("Unable to find log in lookup table, this may be caused by attempting to transport call contexts between AppDomains (eg. with remoting calls)"));
+                        throw new Exception("Unable to find log in lookup table, this may be caused by attempting to transport call contexts between AppDomains (eg. with remoting calls)");
 
                     return sc;
                 }

--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -226,7 +226,7 @@ namespace Duplicati.Library.Main.Database
                     try
                     {
                         using(new Logging.Timer(LOGTAG, "BuildPathTable", "Build path lookup table"))
-                        using (var rd = cmd.ExecuteReader(string.Format(@" SELECT ""Path"", ""BlocksetID"", ""MetadataID"", ""ID"" FROM ""File"" ")))
+                        using (var rd = cmd.ExecuteReader(@" SELECT ""Path"", ""BlocksetID"", ""MetadataID"", ""ID"" FROM ""File"" "))
                             while (rd.Read())
                             {
                                 var path = rd.GetValue(0).ToString();
@@ -921,7 +921,7 @@ namespace Duplicati.Library.Main.Database
         {
             using (var cmd = m_connection.CreateCommand())
             {
-                cmd.CommandText = string.Format(@"SELECT ""Path"" FROM ""File"" ORDER BY LENGTH(""Path"") DESC LIMIT 1");
+                cmd.CommandText = @"SELECT ""Path"" FROM ""File"" ORDER BY LENGTH(""Path"") DESC LIMIT 1";
                 var v0 = cmd.ExecuteScalar();
                 if (v0 == null || v0 == DBNull.Value)
                     return null;

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -810,7 +810,7 @@ ON
                             var expandedCmd = string.Format(@"SELECT COUNT(*) FROM (SELECT DISTINCT ""Path"" FROM ({0}) UNION SELECT DISTINCT ""Path"" FROM ({1}))", LocalDatabase.LIST_FILESETS, LocalDatabase.LIST_FOLDERS_AND_SYMLINKS);
                         var expandedlist = cmd2.ExecuteScalarInt64(expandedCmd, 0, filesetid, FOLDER_BLOCKSET_ID, SYMLINK_BLOCKSET_ID, filesetid);
                         //var storedfilelist = cmd2.ExecuteScalarInt64(string.Format(@"SELECT COUNT(*) FROM ""FilesetEntry"", ""File"" WHERE ""FilesetEntry"".""FilesetID"" = ? AND ""File"".""ID"" = ""FilesetEntry"".""FileID"" AND ""File"".""BlocksetID"" != ? AND ""File"".""BlocksetID"" != ?"), 0, filesetid, FOLDER_BLOCKSET_ID, SYMLINK_BLOCKSET_ID);
-                        var storedlist = cmd2.ExecuteScalarInt64(string.Format(@"SELECT COUNT(*) FROM ""FilesetEntry"" WHERE ""FilesetEntry"".""FilesetID"" = ?"), 0, filesetid);
+                        var storedlist = cmd2.ExecuteScalarInt64(@"SELECT COUNT(*) FROM ""FilesetEntry"" WHERE ""FilesetEntry"".""FilesetID"" = ?", 0, filesetid);
 
                         if (expandedlist != storedlist)
                             throw new Exception(string.Format("Unexpected difference in fileset {0}, found {1} entries, but expected {2}", filesetid, expandedlist, storedlist));

--- a/Duplicati/Library/Main/Database/LocalPurgeDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalPurgeDatabase.cs
@@ -40,7 +40,7 @@ namespace Duplicati.Library.Main.Database
         public string GetRemoteVolumeNameForFileset(long id, System.Data.IDbTransaction transaction)
         {
             using (var cmd = m_connection.CreateCommand(transaction))
-            using (var rd = cmd.ExecuteReader(string.Format(@"SELECT ""B"".""Name"" FROM ""Fileset"" A, ""RemoteVolume"" B WHERE ""A"".""VolumeID"" = ""B"".""ID"" AND ""A"".""ID"" = ? "), id))
+            using (var rd = cmd.ExecuteReader(@"SELECT ""B"".""Name"" FROM ""Fileset"" A, ""RemoteVolume"" B WHERE ""A"".""VolumeID"" = ""B"".""ID"" AND ""A"".""ID"" = ? ", id))
                 if (!rd.Read())
                     throw new Exception(string.Format("No remote volume found for fileset with id {0}", id));
                 else

--- a/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
@@ -501,7 +501,7 @@ namespace Duplicati.Library.Main.Database
         {
             using(var cmd = m_connection.CreateCommand())
             {
-                cmd.CommandText = string.Format(@"SELECT DISTINCT ""BlocklistHash"".""Hash"" FROM ""BlocklistHash"", ""Block"" WHERE ""Block"".""Hash"" = ""BlocklistHash"".""Hash"" AND ""Block"".""VolumeID"" = ?");
+                cmd.CommandText = @"SELECT DISTINCT ""BlocklistHash"".""Hash"" FROM ""BlocklistHash"", ""Block"" WHERE ""Block"".""Hash"" = ""BlocklistHash"".""Hash"" AND ""Block"".""VolumeID"" = ?";
                 cmd.AddParameter(volumeid);
                 
                 using(var rd = cmd.ExecuteReader())

--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -270,7 +270,7 @@ namespace Duplicati.Library.Main.Database
                     {
                         // Restore but filter elements based on the filter expression
                         // If this is too slow, we could add a special handler for wildcard searches too
-                        cmd.CommandText = string.Format(@"SELECT ""File"".""Path"", ""File"".""BlocksetID"", ""File"".""MetadataID"" FROM ""File"", ""FilesetEntry"" WHERE ""File"".""ID"" = ""FilesetEntry"".""FileID"" AND ""FilesetID"" = ?");
+                        cmd.CommandText = @"SELECT ""File"".""Path"", ""File"".""BlocksetID"", ""File"".""MetadataID"" FROM ""File"", ""FilesetEntry"" WHERE ""File"".""ID"" = ""FilesetEntry"".""FileID"" AND ""FilesetID"" = ?";
                         cmd.AddParameter(filesetId);
     
                         object[] values = new object[3];

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -64,7 +64,7 @@ namespace Duplicati.Library.Main.Operation
                 m_result.SetDatabase(db);
 
                 if (db.FindMatchingFilesets(m_options.Time, m_options.Version).Any())
-                    throw new UserInformationException(string.Format("The version(s) being updated to, already exists"), "UpdateVersionAlreadyExists");
+                    throw new UserInformationException("The version(s) being updated to, already exists", "UpdateVersionAlreadyExists");
 
                 // Mark as incomplete
                 db.PartiallyRecreated = true;
@@ -140,13 +140,13 @@ namespace Duplicati.Library.Main.Operation
                     select n;
 
                 if (filelists.Count() <= 0)
-                    throw new UserInformationException(string.Format("No filelists found on the remote destination"), "EmptyRemoteLocation");
+                    throw new UserInformationException("No filelists found on the remote destination", "EmptyRemoteLocation");
                 
                 if (filelistfilter != null)
                     filelists = filelistfilter(filelists).Select(x => x.Value).ToArray();
 
                 if (filelists.Count() <= 0)
-                    throw new UserInformationException(string.Format("No filelists"), "NoMatchingRemoteFilelists");
+                    throw new UserInformationException("No filelists", "NoMatchingRemoteFilelists");
 
                 // If we are updating, all files should be accounted for
                 foreach(var fl in remotefiles)

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeReader.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeReader.cs
@@ -271,7 +271,7 @@ namespace Duplicati.Library.Main.Volumes
                     }
 
                     if (!m_reader.Read())
-                        throw new InvalidDataException(string.Format("Invalid JSON, EOF found while reading hashes"));
+                        throw new InvalidDataException("Invalid JSON, EOF found while reading hashes");
 
                     if (m_reader.TokenType == JsonToken.EndArray)
                     {

--- a/Duplicati/Library/Main/Volumes/IndexVolumeReader.cs
+++ b/Duplicati/Library/Main/Volumes/IndexVolumeReader.cs
@@ -86,7 +86,7 @@ namespace Duplicati.Library.Main.Volumes
                                 return false;
 
                             if (!m_reader.Read())
-                                throw new InvalidDataException(string.Format("Invalid JSON, EOF found while reading hashes"));
+                                throw new InvalidDataException("Invalid JSON, EOF found while reading hashes");
 
                             if (m_reader.TokenType == JsonToken.EndArray)
                             {

--- a/Duplicati/Server/WebServer/RESTMethods/UISettings.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/UISettings.cs
@@ -47,7 +47,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
 			if (data == null)
 			{
-                info.ReportClientError(string.Format("Unable to parse settings object"), System.Net.HttpStatusCode.BadRequest);
+                info.ReportClientError("Unable to parse settings object", System.Net.HttpStatusCode.BadRequest);
 				return;
 			}
 


### PR DESCRIPTION
These strings do not require composite formatting, which makes the calls to `String.Format` unnecessary.