### PR TITLE
Simplify method resolution by removing default parameters

### DIFF
--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -341,8 +341,8 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
                         req.Method = overwrite ? "PUT" : "POST";
                     },
 
-                    new MultipartItem(createreq, name: "metadata"),
-                    new MultipartItem(stream, name: "content", filename: remotename)
+                    new MultipartItem(createreq, "metadata"),
+                    new MultipartItem(stream, "content", remotename)
 
                 );
 

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -218,7 +218,7 @@ namespace Duplicati.Library.Backend.Box
                 {
                     res = m_oauth.PostMultipartAndGetJSONData<FileList>(
                         string.Format("{0}/{1}/content", BOX_UPLOAD_URL, m_filecache[remotename]),
-                        new MultipartItem(stream, name: "file", filename: remotename)
+                        new MultipartItem(stream, "file", remotename)
                     ).Entries.First();
                 }
                 else
@@ -226,8 +226,8 @@ namespace Duplicati.Library.Backend.Box
 
                     res = m_oauth.PostMultipartAndGetJSONData<FileList>(
                         string.Format("{0}/content", BOX_UPLOAD_URL),
-                        new MultipartItem(createreq, name: "attributes"),
-                        new MultipartItem(stream, name: "file", filename: remotename)
+                        new MultipartItem(createreq, "attributes"),
+                        new MultipartItem(stream, "file", remotename)
                     ).Entries.First();
                 }
 

--- a/Duplicati/Library/Backend/OAuthHelper/MultipartItem.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/MultipartItem.cs
@@ -28,28 +28,34 @@ namespace Duplicati.Library
             this.Headers = new Dictionary<string, string>();
         }
 
-        public MultipartItem(string contenttype, string name = null, string filename = null)
+        public MultipartItem(string contenttype, string name, string filename)
             : this()
         {
             ContentType = contenttype;
             SetContentDisposition(name, filename);
         }
 
-        public MultipartItem(object content, string contenttype = "application/json; charset=utf-8", string name = null, string filename = null)
-            : this(JsonConvert.SerializeObject(content), contenttype, name, filename)
+        public MultipartItem(object content, string name)
+            : this(JsonConvert.SerializeObject(content), "application/json; charset=utf-8", name, null)
         {
         }
 
-        public MultipartItem(string content, string contenttype = null, string name = null, string filename = null)
+        public MultipartItem(string content, string contenttype, string name, string filename)
             : this(System.Text.Encoding.UTF8.GetBytes(content), contenttype, name, filename)
         {
         }
 
-        public MultipartItem(byte[] content, string contenttype = "application/octet-stream", string name = null, string filename = null)
+        public MultipartItem(byte[] content, string contenttype, string name, string filename)
             : this(new MemoryStream(content), contenttype, name, filename)
         {
         }
-        public MultipartItem(Stream content, string contenttype = "application/octet-stream", string name = null, string filename = null)
+
+        public MultipartItem(Stream content, string name, string filename)
+            : this(content, "application/octet-stream", name, filename)
+        {
+        }
+
+        public MultipartItem(Stream content, string contenttype, string name, string filename)
             : this(contenttype, name, filename)
         {
             ContentData = content;

--- a/Duplicati/Library/UsageReporter/ReportItem.cs
+++ b/Duplicati/Library/UsageReporter/ReportItem.cs
@@ -42,7 +42,7 @@ namespace Duplicati.Library.UsageReporter
             this.TimeStamp = (long)(DateTime.UtcNow - Library.Utility.Utility.EPOCH).TotalSeconds;
         }
 
-        public ReportItem(ReportType type = ReportType.Information, long? count = null, string eventname = null, string data = null)
+        public ReportItem(ReportType type, long? count, string eventname, string data)
             : this()
         {
             this.Type = type;


### PR DESCRIPTION
This simplifies some method overloads by removing unnecessary default parameters.  The previous implementations resulted in an overload being hidden by one without a default parameter, making it unclear which method was being called.  For example, consider the following signatures:
```c#
public MultipartItem(string content, string contenttype = null, string name = null, string filename = null)
public MultipartItem(string contenttype, string name = null, string filename = null)
```
From the [documentation](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments),

> If two candidates are judged to be equally good, preference goes to a candidate that does not have optional parameters for which arguments were omitted in the call. This is a consequence of a general preference in overload resolution for candidates that have fewer parameters.