### PR TITLE
Remove unused members from Utility class

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1052,11 +1052,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Gets the users default UI language
-        /// </summary>
-        public static System.Globalization.CultureInfo DefaultCulture => new System.Threading.Thread(() => { }).CurrentUICulture;
-
-        /// <summary>
         /// Gets a string comparer that matches the client filesystems case sensitivity
         /// </summary>
         public static StringComparer ClientFilenameStringComparer => IsFSCaseSensitive ? StringComparer.CurrentCulture : StringComparer.CurrentCultureIgnoreCase;

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1082,11 +1082,6 @@ namespace Duplicati.Library.Utility
         private static readonly Regex ENVIRONMENT_VARIABLE_MATCHER_WINDOWS = new Regex(@"\%(?<name>\w+)\%");
 
         /// <summary>
-        /// Regexp for matching environment variables on Linux ($VAR or ${VAR})
-        /// </summary>
-        private static readonly Regex ENVIRONMENT_VARIABLE_MATCHER_LINUX = new Regex(@"\$(?<name>\w+)|(\{(?<name>[^\}]+)\})");
-
-        /// <summary>
         /// Expands environment variables in a RegExp safe format
         /// </summary>
         /// <returns>The expanded string.</returns>
@@ -1099,8 +1094,8 @@ namespace Duplicati.Library.Utility
 
             return
 
-                // TODO: Should we switch to using the native format, instead of following the Windows scheme?
-                //IsClientLinux ? ENVIRONMENT_VARIABLE_MATCHER_LINUX : ENVIRONMENT_VARIABLE_MATCHER_WINDOWS
+                // TODO: Should we switch to using the native format ($VAR or ${VAR}), instead of following the Windows scheme?
+                // IsClientLinux ? new Regex(@"\$(?<name>\w+)|(\{(?<name>[^\}]+)\})") : ENVIRONMENT_VARIABLE_MATCHER_WINDOWS
 
                 ENVIRONMENT_VARIABLE_MATCHER_WINDOWS.Replace(str, m => Regex.Escape(lookup(m.Groups["name"].Value)));
         }

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1178,34 +1178,6 @@ namespace Duplicati.Library.Utility
             return uniqueItems;
         }
 
-        /// <summary>
-        /// Helper method that replaces one file with another
-        /// </summary>
-        /// <param name="target">The file to replace</param>
-        /// <param name="sourcefile">The file to replace with</param>
-        public static void ReplaceFile(string target, string sourcefile)
-        {
-            if (File.Exists(target))
-                File.Delete(target);
-
-            //Nasty workaround for the fact that a recently deleted file occasionally blocks a new write
-            long i = 5;
-            do
-            {
-                try
-                {
-                    File.Move(sourcefile, target);
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    if (i == 0)
-                        throw new Exception(
-                            $"Failed to replace the file \"{target}\" volume with the \"{sourcefile}\", error: {ex.Message}");
-                    System.Threading.Thread.Sleep(250);
-                }
-            } while (i-- > 0);
-        }
         // <summary>
         // Returns the entry assembly or reasonable approximation if no entry assembly is available.
         // This is the case in NUnit tests.  The following approach does not work w/ Mono due to unimplemented members:

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1224,17 +1224,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Decodes a &quot;base64 for url&quot; encoded string into the raw byte array.
-        /// See https://en.wikipedia.org/wiki/Base64#URL_applications
-        /// </summary>
-        /// <param name="data">The data to decode</param>
-        /// <returns>The raw data</returns>
-        public static byte[] Base64UrlDecode(string data)
-        {
-            return Convert.FromBase64String(Base64UrlToBase64Plain(data));
-        }
-
-        /// <summary>
         /// Converts a DateTime instance to a Unix timestamp
         /// </summary>
         /// <returns>The Unix timestamp.</returns>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -654,17 +654,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Calculates the hash of a given file, and returns the results as an base64 encoded string
-        /// </summary>
-        /// <param name="path">The path to the file to calculate the hash for</param>
-        /// <returns>The base64 encoded hash</returns>
-        public static string CalculateHash(string path)
-        {
-            using (FileStream fs = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read))
-                return CalculateHash(fs);
-        }
-
-        /// <summary>
         /// Calculates the hash of a given stream, and returns the results as an base64 encoded string
         /// </summary>
         /// <param name="stream">The stream to calculate the hash for</param>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1078,50 +1078,6 @@ namespace Duplicati.Library.Utility
         public static StringComparison ClientFilenameStringComparison => IsFSCaseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
 
         /// <summary>
-        /// Searches the system paths for the file specified
-        /// </summary>
-        /// <param name="filename">The file to locate</param>
-        /// <returns>The full path to the file, or null if the file was not found</returns>
-        public static string LocateFileInSystemPath(string filename)
-        {
-            try
-            {
-                if (Path.IsPathRooted(filename))
-                    return File.Exists(filename) ? filename : null;
-
-                try
-                {
-                    filename = Path.GetFileName(filename);
-                }
-                catch
-                {
-                    // ignored
-                }
-
-                string homedir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) + Path.PathSeparator.ToString();
-
-                //Look in application base folder and all system path folders
-                foreach (string s in (homedir + Environment.GetEnvironmentVariable("PATH")).Split(Path.PathSeparator))
-                    if (!string.IsNullOrEmpty(s) && s.Trim().Length > 0)
-                        try
-                        {
-                            foreach (string sx in Directory.GetFiles(ExpandEnvironmentVariables(s), filename))
-                                return sx;
-                        }
-                        catch
-                        {
-                            // ignored
-                        }
-            }
-            catch
-            {
-                // ignored
-            }
-
-            return null;
-        }
-
-        /// <summary>
         /// The path to the users home directory
         /// </summary>
         public static readonly string HOME_PATH = Environment.GetFolderPath(IsClientLinux ? Environment.SpecialFolder.Personal : Environment.SpecialFolder.UserProfile);

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1238,16 +1238,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Converts a Unix timestamp to a DateTime instance
-        /// </summary>
-        /// <returns>The DateTime instance represented by the timestamp.</returns>
-        /// <param name="input">The Unix timestamp to use.</param>
-        public static DateTime ToUnixTimestamp(long input)
-        {
-            return EPOCH.AddSeconds(input);
-        }
-
-        /// <summary>
         /// Returns a value indicating if the given type should be treated as a primitive
         /// </summary>
         /// <returns><c>true</c>, if type is primitive for serialization, <c>false</c> otherwise.</returns>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1122,23 +1122,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Checks that a hostname is valid
-        /// </summary>
-        /// <param name="hostname">The hostname to verify</param>
-        /// <returns>True if the hostname is valid, false otherwise</returns>
-        public static bool IsValidHostname(string hostname)
-        {
-            try
-            {
-                return System.Uri.CheckHostName(hostname) != UriHostNameType.Unknown;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// The format string for a DateTime
         /// </summary>
         //Note: Actually the K should be Z which is more correct as it is forced to be Z, but Z as a format specifier is fairly undocumented


### PR DESCRIPTION
In the interest of simplifying the codebase, this removes several unused members from the `Utility` class.  Most of these members had their usages removed many years ago.