### PR TITLE
Fix : improved error handling for insufficient permissions on source folders

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -110,165 +110,6 @@ namespace Duplicati.Library.Main
                 m_messageSink = new MultiMessageSink(m_messageSink, sink);
         }
 
-        /// <summary>
-        /// Helper method that expands the users chosen source input paths,
-        /// and removes duplicate paths
-        /// </summary>
-        /// <returns>The expanded and filtered sources.</returns>
-        /// <param name="inputsources">The paths to use.</param>
-        public string[] ExpandInputSources(string[] inputsources, IFilter filter)
-        {
-            if (inputsources == null || inputsources.Length == 0)
-                throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.NoSourceFoldersError, "NoSourceFolders");
-
-            var sources = new List<string>(inputsources.Length);
-
-            System.IO.DriveInfo[] drives = null;
-
-            //Make sure they all have the same format and exist
-            foreach(var inputsource in inputsources)
-            {
-                List<string> expandedSources = new List<string>();
-
-                if (Library.Utility.Utility.IsClientWindows && (inputsource.StartsWith("*:", StringComparison.Ordinal) || inputsource.StartsWith("?:", StringComparison.Ordinal)))
-                {
-                    // *: drive paths are only supported on Windows clients
-                    // Lazily load the drive info
-                    drives = drives ?? System.IO.DriveInfo.GetDrives();
-
-                    // Replace the drive letter with each available drive
-                    string sourcePath = inputsource.Substring(1);
-                    foreach (System.IO.DriveInfo drive in drives)
-                    {
-                        string expandedSource = drive.Name[0] + sourcePath;
-                        Logging.Log.WriteVerboseMessage(LOGTAG, "AddingSourcePathFromWildcard", @"Adding source path ""{0}"" due to wildcard source path ""{1}""", expandedSource, inputsource);
-                        expandedSources.Add(expandedSource);
-                    }
-                }
-                else if (Library.Utility.Utility.IsClientWindows && inputsource.StartsWith(@"\\?\Volume{", StringComparison.OrdinalIgnoreCase))
-                {
-                    // In order to specify a drive by it's volume name, adopt the volume guid path syntax:
-                    //   \\?\Volume{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
-                    // The volume guid can be found using the 'mountvol' commandline tool.
-                    // However, instead of using this path with Windows APIs directory, it is adapted here to a standard path.
-                    Guid volumeGuid;
-                    if (Guid.TryParse(inputsource.Substring(@"\\?\Volume{".Length, @"XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".Length), out volumeGuid))
-                    {
-                        string driveLetter = Library.Utility.Utility.GetDriveLetterFromVolumeGuid(volumeGuid);
-                        if (!string.IsNullOrEmpty(driveLetter))
-                        {
-                            string expandedSource = driveLetter + inputsource.Substring(@"\\?\Volume{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}".Length);
-                            Logging.Log.WriteVerboseMessage(LOGTAG, "AddingSourceFromGuid", @"Adding source path ""{0}"" in place of volume guid source path ""{1}""", expandedSource, inputsource);
-                            expandedSources.Add(expandedSource);
-                        }
-                        else
-                        {
-                            // If we aren't allow to have missing sources, throw an exception indicating we couldn't find a drive where this volume is mounted
-                            if (!m_options.AllowMissingSource)
-                                throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.SourceVolumeNameNotFoundError(inputsource, volumeGuid), "MissingSourceFolder");
-                        }
-                    }
-                    else
-                    {
-                        // If we aren't allow to have missing sources, throw an exception indicating we couldn't find this volume
-                        if (!m_options.AllowMissingSource)
-                            throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.SourceVolumeNameInvalidError(inputsource), "SourceVolumeNameInvalid");
-                    }
-                }
-                else
-                {
-                    expandedSources.Add(inputsource);
-                }
-
-                bool foundAnyPaths = false;
-                bool insufficientPermissions = false;
-                foreach (string expandedSource in expandedSources)
-                {
-                    string source;
-                    try
-                    {
-                        source = System.IO.Path.GetFullPath(expandedSource);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Note that we use the original source (with the *) in the error
-                        throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.InvalidPathError(expandedSource, ex.Message), "InputSourceInvalid", ex);
-                    }
-
-                    var fi = new System.IO.FileInfo(source);
-                    var di = new System.IO.DirectoryInfo(source);
-                    if (fi.Exists || di.Exists)
-                    {
-                        foundAnyPaths = true;
-
-                        if (!fi.Exists)
-                            source = Library.Utility.Utility.AppendDirSeparator(source);
-
-                        sources.Add(source);
-                    } else {
-                        try
-                        {
-                            // Try to get attributes. Returns -1 if source doesn't exist, otherwise throws an exception.
-                            // In this case, it is irrelevant to use fileinfo or directoryinfo to retrieve attributes.
-                            var attributes = fi.Attributes;
-                        } catch (UnauthorizedAccessException ex) {
-                            Logging.Log.WriteWarningMessage(LOGTAG, "AddingSourceFolder", 
-                                                            ex, @"Insufficient permissions to read ""{0}"", skipping", expandedSource);
-                            insufficientPermissions = true;
-                        }
-                    }
-                }
-
-                // If no paths were found, and we aren't allowed to have missing sources, throw an error
-                if (!foundAnyPaths && !m_options.AllowMissingSource)
-                {
-                    if (insufficientPermissions) {
-                        throw new System.IO.IOException(Strings.Controller.SourceUnauthorizedError(inputsource));
-                    }
-
-                    throw new System.IO.IOException(Strings.Controller.SourceIsMissingError(inputsource));
-                }
-            }
-
-            //Sanity check for duplicate files/folders
-            ISet<string> pathDuplicates;
-            sources = Library.Utility.Utility.GetUniqueItems(sources, Library.Utility.Utility.ClientFilenameStringComparer, out pathDuplicates).OrderBy(a => a).ToList();
-
-            foreach (var pathDuplicate in pathDuplicates)
-                Logging.Log.WriteVerboseMessage(LOGTAG, "RemoveDuplicateSource", "Removing duplicate source: {0}", pathDuplicate);
-
-            //Sanity check for multiple inclusions of the same folder
-            for (int i = 0; i < sources.Count; i++)
-                for (int j = 0; j < sources.Count; j++)
-                    if (i != j && sources[i].StartsWith(sources[j], Library.Utility.Utility.ClientFilenameStringComparison) && sources[i].EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), Library.Utility.Utility.ClientFilenameStringComparison))
-                    {
-                        if (filter != null)
-                        {
-                            bool includes;
-                            bool excludes;
-
-                            FilterExpression.AnalyzeFilters(filter, out includes, out excludes);
-
-                            // If there are no excludes, there is no need to keep the folder as a filter
-                            if (excludes)
-                            {
-                                Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingSubfolderSource", "Removing source \"{0}\" because it is a subfolder of \"{1}\", and using it as an include filter", sources[i], sources[j]);
-                                filter = Library.Utility.JoinedFilterExpression.Join(new FilterExpression(sources[i]), filter);
-                            }
-                            else
-                                Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingSubfolderSource", "Removing source \"{0}\" because it is a subfolder or subfile of \"{1}\"", sources[i], sources[j]);
-                        }
-                        else
-                            Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingSubfolderSource", "Removing source \"{0}\" because it is a subfolder or subfile of \"{1}\"", sources[i], sources[j]);
-
-                        sources.RemoveAt(i);
-                        i--;
-                        break;
-                    }
-
-            return sources.ToArray();
-        }
-
         public Duplicati.Library.Interface.IBackupResults Backup(string[] inputsources, IFilter filter = null)
         {
             Library.UsageReporter.Reporter.Report("USE_BACKEND", new Library.Utility.Uri(m_backend).Scheme);
@@ -984,13 +825,176 @@ namespace Duplicati.Library.Main
         }
 
         /// <summary>
+        /// Helper method that expands the users chosen source input paths,
+        /// and removes duplicate paths
+        /// </summary>
+        /// <returns>The expanded and filtered sources.</returns>
+        private string[] ExpandInputSources(string[] inputsources, IFilter filter)
+        {
+            if (inputsources == null || inputsources.Length == 0)
+                throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.NoSourceFoldersError, "NoSourceFolders");
+
+            var sources = new List<string>(inputsources.Length);
+
+            System.IO.DriveInfo[] drives = null;
+
+            //Make sure they all have the same format and exist
+            foreach (var inputsource in inputsources)
+            {
+                List<string> expandedSources = new List<string>();
+
+                if (Library.Utility.Utility.IsClientWindows && (inputsource.StartsWith("*:", StringComparison.Ordinal) || inputsource.StartsWith("?:", StringComparison.Ordinal)))
+                {
+                    // *: drive paths are only supported on Windows clients
+                    // Lazily load the drive info
+                    drives = drives ?? System.IO.DriveInfo.GetDrives();
+
+                    // Replace the drive letter with each available drive
+                    string sourcePath = inputsource.Substring(1);
+                    foreach (System.IO.DriveInfo drive in drives)
+                    {
+                        string expandedSource = drive.Name[0] + sourcePath;
+                        Logging.Log.WriteVerboseMessage(LOGTAG, "AddingSourcePathFromWildcard", @"Adding source path ""{0}"" due to wildcard source path ""{1}""", expandedSource, inputsource);
+                        expandedSources.Add(expandedSource);
+                    }
+                }
+                else if (Library.Utility.Utility.IsClientWindows && inputsource.StartsWith(@"\\?\Volume{", StringComparison.OrdinalIgnoreCase))
+                {
+                    // In order to specify a drive by it's volume name, adopt the volume guid path syntax:
+                    //   \\?\Volume{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
+                    // The volume guid can be found using the 'mountvol' commandline tool.
+                    // However, instead of using this path with Windows APIs directory, it is adapted here to a standard path.
+                    Guid volumeGuid;
+                    if (Guid.TryParse(inputsource.Substring(@"\\?\Volume{".Length, @"XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".Length), out volumeGuid))
+                    {
+                        string driveLetter = Library.Utility.Utility.GetDriveLetterFromVolumeGuid(volumeGuid);
+                        if (!string.IsNullOrEmpty(driveLetter))
+                        {
+                            string expandedSource = driveLetter + inputsource.Substring(@"\\?\Volume{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}".Length);
+                            Logging.Log.WriteVerboseMessage(LOGTAG, "AddingSourceFromGuid", @"Adding source path ""{0}"" in place of volume guid source path ""{1}""", expandedSource, inputsource);
+                            expandedSources.Add(expandedSource);
+                        }
+                        else
+                        {
+                            // If we aren't allow to have missing sources, throw an exception indicating we couldn't find a drive where this volume is mounted
+                            if (!m_options.AllowMissingSource)
+                                throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.SourceVolumeNameNotFoundError(inputsource, volumeGuid), "MissingSourceFolder");
+                        }
+                    }
+                    else
+                    {
+                        // If we aren't allow to have missing sources, throw an exception indicating we couldn't find this volume
+                        if (!m_options.AllowMissingSource)
+                            throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.SourceVolumeNameInvalidError(inputsource), "SourceVolumeNameInvalid");
+                    }
+                }
+                else
+                {
+                    expandedSources.Add(inputsource);
+                }
+
+                bool foundAnyPaths = false;
+                bool insufficientPermissions = false;
+                foreach (string expandedSource in expandedSources)
+                {
+                    string source;
+                    try
+                    {
+                        source = System.IO.Path.GetFullPath(expandedSource);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Note that we use the original source (with the *) in the error
+                        throw new Duplicati.Library.Interface.UserInformationException(Strings.Controller.InvalidPathError(expandedSource, ex.Message), "InputSourceInvalid", ex);
+                    }
+
+                    var fi = new System.IO.FileInfo(source);
+                    var di = new System.IO.DirectoryInfo(source);
+                    if (fi.Exists || di.Exists)
+                    {
+                        foundAnyPaths = true;
+
+                        if (!fi.Exists)
+                            source = Library.Utility.Utility.AppendDirSeparator(source);
+
+                        sources.Add(source);
+                    }
+                    else
+                    {
+                        try
+                        {
+                            // Try to get attributes. Returns -1 if source doesn't exist, otherwise throws an exception.
+                            // In this case, it is irrelevant to use fileinfo or directoryinfo to retrieve attributes.
+                            var attributes = fi.Attributes;
+                        }
+                        catch (UnauthorizedAccessException ex)
+                        {
+                            Logging.Log.WriteWarningMessage(LOGTAG, "AddingSourceFolder",
+                                                            ex, @"Insufficient permissions to read ""{0}"", skipping", expandedSource);
+                            insufficientPermissions = true;
+                        }
+                    }
+                }
+
+                // If no paths were found, and we aren't allowed to have missing sources, throw an error
+                if (!foundAnyPaths && !m_options.AllowMissingSource)
+                {
+                    if (insufficientPermissions)
+                    {
+                        throw new System.IO.IOException(Strings.Controller.SourceUnauthorizedError(inputsource));
+                    }
+
+                    throw new System.IO.IOException(Strings.Controller.SourceIsMissingError(inputsource));
+                }
+            }
+
+            //Sanity check for duplicate files/folders
+            ISet<string> pathDuplicates;
+            sources = Library.Utility.Utility.GetUniqueItems(sources, Library.Utility.Utility.ClientFilenameStringComparer, out pathDuplicates).OrderBy(a => a).ToList();
+
+            foreach (var pathDuplicate in pathDuplicates)
+                Logging.Log.WriteVerboseMessage(LOGTAG, "RemoveDuplicateSource", "Removing duplicate source: {0}", pathDuplicate);
+
+            //Sanity check for multiple inclusions of the same folder
+            for (int i = 0; i < sources.Count; i++)
+                for (int j = 0; j < sources.Count; j++)
+                    if (i != j && sources[i].StartsWith(sources[j], Library.Utility.Utility.ClientFilenameStringComparison) && sources[i].EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), Library.Utility.Utility.ClientFilenameStringComparison))
+                    {
+                        if (filter != null)
+                        {
+                            bool includes;
+                            bool excludes;
+
+                            FilterExpression.AnalyzeFilters(filter, out includes, out excludes);
+
+                            // If there are no excludes, there is no need to keep the folder as a filter
+                            if (excludes)
+                            {
+                                Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingSubfolderSource", "Removing source \"{0}\" because it is a subfolder of \"{1}\", and using it as an include filter", sources[i], sources[j]);
+                                filter = Library.Utility.JoinedFilterExpression.Join(new FilterExpression(sources[i]), filter);
+                            }
+                            else
+                                Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingSubfolderSource", "Removing source \"{0}\" because it is a subfolder or subfile of \"{1}\"", sources[i], sources[j]);
+                        }
+                        else
+                            Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingSubfolderSource", "Removing source \"{0}\" because it is a subfolder or subfile of \"{1}\"", sources[i], sources[j]);
+
+                        sources.RemoveAt(i);
+                        i--;
+                        break;
+                    }
+
+            return sources.ToArray();
+        }
+
+        /// <summary>
         /// Checks if the value passed to an option is actually valid.
         /// </summary>
         /// <param name="arg">The argument being validated</param>
         /// <param name="optionname">The name of the option to validate</param>
         /// <param name="value">The value to check</param>
         /// <returns>Null if no errors are found, an error message otherwise</returns>
-        public static string ValidateOptionValue(Library.Interface.ICommandLineArgument arg, string optionname, string value)
+        private static string ValidateOptionValue(Library.Interface.ICommandLineArgument arg, string optionname, string value)
         {
             if (arg.Type == Duplicati.Library.Interface.CommandLineArgument.ArgumentType.Enumeration)
             {

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -11,6 +11,7 @@ namespace Duplicati.Library.Main.Strings
         public static string DuplicateOptionNameWarning(string optionname) { return LC.L(@"The option --{0} exists more than once, please report this to the developers", optionname); }
         public static string NoSourceFoldersError { get { return LC.L(@"No source folders specified for backup"); } }
         public static string SourceIsMissingError(string foldername) { return LC.L(@"The source folder {0} does not exist, aborting backup", foldername); }
+        public static string SourceUnauthorizedError(string foldername) { return LC.L(@"Unauthorized to access source folder {0}, aborting backup", foldername); }
         public static string UnsupportedBooleanValue(string optionname, string value) { return LC.L(@"The value ""{1}"" supplied to --{0} does not parse into a valid boolean, this will be treated as if it was set to ""true""", optionname, value); }
         public static string UnsupportedEnumerationValue(string optionname, string value, string[] values) { return LC.L(@"The option --{0} does not support the value ""{1}"", supported values are: {2}", optionname, value, string.Join(", ", values)); }
         public static string UnsupportedFlagsValue(string optionname, string value, string[] values) { return LC.L(@"The option --{0} does not support the value ""{1}"", supported flag values are: {2}", optionname, value, string.Join(", ", values)); }


### PR DESCRIPTION
See https://github.com/duplicati/duplicati/issues/3261 .
The System.Io.Fileinfo/DirectoryInfo.Exist call returns false also in case of insufficient permissions, which is confusing to the user.