### PR TITLE
[FIX] Localizations that have a sub-code are not loaded

### DIFF
--- a/Duplicati/Library/Localization/MoLocalizationService.cs
+++ b/Duplicati/Library/Localization/MoLocalizationService.cs
@@ -74,7 +74,7 @@ namespace Duplicati.Library.Localization
                 // Load the specialized version first
                 string.Format("localization-{0}.mo", ci.Name), 
                 // Then try the generic language version
-                string.Format("localization-{0}.mo", ci.TwoLetterISOLanguageName) 
+                string.Format("localization-{0}.mo", ci.TwoLetterISOLanguageName.Replace('-', '_')) 
             };
 
             foreach(var fn in filenames)

--- a/Duplicati/Library/Localization/MoLocalizationService.cs
+++ b/Duplicati/Library/Localization/MoLocalizationService.cs
@@ -72,9 +72,9 @@ namespace Duplicati.Library.Localization
         {
             var filenames = new string[] { 
                 // Load the specialized version first
-                string.Format("localization-{0}.mo", ci.Name), 
+                string.Format("localization-{0}.mo", ci.Name.Replace('-', '_')), 
                 // Then try the generic language version
-                string.Format("localization-{0}.mo", ci.TwoLetterISOLanguageName.Replace('-', '_')) 
+                string.Format("localization-{0}.mo", ci.TwoLetterISOLanguageName) 
             };
 
             foreach(var fn in filenames)


### PR DESCRIPTION
The loader tries to load files in the format `code-subCode` while the files are saved as `code_subCode`.