### PR TITLE
Fix line ending issues

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Properties/AssemblyInfo.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-//  Copyright (C) 2015, The Duplicati Team
+//  Copyright (C) 2015, The Duplicati Team
 //  http://www.duplicati.com, info@duplicati.com
 //
 //  This library is free software; you can redistribute it and/or modify

--- a/Duplicati/Library/Backend/GoogleServices/GCSConfig.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GCSConfig.cs
@@ -14,15 +14,69 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using Duplicati.Library.Interface;using System.Collections.Generic;using System.Linq;
+using System;
+using Duplicati.Library.Interface;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Duplicati.Library.Backend.GoogleServices
 {
     public class GCSConfig : IWebModule
-    {        private const ConfigType DEFAULT_CONFIG_TYPE = ConfigType.Locations;        private static readonly string DEFAULT_CONFIG_TYPE_STR = Enum.GetName(typeof(ConfigType), DEFAULT_CONFIG_TYPE);        private const string KEY_CONFIGTYPE = "gcs-config";        public enum ConfigType        {            Locations,            StorageClasses        }
+    {
+        private const ConfigType DEFAULT_CONFIG_TYPE = ConfigType.Locations;
+        private static readonly string DEFAULT_CONFIG_TYPE_STR = Enum.GetName(typeof(ConfigType), DEFAULT_CONFIG_TYPE);
+        private const string KEY_CONFIGTYPE = "gcs-config";
+
+        public enum ConfigType
+        {
+            Locations,
+            StorageClasses
+        }
         public GCSConfig()
         {
         }
-        #region IWebModule implementation        public System.Collections.Generic.IDictionary<string, string> Execute(System.Collections.Generic.IDictionary<string, string> options)        {            string k;            options.TryGetValue(KEY_CONFIGTYPE, out k);            if (string.IsNullOrWhiteSpace(k))                k = DEFAULT_CONFIG_TYPE_STR;            ConfigType ct;            if (!Enum.TryParse<ConfigType>(k, true, out ct))                ct = DEFAULT_CONFIG_TYPE;            switch (ct)            {                case ConfigType.StorageClasses:                    return GoogleCloudStorage.GoogleCloudStorage.KNOWN_GCS_STORAGE_CLASSES.ToDictionary((x) => x.Key, (y) => y.Value);                default:                    return GoogleCloudStorage.GoogleCloudStorage.KNOWN_GCS_LOCATIONS.ToDictionary((x) => x.Key, (y) => y.Value);            }        }        public string Key { get { return "gcs-getconfig"; } }        public string DisplayName { get { return "Google Cloud Storage configuration module"; } }        public string Description { get { return "Exposes Google Cloud Storage configuration as a web module"; } }        public System.Collections.Generic.IList<ICommandLineArgument> SupportedCommands        {            get            {                return new List<ICommandLineArgument>(new ICommandLineArgument[] {                    new CommandLineArgument(KEY_CONFIGTYPE, CommandLineArgument.ArgumentType.Enumeration, "The config to get", "Provides different config values", DEFAULT_CONFIG_TYPE_STR, Enum.GetNames(typeof(ConfigType)))                });            }        }        #endregion    }
+
+        #region IWebModule implementation
+
+        public System.Collections.Generic.IDictionary<string, string> Execute(System.Collections.Generic.IDictionary<string, string> options)
+        {
+            string k;
+            options.TryGetValue(KEY_CONFIGTYPE, out k);
+            if (string.IsNullOrWhiteSpace(k))
+                k = DEFAULT_CONFIG_TYPE_STR;
+
+            ConfigType ct;
+            if (!Enum.TryParse<ConfigType>(k, true, out ct))
+                ct = DEFAULT_CONFIG_TYPE;
+
+            switch (ct)
+            {
+                case ConfigType.StorageClasses:
+                    return GoogleCloudStorage.GoogleCloudStorage.KNOWN_GCS_STORAGE_CLASSES.ToDictionary((x) => x.Key, (y) => y.Value);
+                default:
+                    return GoogleCloudStorage.GoogleCloudStorage.KNOWN_GCS_LOCATIONS.ToDictionary((x) => x.Key, (y) => y.Value);
+            }
+        }
+
+        public string Key { get { return "gcs-getconfig"; } }
+
+        public string DisplayName { get { return "Google Cloud Storage configuration module"; } }
+
+        public string Description { get { return "Exposes Google Cloud Storage configuration as a web module"; } }
+
+
+        public System.Collections.Generic.IList<ICommandLineArgument> SupportedCommands
+        {
+            get
+            {
+                return new List<ICommandLineArgument>(new ICommandLineArgument[] {
+                    new CommandLineArgument(KEY_CONFIGTYPE, CommandLineArgument.ArgumentType.Enumeration, "The config to get", "Provides different config values", DEFAULT_CONFIG_TYPE_STR, Enum.GetNames(typeof(ConfigType)))
+
+                });
+            }
+        }
+
+        #endregion
+    }
 }
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCommon.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCommon.cs
@@ -14,12 +14,226 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using Duplicati.Library.Utility;using System.Net;using Newtonsoft.Json;
+using System;
+using Duplicati.Library.Utility;
+using System.Net;
+using Newtonsoft.Json;
 
 namespace Duplicati.Library.Backend.GoogleServices
 {
     internal static class GoogleCommon
-    {        /// <summary>        /// The size of upload chunks        /// </summary>        private const long UPLOAD_CHUNK_SIZE = 1024 * 1024 * 10;        /// <summary>        /// Helper method that queries a resumeable upload uri for progress        /// </summary>        /// <returns>The upload range.</returns>        /// <param name="oauth">The Oauth instance</param>        /// <param name="uploaduri">The resumeable uploaduri</param>        /// <param name="streamlength">The length of the entire stream</param>        private static long QueryUploadRange<T>(OAuthHelper oauth, string uploaduri, long streamlength, out T response)            where T : class        {            response = null;            var req = oauth.CreateRequest(uploaduri);            req.Method = "PUT";            req.ContentLength = 0;            req.Headers["Content-Range"] = string.Format("bytes */{0}", streamlength);            var areq = new AsyncHttpRequest(req);            using(var resp = oauth.GetResponseWithoutException(areq))            {                var code = (int)resp.StatusCode;                // If the upload is completed, we get 201 or 200                if (code >= 200 && code <= 299)                {                    response = oauth.ReadJSONResponse<T>(resp);                    if (response == null)                        throw new Exception(string.Format("Upload succeeded, but no data was returned, status code: {0}", code));                                        return streamlength;                }                if (code == 308)                {                    // A lack of a Range header is undocumented,                     // but seems to occur when no data has reached the server:                    // https://code.google.com/a/google.com/p/apps-api-issues/issues/detail?id=3884                    if (resp.Headers["Range"] == null)                        return 0;                     else                        return long.Parse(resp.Headers["Range"].Split(new char[] { '-' })[1]) + 1;                }                else                    throw new WebException(string.Format("Unexpected status code: {0}", code), null, WebExceptionStatus.ServerProtocolViolation, resp);            }        }        /// <summary>        /// Uploads the requestdata as JSON and starts a resumeable upload session, then uploads the stream in chunks        /// </summary>        /// <returns>Serialized result of the last request.</returns>        /// <param name="oauth">The Oauth instance.</param>        /// <param name="requestdata">The data to submit as JSON metadata.</param>        /// <param name="url">The URL to register the upload session against.</param>        /// <param name="stream">The stream with content data to upload.</param>        /// <param name="method">The HTTP Method.</param>        /// <typeparam name="TRequest">The type of data to upload as metadata.</typeparam>        /// <typeparam name="TResponse">The type of data returned from the upload.</typeparam>        public static TResponse ChunckedUploadWithResume<TRequest, TResponse>(OAuthHelper oauth, TRequest requestdata, string url, System.IO.Stream stream, string method = "POST")            where TRequest : class            where TResponse : class        {            var data = requestdata == null ? null : System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(requestdata));            var req = oauth.CreateRequest(url);            req.Method = method;            req.ContentLength = data == null ? 0 : data.Length;            if (data != null)                req.ContentType = "application/json; charset=UTF-8";                        req.Headers["X-Upload-Content-Type"] = "application/octet-stream";            req.Headers["X-Upload-Content-Length"] = stream.Length.ToString();            var areq = new AsyncHttpRequest(req);            if (data != null)                using(var rs = areq.GetRequestStream())                    rs.Write(data, 0, data.Length);            string uploaduri;            using(var resp = (HttpWebResponse)areq.GetResponse())            {                if (resp.StatusCode != HttpStatusCode.OK || string.IsNullOrWhiteSpace(resp.Headers["Location"]))                    throw new WebException("Failed to start upload session", null, WebExceptionStatus.UnknownError, resp);                uploaduri = resp.Headers["Location"];            }            return ChunkedUpload<TResponse>(oauth, uploaduri, stream);        }        /// <summary>        /// Helper method that performs a chunked upload, and queries for http status after each chunk        /// </summary>        /// <returns>The response item</returns>        /// <param name="oauth">The Oauth instance</param>        /// <param name="uploaduri">The resumeable uploaduri</param>        /// <param name="stream">The stream with data to upload.</param>        /// <typeparam name="T">The type of data in the response.</typeparam>        private static T ChunkedUpload<T>(OAuthHelper oauth, string uploaduri, System.IO.Stream stream)            where T : class        {            var queryRange = false;            var retries = 0;            var offset = 0L;            var buffer = new byte[Library.Utility.Utility.DEFAULT_BUFFER_SIZE];            // Repeatedly try uploading until all retries are done            while(true)            {                try                {                    if (queryRange)                    {                        T re;                        offset = GoogleCommon.QueryUploadRange(oauth, uploaduri, stream.Length, out re);                        queryRange = false;                        if (re != null)                            return re;                    }                    //Seek into the right place                    if (stream.Position != offset)                        stream.Position = offset;                    var req = oauth.CreateRequest(uploaduri);                    req.Method = "PUT";                    req.ContentType = "application/octet-stream";                    var chunkSize = Math.Min(UPLOAD_CHUNK_SIZE, stream.Length - offset);                    req.ContentLength = chunkSize;                    req.Headers["Content-Range"] = string.Format("bytes {0}-{1}/{2}", offset, offset + chunkSize - 1, stream.Length);;                    // Upload the remaining data                    var areq = new AsyncHttpRequest(req);                    using(var rs = areq.GetRequestStream())                    {                        var remaining = chunkSize;                        while(remaining > 0)                        {                            var n = stream.Read(buffer, 0, (int)Math.Min(remaining, Library.Utility.Utility.DEFAULT_BUFFER_SIZE));                            rs.Write(buffer, 0, n);                            remaining -= n;                        }                    }                    // Check the response                    using(var resp = oauth.GetResponseWithoutException(areq))                    {                        var code = (int)resp.StatusCode;                        if (code == 308 && resp.Headers["Range"] != null)                        {                            offset = long.Parse(resp.Headers["Range"].Split(new char[] {'-'})[1]) + 1;                            retries = 0;                        }                        else if (code >= 200 && code <= 299)                        {                            offset += chunkSize;                            if (offset != stream.Length)                                throw new Exception(string.Format("Upload succeeded prematurely. Uploaded: {0}, total size: {1}", offset, stream.Length));                            //Verify that the response is also valid                            var res = oauth.ReadJSONResponse<T>(resp);                            if (res == null)                                throw new Exception(string.Format("Upload succeeded, but no data was returned, status code: {0}", code));                            return res;                        }                        else                        {                            throw new WebException(string.Format("Unexpected status code: {0}", code), null, WebExceptionStatus.ServerProtocolViolation, resp);                        }                    }                }                catch (Exception ex)                {                    var retry = false;                    // If we get a 5xx error, or some network issue, we retry                    if (ex is WebException && ((WebException)ex).Response is HttpWebResponse)                    {                        var code = (int)((HttpWebResponse)((WebException)ex).Response).StatusCode;                        retry = code >= 500 && code <= 599;                    }                    else if (ex is System.Net.Sockets.SocketException || ex is System.IO.IOException || ex.InnerException is System.Net.Sockets.SocketException || ex.InnerException is System.IO.IOException)                    {                        retry = true;                    }                    // Retry with exponential backoff                    if (retry && retries < 5)                    {                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(Math.Pow(2, retries)));                        retries++;                        // Ask server where we left off                        queryRange = true;                    }                    else                        throw;                }            }        }
+    {
+        /// <summary>
+        /// The size of upload chunks
+        /// </summary>
+        private const long UPLOAD_CHUNK_SIZE = 1024 * 1024 * 10;
+
+        /// <summary>
+        /// Helper method that queries a resumeable upload uri for progress
+        /// </summary>
+        /// <returns>The upload range.</returns>
+        /// <param name="oauth">The Oauth instance</param>
+        /// <param name="uploaduri">The resumeable uploaduri</param>
+        /// <param name="streamlength">The length of the entire stream</param>
+        private static long QueryUploadRange<T>(OAuthHelper oauth, string uploaduri, long streamlength, out T response)
+            where T : class
+        {
+            response = null;
+            var req = oauth.CreateRequest(uploaduri);
+            req.Method = "PUT";
+            req.ContentLength = 0;
+            req.Headers["Content-Range"] = string.Format("bytes */{0}", streamlength);
+
+            var areq = new AsyncHttpRequest(req);
+            using(var resp = oauth.GetResponseWithoutException(areq))
+            {
+                var code = (int)resp.StatusCode;
+
+                // If the upload is completed, we get 201 or 200
+                if (code >= 200 && code <= 299)
+                {
+                    response = oauth.ReadJSONResponse<T>(resp);
+                    if (response == null)
+                        throw new Exception(string.Format("Upload succeeded, but no data was returned, status code: {0}", code));
+                    
+                    return streamlength;
+                }
+
+                if (code == 308)
+                {
+                    // A lack of a Range header is undocumented, 
+                    // but seems to occur when no data has reached the server:
+                    // https://code.google.com/a/google.com/p/apps-api-issues/issues/detail?id=3884
+
+                    if (resp.Headers["Range"] == null)
+                        return 0; 
+                    else
+                        return long.Parse(resp.Headers["Range"].Split(new char[] { '-' })[1]) + 1;
+                }
+                else
+                    throw new WebException(string.Format("Unexpected status code: {0}", code), null, WebExceptionStatus.ServerProtocolViolation, resp);
+            }
+        }
+
+        /// <summary>
+        /// Uploads the requestdata as JSON and starts a resumeable upload session, then uploads the stream in chunks
+        /// </summary>
+        /// <returns>Serialized result of the last request.</returns>
+        /// <param name="oauth">The Oauth instance.</param>
+        /// <param name="requestdata">The data to submit as JSON metadata.</param>
+        /// <param name="url">The URL to register the upload session against.</param>
+        /// <param name="stream">The stream with content data to upload.</param>
+        /// <param name="method">The HTTP Method.</param>
+        /// <typeparam name="TRequest">The type of data to upload as metadata.</typeparam>
+        /// <typeparam name="TResponse">The type of data returned from the upload.</typeparam>
+        public static TResponse ChunckedUploadWithResume<TRequest, TResponse>(OAuthHelper oauth, TRequest requestdata, string url, System.IO.Stream stream, string method = "POST")
+            where TRequest : class
+            where TResponse : class
+        {
+            var data = requestdata == null ? null : System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(requestdata));
+
+            var req = oauth.CreateRequest(url);
+            req.Method = method;
+            req.ContentLength = data == null ? 0 : data.Length;
+
+            if (data != null)
+                req.ContentType = "application/json; charset=UTF-8";
+            
+            req.Headers["X-Upload-Content-Type"] = "application/octet-stream";
+            req.Headers["X-Upload-Content-Length"] = stream.Length.ToString();
+
+            var areq = new AsyncHttpRequest(req);
+            if (data != null)
+                using(var rs = areq.GetRequestStream())
+                    rs.Write(data, 0, data.Length);
+
+            string uploaduri;
+            using(var resp = (HttpWebResponse)areq.GetResponse())
+            {
+                if (resp.StatusCode != HttpStatusCode.OK || string.IsNullOrWhiteSpace(resp.Headers["Location"]))
+                    throw new WebException("Failed to start upload session", null, WebExceptionStatus.UnknownError, resp);
+
+                uploaduri = resp.Headers["Location"];
+            }
+
+            return ChunkedUpload<TResponse>(oauth, uploaduri, stream);
+        }
+
+        /// <summary>
+        /// Helper method that performs a chunked upload, and queries for http status after each chunk
+        /// </summary>
+        /// <returns>The response item</returns>
+        /// <param name="oauth">The Oauth instance</param>
+        /// <param name="uploaduri">The resumeable uploaduri</param>
+        /// <param name="stream">The stream with data to upload.</param>
+        /// <typeparam name="T">The type of data in the response.</typeparam>
+        private static T ChunkedUpload<T>(OAuthHelper oauth, string uploaduri, System.IO.Stream stream)
+            where T : class
+        {
+            var queryRange = false;
+            var retries = 0;
+            var offset = 0L;
+            var buffer = new byte[Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
+
+            // Repeatedly try uploading until all retries are done
+            while(true)
+            {
+                try
+                {
+                    if (queryRange)
+                    {
+                        T re;
+                        offset = GoogleCommon.QueryUploadRange(oauth, uploaduri, stream.Length, out re);
+                        queryRange = false;
+
+                        if (re != null)
+                            return re;
+                    }
+
+                    //Seek into the right place
+                    if (stream.Position != offset)
+                        stream.Position = offset;
+
+                    var req = oauth.CreateRequest(uploaduri);
+                    req.Method = "PUT";
+                    req.ContentType = "application/octet-stream";
+
+                    var chunkSize = Math.Min(UPLOAD_CHUNK_SIZE, stream.Length - offset);
+
+                    req.ContentLength = chunkSize;
+                    req.Headers["Content-Range"] = string.Format("bytes {0}-{1}/{2}", offset, offset + chunkSize - 1, stream.Length);;
+
+                    // Upload the remaining data
+                    var areq = new AsyncHttpRequest(req);
+                    using(var rs = areq.GetRequestStream())
+                    {
+                        var remaining = chunkSize;
+                        while(remaining > 0)
+                        {
+                            var n = stream.Read(buffer, 0, (int)Math.Min(remaining, Library.Utility.Utility.DEFAULT_BUFFER_SIZE));
+                            rs.Write(buffer, 0, n);
+                            remaining -= n;
+                        }
+                    }
+
+                    // Check the response
+                    using(var resp = oauth.GetResponseWithoutException(areq))
+                    {
+                        var code = (int)resp.StatusCode;
+
+                        if (code == 308 && resp.Headers["Range"] != null)
+                        {
+                            offset = long.Parse(resp.Headers["Range"].Split(new char[] {'-'})[1]) + 1;
+                            retries = 0;
+                        }
+                        else if (code >= 200 && code <= 299)
+                        {
+                            offset += chunkSize;
+                            if (offset != stream.Length)
+                                throw new Exception(string.Format("Upload succeeded prematurely. Uploaded: {0}, total size: {1}", offset, stream.Length));
+
+                            //Verify that the response is also valid
+                            var res = oauth.ReadJSONResponse<T>(resp);
+                            if (res == null)
+                                throw new Exception(string.Format("Upload succeeded, but no data was returned, status code: {0}", code));
+
+                            return res;
+                        }
+                        else
+                        {
+                            throw new WebException(string.Format("Unexpected status code: {0}", code), null, WebExceptionStatus.ServerProtocolViolation, resp);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    var retry = false;
+
+                    // If we get a 5xx error, or some network issue, we retry
+                    if (ex is WebException && ((WebException)ex).Response is HttpWebResponse)
+                    {
+                        var code = (int)((HttpWebResponse)((WebException)ex).Response).StatusCode;
+                        retry = code >= 500 && code <= 599;
+                    }
+                    else if (ex is System.Net.Sockets.SocketException || ex is System.IO.IOException || ex.InnerException is System.Net.Sockets.SocketException || ex.InnerException is System.IO.IOException)
+                    {
+                        retry = true;
+                    }
+
+                    // Retry with exponential backoff
+                    if (retry && retries < 5)
+                    {
+                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(Math.Pow(2, retries)));
+                        retries++;
+
+                        // Ask server where we left off
+                        queryRange = true;
+                    }
+                    else
+                        throw;
+                }
+            }
+        }
     }
 }
 

--- a/Duplicati/Library/Backend/OpenStack/OpenStackConfig.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackConfig.cs
@@ -14,18 +14,65 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using Duplicati.Library.Interface;using System.Collections.Generic;using System.Linq;
+using System;
+using Duplicati.Library.Interface;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Duplicati.Library.Backend.OpenStack
 {
     public class SwiftConfig : IWebModule
-    {        private const ConfigType DEFAULT_CONFIG_TYPE = ConfigType.Providers;        private static readonly string DEFAULT_CONFIG_TYPE_STR = Enum.GetName(typeof(ConfigType), DEFAULT_CONFIG_TYPE);        private const string KEY_CONFIGTYPE = "openstack-config";        public enum ConfigType        {            Providers,
-            Versions,        }
+    {
+        private const ConfigType DEFAULT_CONFIG_TYPE = ConfigType.Providers;
+        private static readonly string DEFAULT_CONFIG_TYPE_STR = Enum.GetName(typeof(ConfigType), DEFAULT_CONFIG_TYPE);
+        private const string KEY_CONFIGTYPE = "openstack-config";
+
+        public enum ConfigType
+        {
+            Providers,
+            Versions,
+        }
         public SwiftConfig()
         {
-        }        public System.Collections.Generic.IDictionary<string, string> Execute(System.Collections.Generic.IDictionary<string, string> options)        {            string k;            options.TryGetValue(KEY_CONFIGTYPE, out k);            if (string.IsNullOrWhiteSpace(k))                k = DEFAULT_CONFIG_TYPE_STR;            ConfigType ct;            if (!Enum.TryParse<ConfigType>(k, true, out ct))                ct = DEFAULT_CONFIG_TYPE;            switch (ct)            {
+        }
+
+        public System.Collections.Generic.IDictionary<string, string> Execute(System.Collections.Generic.IDictionary<string, string> options)
+        {
+            string k;
+            options.TryGetValue(KEY_CONFIGTYPE, out k);
+            if (string.IsNullOrWhiteSpace(k))
+                k = DEFAULT_CONFIG_TYPE_STR;
+
+            ConfigType ct;
+            if (!Enum.TryParse<ConfigType>(k, true, out ct))
+                ct = DEFAULT_CONFIG_TYPE;
+
+            switch (ct)
+            {
                 case ConfigType.Versions:
-                    return OpenStack.OpenStackStorage.OPENSTACK_VERSIONS.ToDictionary((x) => x.Key, (y) => y.Value);                default:                    return OpenStack.OpenStackStorage.KNOWN_OPENSTACK_PROVIDERS.ToDictionary((x) => x.Key, (y) => y.Value);            }        }        public string Key { get { return "openstack-getconfig"; } }        public string DisplayName { get { return "OpenStack configuration module"; } }        public string Description { get { return "Exposes OpenStack configuration as a web module"; } }        public System.Collections.Generic.IList<ICommandLineArgument> SupportedCommands        {            get            {                return new List<ICommandLineArgument>(new ICommandLineArgument[] {                    new CommandLineArgument(KEY_CONFIGTYPE, CommandLineArgument.ArgumentType.Enumeration, "The config to get", "Provides different config values", DEFAULT_CONFIG_TYPE_STR, Enum.GetNames(typeof(ConfigType)))                });            }        }
+                    return OpenStack.OpenStackStorage.OPENSTACK_VERSIONS.ToDictionary((x) => x.Key, (y) => y.Value);
+                default:
+                    return OpenStack.OpenStackStorage.KNOWN_OPENSTACK_PROVIDERS.ToDictionary((x) => x.Key, (y) => y.Value);
+            }
+        }
+
+        public string Key { get { return "openstack-getconfig"; } }
+
+        public string DisplayName { get { return "OpenStack configuration module"; } }
+
+        public string Description { get { return "Exposes OpenStack configuration as a web module"; } }
+
+
+        public System.Collections.Generic.IList<ICommandLineArgument> SupportedCommands
+        {
+            get
+            {
+                return new List<ICommandLineArgument>(new ICommandLineArgument[] {
+                    new CommandLineArgument(KEY_CONFIGTYPE, CommandLineArgument.ArgumentType.Enumeration, "The config to get", "Provides different config values", DEFAULT_CONFIG_TYPE_STR, Enum.GetNames(typeof(ConfigType)))
+
+                });
+            }
+        }
     }
 }
 

--- a/Duplicati/Library/Backend/OpenStack/Strings.cs
+++ b/Duplicati/Library/Backend/OpenStack/Strings.cs
@@ -13,15 +13,33 @@
 //
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
-//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USAusing Duplicati.Library.Localization.Short;
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+using Duplicati.Library.Localization.Short;
 
 namespace Duplicati.Library.Backend.Strings
 {
-    internal static class OpenStack {        public static string Description { get { return LC.L(@"This backend can read and write data to Swift (OpenStack Object Storage). Supported format is ""openstack://container/folder""."); } }        public static string DisplayName { get { return LC.L(@"OpenStack Simple Storage"); } }        public static string MissingOptionError(string optionname) { return LC.L(@"Missing required option: {0}", optionname); }        public static string PasswordOptionLong(string tenantnameoption) { return LC.L(@"The password used to connect to the server. This may also be supplied as the environment variable ""AUTH_PASSWORD"". If the password is supplied, --{0} must also be set", tenantnameoption); }        public static string PasswordOptionShort { get { return LC.L(@"Supplies the password used to connect to the server"); } }        public static string DomainnameOptionLong { get { return LC.L(@"The domain name of the user used to connect to the server."); } }
+    internal static class OpenStack {
+        public static string Description { get { return LC.L(@"This backend can read and write data to Swift (OpenStack Object Storage). Supported format is ""openstack://container/folder""."); } }
+        public static string DisplayName { get { return LC.L(@"OpenStack Simple Storage"); } }
+        public static string MissingOptionError(string optionname) { return LC.L(@"Missing required option: {0}", optionname); }
+        public static string PasswordOptionLong(string tenantnameoption) { return LC.L(@"The password used to connect to the server. This may also be supplied as the environment variable ""AUTH_PASSWORD"". If the password is supplied, --{0} must also be set", tenantnameoption); }
+        public static string PasswordOptionShort { get { return LC.L(@"Supplies the password used to connect to the server"); } }
+        public static string DomainnameOptionLong { get { return LC.L(@"The domain name of the user used to connect to the server."); } }
         public static string DomainnameOptionShort { get { return LC.L(@"Supplies the domain used to connect to the server"); } }
         public static string UsernameOptionLong { get { return LC.L(@"The username used to connect to the server. This may also be supplied as the environment variable ""AUTH_USERNAME""."); } }
         public static string UsernameOptionShort { get { return LC.L(@"Supplies the username used to connect to the server"); } }
-        public static string TenantnameOptionLong { get { return LC.L(@"The Tenant Name is commonly the paying user account name. This option must be supplied when authenticating with a password, but is not required when using an API key."); } }        public static string TenantnameOptionShort { get { return LC.L(@"Supplies the Tenant Name used to connect to the server"); } }        public static string ApikeyOptionLong { get { return LC.L(@"The API key can be used to connect without supplying a password and tenant ID with some providers."); } }        public static string ApikeyOptionShort { get { return LC.L(@"Supplies the API key used to connect to the server"); } }        public static string AuthuriOptionLong(string providers) { return LC.L(@"The authentication URL is used to authenticate the user and find the storage service. The URL commonly ends with ""/v2.0"". Known providers are: {0}{1}", System.Environment.NewLine, providers); }        public static string AuthuriOptionShort { get { return LC.L(@"Supplies the authentication URL"); } }        public static string VersionOptionLong { get { return LC.L(@"The keystone API version to use, valid values are 'v2' and 'v3'."); } }
+        public static string TenantnameOptionLong { get { return LC.L(@"The Tenant Name is commonly the paying user account name. This option must be supplied when authenticating with a password, but is not required when using an API key."); } }
+        public static string TenantnameOptionShort { get { return LC.L(@"Supplies the Tenant Name used to connect to the server"); } }
+        public static string ApikeyOptionLong { get { return LC.L(@"The API key can be used to connect without supplying a password and tenant ID with some providers."); } }
+        public static string ApikeyOptionShort { get { return LC.L(@"Supplies the API key used to connect to the server"); } }
+        public static string AuthuriOptionLong(string providers) { return LC.L(@"The authentication URL is used to authenticate the user and find the storage service. The URL commonly ends with ""/v2.0"". Known providers are: {0}{1}", System.Environment.NewLine, providers); }
+        public static string AuthuriOptionShort { get { return LC.L(@"Supplies the authentication URL"); } }
+        public static string VersionOptionLong { get { return LC.L(@"The keystone API version to use, valid values are 'v2' and 'v3'."); } }
         public static string VersionOptionShort { get { return LC.L(@"The keystone API version to use"); } }
-        public static string RegionOptionLong { get { return LC.L(@"This option is only used when creating a container, and is used to indicate where the container should be placed. Consult your provider for a list of valid regions, or leave empty for the default region."); } }        public static string RegionOptionShort { get { return LC.L(@"Supplies the region used for creating a container"); } }    }}
+        public static string RegionOptionLong { get { return LC.L(@"This option is only used when creating a container, and is used to indicate where the container should be placed. Consult your provider for a list of valid regions, or leave empty for the default region."); } }
+        public static string RegionOptionShort { get { return LC.L(@"Supplies the region used for creating a container"); } }
+
+    }
+}
 

--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -283,10 +283,14 @@ namespace Duplicati.Library.Backend
             }
         }
 
+
+
         public string[] DNSName
         {
             get { return new string[] { remote_repo }; }
         }
+
+
 
         public void Test()
         {

--- a/Duplicati/Server/WebServer/RESTMethods/Help.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Help.cs
@@ -14,11 +14,88 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Linq;using System.Text;using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class Help : IRESTMethodGET
-    {        public void GET(string key, RequestInfo info)        {            var sb = new StringBuilder();            if (string.IsNullOrWhiteSpace(key))            {                foreach(var m in RESTHandler.Modules.Keys.OrderBy(x => x))                {                                        var mod = RESTHandler.Modules[m];                    if (mod == this)                        continue;                    var desc = mod.GetType().Name;                    if (mod is IRESTMethodDocumented)                        desc = ((IRESTMethodDocumented)mod).Description;                    sb.AppendFormat(ITEM_TEMPLATE, RESTHandler.API_URI_PATH, m, mod.GetType().Name, desc);                }                var data = Encoding.UTF8.GetBytes(string.Format(TEMPLATE, "API Information", "", sb.ToString()));                info.Response.ContentType = "text/html";                info.Response.ContentLength = data.Length;                info.Response.Body.Write(data, 0, data.Length);                info.Response.Send();            }            else            {                IRESTMethod m;                RESTHandler.Modules.TryGetValue(key, out m);                if (m == null)                {                    info.Response.Status = System.Net.HttpStatusCode.NotFound;                    info.Response.Reason = "Module not found";                }                else                {                    var desc = "";                    if (m is IRESTMethodDocumented)                    {                        var doc = m as IRESTMethodDocumented;                        desc = doc.Description;                        foreach(var t in doc.Types)                            sb.AppendFormat(METHOD_TEMPLATE, t.Key, JsonConvert.SerializeObject(t.Value)); //TODO: Format the type                    }                    var data = Encoding.UTF8.GetBytes(string.Format(TEMPLATE, m.GetType().Name, desc, sb.ToString()));                    info.Response.ContentType = "text/html";                    info.Response.ContentLength = data.Length;                    info.Response.Body.Write(data, 0, data.Length);                    info.Response.Send();                                   }            }        }        private const string TEMPLATE = @"<html><head><title>{0}</title></head><body><h1>{0}</h1><p>{1}</p><ul>{2}</ul></body>";        private const string ITEM_TEMPLATE = @"<li><a href=""{0}/help/{1}"">{2}</a>: {3}</li>";        private const string METHOD_TEMPLATE = @"<b>{0}:</b><br><code>{1}</code><br>";    }
+    {
+        public void GET(string key, RequestInfo info)
+        {
+            var sb = new StringBuilder();
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                foreach(var m in RESTHandler.Modules.Keys.OrderBy(x => x))
+                {                    
+                    var mod = RESTHandler.Modules[m];
+                    if (mod == this)
+                        continue;
+
+                    var desc = mod.GetType().Name;
+                    if (mod is IRESTMethodDocumented)
+                        desc = ((IRESTMethodDocumented)mod).Description;
+                    sb.AppendFormat(ITEM_TEMPLATE, RESTHandler.API_URI_PATH, m, mod.GetType().Name, desc);
+                }
+
+
+                var data = Encoding.UTF8.GetBytes(string.Format(TEMPLATE, "API Information", "", sb.ToString()));
+
+                info.Response.ContentType = "text/html";
+                info.Response.ContentLength = data.Length;
+                info.Response.Body.Write(data, 0, data.Length);
+                info.Response.Send();
+            }
+            else
+            {
+                IRESTMethod m;
+                RESTHandler.Modules.TryGetValue(key, out m);
+                if (m == null)
+                {
+                    info.Response.Status = System.Net.HttpStatusCode.NotFound;
+                    info.Response.Reason = "Module not found";
+                }
+                else
+                {
+                    var desc = "";
+                    if (m is IRESTMethodDocumented)
+                    {
+                        var doc = m as IRESTMethodDocumented;
+                        desc = doc.Description;
+                        foreach(var t in doc.Types)
+                            sb.AppendFormat(METHOD_TEMPLATE, t.Key, JsonConvert.SerializeObject(t.Value)); //TODO: Format the type
+                    }
+
+                    var data = Encoding.UTF8.GetBytes(string.Format(TEMPLATE, m.GetType().Name, desc, sb.ToString()));
+
+                    info.Response.ContentType = "text/html";
+                    info.Response.ContentLength = data.Length;
+                    info.Response.Body.Write(data, 0, data.Length);
+                    info.Response.Send();
+                   
+                }
+            }
+        }
+
+        private const string TEMPLATE = @"
+<html><head><title>{0}</title></head>
+<body>
+<h1>{0}</h1>
+<p>{1}</p>
+<ul>
+{2}
+</ul>
+</body>
+";
+        private const string ITEM_TEMPLATE = @"
+<li><a href=""{0}/help/{1}"">{2}</a>: {3}</li>
+";
+
+        private const string METHOD_TEMPLATE = @"
+<b>{0}:</b><br><code>{1}</code><br>
+";
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/IRESTMethod.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/IRESTMethod.cs
@@ -14,11 +14,43 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public interface IRESTMethod
-    {    }    public interface IRESTMethodDocumented    {        string Description { get; }        IEnumerable<KeyValuePair<string, Type>> Types { get; }    }    public interface IRESTMethodGET : IRESTMethod    {        void GET(string key, RequestInfo info);    }
-    public interface IRESTMethodPUT : IRESTMethod    {        void PUT(string key, RequestInfo info);    }    public interface IRESTMethodPOST : IRESTMethod    {        void POST(string key, RequestInfo info);    }    public interface IRESTMethodDELETE : IRESTMethod    {        void DELETE(string key, RequestInfo info);    }    public interface IRESTMethodPATCH : IRESTMethod    {        void PATCH(string key, RequestInfo info);    }}
+    {
+    }
+
+    public interface IRESTMethodDocumented
+    {
+        string Description { get; }
+        IEnumerable<KeyValuePair<string, Type>> Types { get; }
+    }
+
+    public interface IRESTMethodGET : IRESTMethod
+    {
+        void GET(string key, RequestInfo info);
+    }
+    public interface IRESTMethodPUT : IRESTMethod
+    {
+        void PUT(string key, RequestInfo info);
+    }
+
+    public interface IRESTMethodPOST : IRESTMethod
+    {
+        void POST(string key, RequestInfo info);
+    }
+
+    public interface IRESTMethodDELETE : IRESTMethod
+    {
+        void DELETE(string key, RequestInfo info);
+    }
+
+    public interface IRESTMethodPATCH : IRESTMethod
+    {
+        void PATCH(string key, RequestInfo info);
+    }
+}
 

--- a/Duplicati/Server/WebServer/RESTMethods/Notification.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Notification.cs
@@ -14,12 +14,47 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Linq;
+using System;
+using System.Linq;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class Notification : IRESTMethodGET, IRESTMethodDELETE
     {
-        public void GET(string key, RequestInfo info)        {            long id;            if (!long.TryParse(key, out id))            {                info.ReportClientError("Invalid ID", System.Net.HttpStatusCode.BadRequest);                return;            }            var el = Program.DataConnection.GetNotifications().Where(x => x.ID == id).FirstOrDefault();            if (el == null)                info.ReportClientError("No such notification", System.Net.HttpStatusCode.NotFound);            else                info.OutputOK(el);        }        public void DELETE(string key, RequestInfo info)        {            long id;            if (!long.TryParse(key, out id))            {                info.ReportClientError("Invalid ID", System.Net.HttpStatusCode.BadRequest);                return;            }            var el = Program.DataConnection.GetNotifications().Where(x => x.ID == id).FirstOrDefault();            if (el == null)                info.ReportClientError("No such notification", System.Net.HttpStatusCode.NotFound);            else            {                Program.DataConnection.DismissNotification(id);                info.OutputOK();            }        }    }
+        public void GET(string key, RequestInfo info)
+        {
+            long id;
+            if (!long.TryParse(key, out id))
+            {
+                info.ReportClientError("Invalid ID", System.Net.HttpStatusCode.BadRequest);
+                return;
+            }
+
+            var el = Program.DataConnection.GetNotifications().Where(x => x.ID == id).FirstOrDefault();
+            if (el == null)
+                info.ReportClientError("No such notification", System.Net.HttpStatusCode.NotFound);
+            else
+                info.OutputOK(el);
+        }
+
+        public void DELETE(string key, RequestInfo info)
+        {
+            long id;
+            if (!long.TryParse(key, out id))
+            {
+                info.ReportClientError("Invalid ID", System.Net.HttpStatusCode.BadRequest);
+                return;
+            }
+
+            var el = Program.DataConnection.GetNotifications().Where(x => x.ID == id).FirstOrDefault();
+            if (el == null)
+                info.ReportClientError("No such notification", System.Net.HttpStatusCode.NotFound);
+            else
+            {
+                Program.DataConnection.DismissNotification(id);
+                info.OutputOK();
+            }
+        }
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/Notifications.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Notifications.cs
@@ -19,7 +19,11 @@ using System;
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class Notifications : IRESTMethodGET
-    {        public void GET(string key, RequestInfo info)        {            info.OutputOK(Program.DataConnection.GetNotifications());        }
+    {
+        public void GET(string key, RequestInfo info)
+        {
+            info.OutputOK(Program.DataConnection.GetNotifications());
+        }
     }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/ProgressState.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/ProgressState.cs
@@ -14,12 +14,32 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class ProgressState : IRESTMethodGET, IRESTMethodDocumented
     {
-        public void GET(string key, RequestInfo info)        {            if (Program.GenerateProgressState == null)                info.ReportClientError("No active backup", System.Net.HttpStatusCode.NotFound);            else                info.OutputOK(Program.GenerateProgressState());        }        public string Description { get { return "Return the progress of the currently running operation."; } }        public IEnumerable<KeyValuePair<string, Type>> Types        {            get            {                return new KeyValuePair<string, Type>[] {                    new KeyValuePair<string, Type>(HttpServer.Method.Get, typeof(Serialization.Interface.IProgressEventData))                };            }        }        }
+        public void GET(string key, RequestInfo info)
+        {
+            if (Program.GenerateProgressState == null)
+                info.ReportClientError("No active backup", System.Net.HttpStatusCode.NotFound);
+            else
+                info.OutputOK(Program.GenerateProgressState());
+        }
+
+        public string Description { get { return "Return the progress of the currently running operation."; } }
+
+        public IEnumerable<KeyValuePair<string, Type>> Types
+        {
+            get
+            {
+                return new KeyValuePair<string, Type>[] {
+                    new KeyValuePair<string, Type>(HttpServer.Method.Get, typeof(Serialization.Interface.IProgressEventData))
+                };
+            }
+        }    
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/RequestInfo.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/RequestInfo.cs
@@ -19,9 +19,91 @@ using System;
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class RequestInfo : IDisposable
-    {        public HttpServer.IHttpRequest Request { get; private set; }        public HttpServer.IHttpResponse Response { get; private set; }        public HttpServer.Sessions.IHttpSession Session { get; private set; }        public BodyWriter BodyWriter { get; private set; }
+    {
+        public HttpServer.IHttpRequest Request { get; private set; }
+        public HttpServer.IHttpResponse Response { get; private set; }
+        public HttpServer.Sessions.IHttpSession Session { get; private set; }
+        public BodyWriter BodyWriter { get; private set; }
         public RequestInfo(HttpServer.IHttpRequest request, HttpServer.IHttpResponse response, HttpServer.Sessions.IHttpSession session)
-        {            Request = request;            Response = response;            Session = session;            BodyWriter = new BodyWriter(response, request);
-        }        public void ReportServerError(string message, System.Net.HttpStatusCode code = System.Net.HttpStatusCode.InternalServerError)        {            Response.Status = code;            Response.Reason = message;            BodyWriter.WriteJsonObject(new { Error = message });        }        public void ReportClientError(string message, System.Net.HttpStatusCode code = System.Net.HttpStatusCode.BadRequest)        {            ReportServerError(message, code);        }        public bool LongPollCheck(EventPollNotify poller, ref long id, out bool isError)        {            HttpServer.HttpInput input = Request.Method.ToUpper() == "POST" ? Request.Form : Request.QueryString;            if (Library.Utility.Utility.ParseBool(input["longpoll"].Value, false))            {                long lastEventId;                if (!long.TryParse(input["lasteventid"].Value, out lastEventId))                {                    ReportClientError("When activating long poll, the request must include the last event id", System.Net.HttpStatusCode.BadRequest);                    isError = true;                    return false;                }                TimeSpan ts;                try { ts = Library.Utility.Timeparser.ParseTimeSpan(input["duration"].Value); }                catch (Exception ex)                {                    ReportClientError("Invalid duration: " + ex.Message, System.Net.HttpStatusCode.BadRequest);                    isError = true;                    return false;                }                if (ts <= TimeSpan.FromSeconds(10) || ts.TotalMilliseconds > int.MaxValue)                {                    ReportClientError("Invalid duration, must be at least 10 seconds, and less than " + int.MaxValue + " milliseconds", System.Net.HttpStatusCode.BadRequest);                    isError = true;                    return false;                }                isError = false;                id = poller.Wait(lastEventId, (int)ts.TotalMilliseconds);                return true;            }            isError = false;            return false;        }        public void OutputOK(object item = null)        {            BodyWriter.OutputOK(item);        }        public void OutputError(object item = null, System.Net.HttpStatusCode code = System.Net.HttpStatusCode.InternalServerError, string reason = null)        {            Response.Status = code;            Response.Reason = reason ?? "Error";            BodyWriter.WriteJsonObject(item);        }        public void Dispose()        {            if (BodyWriter != null)            {                var bw = BodyWriter;                BodyWriter = null;                bw.Dispose();            }        }    }
+        {
+            Request = request;
+            Response = response;
+            Session = session;
+            BodyWriter = new BodyWriter(response, request);
+        }
+
+        public void ReportServerError(string message, System.Net.HttpStatusCode code = System.Net.HttpStatusCode.InternalServerError)
+        {
+            Response.Status = code;
+            Response.Reason = message;
+
+            BodyWriter.WriteJsonObject(new { Error = message });
+        }
+
+        public void ReportClientError(string message, System.Net.HttpStatusCode code = System.Net.HttpStatusCode.BadRequest)
+        {
+            ReportServerError(message, code);
+        }
+
+        public bool LongPollCheck(EventPollNotify poller, ref long id, out bool isError)
+        {
+            HttpServer.HttpInput input = Request.Method.ToUpper() == "POST" ? Request.Form : Request.QueryString;
+            if (Library.Utility.Utility.ParseBool(input["longpoll"].Value, false))
+            {
+                long lastEventId;
+                if (!long.TryParse(input["lasteventid"].Value, out lastEventId))
+                {
+                    ReportClientError("When activating long poll, the request must include the last event id", System.Net.HttpStatusCode.BadRequest);
+                    isError = true;
+                    return false;
+                }
+
+                TimeSpan ts;
+                try { ts = Library.Utility.Timeparser.ParseTimeSpan(input["duration"].Value); }
+                catch (Exception ex)
+                {
+                    ReportClientError("Invalid duration: " + ex.Message, System.Net.HttpStatusCode.BadRequest);
+                    isError = true;
+                    return false;
+                }
+
+                if (ts <= TimeSpan.FromSeconds(10) || ts.TotalMilliseconds > int.MaxValue)
+                {
+                    ReportClientError("Invalid duration, must be at least 10 seconds, and less than " + int.MaxValue + " milliseconds", System.Net.HttpStatusCode.BadRequest);
+                    isError = true;
+                    return false;
+                }
+
+                isError = false;
+                id = poller.Wait(lastEventId, (int)ts.TotalMilliseconds);
+                return true;
+            }
+
+            isError = false;
+            return false;
+        }
+
+        public void OutputOK(object item = null)
+        {
+            BodyWriter.OutputOK(item);
+        }
+
+        public void OutputError(object item = null, System.Net.HttpStatusCode code = System.Net.HttpStatusCode.InternalServerError, string reason = null)
+        {
+            Response.Status = code;
+            Response.Reason = reason ?? "Error";
+            BodyWriter.WriteJsonObject(item);
+        }
+
+        public void Dispose()
+        {
+            if (BodyWriter != null)
+            {
+                var bw = BodyWriter;
+                BodyWriter = null;
+                bw.Dispose();
+            }
+        }
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/SystemWideSettings.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/SystemWideSettings.cs
@@ -14,12 +14,31 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Collections.Generic;using Duplicati.Library.Interface;
+using System;
+using System.Collections.Generic;
+using Duplicati.Library.Interface;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class SystemWideSettings : IRESTMethodGET, IRESTMethodDocumented
     {
-        public void GET(string key, RequestInfo info)        {            info.OutputOK(new Duplicati.Library.Main.Options(new Dictionary<string, string>()).SupportedCommands);        }        public string Description { get { return "Return a list of settings that can be applied to all backups on a system-wide basis"; } }        public IEnumerable<KeyValuePair<string, Type>> Types        {            get            {                return new KeyValuePair<string, Type>[] {                    new KeyValuePair<string, Type>(HttpServer.Method.Get, typeof(ICommandLineArgument[]))                };            }        }    }
+        public void GET(string key, RequestInfo info)
+        {
+            info.OutputOK(new Duplicati.Library.Main.Options(new Dictionary<string, string>()).SupportedCommands);
+        }
+
+        public string Description { get { return "Return a list of settings that can be applied to all backups on a system-wide basis"; } }
+
+        public IEnumerable<KeyValuePair<string, Type>> Types
+        {
+            get
+            {
+                return new KeyValuePair<string, Type>[] {
+                    new KeyValuePair<string, Type>(HttpServer.Method.Get, typeof(ICommandLineArgument[]))
+                };
+            }
+        }
+
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/Tags.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Tags.cs
@@ -14,11 +14,40 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Collections.Generic;using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class Tags : IRESTMethodGET, IRESTMethodDocumented
-    {        public void GET(string key, RequestInfo info)        {            var r =                 from n in                 Serializable.ServerSettings.CompressionModules                    .Union(Serializable.ServerSettings.EncryptionModules)                    .Union(Serializable.ServerSettings.BackendModules)                    .Union(Serializable.ServerSettings.GenericModules)                    select n.Key.ToLower();            // Append all known tags            r = r.Union(from n in Program.DataConnection.Backups select n.Tags into p from x in p select x.ToLower());            info.OutputOK(r);               }        public string Description { get { return "Gets the list of tags"; } }        public IEnumerable<KeyValuePair<string, Type>> Types        {            get            {                return new KeyValuePair<string, Type>[] {                    new KeyValuePair<string, Type>(HttpServer.Method.Get, typeof(string[])),                };            }        }    }
+    {
+        public void GET(string key, RequestInfo info)
+        {
+            var r = 
+                from n in 
+                Serializable.ServerSettings.CompressionModules
+                    .Union(Serializable.ServerSettings.EncryptionModules)
+                    .Union(Serializable.ServerSettings.BackendModules)
+                    .Union(Serializable.ServerSettings.GenericModules)
+                    select n.Key.ToLower();
+
+            // Append all known tags
+            r = r.Union(from n in Program.DataConnection.Backups select n.Tags into p from x in p select x.ToLower());
+            info.OutputOK(r);       
+        }
+
+        public string Description { get { return "Gets the list of tags"; } }
+
+        public IEnumerable<KeyValuePair<string, Type>> Types
+        {
+            get
+            {
+                return new KeyValuePair<string, Type>[] {
+                    new KeyValuePair<string, Type>(HttpServer.Method.Get, typeof(string[])),
+                };
+            }
+        }
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/Tasks.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Tasks.cs
@@ -14,11 +14,23 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class Tasks : IRESTMethodGET
-    {        public void GET(string key, RequestInfo info)        {            var cur = Program.WorkThread.CurrentTask;            var n = Program.WorkThread.CurrentTasks;            if (cur != null)                n.Insert(0, cur);            info.OutputOK(n);        }    }
+    {
+        public void GET(string key, RequestInfo info)
+        {
+            var cur = Program.WorkThread.CurrentTask;
+            var n = Program.WorkThread.CurrentTasks;
+
+            if (cur != null)
+                n.Insert(0, cur);
+
+            info.OutputOK(n);
+        }
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/UISettings.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/UISettings.cs
@@ -14,49 +14,64 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Collections.Generic;using Duplicati.Server.Serialization;using System.IO;
+using System;
+using System.Collections.Generic;
+using Duplicati.Server.Serialization;
+using System.IO;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class UISettings : IRESTMethodGET, IRESTMethodPOST, IRESTMethodPATCH
-    {        public void GET(string key, RequestInfo info)        {            if (string.IsNullOrWhiteSpace(key))            {                info.OutputOK(Program.DataConnection.GetUISettingsSchemes());            }            else            {                info.OutputOK(Program.DataConnection.GetUISettings(key));            }        }
-
-		public void POST(string key, RequestInfo info)
-		{
-			PATCH(key, info);
-		}
-
-		public void PATCH(string key, RequestInfo info)
+    {
+        public void GET(string key, RequestInfo info)
         {
-			if (string.IsNullOrWhiteSpace(key))
-			{
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                info.OutputOK(Program.DataConnection.GetUISettingsSchemes());
+            }
+            else
+            {
+                info.OutputOK(Program.DataConnection.GetUISettings(key));
+            }
+        }
+
+        public void POST(string key, RequestInfo info)
+        {
+            PATCH(key, info);
+        }
+
+        public void PATCH(string key, RequestInfo info)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
                 info.ReportClientError("Scheme is missing", System.Net.HttpStatusCode.BadRequest);
-				return;
-			}
+                return;
+            }
 
             IDictionary<string, string> data;
-			try
-			{
-				data = Serializer.Deserialize<Dictionary<string, string>>(new StreamReader(info.Request.Body));
-			}
-			catch (Exception ex)
-			{
+            try
+            {
+                data = Serializer.Deserialize<Dictionary<string, string>>(new StreamReader(info.Request.Body));
+            }
+            catch (Exception ex)
+            {
                 info.ReportClientError(string.Format("Unable to parse settings object: {0}", ex.Message), System.Net.HttpStatusCode.BadRequest);
-				return;
-			}
+                return;
+            }
 
-			if (data == null)
-			{
+            if (data == null)
+            {
                 info.ReportClientError(string.Format("Unable to parse settings object"), System.Net.HttpStatusCode.BadRequest);
-				return;
-			}
+                return;
+            }
 
             if (info.Request.Method == "POST")
-			    Program.DataConnection.SetUISettings(key, data);
+                Program.DataConnection.SetUISettings(key, data);
             else
                 Program.DataConnection.UpdateUISettings(key, data);
-			info.OutputOK();
-		}
-    }
+            info.OutputOK();
+        }
+
+    }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/Updates.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Updates.cs
@@ -19,7 +19,38 @@ using System;
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class Updates : IRESTMethodPOST
-    {        public void POST(string key, RequestInfo info)        {            switch ((key ?? "").ToLowerInvariant())            {                case "check":                    Program.UpdatePoller.CheckNow();                    info.OutputOK();                    return;                case "install":                    Program.UpdatePoller.InstallUpdate();                    info.OutputOK();                    return;                case "activate":                    if (Program.WorkThread.CurrentTask != null || Program.WorkThread.CurrentTasks.Count != 0)                    {                        info.ReportServerError("Cannot activate update while task is running or scheduled");                    }                    else                    {                        Program.UpdatePoller.ActivateUpdate();                        info.OutputOK();                    }                    return;                                default:                    info.ReportClientError("No such action", System.Net.HttpStatusCode.NotFound);                    return;            }        }
+    {
+        public void POST(string key, RequestInfo info)
+        {
+            switch ((key ?? "").ToLowerInvariant())
+            {
+                case "check":
+                    Program.UpdatePoller.CheckNow();
+                    info.OutputOK();
+                    return;
+
+                case "install":
+                    Program.UpdatePoller.InstallUpdate();
+                    info.OutputOK();
+                    return;
+
+                case "activate":
+                    if (Program.WorkThread.CurrentTask != null || Program.WorkThread.CurrentTasks.Count != 0)
+                    {
+                        info.ReportServerError("Cannot activate update while task is running or scheduled");
+                    }
+                    else
+                    {
+                        Program.UpdatePoller.ActivateUpdate();
+                        info.OutputOK();
+                    }
+                    return;
+                
+                default:
+                    info.ReportClientError("No such action", System.Net.HttpStatusCode.NotFound);
+                    return;
+            }
+        }
     }
 }
 

--- a/Duplicati/Server/WebServer/RESTMethods/WebModules.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/WebModules.cs
@@ -14,14 +14,16 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using System.Linq;
+using System;
+using System.Linq;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
     public class WebModules : IRESTMethodGET
     {
         public void GET(string key, RequestInfo info)
-        {            info.OutputOK(Duplicati.Library.DynamicLoader.WebLoader.Modules);
+        {
+            info.OutputOK(Duplicati.Library.DynamicLoader.WebLoader.Modules);
         }
     }
 }

--- a/Duplicati/UnitTest/RandomErrorBackend.cs
+++ b/Duplicati/UnitTest/RandomErrorBackend.cs
@@ -14,22 +14,133 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;using Duplicati.Library.Interface;using System.Collections.Generic;using System.IO;
+using System;
+using Duplicati.Library.Interface;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Duplicati.UnitTest
 {
     public class RandomErrorBackend : IBackend, IStreamingBackend
-    {        static RandomErrorBackend() { WrappedBackend = "file"; }        private static Random random = new Random(42);        public static string WrappedBackend { get; set; }        private IStreamingBackend m_backend;
+    {
+        static RandomErrorBackend() { WrappedBackend = "file"; }
+
+        private static Random random = new Random(42);
+
+        public static string WrappedBackend { get; set; }
+
+        private IStreamingBackend m_backend;
         public RandomErrorBackend()
         {
-        }        public RandomErrorBackend(string url, Dictionary<string, string> options)        {            var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();            m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(u, options);        }        private void ThrowErrorRandom()        {            if (random.NextDouble() > 0.90)                throw new Exception("Random upload failure");        }
-        #region IStreamingBackend implementation        public void Put(string remotename, Stream stream)        {            var uploadError = random.NextDouble() > 0.9;            using(var f = new Library.Utility.ProgressReportingStream(stream, stream.Length, x => { if (uploadError && stream.Position > stream.Length / 2) throw new Exception("Random upload failure"); }))                m_backend.Put(remotename, f);            ThrowErrorRandom();        }        public void Get(string remotename, Stream stream)        {            ThrowErrorRandom();            m_backend.Get(remotename, stream);            ThrowErrorRandom();        }        #endregion        #region IBackend implementation        public IEnumerable<IFileEntry> List()        {            return m_backend.List();        }        public void Put(string remotename, string filename)        {            ThrowErrorRandom();            m_backend.Put(remotename, filename);            ThrowErrorRandom();        }        public void Get(string remotename, string filename)        {            ThrowErrorRandom();            m_backend.Get(remotename, filename);            ThrowErrorRandom();        }        public void Delete(string remotename)        {            ThrowErrorRandom();            m_backend.Delete(remotename);            ThrowErrorRandom();        }        public void Test()        {            m_backend.Test();        }        public void CreateFolder()        {            m_backend.CreateFolder();        }
+        }
+
+        public RandomErrorBackend(string url, Dictionary<string, string> options)
+        {
+            var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();
+            m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(u, options);
+        }
+
+        private void ThrowErrorRandom()
+        {
+            if (random.NextDouble() > 0.90)
+                throw new Exception("Random upload failure");
+        }
+        #region IStreamingBackend implementation
+        public void Put(string remotename, Stream stream)
+        {
+            var uploadError = random.NextDouble() > 0.9;
+
+            using(var f = new Library.Utility.ProgressReportingStream(stream, stream.Length, x => { if (uploadError && stream.Position > stream.Length / 2) throw new Exception("Random upload failure"); }))
+                m_backend.Put(remotename, f);
+            ThrowErrorRandom();
+        }
+        public void Get(string remotename, Stream stream)
+        {
+            ThrowErrorRandom();
+            m_backend.Get(remotename, stream);
+            ThrowErrorRandom();
+        }
+        #endregion
+
+        #region IBackend implementation
+        public IEnumerable<IFileEntry> List()
+        {
+            return m_backend.List();
+        }
+        public void Put(string remotename, string filename)
+        {
+            ThrowErrorRandom();
+            m_backend.Put(remotename, filename);
+            ThrowErrorRandom();
+        }
+        public void Get(string remotename, string filename)
+        {
+            ThrowErrorRandom();
+            m_backend.Get(remotename, filename);
+            ThrowErrorRandom();
+        }
+        public void Delete(string remotename)
+        {
+            ThrowErrorRandom();
+            m_backend.Delete(remotename);
+            ThrowErrorRandom();
+        }
+        public void Test()
+        {
+            m_backend.Test();
+        }
+        public void CreateFolder()
+        {
+            m_backend.CreateFolder();
+        }
         public string[] DNSName
         {
             get
             {
                 return m_backend.DNSName;
             }
-        }        public string DisplayName        {            get            {                return "Random Error Backend";            }        }        public string ProtocolKey        {            get            {                return "randomerror";            }        }        public IList<ICommandLineArgument> SupportedCommands        {            get            {                if (m_backend == null)                    try { return Duplicati.Library.DynamicLoader.BackendLoader.GetSupportedCommands(WrappedBackend + "://"); }                    catch { }                return m_backend.SupportedCommands;            }        }        public string Description        {            get            {                return "A testing backend that randomly fails";            }        }        #endregion        #region IDisposable implementation        public void Dispose()        {            if (m_backend != null)                try { m_backend.Dispose(); }                finally { m_backend = null; }        }        #endregion    }
+        }
+        public string DisplayName
+        {
+            get
+            {
+                return "Random Error Backend";
+            }
+        }
+        public string ProtocolKey
+        {
+            get
+            {
+                return "randomerror";
+            }
+        }
+        public IList<ICommandLineArgument> SupportedCommands
+        {
+            get
+            {
+                if (m_backend == null)
+                    try { return Duplicati.Library.DynamicLoader.BackendLoader.GetSupportedCommands(WrappedBackend + "://"); }
+                    catch { }
+
+                return m_backend.SupportedCommands;
+            }
+        }
+        public string Description
+        {
+            get
+            {
+                return "A testing backend that randomly fails";
+            }
+        }
+        #endregion
+        #region IDisposable implementation
+        public void Dispose()
+        {
+            if (m_backend != null)
+                try { m_backend.Dispose(); }
+                finally { m_backend = null; }
+        }
+        #endregion
+    }
 }
 


### PR DESCRIPTION
This fixes several cases where carriage returns were not followed by line feeds, which caused many editors (and GitHub) to render multiple lines as a single line.

It appears that these carriage-return-only lines prevented Codacy from performing its analysis, as new issues are now being reported in these files.