### PR TITLE
Allow tasks to complete on any thread when context is irrelevant

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -213,7 +213,7 @@ namespace Duplicati.GUI.TrayIcon
                         while(true)
                         {
                             var line = await self.Input.ReadAsync();
-                            await stream.WriteLineAsync(line);
+                            await stream.WriteLineAsync(line).ConfigureAwait(false);
                             //Console.WriteLine("Wrote {0}", line);
                         }
                     }
@@ -225,7 +225,7 @@ namespace Duplicati.GUI.TrayIcon
         {
             string line;
             using(stream)
-                while ((line = await stream.ReadLineAsync()) != null)
+                while ((line = await stream.ReadLineAsync().ConfigureAwait(false)) != null)
                 {
                     //Console.WriteLine("Got message: {0}", line);
 

--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
@@ -67,7 +67,7 @@ namespace Duplicati.Library
                 this.PreventAuthentication(request);
             }
 
-            return await this.SendAsync(request);
+            return await this.SendAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Duplicati/Library/Logging/RepeatingLogScope.cs
+++ b/Duplicati/Library/Logging/RepeatingLogScope.cs
@@ -66,7 +66,7 @@ namespace Duplicati.Library.Logging
             var remainingTime = m_maxIdleTime;
             while (!m_completed)
             {
-                await Task.Delay(new TimeSpan(Math.Max(TimeSpan.FromMilliseconds(500).Ticks, remainingTime)));
+                await Task.Delay(new TimeSpan(Math.Max(TimeSpan.FromMilliseconds(500).Ticks, remainingTime))).ConfigureAwait(false);
                 if (m_completed)
                     return;
                 if (m_lastEntry == null)

--- a/Duplicati/Library/Main/Operation/Backup/DataBlock.cs
+++ b/Duplicati/Library/Main/Operation/Backup/DataBlock.cs
@@ -48,7 +48,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                 TaskCompletion = tcs
             });
 
-            var r = await tcs.Task;
+            var r = await tcs.Task.ConfigureAwait(false);
             return r;
         }
     }

--- a/Duplicati/Library/Main/Operation/Backup/MetadataPreProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/MetadataPreProcess.cs
@@ -92,7 +92,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                     }
 
                     // If we only have metadata, stop here
-                    if (await ProcessMetadata(path, attributes, lastwrite, options, snapshot, emptymetadata, database, self.StreamBlockChannel))
+                    if (await ProcessMetadata(path, attributes, lastwrite, options, snapshot, emptymetadata, database, self.StreamBlockChannel).ConfigureAwait(false))
                     {
                         try
                         {
@@ -165,7 +165,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                             metadata["CoreSymlinkTarget"] = symlinkTarget;
 
                         var metahash = Utility.WrapMetadata(metadata, options);
-                        await AddSymlinkToOutputAsync(path, DateTime.UtcNow, metahash, database, streamblockchannel);
+                        await AddSymlinkToOutputAsync(path, DateTime.UtcNow, metahash, database, streamblockchannel).ConfigureAwait(false);
 
                         Logging.Log.WriteVerboseMessage(FILELOGTAG, "StoreSymlink", "Stored symlink {0}", path);
                         // Don't process further
@@ -192,7 +192,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                 }
 
                 Logging.Log.WriteVerboseMessage(FILELOGTAG, "AddDirectory", "Adding directory {0}", path);
-                await AddFolderToOutputAsync(path, lastwrite, metahash, database, streamblockchannel);
+                await AddFolderToOutputAsync(path, lastwrite, metahash, database, streamblockchannel).ConfigureAwait(false);
                 return false;
             }
 
@@ -224,7 +224,7 @@ namespace Duplicati.Library.Main.Operation.Backup
         /// <param name="lastModified">The value of the lastModified timestamp</param>
         private static async Task AddFolderToOutputAsync(string filename, DateTime lastModified, IMetahash meta, BackupDatabase database, IWriteChannel<StreamBlock> streamblockchannel)
         {
-            var metadataid = await AddMetadataToOutputAsync(filename, meta, database, streamblockchannel);
+            var metadataid = await AddMetadataToOutputAsync(filename, meta, database, streamblockchannel).ConfigureAwait(false);
             await database.AddDirectoryEntryAsync(filename, metadataid.Item2, lastModified);
         }
 

--- a/Duplicati/Library/Main/Operation/Backup/StreamBlock.cs
+++ b/Duplicati/Library/Main/Operation/Backup/StreamBlock.cs
@@ -49,7 +49,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                 Result = tcs
             });
 
-            return await tcs.Task;
+            return await tcs.Task.ConfigureAwait(false);
         }
     }
 }

--- a/Duplicati/Library/Main/Operation/Backup/StreamBlockSplitter.cs
+++ b/Duplicati/Library/Main/Operation/Backup/StreamBlockSplitter.cs
@@ -145,7 +145,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 }
 
                                 // Make sure the filehasher is done with the buf instance before we pass it on
-                                await pftask;
+                                await pftask.ConfigureAwait(false);
                                 await DataBlock.AddBlockToOutputAsync(self.BlockOutput, hashkey, buf, 0, lastread, e.Hint, false);
                                 buf = new byte[blocksize];
                             }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -201,7 +201,7 @@ namespace Duplicati.Library.Main.Operation
                     );
                 }
 
-                await all;
+                await all.ConfigureAwait(false);
 
                 if (options.ChangedFilelist != null && options.ChangedFilelist.Length >= 1)
                 {
@@ -354,7 +354,7 @@ namespace Duplicati.Library.Main.Operation
 
             // In case the uploader crashes, we grab the exception here
             if (await Task.WhenAny(uploader, flushReq.LastWriteSizeAync) == uploader)
-                await uploader;
+                await uploader.ConfigureAwait(false);
 
             // Grab the size of the last uploaded volume
             return await flushReq.LastWriteSizeAync;
@@ -477,7 +477,7 @@ namespace Duplicati.Library.Main.Operation
 
                                 // Run the backup operation
                                 if (await m_result.TaskReader.ProgressAsync)
-                                    await RunMainOperation(sources, snapshot, journalService, db, stats, m_options, m_sourceFilter, m_filter, m_result, m_result.TaskReader, lastfilesetid);
+                                    await RunMainOperation(sources, snapshot, journalService, db, stats, m_options, m_sourceFilter, m_filter, m_result, m_result.TaskReader, lastfilesetid).ConfigureAwait(false);
                             }
                             finally
                             {
@@ -496,7 +496,7 @@ namespace Duplicati.Library.Main.Operation
 
                         // Wait for upload completion
                         m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_WaitForUpload);
-                        var lastVolumeSize = await FlushBackend(m_result, uploadtarget, uploader);
+                        var lastVolumeSize = await FlushBackend(m_result, uploadtarget, uploader).ConfigureAwait(false);
 
                         // Make sure we have the database up-to-date
                         await db.CommitTransactionAsync("CommitAfterUpload", false);

--- a/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
+++ b/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.Main.Operation.Common
                     using(var enc = DynamicLoader.EncryptionLoader.GetModule(options.EncryptionModule, options.Passphrase, options.RawOptions))
                         enc.Encrypt(this.LocalFilename, tempfile);
 
-                    await this.DeleteLocalFile();
+                    await this.DeleteLocalFile().ConfigureAwait(false);
 
                     this.LocalTempfile = tempfile;
                     this.Hash = null;
@@ -201,7 +201,7 @@ namespace Duplicati.Library.Main.Operation.Common
 
             return RunRetryOnMain<bool>(fe, async () =>
             {
-                await DoPut(fe);
+                await DoPut(fe).ConfigureAwait(false);
                 m_uploadSuccess = true;
                 return true;
             });
@@ -227,17 +227,17 @@ namespace Duplicati.Library.Main.Operation.Common
                 {
                     await DoWithRetry(fe, async () => {
                         if (fe.IsRetry)
-                            await RenameFileAfterErrorAsync(fe);
+                            await RenameFileAfterErrorAsync(fe).ConfigureAwait(false);
 
                         // Make sure the encryption and hashing has completed
-                        await backgroundhashAndEncrypt;
+                        await backgroundhashAndEncrypt.ConfigureAwait(false);
 
-                        return await DoPut(fe);
-                    });
+                        return await DoPut(fe).ConfigureAwait(false);
+                    }).ConfigureAwait(false);
 
                     if (createIndexFile != null)
                     {
-                        var ix = await createIndexFile(fe.RemoteFilename);
+                        var ix = await createIndexFile(fe.RemoteFilename).ConfigureAwait(false);
                         var indexFile = new FileEntryItem(BackendActionType.Put, ix.RemoteFilename);
                         indexFile.SetLocalfilename(ix.LocalFilename);
 
@@ -245,15 +245,15 @@ namespace Duplicati.Library.Main.Operation.Common
 
                         await DoWithRetry(indexFile, async () => {
                             if (indexFile.IsRetry)
-                                await RenameFileAfterErrorAsync(indexFile);
+                                await RenameFileAfterErrorAsync(indexFile).ConfigureAwait(false);
 
-                            var res = await DoPut(indexFile);
+                            var res = await DoPut(indexFile).ConfigureAwait(false);
 
                             // Register that the index file is tracking the block file
                             await m_database.AddIndexBlockLinkAsync(
                                 ix.VolumeID,
                                 await m_database.GetRemoteVolumeIDAsync(fe.RemoteFilename)
-                            );
+                            ).ConfigureAwait(false);
 
 
                             return res;
@@ -271,7 +271,7 @@ namespace Duplicati.Library.Main.Operation.Common
                 }
             });
 
-            await tcs.Task;
+            await tcs.Task.ConfigureAwait(false);
         }
 
         public Task DeleteFileAsync(string remotename, bool suppressCleanup = false)
@@ -309,7 +309,7 @@ namespace Duplicati.Library.Main.Operation.Common
         {
             var fe = new FileEntryItem(BackendActionType.Get, remotename);
             return RunRetryOnMain(fe, async () => {
-                var res = await DoGet(fe);
+                var res = await DoGet(fe).ConfigureAwait(false);
                 return new Tuple<Library.Utility.TempFile, long, string>(
                     res,
                     fe.Size,
@@ -354,7 +354,7 @@ namespace Duplicati.Library.Main.Operation.Common
             for(var i = 0; i < m_options.NumberOfRetries; i++)
             {
                 if (m_options.RetryDelay.Ticks != 0 && i != 0)
-                    await Task.Delay(m_options.RetryDelay);
+                    await Task.Delay(m_options.RetryDelay).ConfigureAwait(false);
 
                 if (!await m_taskreader.TransferProgressAsync)
                     throw new OperationCanceledException();
@@ -368,8 +368,8 @@ namespace Duplicati.Library.Main.Operation.Common
                         m_backend = DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions);
                     if (m_backend == null)
                         throw new Exception("Backend failed to re-load");
-                    
-                    var r = await method();
+
+                    var r = await method().ConfigureAwait(false);
                     return r;
                 }
                 catch (Exception ex)
@@ -397,14 +397,14 @@ namespace Duplicati.Library.Main.Operation.Common
                             Logging.Log.WriteWarningMessage(LOGTAG, "FolderCreateError", dex, "Failed to create folder: {0}", ex.Message);
                         }
                     }
-                        
+
                     if (!recovered)
-                        await ResetBackendAsync(ex);
+                        await ResetBackendAsync(ex).ConfigureAwait(false);
                 }
                 finally
                 {
                     if (m_options.NoConnectionReuse)
-                        await ResetBackendAsync(null);
+                        await ResetBackendAsync(null).ConfigureAwait(false);
                 }
             }
 
@@ -429,7 +429,7 @@ namespace Duplicati.Library.Main.Operation.Common
         private async Task<bool> DoPut(FileEntryItem item, bool updatedHash = false)
         {
             // If this is not already encrypted, do it now
-            await item.Encrypt(m_options);
+            await item.Encrypt(m_options).ConfigureAwait(false);
 
             updatedHash |= item.UpdateHashAndSize(m_options);
 
@@ -439,7 +439,7 @@ namespace Duplicati.Library.Main.Operation.Common
             if (m_options.Dryrun)
             {
                 Logging.Log.WriteDryrunMessage(LOGTAG, "WouldUploadVolume", "Would upload volume: {0}, size: {1}", item.RemoteFilename, Library.Utility.Utility.FormatSizeString(new FileInfo(item.LocalFilename).Length));
-                await item.DeleteLocalFile();
+                await item.DeleteLocalFile().ConfigureAwait(false);
                 return true;
             }
             

--- a/Duplicati/Library/UsageReporter/EventProcessor.cs
+++ b/Duplicati/Library/UsageReporter/EventProcessor.cs
@@ -90,12 +90,12 @@ namespace Duplicati.Library.UsageReporter
                     // Wait 20 seconds before we start transmitting
                     for(var i = 0; i < 20; i++)
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(1));
+                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                         if (await self.Input.IsRetiredAsync)
                             return;
                     }
 
-                    await ProcessAbandonedFiles(self.Output, self.Input, null);
+                    await ProcessAbandonedFiles(self.Output, self.Input, null).ConfigureAwait(false);
 
                     var rs = new ReportSet();
                     var tf = GetTempFilename(instanceid);

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -596,7 +596,7 @@ namespace Duplicati.Library.Utility
             int index = 0;
             do
             {
-                a = await stream.ReadAsync(buf, index, count);
+                a = await stream.ReadAsync(buf, index, count).ConfigureAwait(false);
                 index += a;
                 count -= a;
             } while (a != 0 && count > 0);

--- a/Duplicati/Server/WebServer/RESTMethods/CommandLine.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/CommandLine.cs
@@ -198,7 +198,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                     continue;
                 }
 
-                await System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(60));
+                await System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(60)).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
When the code following the `await` can be executed on any thread, it's recommended to use `ConfigureAwait(false)` to avoid unnecessary context switching and potential deadlocks.