### PR TITLE
Use helper method to read from Streams and add unit tests

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -398,7 +398,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                         using (var fs = m_cache.ReadBlock(v.Value, hash))
                         {
                             var buf = new byte[m_blocksize];
-                            var l = fs.Read(buf, 0, buf.Length);
+                            var l = Duplicati.Library.Utility.Utility.ForceStreamRead(fs, buf, buf.Length);
                             Array.Resize(ref buf, l);
 
                             return buf;

--- a/Duplicati/Library/AutoUpdater/SignatureReadingStream.cs
+++ b/Duplicati/Library/AutoUpdater/SignatureReadingStream.cs
@@ -48,7 +48,7 @@ namespace Duplicati.Library.AutoUpdater
         {
             stream.Position = 0;
             var signature = new byte[SIGNED_HASH_SIZE];
-            if (stream.Read(signature, 0, signature.Length) != signature.Length)
+            if (Duplicati.Library.Utility.Utility.ForceStreamRead(stream, signature, signature.Length) != signature.Length)
                 throw new System.IO.InvalidDataException("Unexpected end-of-stream while reading signature");
             var sha256 = System.Security.Cryptography.SHA256.Create();
             sha256.Initialize();

--- a/Duplicati/Library/Main/Blockprocessor.cs
+++ b/Duplicati/Library/Main/Blockprocessor.cs
@@ -29,20 +29,10 @@ namespace Duplicati.Library.Main
             if (m_depleted)
                 return 0;
             
-            var bytesleft = m_buffer.Length;
-            var bytesread = 0;
-            var read = 1;
+            int bytesRead = Duplicati.Library.Utility.Utility.ForceStreamRead(this.m_stream, this.m_buffer, this.m_buffer.Length);
+            m_depleted = this.m_buffer.Length > bytesRead;
 
-            while (bytesleft > 0 && read > 0)
-            {
-                read = m_stream.Read(m_buffer, bytesread, bytesleft);
-                bytesleft -= read;
-                bytesread += read;
-            }
-
-            m_depleted = bytesleft != 0;
-
-            return bytesread;
+            return bytesRead;
         }
         
         public long Length { get { return m_stream.Length; } }

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -610,8 +610,8 @@ namespace Duplicati.Library.Main.Operation
                                             if (sourcestream.Length > block.Offset)
                                             {
                                                 sourcestream.Position = block.Offset;
-                                                
-                                                var size = sourcestream.Read(blockbuffer, 0, blockbuffer.Length);
+
+                                                int size = Library.Utility.Utility.ForceStreamRead(sourcestream, blockbuffer, blockbuffer.Length);
                                                 if (size == block.Size)
                                                 {
                                                     var key = Convert.ToBase64String(hasher.ComputeHash(blockbuffer, 0, size));
@@ -720,7 +720,7 @@ namespace Duplicati.Library.Main.Operation
                                                 using (var sourcefile = m_systemIO.FileOpenRead(source.Path))
                                                 {
                                                     sourcefile.Position = source.Offset;
-                                                    var size = sourcefile.Read(blockbuffer, 0, blockbuffer.Length);
+                                                    int size = Library.Utility.Utility.ForceStreamRead(sourcefile, blockbuffer, blockbuffer.Length);
                                                     if (size == targetblock.Size)
                                                     {
                                                         var key = Convert.ToBase64String(hasher.ComputeHash(blockbuffer, 0, size));

--- a/Duplicati/Library/Utility/FileBackedList.cs
+++ b/Duplicati/Library/Utility/FileBackedList.cs
@@ -82,7 +82,7 @@ namespace Duplicati.Library.Utility
                     throw new Exception("Collection modified");
                     
                 m_stream.Position = m_position;
-                if (m_stream.Read(m_sizebuffer, 0, m_sizebuffer.Length) != m_sizebuffer.Length)
+                if (Utility.ForceStreamRead(m_stream, m_sizebuffer, m_sizebuffer.Length) != m_sizebuffer.Length)
                     throw new IOException("Unexpected EOS");
                 var len = BitConverter.ToInt64(m_sizebuffer, 0);
                 m_current = m_deserialize(m_stream, len);

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -680,7 +680,9 @@ namespace Duplicati.Library.Utility
             // So we read the first 4096 bytes and try to decode them as UTF8. 
             var buffer = new byte[4096];
             using (var file = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read))
-                file.Read(buffer, 0, 4096);
+            {
+                Utility.ForceStreamRead(file, buffer, 4096);
+            }
 
             var enc = Encoding.UTF8;
             try

--- a/Duplicati/Server/WebServer/RESTMethods/Backups.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backups.cs
@@ -74,7 +74,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                     var buf = new byte[3];
                     using(var fs = System.IO.File.OpenRead(file.Filename))
                     {
-                        fs.Read(buf, 0, buf.Length);
+                        Duplicati.Library.Utility.Utility.ForceStreamRead(fs, buf, buf.Length);
 
                         fs.Position = 0;
                         if (buf[0] == 'A' && buf[1] == 'E' && buf[2] == 'S')


### PR DESCRIPTION
A call to `Stream.Read` can theoretically read just a single byte.  While local file and memory streams will likely read as many bytes as requested, it is not guaranteed.  As such, we should use the `Utility.ForceStreamRead` method in cases where a `Stream` should be read until it is exhausted, or a maximum number of bytes has been read.

We also added some unit tests to verify the behavior of the `Utility.ForceStreamRead` method.
