### PR TITLE
Fix URL for Google Cloud Storage backend

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -100,7 +100,7 @@ namespace Duplicati.Library.Backend.WebApi
             {
                 { QueryParam.UploadType, QueryValue.Resumable }
             };
-            var path = UrlPath.Create(Path.Bucket).Append(bucketId).ToString();
+            var path = UrlPath.Create(Path.Bucket).Append(bucketId).Append(Path.Object).ToString();
             return Uri.UriBuilder(Url.UPLOAD, path, queryParams);
         }
 


### PR DESCRIPTION
This fixes an issue where Google Cloud Storage users encountered the following exception:

`System.Net.WebException: The remote server returned an error: (404) Not Found.`

The refactoring in revision 18de687530 ("Updated Put and Createfolder using WebApi") omitted the `/o` in the endpoint for object uploads.

This addresses issue #3328.