### PR TITLE
Fix - Console.ReadKey for encryption passphrase

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -1106,10 +1106,7 @@ namespace Duplicati.Library.AutoUpdater
                 {
                     CreateNoWindow = true,
                     UseShellExecute = false,
-                    RedirectStandardError = true,
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    ErrorDialog = false,
+                    ErrorDialog = false
                 };
                 pi.EnvironmentVariables.Clear();
 
@@ -1122,14 +1119,7 @@ namespace Duplicati.Library.AutoUpdater
                 pi.EnvironmentVariables["LOCALIZATION_FOLDER"] = InstalledBaseDir;
 
                 var proc = System.Diagnostics.Process.Start(pi);
-                var tasks = Task.WhenAll(
-                    Console.OpenStandardInput().CopyToAsync(proc.StandardInput.BaseStream),
-                    proc.StandardOutput.BaseStream.CopyToAsync(Console.OpenStandardOutput()),
-                    proc.StandardError.BaseStream.CopyToAsync(Console.OpenStandardError())
-                );
-
                 proc.WaitForExit();
-                tasks.Wait(1000);
 
                 if (proc.ExitCode != MAGIC_EXIT_CODE)
                     return proc.ExitCode;

--- a/Duplicati/Library/Encryption/GPGEncryption.cs
+++ b/Duplicati/Library/Encryption/GPGEncryption.cs
@@ -224,15 +224,17 @@ namespace Duplicati.Library.Encryption
         /// <param name="input">The input stream</param>
         private System.IO.Stream Execute(string args, System.IO.Stream input, bool encrypt)
         {
-            System.Diagnostics.ProcessStartInfo psi = new System.Diagnostics.ProcessStartInfo();
-            psi.Arguments = args;
-            psi.CreateNoWindow = true;
-            psi.FileName = m_programpath;
-            psi.RedirectStandardError = true;
-            psi.RedirectStandardInput = true;
-            psi.RedirectStandardOutput = true;
-            psi.UseShellExecute = false;
-            psi.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                Arguments = args,
+                CreateNoWindow = true,
+                FileName = m_programpath,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden
+            };
 
 #if DEBUG
             psi.CreateNoWindow = false;

--- a/Duplicati/Library/Main/ProcessController.cs
+++ b/Duplicati/Library/Main/ProcessController.cs
@@ -115,9 +115,13 @@ namespace Duplicati.Library.Main
                 try
                 {
                     // -s prevents sleep on AC, -i prevents sleep generally
-                    var psi = new System.Diagnostics.ProcessStartInfo("caffeinate", "-s");
-                    psi.RedirectStandardInput = true;
-                    psi.UseShellExecute = false;
+                    var psi = new System.Diagnostics.ProcessStartInfo("caffeinate", "-s")
+                    {
+                        RedirectStandardInput = true,
+                        RedirectStandardError = false,
+                        RedirectStandardOutput = false,
+                        UseShellExecute = false
+                    };
                     m_caffeinate = System.Diagnostics.Process.Start(psi);
                     m_runningSleepPrevention = true;
                 }
@@ -380,10 +384,13 @@ namespace Duplicati.Library.Main
         /// <param name="arguments">The commandline arguments.</param>
         private static Tuple<int, string, string> RunProcessAndGetResult(string filename, string arguments)
         {
-            var psi = new System.Diagnostics.ProcessStartInfo(filename, arguments);
-            psi.RedirectStandardOutput = true;
-            psi.RedirectStandardError = true;
-            psi.UseShellExecute = false;
+            var psi = new System.Diagnostics.ProcessStartInfo(filename, arguments)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = false,
+                UseShellExecute = false
+            };
 
             Logging.Log.WriteExplicitMessage(LOGTAG, "RunningCommand", null, "Running: {0} {1}", filename, arguments);
 

--- a/Duplicati/Library/Modules/Builtin/CheckMonoSSL.cs
+++ b/Duplicati/Library/Modules/Builtin/CheckMonoSSL.cs
@@ -129,8 +129,10 @@ namespace Duplicati.Library.Modules.Builtin
                     try
                     {
                         var path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "mozroots.exe");
-                        var pi = new System.Diagnostics.ProcessStartInfo(path, "--import --sync --quiet");
-                        pi.UseShellExecute = false;
+                        var pi = new System.Diagnostics.ProcessStartInfo(path, "--import --sync --quiet")
+                        {
+                            UseShellExecute = false
+                        };
                         var p = System.Diagnostics.Process.Start(pi);
                         p.WaitForExit((int)TimeSpan.FromMinutes(5).TotalMilliseconds);
                     }

--- a/Duplicati/Library/Modules/Builtin/RunScript.cs
+++ b/Duplicati/Library/Modules/Builtin/RunScript.cs
@@ -199,14 +199,17 @@ namespace Duplicati.Library.Modules.Builtin
         {
             try
             {
-                System.Diagnostics.ProcessStartInfo psi = new System.Diagnostics.ProcessStartInfo(scriptpath);
-                psi.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
-                psi.CreateNoWindow = true;
-                psi.UseShellExecute = false;
-                psi.RedirectStandardOutput = true;
-                psi.RedirectStandardError = true;
+                System.Diagnostics.ProcessStartInfo psi = new System.Diagnostics.ProcessStartInfo(scriptpath)
+                {
+                    WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    RedirectStandardInput = false
+                };
 
-                foreach(KeyValuePair<string, string> kv in options)
+                foreach (KeyValuePair<string, string> kv in options)
                     psi.EnvironmentVariables["DUPLICATI__" + kv.Key.Replace('-', '_')] = kv.Value;
 
                 if (!options.ContainsKey("backup-name"))

--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -226,6 +226,7 @@ namespace Duplicati.Library.Snapshots
                     CreateNoWindow = true,
                     RedirectStandardError = true,
                     RedirectStandardOutput = true,
+                    RedirectStandardInput = false,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     UseShellExecute = false
                 };

--- a/Duplicati/Library/UsageReporter/OSInfoHelper.cs
+++ b/Duplicati/Library/UsageReporter/OSInfoHelper.cs
@@ -36,10 +36,13 @@ namespace Duplicati.Library.UsageReporter
             System.Diagnostics.Process pi = null;
             try
             {
-                var psi = new System.Diagnostics.ProcessStartInfo(cmd, args);
-                psi.RedirectStandardOutput = true;
-                psi.RedirectStandardError = true; // Suppress error messages
-                psi.UseShellExecute = false;
+                var psi = new System.Diagnostics.ProcessStartInfo(cmd, args)
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true, // Suppress error messages
+                    RedirectStandardInput = false,
+                    UseShellExecute = false
+                };
 
                 pi = System.Diagnostics.Process.Start(psi);
                 pi.WaitForExit(5000);

--- a/Duplicati/Library/Utility/Power/MacOSPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/MacOSPowerSupplyState.cs
@@ -38,9 +38,13 @@ namespace Duplicati.Library.Utility.Power
         {
             try
             {
-                var psi = new System.Diagnostics.ProcessStartInfo("pmset", "-g batt");
-                psi.RedirectStandardOutput = true;
-                psi.UseShellExecute = false;
+                var psi = new System.Diagnostics.ProcessStartInfo("pmset", "-g batt")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardInput = false,
+                    RedirectStandardError = false,
+                    UseShellExecute = false
+                };
 
                 var pi = System.Diagnostics.Process.Start(psi);
                 pi.WaitForExit(1000);
@@ -71,9 +75,13 @@ namespace Duplicati.Library.Utility.Power
         {
             try
             {
-                var psi = new System.Diagnostics.ProcessStartInfo("ioreg", "-n AppleSmartBattery -r");
-                psi.RedirectStandardOutput = true;
-                psi.UseShellExecute = false;
+                var psi = new System.Diagnostics.ProcessStartInfo("ioreg", "-n AppleSmartBattery -r")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = false,
+                    RedirectStandardInput = false,
+                    UseShellExecute = false
+                };
 
                 var pi = System.Diagnostics.Process.Start(psi);
                 pi.WaitForExit(1000);

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -872,9 +872,13 @@ namespace Duplicati.Library.Utility
 
             try
             {
-                var psi = new System.Diagnostics.ProcessStartInfo("which", appname);
-                psi.RedirectStandardOutput = true;
-                psi.UseShellExecute = false;
+                var psi = new System.Diagnostics.ProcessStartInfo("which", appname)
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = false,
+                    RedirectStandardInput = false,
+                    UseShellExecute = false
+                };
 
                 var pi = System.Diagnostics.Process.Start(psi);
                 pi.WaitForExit(5000);
@@ -912,6 +916,8 @@ namespace Duplicati.Library.Utility
                         var psi = new System.Diagnostics.ProcessStartInfo("uname")
                         {
                             RedirectStandardOutput = true,
+                            RedirectStandardInput = false,
+                            RedirectStandardError = false,
                             UseShellExecute = false
                         };
 
@@ -941,9 +947,13 @@ namespace Duplicati.Library.Utility
 
                 try
                 {
-                    var psi = new System.Diagnostics.ProcessStartInfo("uname", "-a");
-                    psi.RedirectStandardOutput = true;
-                    psi.UseShellExecute = false;
+                    var psi = new System.Diagnostics.ProcessStartInfo("uname", "-a")
+                    {
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = false,
+                        RedirectStandardInput = false,
+                        UseShellExecute = false
+                    };
 
                     var pi = System.Diagnostics.Process.Start(psi);
                     pi.WaitForExit(5000);

--- a/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
@@ -237,7 +237,8 @@ namespace Duplicati.Server.WebServer
                 Arguments = shell ? null : args,
                 UseShellExecute = false,
                 RedirectStandardInput = shell,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                RedirectStandardError = false
             };
 
             if (env != null)

--- a/Duplicati/Service/Runner.cs
+++ b/Duplicati/Service/Runner.cs
@@ -80,11 +80,14 @@ namespace Duplicati.Service
 
                         m_reportMessage(string.Format("Starting process {0} with cmd args {1}", exec, cmdargs), false);
 
-                        var pr = new System.Diagnostics.ProcessStartInfo(exec, cmdargs);
-                        pr.UseShellExecute = false;
-                        pr.RedirectStandardInput = true;
-                        pr.RedirectStandardOutput = true;
-                        pr.WorkingDirectory = path;
+                        var pr = new System.Diagnostics.ProcessStartInfo(exec, cmdargs)
+                        {
+                            UseShellExecute = false,
+                            RedirectStandardInput = true,
+                            RedirectStandardOutput = true,
+                            RedirectStandardError = false,
+                            WorkingDirectory = path
+                        };
 
                         if (!m_terminate)
                             m_process = System.Diagnostics.Process.Start(pr);


### PR DESCRIPTION
See https://github.com/duplicati/duplicati/issues/3245 .

Before, the update manager didn't share the console with the actual duplicati process properly, preventing Console.ReadKey for the encryption passphrase to be processed.

Made other places with standard stream redirecting more explicit. I didn't see immediate problems here but please double check if no similar issues can arise here.