### PR TITLE
Avoid referencing virtual members in MicrosoftGraphBackend constructor

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -83,12 +83,12 @@ namespace Duplicati.Library.Backend
 
         protected MicrosoftGraphBackend() { } // Constructor needed for dynamic loading to find it
 
-        protected MicrosoftGraphBackend(string url, Dictionary<string, string> options)
+        protected MicrosoftGraphBackend(string url, string protocolKey, Dictionary<string, string> options)
         {
             string authid;
             options.TryGetValue(AUTHID_OPTION, out authid);
             if (string.IsNullOrEmpty(authid))
-                throw new UserInformationException(Strings.MicrosoftGraph.MissingAuthId(OAuthHelper.OAUTH_LOGIN_URL(this.ProtocolKey)), "MicrosoftGraphBackendMissingAuthId");
+                throw new UserInformationException(Strings.MicrosoftGraph.MissingAuthId(OAuthHelper.OAUTH_LOGIN_URL(protocolKey)), "MicrosoftGraphBackendMissingAuthId");
 
             string fragmentSizeStr;
             if (options.TryGetValue(UPLOAD_SESSION_FRAGMENT_SIZE_OPTION, out fragmentSizeStr) && int.TryParse(fragmentSizeStr, out this.fragmentSize))
@@ -117,7 +117,7 @@ namespace Duplicati.Library.Backend
                 this.fragmentRetryDelay = UPLOAD_SESSION_FRAGMENT_DEFAULT_RETRY_DELAY;
             }
 
-            this.m_client = new OAuthHttpClient(authid, this.ProtocolKey);
+            this.m_client = new OAuthHttpClient(authid, protocolKey);
             this.m_client.BaseAddress = new System.Uri(BASE_ADDRESS);
 
             // Extract out the path to the backup root folder from the given URI

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -74,12 +74,14 @@ namespace Duplicati.Library.Backend
 
         private readonly JsonSerializer m_serializer = new JsonSerializer();
         private readonly OAuthHttpClient m_client;
-        private readonly string m_path;
         private readonly int fragmentSize;
         private readonly int fragmentRetryCount;
         private readonly int fragmentRetryDelay; // In milliseconds
 
         private string[] dnsNames = null;
+
+        private Lazy<string> rootPathFromURL;
+        private string m_path => this.rootPathFromURL.Value;
 
         protected MicrosoftGraphBackend() { } // Constructor needed for dynamic loading to find it
 
@@ -121,7 +123,7 @@ namespace Duplicati.Library.Backend
             this.m_client.BaseAddress = new System.Uri(BASE_ADDRESS);
 
             // Extract out the path to the backup root folder from the given URI
-            this.m_path = NormalizeSlashes(this.GetRootPathFromUrl(url));
+            this.rootPathFromURL = new Lazy<string>(() => this.GetRootPathFromUrl(url));
         }
 
         public abstract string ProtocolKey { get; }

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -122,7 +122,8 @@ namespace Duplicati.Library.Backend
             this.m_client = new OAuthHttpClient(authid, protocolKey);
             this.m_client.BaseAddress = new System.Uri(BASE_ADDRESS);
 
-            // Extract out the path to the backup root folder from the given URI
+            // Extract out the path to the backup root folder from the given URI.  Since this can be an expensive operation, 
+            // we will cache the value using a lazy initializer.
             this.rootPathFromURL = new Lazy<string>(() => this.GetRootPathFromUrl(url));
         }
 

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -80,7 +80,7 @@ namespace Duplicati.Library.Backend
 
         private string[] dnsNames = null;
 
-        private Lazy<string> rootPathFromURL;
+        private readonly Lazy<string> rootPathFromURL;
         private string RootPath => this.rootPathFromURL.Value;
 
         protected MicrosoftGraphBackend() { } // Constructor needed for dynamic loading to find it

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGroup.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGroup.cs
@@ -17,7 +17,7 @@ namespace Duplicati.Library.Backend
         public MicrosoftGroup() { } // Constructor needed for dynamic loading to find it
 
         public MicrosoftGroup(string url, Dictionary<string, string> options)
-            : base(url, options)
+            : base(url, MicrosoftGroup.PROTOCOL_KEY, options)
         {
             string groupId = null;
             string groupEmail;

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGroup.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGroup.cs
@@ -10,6 +10,7 @@ namespace Duplicati.Library.Backend
     {
         private const string GROUP_EMAIL_OPTION = "group-email";
         private const string GROUP_ID_OPTION = "group-id";
+        private const string PROTOCOL_KEY = "msgroup";
 
         private readonly string drivePath;
 
@@ -46,7 +47,7 @@ namespace Duplicati.Library.Backend
 
         public override string ProtocolKey
         {
-            get { return "msgroup"; }
+            get { return MicrosoftGroup.PROTOCOL_KEY; }
         }
 
         public override string DisplayName

--- a/Duplicati/Library/Backend/OneDrive/OneDriveV2.cs
+++ b/Duplicati/Library/Backend/OneDrive/OneDriveV2.cs
@@ -15,7 +15,7 @@ namespace Duplicati.Library.Backend
         public OneDriveV2() { } // Constructor needed for dynamic loading to find it
 
         public OneDriveV2(string url, Dictionary<string, string> options)
-            : base(url, options)
+            : base(url, OneDriveV2.PROTOCOL_KEY, options)
         {
             string driveId;
             if (options.TryGetValue(DRIVE_ID_OPTION, out driveId))

--- a/Duplicati/Library/Backend/OneDrive/OneDriveV2.cs
+++ b/Duplicati/Library/Backend/OneDrive/OneDriveV2.cs
@@ -7,8 +7,8 @@ namespace Duplicati.Library.Backend
     public class OneDriveV2 : MicrosoftGraphBackend
     {
         private const string DRIVE_ID_OPTION = "drive-id";
-
         private const string DEFAULT_DRIVE_PATH = "/me/drive";
+        private const string PROTOCOL_KEY = "onedrivev2";
 
         private readonly string drivePath;
 
@@ -30,7 +30,7 @@ namespace Duplicati.Library.Backend
 
         public override string ProtocolKey
         {
-            get { return "onedrivev2"; }
+            get { return OneDriveV2.PROTOCOL_KEY; }
         }
 
         public override string DisplayName

--- a/Duplicati/Library/Backend/OneDrive/SharePointV2.cs
+++ b/Duplicati/Library/Backend/OneDrive/SharePointV2.cs
@@ -19,7 +19,7 @@ namespace Duplicati.Library.Backend
         public SharePointV2() { } // Constructor needed for dynamic loading to find it
 
         public SharePointV2(string url, Dictionary<string, string> options)
-            : base(url, options)
+            : base(url, SharePointV2.PROTOCOL_KEY, options)
         {
             // Check to see if a site ID was explicitly provided
             string siteIdOption;

--- a/Duplicati/Library/Backend/OneDrive/SharePointV2.cs
+++ b/Duplicati/Library/Backend/OneDrive/SharePointV2.cs
@@ -11,6 +11,7 @@ namespace Duplicati.Library.Backend
     public class SharePointV2 : MicrosoftGraphBackend
     {
         private const string SITE_ID_OPTION = "site-id";
+        private const string PROTOCOL_KEY = "sharepoint";
 
         private readonly string drivePath;
         private string siteId = null;
@@ -42,7 +43,7 @@ namespace Duplicati.Library.Backend
 
         public override string ProtocolKey
         {
-            get { return "sharepoint"; }
+            get { return SharePointV2.PROTOCOL_KEY; }
         }
 
         public override string DisplayName


### PR DESCRIPTION
This modifies the `MicrosoftGraphBackend` class (and its subclasses) so that the constructor does not reference virtual members.  When referencing virtual members in a constructor, the behavior may be ill-defined as the overridden implementation may depend on uninitialized instance members.