### PR TITLE
Remove unnecessary call to String.Format

### DIFF
--- a/Duplicati/Server/WebServer/RESTMethods/UISettings.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/UISettings.cs
@@ -61,7 +61,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             if (data == null)
             {
-                info.ReportClientError(string.Format("Unable to parse settings object"), System.Net.HttpStatusCode.BadRequest);
+                info.ReportClientError("Unable to parse settings object", System.Net.HttpStatusCode.BadRequest);
                 return;
             }
 


### PR DESCRIPTION
This removes an unnecessary call to `String.Format`.  The provided string does not contain any format items.