### PR TITLE
Fixed #3373 - LVM: Backup failure on removed files

### DIFF
--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -487,18 +487,28 @@ namespace Duplicati.Library.Snapshots
         /// <param name="localPath">The file or folder to examine</param>
         public override bool IsBlockDevice(string localPath)
         {
-            var n = UnixSupport.File.GetFileType(SystemIOLinux.NormalizePath(localPath));
-            switch (n)
+            try
             {
-                case UnixSupport.File.FileType.Directory:
-                case UnixSupport.File.FileType.Symlink:
-                case UnixSupport.File.FileType.File:
+                var n = UnixSupport.File.GetFileType(SystemIOLinux.NormalizePath(localPath));
+                switch (n)
+                {
+                    case UnixSupport.File.FileType.Directory:
+                    case UnixSupport.File.FileType.Symlink:
+                    case UnixSupport.File.FileType.File:
+                        return false;
+                    default:
+                        return true;
+                }
+            } 
+            catch 
+            {
+                if (!System.IO.File.Exists(SystemIOLinux.NormalizePath(localPath)))
                     return false;
-                default:
-                    return true;
+
+                throw;
             }
         }
-
+        
         /// <summary>
         /// Gets a unique hardlink target ID
         /// </summary>


### PR DESCRIPTION
Fixes a problem in `LinuxSnapshot.IsBlockDevice(localPath)` which was throwing an exception when a path that exists in the snapshot is removed from the disk during the backup run.

I verified the fix (in a backport to "v2.0.3.3-2.0.3.3_beta_2018-04-02") and backups are complete now.