### PR TITLE
Use ordinal sort rules to compare path names

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1054,12 +1054,12 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// Gets a string comparer that matches the client filesystems case sensitivity
         /// </summary>
-        public static StringComparer ClientFilenameStringComparer => IsFSCaseSensitive ? StringComparer.CurrentCulture : StringComparer.CurrentCultureIgnoreCase;
+        public static StringComparer ClientFilenameStringComparer => IsFSCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 
         /// <summary>
         /// Gets the string comparision that matches the client filesystems case sensitivity
         /// </summary>
-        public static StringComparison ClientFilenameStringComparison => IsFSCaseSensitive ? StringComparison.CurrentCulture : StringComparison.CurrentCultureIgnoreCase;
+        public static StringComparison ClientFilenameStringComparison => IsFSCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
         /// <summary>
         /// The path to the users home directory

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -122,7 +122,7 @@ namespace Duplicati.UnitTest
 
             // Test with custom comparer.
             IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
-            uniqueItems = new string[] {"a", "b", "c"};
+            uniqueItems = new string[] { "a", "b", "c" };
             duplicateItems = new string[] { "a", "c" };
 
             actualDuplicateItems = null;

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -26,6 +26,46 @@ namespace Duplicati.UnitTest
     {
         [Test]
         [Category("Utility")]
+        [TestCase("da-DK")]
+        [TestCase("en-US")]
+        [TestCase("hu-HU")]
+        [TestCase("tr-TR")]
+        public static void FilenameStringComparison(string cultureName)
+        {
+            Action<string, string> checkStringComparison = (x, y) => Assert.IsFalse(String.Equals(x, y, Utility.ClientFilenameStringComparison));
+            Action<string, string> checkStringComparer = (x, y) => Assert.IsFalse(new HashSet<string>(new[] { x }).Contains(y, Utility.ClientFilenameStringComparer));
+
+            System.Globalization.CultureInfo originalCulture = System.Globalization.CultureInfo.CurrentCulture;
+            try
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(cultureName, false);
+
+                // These are equivalent with respect to hu-HU, but different with respect to en-US.
+                string ddzs = "ddzs";
+                string dzsdzs = "dzsdzs";
+                checkStringComparison(ddzs, dzsdzs);
+                checkStringComparer(ddzs, dzsdzs);
+
+                // Many cultures treat the following as equivalent.
+                string eAcuteOneCharacter = System.Text.Encoding.GetEncoding("iso-8859-1").GetString(new byte[] { 233 }); // 'é' as one character (ALT+0233).
+                string eAcuteTwoCharacters = "\u0065\u0301"; // 'e', combined with an acute accent (U+301).
+                checkStringComparison(eAcuteOneCharacter, eAcuteTwoCharacters);
+                checkStringComparer(eAcuteOneCharacter, eAcuteTwoCharacters);
+
+                // These are equivalent with respect to en-US, but different with respect to da-DK.
+                string aDiaeresisOneCharacter = "\u00C4"; // 'A' with a diaeresis.
+                string aDiaeresisTwoCharacters = "\u0041\u0308"; // 'A', combined with a diaeresis.
+                checkStringComparison(aDiaeresisOneCharacter, aDiaeresisTwoCharacters);
+                checkStringComparer(aDiaeresisOneCharacter, aDiaeresisTwoCharacters);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Test]
+        [Category("Utility")]
         public static void ForceStreamRead()
         {
             byte[] source = { 0x10, 0x20, 0x30, 0x40, 0x50 };


### PR DESCRIPTION
It's [recommended](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings) that file paths be compared using ordinal rules.  However, the `Utility.ClientFilenameStringComparer` and `Utility.ClientFilenameStringComparison` properties returned values that resulted in culture-aware comparisons.  By using ordinal sort rules, we avoid issues where two different files on the filesystem can have names that are equivalent in certain cultures (e.g., `"ddzs"` and `"dzsdzs"` are equivalent with respect to the `hu-HU` culture), which could lead to strange "collisions" in the code.

This addresses issue #3342.