### PR TITLE
Check for null reference before accessing property

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -623,7 +623,7 @@ namespace Duplicati.CommandLine
                 output.MessageEvent(string.Format("  Data uploaded: {0}", Library.Utility.Utility.FormatSizeString(result.BackendStatistics.BytesUploaded)));
                 output.MessageEvent(string.Format("  Data downloaded: {0}", Library.Utility.Utility.FormatSizeString(result.BackendStatistics.BytesDownloaded)));
 
-                if (result.ExaminedFiles == 0 && (filter != null || !filter.Empty))
+                if (result.ExaminedFiles == 0 && (filter != null && !filter.Empty))
                     output.MessageEvent("No files were processed. If this was not intentional you may want to use the \"test-filters\" command");
 
                 output.MessageEvent("Backup completed successfully!");


### PR DESCRIPTION
In revision 58a4fc5271cb4531592fb25101d83a796905e200 ("Added message if filters are applied and zero files were matched"), a message event was added to notify that no files were processed when a filter was applied.  However, when checking for the presence of a filter, the logic allowed for a possible null reference exception.

