### PR TITLE
Use built-in method to expand environment variables

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -71,7 +71,7 @@ namespace Duplicati.CommandLine.BackendTester
                 {
                     try
                     {
-                        var p = Library.Utility.Utility.ExpandEnvironmentVariables(_args[0]);
+                        var p = Environment.ExpandEnvironmentVariables(_args[0]);
                         if (System.IO.File.Exists(p))
                             _args = (from x in System.IO.File.ReadLines(p)
                                 where !string.IsNullOrWhiteSpace(x) && !x.Trim().StartsWith("#", StringComparison.Ordinal)

--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -298,7 +298,7 @@ namespace Duplicati.CommandLine
         {
             try
             {
-                List<string> fargs = new List<string>(Library.Utility.Utility.ReadFileWithDefaultEncoding(Library.Utility.Utility.ExpandEnvironmentVariables(filename)).Replace("\r\n", "\n").Replace("\r", "\n").Split(new String[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
+                List<string> fargs = new List<string>(Library.Utility.Utility.ReadFileWithDefaultEncoding(Environment.ExpandEnvironmentVariables(filename)).Replace("\r\n", "\n").Replace("\r", "\n").Split(new String[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
                 var newsource = new List<string>();
                 string newtarget = null;
                 string prependfilter = null;

--- a/Duplicati/CommandLine/RecoveryTool/Program.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Program.cs
@@ -106,7 +106,7 @@ namespace Duplicati.CommandLine.RecoveryTool
         {
             try
             {
-                List<string> fargs = new List<string>(Library.Utility.Utility.ReadFileWithDefaultEncoding(Library.Utility.Utility.ExpandEnvironmentVariables(filename)).Replace("\r\n", "\n").Replace("\r", "\n").Split(new String[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
+                List<string> fargs = new List<string>(Library.Utility.Utility.ReadFileWithDefaultEncoding(Environment.ExpandEnvironmentVariables(filename)).Replace("\r\n", "\n").Replace("\r", "\n").Split(new String[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
                 var tmpparsed = Library.Utility.FilterCollector.ExtractOptions(fargs);
 
                 var opt = tmpparsed.Item1;

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -51,7 +51,7 @@ namespace Duplicati.Library.AutoUpdater
         private static readonly string INSTALLED_BASE_DIR =
             string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)))
             ? System.IO.Path.GetDirectoryName(Duplicati.Library.Utility.Utility.getEntryAssembly().Location)
-            : Library.Utility.Utility.ExpandEnvironmentVariables(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)));
+            : Environment.ExpandEnvironmentVariables(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)));
 
         private static readonly bool DISABLE_UPDATE_DOMAIN = !string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable(string.Format(SKIPUPDATE_ENVNAME_TEMPLATE, APPNAME)));
 
@@ -187,7 +187,7 @@ namespace Duplicati.Library.AutoUpdater
             }
             else
             {
-                INSTALLDIR = Library.Utility.Utility.ExpandEnvironmentVariables(System.Environment.GetEnvironmentVariable(string.Format(UPDATEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)));
+                INSTALLDIR = Environment.ExpandEnvironmentVariables(System.Environment.GetEnvironmentVariable(string.Format(UPDATEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)));
             }
 
 

--- a/Duplicati/Library/Encryption/GPGEncryption.cs
+++ b/Duplicati/Library/Encryption/GPGEncryption.cs
@@ -178,7 +178,7 @@ namespace Duplicati.Library.Encryption
                 m_decryption_args += " " + GPG_DECRYPTION_COMMAND;
 
             if (options.ContainsKey(COMMANDLINE_OPTIONS_PATH))
-                m_programpath = Library.Utility.Utility.ExpandEnvironmentVariables(options[COMMANDLINE_OPTIONS_PATH]);
+                m_programpath = Environment.ExpandEnvironmentVariables(options[COMMANDLINE_OPTIONS_PATH]);
 
         }
 

--- a/Duplicati/Library/Utility/FilterCollector.cs
+++ b/Duplicati/Library/Utility/FilterCollector.cs
@@ -47,7 +47,7 @@ namespace Duplicati.Library.Utility
 
                     if (include || exclude)
                     {
-                        m_filters.Add(new Library.Utility.FilterExpression(Library.Utility.Utility.ExpandEnvironmentVariables(value), include));
+                        m_filters.Add(new Library.Utility.FilterExpression(Environment.ExpandEnvironmentVariables(value), include));
                         return false;
                     }
                 }

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1067,16 +1067,6 @@ namespace Duplicati.Library.Utility
         public static readonly string HOME_PATH = Environment.GetFolderPath(IsClientLinux ? Environment.SpecialFolder.Personal : Environment.SpecialFolder.UserProfile);
 
         /// <summary>
-        /// Expands environment variables.
-        /// </summary>
-        /// <returns>The expanded string.</returns>
-        /// <param name="str">The string to expand.</param>
-        public static string ExpandEnvironmentVariables(string str)
-        {
-            return Environment.ExpandEnvironmentVariables(str);
-        }
-
-        /// <summary>
         /// Regexp for matching environment variables on Windows (%VAR%)
         /// </summary>
         private static readonly Regex ENVIRONMENT_VARIABLE_MATCHER_WINDOWS = new Regex(@"\%(?<name>\w+)\%");

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -575,7 +575,7 @@ namespace Duplicati.Server
 #endif
             }
             else
-                DataFolder = Library.Utility.Utility.AppendDirSeparator(Library.Utility.Utility.ExpandEnvironmentVariables(serverDataFolder).Trim('"'));
+                DataFolder = Library.Utility.Utility.AppendDirSeparator(Environment.ExpandEnvironmentVariables(serverDataFolder).Trim('"'));
 
             var sqliteVersion = new Version((string)Duplicati.Library.SQLiteHelper.SQLiteLoader.SQLiteConnectionType.GetProperty("SQLiteVersion").GetValue(null, null));
 
@@ -764,7 +764,7 @@ namespace Duplicati.Server
         {
             try
             {
-                List<string> fargs = new List<string>(Library.Utility.Utility.ReadFileWithDefaultEncoding(Library.Utility.Utility.ExpandEnvironmentVariables(filename)).Replace("\r\n", "\n").Replace("\r", "\n").Split(new String[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
+                List<string> fargs = new List<string>(Library.Utility.Utility.ReadFileWithDefaultEncoding(Environment.ExpandEnvironmentVariables(filename)).Replace("\r\n", "\n").Replace("\r", "\n").Split(new String[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
                 var newsource = new List<string>();
                 string newtarget = null;
                 string prependfilter = null;

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -901,7 +901,7 @@ namespace Duplicati.Server
            return
                 (from n in filters
                 orderby n.Order
-                let exp = Library.Utility.Utility.ExpandEnvironmentVariables(n.Expression)
+                let exp = Environment.ExpandEnvironmentVariables(n.Expression)
                 select (Duplicati.Library.Utility.IFilter)(new Duplicati.Library.Utility.FilterExpression(exp, n.Include)))
                 .Aggregate((a, b) => Duplicati.Library.Utility.FilterExpression.Combine(a, b));
         }

--- a/Duplicati/Server/SpecialFolders.cs
+++ b/Duplicati/Server/SpecialFolders.cs
@@ -32,7 +32,7 @@ namespace Duplicati.Server
             foreach(var n in Nodes)
                 if (path.StartsWith(n.id, StringComparison.Ordinal))
                     path = path.Replace(n.id, n.resolvedpath);
-            return Library.Utility.Utility.ExpandEnvironmentVariables(path);
+            return Environment.ExpandEnvironmentVariables(path);
         }
 
         public static string ExpandEnvironmentVariablesRegexp(string path)

--- a/Duplicati/UnitTest/SVNCheckoutsTest.cs
+++ b/Duplicati/UnitTest/SVNCheckoutsTest.cs
@@ -101,7 +101,7 @@ namespace Duplicati.UnitTest
                 //Filter empty entries, commonly occuring with copy/paste and newlines
                 folders = (from x in folders
                            where !string.IsNullOrWhiteSpace(x)
-                           select Library.Utility.Utility.ExpandEnvironmentVariables(x)).ToArray();
+                           select Environment.ExpandEnvironmentVariables(x)).ToArray();
 
                 foreach (var f in folders)
                     foreach (var n in f.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))


### PR DESCRIPTION
After we removed the tilde expansion in revision c9aa6cf5fb ("Avoid performing tilde expansion"), the `Utility.ExpandEnvironmentVariables` method simply called `System.Environment.ExpandEnvironmentVariables`.  We can simplify the code by just referencing the built-in method directly.