### PR TITLE
Avoid null reference exceptions with Box.com backend

### DIFF
--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -40,7 +40,7 @@ namespace Duplicati.Library.Backend.Box
         private readonly bool m_deleteFromTrash;
 
         private string m_currentfolder;
-        private Dictionary<string, string> m_filecache;
+        private readonly Dictionary<string, string> m_filecache = new Dictionary<string, string>();
 
         private class BoxHelper : OAuthHelper
         {
@@ -144,13 +144,13 @@ namespace Duplicati.Library.Backend.Box
 
         private string GetFileID(string name)
         {
-            if (m_filecache != null && m_filecache.ContainsKey(name))
+            if (m_filecache.ContainsKey(name))
                 return m_filecache[name];
 
-            // Make sure we enumerate this, otherwise the m_filecache is not assigned
+            // Make sure we enumerate this, otherwise the m_filecache is empty.
             PagedFileListResponse(CurrentFolder, false).LastOrDefault();
 
-            if (m_filecache != null && m_filecache.ContainsKey(name))
+            if (m_filecache.ContainsKey(name))
                 return m_filecache[name];
 
             throw new FileMissingException();
@@ -162,9 +162,8 @@ namespace Duplicati.Library.Backend.Box
             var done = false;
 
             if (!onlyfolders)
-                m_filecache = null;
+                m_filecache.Clear();
             
-            var cache = onlyfolders ? null : new Dictionary<string, string>();
             do
             {
                 var resp = m_oauth.GetJSONData<ShortListResponse>(string.Format("{0}/folders/{1}/items?limit={2}&offset={3}&fields=name,size,modified_at", BOX_API_URL, parentid, PAGE_SIZE, offset));
@@ -182,7 +181,7 @@ namespace Duplicati.Library.Backend.Box
                     else
                     {
                         if (!onlyfolders && f.Type == "file")
-                            cache[f.Name] = f.ID;
+                            m_filecache[f.Name] = f.ID;
                         
                         yield return f;
                     }
@@ -194,9 +193,6 @@ namespace Duplicati.Library.Backend.Box
                     break;
 
             } while(!done);
-
-            if (!onlyfolders)
-                m_filecache = cache;
         }
 
         #region IStreamingBackend implementation
@@ -210,7 +206,7 @@ namespace Duplicati.Library.Backend.Box
                 }
             };
 
-            if (m_filecache == null)
+            if (m_filecache.Count == 0)
                 PagedFileListResponse(CurrentFolder, false);
 
             var existing = m_filecache.ContainsKey(remotename);
@@ -239,7 +235,7 @@ namespace Duplicati.Library.Backend.Box
             }
             catch
             {
-                m_filecache = null;
+                m_filecache.Clear();
                 throw;
             }
         }
@@ -290,7 +286,7 @@ namespace Duplicati.Library.Backend.Box
             }
             catch
             {
-                m_filecache = null;
+                m_filecache.Clear();
                 throw;
             }
         }


### PR DESCRIPTION
This fixes an issue in the `BoxBackend` class, where a reference to a `Dictionary` was being assigned to `null` in several places.  By clearing the `Dictionary` instead, we avoid encountering null reference exceptions when performing concurrent operations.

This addresses issue #3276, and possibly issue #3062.