### PR TITLE
Provide missing values to format items

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Download.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Download.cs
@@ -137,7 +137,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 Console.WriteLine("Download complete, of {0} remote files, {1} were downloaded with {2} errors", lst.Count, downloaded, errors);
                 if (needspass > 0)
-                    Console.WriteLine("Additonally {0} remote files were skipped because of encryption, supply --passphrase to download those");
+                    Console.WriteLine("Additonally {0} remote files were skipped because of encryption, supply --passphrase to download those", needspass);
 
                 if (errors > 0)
                     return 200;

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -86,7 +86,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
             if (blocksize <= 0)
             {
-                Console.WriteLine("Invalid blocksize: {0}, try setting --blocksize manually");
+                Console.WriteLine("Invalid blocksize: {0}, try setting --blocksize manually", blocksize);
                 return 100;
             }
 


### PR DESCRIPTION
These statements contain a format item `{0}` that was previously missing a value.