### PR TITLE
Fix/sqlite file permissions

### DIFF
--- a/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
+++ b/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
@@ -182,7 +182,7 @@ namespace Duplicati.Library.SQLiteHelper
         /// </summary>
         /// <param name="connection">The database connection to use</param>
         /// <param name="sourcefile">The file the database is placed in</param>
-        public static void UpgradeDatabase(IDbConnection connection, string sourcefile, string schema, IList<string> versions)
+        private static void UpgradeDatabase(IDbConnection connection, string sourcefile, string schema, IList<string> versions)
         {
             if (connection.State != ConnectionState.Open)
             {

--- a/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
+++ b/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="Mono.Posix" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DBSchemaUpgrades\DbUpgradesRegistry.cs" />

--- a/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
+++ b/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
@@ -33,7 +33,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <DefineConstants>_NOTWINDOWS</DefineConstants>
+    <DefineConstants>_NOT_WINDOWS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
+++ b/Duplicati/Library/SQLiteHelper/Duplicati.Library.SQLiteHelper.csproj
@@ -32,9 +32,14 @@
     <ConsolePause>false</ConsolePause>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <DefineConstants>_NOTWINDOWS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
     <Reference Include="Mono.Posix" />
   </ItemGroup>
   <ItemGroup>

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -25,10 +25,10 @@ namespace Duplicati.Library.SQLiteHelper
 {
     public static class SQLiteLoader
     {
-		/// <summary>
+        /// <summary>
         /// The tag used for logging
         /// </summary>
-		private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(SQLiteLoader));
+        private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(SQLiteLoader));
 
         /// <summary>
         /// A cached copy of the type
@@ -44,7 +44,7 @@ namespace Duplicati.Library.SQLiteHelper
         /// <param name="password">Encryption password</param>
         public static void OpenDatabase(System.Data.IDbConnection con, string DatabasePath, bool useDatabaseEncryption, string password)
         {
-            System.Reflection.MethodInfo setPwdMethod = con.GetType().GetMethod("SetPassword", new [] { typeof(string) });
+            System.Reflection.MethodInfo setPwdMethod = con.GetType().GetMethod("SetPassword", new[] { typeof(string) });
             string attemptedPassword;
 
             if (!useDatabaseEncryption || string.IsNullOrEmpty(password))
@@ -91,7 +91,7 @@ namespace Duplicati.Library.SQLiteHelper
                     throw; //Report original error
 
                 //The open method succeeded with the non-default method, now change the password
-                System.Reflection.MethodInfo changePwdMethod = con.GetType().GetMethod("ChangePassword", new [] { typeof(string) });
+                System.Reflection.MethodInfo changePwdMethod = con.GetType().GetMethod("ChangePassword", new[] { typeof(string) });
                 changePwdMethod.Invoke(con, new object[] { useDatabaseEncryption ? password : null });
             }
         }
@@ -150,7 +150,7 @@ namespace Duplicati.Library.SQLiteHelper
                 System.Environment.SetEnvironmentVariable("SQLITE_TMPDIR", prev);
             }
 
-            
+
             return con;
         }
 
@@ -194,16 +194,18 @@ namespace Duplicati.Library.SQLiteHelper
                             catch { }
                         }
 
-                    } else {
+                    }
+                    else
+                    {
                         //On Mono, we try to find the Mono version of SQLite
-                        
+
                         //This secret environment variable can be used to support older installations
                         var envvalue = System.Environment.GetEnvironmentVariable("DISABLE_MONO_DATA_SQLITE");
                         if (!Utility.Utility.ParseBool(envvalue, envvalue != null))
                         {
-                            foreach(var asmversion in new string[] {"4.0.0.0", "2.0.0.0"})
+                            foreach (var asmversion in new string[] { "4.0.0.0", "2.0.0.0" })
                             {
-                                try 
+                                try
                                 {
                                     Type t = System.Reflection.Assembly.Load(string.Format("Mono.Data.Sqlite, Version={0}, Culture=neutral, PublicKeyToken=0738eb9f132ed756", asmversion)).GetType("Mono.Data.Sqlite.SqliteConnection");
                                     if (t != null && t.GetInterface("System.Data.IDbConnection", false) != null)
@@ -215,12 +217,14 @@ namespace Duplicati.Library.SQLiteHelper
                                             return m_type;
                                         }
                                     }
-                                    
-                                } catch {
+
+                                }
+                                catch
+                                {
                                 }
                             }
 
-							Logging.Log.WriteVerboseMessage(LOGTAG, "FailedToLoadSQLite", "Failed to load Mono.Data.Sqlite.SqliteConnection, reverting to built-in.");
+                            Logging.Log.WriteVerboseMessage(LOGTAG, "FailedToLoadSQLite", "Failed to load Mono.Data.Sqlite.SqliteConnection, reverting to built-in.");
                         }
                     }
 
@@ -235,15 +239,13 @@ namespace Duplicati.Library.SQLiteHelper
         {
             con.ConnectionString = "Data Source=" + path;
             con.Open();
-            SecureDatabasePermissions(path);
-        }
 
-        private static void SecureDatabasePermissions(string path)
-        {
+            #if _NOTWINDOWS
             if (!Library.Utility.Utility.IsClientWindows)
             {
                 Mono.Unix.Native.Syscall.chmod(path, Mono.Unix.Native.FilePermissions.S_IRUSR | Mono.Unix.Native.FilePermissions.S_IWUSR);
             }
+            #endif
         }
 
         private static void TestSQLiteFile(System.Data.IDbConnection con)

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -36,6 +36,76 @@ namespace Duplicati.Library.SQLiteHelper
         private static Type m_type = null;
 
         /// <summary>
+        /// Helper method with logic to handle opening a database in possibly encrypted format
+        /// </summary>
+        /// <param name="con">The SQLite connection object</param>
+        /// <param name="useDatabaseEncryption">Specify if database is encrypted</param>
+        /// <param name="password">Encryption password</param>
+        public static void OpenDatabase(System.Data.IDbConnection con, bool useDatabaseEncryption, string password)
+        {
+            System.Reflection.MethodInfo setPwdMethod = con.GetType().GetMethod("SetPassword", new Type[] { typeof(string) });
+            string attemptedPassword;
+
+            if (!useDatabaseEncryption || string.IsNullOrEmpty(password))
+                attemptedPassword = null; //No encryption specified, attempt to open without
+            else
+                attemptedPassword = password; //Encryption specified, attempt to open with
+
+            if (setPwdMethod != null)
+                setPwdMethod.Invoke(con, new object[] { attemptedPassword });
+
+            try
+            {
+                //Attempt to open in preferred state
+                con.Open();
+
+                // Do a dummy query to make sure we have a working db
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "SELECT COUNT(*) FROM SQLITE_MASTER";
+                    cmd.ExecuteScalar();
+                }
+            }
+            catch
+            {
+                try
+                {
+                    //We can't try anything else without a password
+                    if (string.IsNullOrEmpty(password))
+                        throw;
+
+                    //Open failed, now try the reverse
+                    attemptedPassword = attemptedPassword == null ? password : null;
+
+                    con.Close();
+                    if (setPwdMethod != null)
+                        setPwdMethod.Invoke(con, new object[] { attemptedPassword });
+                    con.Open();
+
+                    // Do a dummy query to make sure we have a working db
+                    using (var cmd = con.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT COUNT(*) FROM SQLITE_MASTER";
+                        cmd.ExecuteScalar();
+                    }
+                }
+                catch
+                {
+                    try { con.Close(); }
+                    catch { }
+                }
+
+                //If the db is not open now, it won't open
+                if (con.State != System.Data.ConnectionState.Open)
+                    throw; //Report original error
+
+                //The open method succeeded with the non-default method, now change the password
+                System.Reflection.MethodInfo changePwdMethod = con.GetType().GetMethod("ChangePassword", new Type[] { typeof(string) });
+                changePwdMethod.Invoke(con, new object[] { useDatabaseEncryption ? password : null });
+            }
+        }
+
+        /// <summary>
         /// Loads an SQLite connection instance, optionally setting the tempfolder and opening the the database
         /// </summary>
         /// <returns>The SQLite connection instance.</returns>

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -44,7 +44,7 @@ namespace Duplicati.Library.SQLiteHelper
         /// <param name="password">Encryption password</param>
         public static void OpenDatabase(System.Data.IDbConnection con, string DatabasePath, bool useDatabaseEncryption, string password)
         {
-            System.Reflection.MethodInfo setPwdMethod = con.GetType().GetMethod("SetPassword", new Type[] { typeof(string) });
+            System.Reflection.MethodInfo setPwdMethod = con.GetType().GetMethod("SetPassword", new [] { typeof(string) });
             string attemptedPassword;
 
             if (!useDatabaseEncryption || string.IsNullOrEmpty(password))
@@ -91,7 +91,7 @@ namespace Duplicati.Library.SQLiteHelper
                     throw; //Report original error
 
                 //The open method succeeded with the non-default method, now change the password
-                System.Reflection.MethodInfo changePwdMethod = con.GetType().GetMethod("ChangePassword", new Type[] { typeof(string) });
+                System.Reflection.MethodInfo changePwdMethod = con.GetType().GetMethod("ChangePassword", new [] { typeof(string) });
                 changePwdMethod.Invoke(con, new object[] { useDatabaseEncryption ? password : null });
             }
         }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -596,10 +596,9 @@ namespace Duplicati.Server
 #else
                 var useDatabaseEncryption = !commandlineOptions.ContainsKey("unencrypted-database") || !Library.Utility.Utility.ParseBool(commandlineOptions["unencrypted-database"], true);
 #endif
-                con.ConnectionString = "Data Source=" + DatabasePath;
 
                 //Attempt to open the database, handling any encryption present
-                Duplicati.Library.SQLiteHelper.SQLiteLoader.OpenDatabase(con, useDatabaseEncryption, dbPassword);
+                Duplicati.Library.SQLiteHelper.SQLiteLoader.OpenDatabase(con, DatabasePath, useDatabaseEncryption, dbPassword);
 
                 Duplicati.Library.SQLiteHelper.DatabaseUpgrader.UpgradeDatabase(con, DatabasePath, typeof(Database.Connection));
             }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -599,7 +599,7 @@ namespace Duplicati.Server
                 con.ConnectionString = "Data Source=" + DatabasePath;
 
                 //Attempt to open the database, handling any encryption present
-                OpenDatabase(con, useDatabaseEncryption, dbPassword);
+                Duplicati.Library.SQLiteHelper.SQLiteLoader.OpenDatabase(con, useDatabaseEncryption, dbPassword);
 
                 Duplicati.Library.SQLiteHelper.DatabaseUpgrader.UpgradeDatabase(con, DatabasePath, typeof(Database.Connection));
             }
@@ -692,77 +692,7 @@ namespace Duplicati.Server
 
             StatusEventNotifyer.SignalNewEvent();
         }
-
-        /// <summary>
-        /// Helper method with logic to handle opening a database in possibly encrypted format
-        /// </summary>
-        /// <param name="con">The SQLite connection object</param>
-        /// <param name="useDatabaseEncryption">Specify if database is encrypted</param>
-        /// <param name="password">Encryption password</param>
-        public static void OpenDatabase(System.Data.IDbConnection con, bool useDatabaseEncryption, string password)
-        {
-            System.Reflection.MethodInfo setPwdMethod = con.GetType().GetMethod("SetPassword", new Type[] { typeof(string) });
-            string attemptedPassword;
-
-            if (!useDatabaseEncryption || string.IsNullOrEmpty(password))
-                attemptedPassword = null; //No encryption specified, attempt to open without
-            else
-                attemptedPassword = password; //Encryption specified, attempt to open with
-
-            if (setPwdMethod != null)
-                setPwdMethod.Invoke(con, new object[] { attemptedPassword });
-
-            try
-            {
-                //Attempt to open in preferred state
-                con.Open();
-
-                // Do a dummy query to make sure we have a working db
-                using (var cmd = con.CreateCommand())
-                {
-                    cmd.CommandText = "SELECT COUNT(*) FROM SQLITE_MASTER";
-                    cmd.ExecuteScalar();
-                }
-            }
-            catch
-            {
-                try
-                {
-                    //We can't try anything else without a password
-                    if (string.IsNullOrEmpty(password))
-                        throw;
-
-                    //Open failed, now try the reverse
-                    attemptedPassword = attemptedPassword == null ? password : null;
-
-                    con.Close();
-                    if (setPwdMethod != null)
-                        setPwdMethod.Invoke(con, new object[] { attemptedPassword });
-                    con.Open();
-
-                    // Do a dummy query to make sure we have a working db
-                    using (var cmd = con.CreateCommand())
-                    {
-                        cmd.CommandText = "SELECT COUNT(*) FROM SQLITE_MASTER";
-                        cmd.ExecuteScalar();
-                    }
-                }
-                catch
-                {
-                    try { con.Close(); }
-                    catch { }
-                }
-
-                //If the db is not open now, it won't open
-                if (con.State != System.Data.ConnectionState.Open)
-                    throw; //Report original error
-
-                //The open method succeeded with the non-default method, now change the password
-                System.Reflection.MethodInfo changePwdMethod = con.GetType().GetMethod("ChangePassword", new Type[] { typeof(string) });
-                changePwdMethod.Invoke(con, new object[] { useDatabaseEncryption ? password : null });
-            }
-        }
-
+               
         /// <summary>
         /// Simple method for tracking if the server has crashed
         /// </summary>


### PR DESCRIPTION
See https://github.com/duplicati/duplicati/issues/3278 . Just for Linux (Windows I could add later). By default all sqlite files are created with file permissions 600 (I guess this is enough, if not let me know, maybe group rights have to be elevated in case of technical users duplicati runs with?). If a file already exists, permissions are unchanged. Reason for this is some users might want to alter permissions manually after creation.

Fix is not ideal, nicer would be to do it through SQLite's open. It looks like there is no functionality for this (http://sqlite.1065341.n5.nabble.com/about-default-file-permission-of-SQLite-database-file-td19582.html).