### PR TITLE
Allow tasks to complete on any thread when context is irrelevant

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -1141,7 +1141,7 @@ namespace Duplicati.Library.AutoUpdater
                         Task.Run(async () => {
                             var stdin = new StreamReader(Console.OpenStandardInput());
                             var line = string.Empty;
-                            while ((line = await stdin.ReadLineAsync()) != null)
+                            while ((line = await stdin.ReadLineAsync().ConfigureAwait(false)) != null)
                                 await proc.StandardInput.WriteLineAsync(line);
                         }),
                         proc.StandardOutput.BaseStream.CopyToAsync(Console.OpenStandardOutput()),

--- a/Duplicati/Library/Main/Operation/Backup/MetadataPreProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/MetadataPreProcess.cs
@@ -241,7 +241,7 @@ namespace Duplicati.Library.Main.Operation.Backup
         /// <param name="meta">The metadata ti record</param>
         private static async Task AddSymlinkToOutputAsync(string filename, DateTime lastModified, IMetahash meta, BackupDatabase database, IWriteChannel<StreamBlock> streamblockchannel)
         {
-            var metadataid = await AddMetadataToOutputAsync(filename, meta, database, streamblockchannel);
+            var metadataid = await AddMetadataToOutputAsync(filename, meta, database, streamblockchannel).ConfigureAwait(false);
             await database.AddSymlinkEntryAsync(filename, metadataid.Item2, lastModified);
         }
 

--- a/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
+++ b/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
@@ -263,7 +263,7 @@ namespace Duplicati.Library.Main.Operation.Common
 
 
                             return res;
-                        });
+                        }).ConfigureAwait(false);
                     }
 
                     tcs.TrySetResult(true);

--- a/Duplicati/Library/UsageReporter/EventProcessor.cs
+++ b/Duplicati/Library/UsageReporter/EventProcessor.cs
@@ -134,7 +134,7 @@ namespace Duplicati.Library.UsageReporter
                             self.Output.WriteNoWait(tf);
                             rs = new ReportSet();
 
-                            await ProcessAbandonedFiles(self.Output, self.Input, null);
+                            await ProcessAbandonedFiles(self.Output, self.Input, null).ConfigureAwait(false);
 
                             tf = nextFilename;
                         }


### PR DESCRIPTION
When the code following the `await` can be executed on any thread, it's recommended to use `ConfigureAwait(false)` to avoid unnecessary context switching and potential deadlocks.