### PR TITLE
clarified application/account Id field for b2 backend

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/backends/b2.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/b2.html
@@ -9,7 +9,7 @@
 </div>
 
 <div class="input text">
-    <label for="b2_username" translate>B2 Account ID</label>
+    <label for="b2_username" translate>B2 Account ID or Application ID</label>
     <input type="text" name="b2_username" id="b2_username" ng-model="$parent.Username" placeholder="{{'B2 Cloud Storage Account ID' | translate}}" />
 </div>
 <div class="input password">


### PR DESCRIPTION
When using an applicationkey (I use a key per bucket) you should enter the applicationkey ID instead of the account ID

It's a bit rough, but maybe it sends some users in the right direction. Would've saved me some headscratching.