### PR TITLE
Use existing local variable to improve readability

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -996,7 +996,7 @@ namespace Duplicati.CommandLine
 
 
             using (var console = new ConsoleOutput(outwriter, options))
-            using (var i = new Library.Main.Controller(args[0], options, console))
+            using (var i = new Library.Main.Controller(backend, options, console))
             {
                 setup(i);
                 i.PurgeFiles(filter);


### PR DESCRIPTION
This makes use of an existing (and previously unused) local variable to improve readability.