### PR TITLE
Simplify enumeration of collections

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -174,7 +174,7 @@ namespace Duplicati.CommandLine
                 setup(i);
                 i.ListAffected(args, res => 
                 { 
-                    if (res.Filesets != null && res.Filesets.Count() != 0)
+                    if (res.Filesets != null && res.Filesets.Any())
                     {
                         outwriter.WriteLine("The following filesets are affected:");
                         foreach (var e in res.Filesets)
@@ -314,8 +314,8 @@ namespace Duplicati.CommandLine
                 // try again with all-versions set
                 var compareFilter = Library.Utility.JoinedFilterExpression.Join(new Library.Utility.FilterExpression(args), filter);
                 var isRequestForFiles = 
-                    !controlFiles && res.Filesets.Count() != 0 && 
-                    (res.Files == null || res.Files.Count() == 0) && 
+                    !controlFiles && res.Filesets.Any() && 
+                    (res.Files == null || !res.Files.Any()) && 
                     !compareFilter.Empty;
                 
                 if (isRequestForFiles && !Library.Utility.Utility.ParseBoolOption(options, "all-versions"))
@@ -327,7 +327,7 @@ namespace Duplicati.CommandLine
                     res = i.List(args, filter);
                 }
 
-                if (res.Filesets.Count() != 0 && (res.Files == null || res.Files.Count() == 0) && compareFilter.Empty)
+                if (res.Filesets.Any() && (res.Files == null || !res.Files.Any()) && compareFilter.Empty)
                 {
                     outwriter.WriteLine("Listing filesets:");
                     
@@ -345,11 +345,11 @@ namespace Duplicati.CommandLine
                 }
                 else
                 {
-                    if (res.Filesets.Count() == 0)
+                    if (!res.Filesets.Any())
                     {
                         outwriter.WriteLine("No time or version matched a fileset");
                     }
-                    else if (res.Files == null || res.Files.Count() == 0)
+                    else if (res.Files == null || !res.Files.Any())
                     {
                         outwriter.WriteLine("Found {0} filesets, but no files matched", res.Filesets.Count());
                     }
@@ -396,7 +396,7 @@ namespace Duplicati.CommandLine
                 args.RemoveAt(0);
                 var res = i.Delete();
                 
-                if (res.DeletedSets.Count() == 0)
+                if (!res.DeletedSets.Any())
                 {
                     outwriter.WriteLine(Strings.Program.NoFilesetsMatching);
                 }
@@ -519,7 +519,7 @@ namespace Duplicati.CommandLine
                         if (output.FullResults)
                             Library.Utility.Utility.PrintSerializeObject(res, outwriter);
 
-                        if (res.Warnings.Count() > 0)
+                        if (res.Warnings.Any())
                             return 2;
                     }
                 }
@@ -694,8 +694,8 @@ namespace Duplicati.CommandLine
             }
             else
             {
-                var filtered = from n in result.Verifications where n.Value.Count() != 0 select n;
-                if (filtered.Count() == 0)
+                var filtered = from n in result.Verifications where n.Value.Any() select n;
+                if (!filtered.Any())
                 {
                     outwriter.WriteLine("Examined {0} files and found no errors", totalFiles);
                     return 0;

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -383,7 +383,7 @@ namespace Duplicati.CommandLine
         {
             var requiredOptions = new string[] { "keep-time", "keep-versions", "version" };
             
-            if (!options.Keys.Where(x => requiredOptions.Contains(x, StringComparer.OrdinalIgnoreCase)).Any())
+            if (!options.Keys.Any(x => requiredOptions.Contains(x, StringComparer.OrdinalIgnoreCase)))
             {
                 outwriter.WriteLine(Strings.Program.DeleteCommandNeedsOptions("delete", requiredOptions)); 
                 return 200;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -235,7 +235,7 @@ namespace Duplicati.GUI.TrayIcon
                     if (line.StartsWith("click:", StringComparison.OrdinalIgnoreCase))
                     {
                         var key = line.Substring("click:".Length);
-                        var menu = m_menus.Where(x => string.Equals(x.Key, key)).FirstOrDefault();
+                        var menu = m_menus.FirstOrDefault(x => string.Equals(x.Key, key));
                         if (menu == null)
                         {
                             Console.WriteLine("Menu not found: {0}", key);

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -169,7 +169,7 @@ namespace Duplicati.Library.AutoUpdater
 
                 if (string.IsNullOrWhiteSpace(installdir))
                     foreach (var p in legacypaths)
-                        if (!string.IsNullOrWhiteSpace(p) && System.IO.Directory.Exists(p) && System.IO.Directory.EnumerateFiles(p, "*", System.IO.SearchOption.TopDirectoryOnly).Count() > 0 && TestDirectoryIsWriteable(p))
+                        if (!string.IsNullOrWhiteSpace(p) && System.IO.Directory.Exists(p) && System.IO.Directory.EnumerateFiles(p, "*", System.IO.SearchOption.TopDirectoryOnly).Any() && TestDirectoryIsWriteable(p))
                         {
                             installdir = p;
                             break;

--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -116,7 +116,7 @@ namespace Duplicati.Library.Backend.Backblaze
                     );
 
                     if (buckets != null && buckets.Buckets != null)
-                        m_bucket = buckets.Buckets.Where(x => string.Equals(x.BucketName, m_bucketname, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                        m_bucket = buckets.Buckets.FirstOrDefault(x => string.Equals(x.BucketName, m_bucketname, StringComparison.OrdinalIgnoreCase));
 
                     if (m_bucket == null)
                         throw new FolderMissingException();

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -122,7 +122,7 @@ namespace Duplicati.Library.Backend.Box
 
             foreach(var p in m_path.Split(new string[] {"/"}, StringSplitOptions.RemoveEmptyEntries))
             {
-                var el = (MiniFolder)PagedFileListResponse(parentid, true).Where(x => x.Name == p).FirstOrDefault();
+                var el = (MiniFolder)PagedFileListResponse(parentid, true).FirstOrDefault(x => x.Name == p);
                 if (el == null)
                 {
                     if (!create)

--- a/Duplicati/Library/Backend/Mega/MegaBackend.cs
+++ b/Duplicati/Library/Backend/Mega/MegaBackend.cs
@@ -77,11 +77,11 @@ namespace Duplicati.Library.Backend.Mega
         {
             var parts = m_prefix.Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
             var nodes = Client.GetNodes();
-            INode parent = nodes.Where(x => x.Type == NodeType.Root).First();
+            INode parent = nodes.First(x => x.Type == NodeType.Root);
 
             foreach(var n in parts)
             {
-                var item = nodes.Where(x => x.Name == n && x.Type == NodeType.Directory && x.ParentId == parent.Id).FirstOrDefault();
+                var item = nodes.FirstOrDefault(x => x.Name == n && x.Type == NodeType.Directory && x.ParentId == parent.Id);
                 if (item == null)
                 {
                     if (!autocreate)

--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -459,11 +459,11 @@ namespace Duplicati.Library.Backend.OpenStack
             m_accessToken = resp.access.token;
 
             // Grab the endpoint now that we have received it anyway
-            var fileservice = resp.access.serviceCatalog.Where(x => string.Equals(x.type, "object-store", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            var fileservice = resp.access.serviceCatalog.FirstOrDefault(x => string.Equals(x.type, "object-store", StringComparison.OrdinalIgnoreCase));
             if (fileservice == null)
                 throw new Exception("No object-store service found, is this service supported by the provider?");
 
-            var endpoint = fileservice.endpoints.Where(x => string.Equals(m_region, x.region)).FirstOrDefault() ?? fileservice.endpoints.First();
+            var endpoint = fileservice.endpoints.FirstOrDefault(x => string.Equals(m_region, x.region)) ?? fileservice.endpoints.First();
 
             m_simplestorageendpoint = endpoint.publicURL;
 

--- a/Duplicati/Library/Backend/S3/S3Wrapper.cs
+++ b/Duplicati/Library/Backend/S3/S3Wrapper.cs
@@ -52,7 +52,7 @@ namespace Duplicati.Library.Backend
 
             foreach(var opt in options.Keys.Where(x => x.StartsWith("s3-ext-", StringComparison.OrdinalIgnoreCase)))
             {
-                var prop = cfg.GetType().GetProperties().Where(x => string.Equals(x.Name, opt.Substring("s3-ext-".Length), StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var prop = cfg.GetType().GetProperties().FirstOrDefault(x => string.Equals(x.Name, opt.Substring("s3-ext-".Length), StringComparison.OrdinalIgnoreCase));
                 if (prop != null && prop.CanWrite)
                 {
                     if (prop.PropertyType == typeof(bool))

--- a/Duplicati/Library/Backend/SSHv2/KeyUploader.cs
+++ b/Duplicati/Library/Backend/SSHv2/KeyUploader.cs
@@ -78,7 +78,7 @@ namespace Duplicati.Library.Backend
                     client.ChangeDirectory(SSH_FOLDER);
                 }
                 
-                var sshfolder = client.ListDirectory(".").Where(x => x.Name == ".").First();                    
+                var sshfolder = client.ListDirectory(".").First(x => x.Name == ".");                    
                 client.ChangeDirectory("..");
                 
                 if (!sshfolder.OwnerCanRead || !sshfolder.OwnerCanWrite)
@@ -87,7 +87,7 @@ namespace Duplicati.Library.Backend
                 string authorized_keys = "";
                 byte[] authorized_keys_bytes = null;
                 
-                var existing_authorized_keys = client.ListDirectory(SSH_FOLDER).Where(x => x.Name == AUTHORIZED_KEYS_FILE).Any();
+                var existing_authorized_keys = client.ListDirectory(SSH_FOLDER).Any(x => x.Name == AUTHORIZED_KEYS_FILE);
                 if (existing_authorized_keys)
                 {
                     using(var ms = new System.IO.MemoryStream())
@@ -102,11 +102,11 @@ namespace Duplicati.Library.Backend
                 var cleaned_keys = keys.Select(x => x.Trim()).Where(x => x.Length > 0 && !x.StartsWith("#", StringComparison.Ordinal));
                 
                 // Does the key already exist?
-                if (cleaned_keys.Where(x =>
+                if (cleaned_keys.Any(x =>
                 {
                     var els = x.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(y => y.Trim()).Where(y => y.Length > 0).ToArray();
                     return els.Length == 3 && els[0] == pubkey[0] && els[1] == pubkey[1];
-                }).Any())
+                }))
                 {
                     res["status"] = "Key already existed";
                 }

--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -83,10 +83,10 @@ namespace Duplicati.Library.DynamicLoader
                             if (m_interfaces.ContainsKey(tmpscheme))
                             {
                                 var commands = m_interfaces[tmpscheme].SupportedCommands;
-                                if (commands != null && (commands.Where(x =>
+                                if (commands != null && (commands.Any(x =>
                                 x.Name.Equals("use-ssl", StringComparison.OrdinalIgnoreCase) ||
-                                (x.Aliases != null && x.Aliases.Where(y => y.Equals("use-ssl", StringComparison.OrdinalIgnoreCase)).Any())
-                                ).Any()))
+                                (x.Aliases != null && x.Aliases.Any(y => y.Equals("use-ssl", StringComparison.OrdinalIgnoreCase)))
+                                )))
                                 {
                                     newOpts["use-ssl"] = "true";
                                     return (IBackend)Activator.CreateInstance(m_interfaces[tmpscheme].GetType(), url, newOpts);

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -749,7 +749,7 @@ namespace Duplicati.Library.Main
 
             if (m_options.ListVerifyUploads)
             {
-                var f = m_backend.List().Where(n => n.Name.Equals(item.RemoteFilename, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var f = m_backend.List().FirstOrDefault(n => n.Name.Equals(item.RemoteFilename, StringComparison.OrdinalIgnoreCase));
                 if (f == null)
                     throw new Exception(string.Format("List verify failed, file was not found after upload: {0}", item.RemoteFilename));
                 else if (f.Size != item.Size && f.Size >= 0)

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -667,7 +667,7 @@ namespace Duplicati.Library.Main
                 selectedRetentionOptions.Add("keep-versions");
             }
 
-            if (m_options.RetentionPolicy.Count() > 0)
+            if (m_options.RetentionPolicy.Any())
             {
                 selectedRetentionOptions.Add("retention-policy");
             }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -269,7 +269,7 @@ namespace Duplicati.Library.Main.Operation
                 backend.WaitForComplete(m_database, null);
             }
 
-            if (m_options.BackupTestSampleCount > 0 && m_database.GetRemoteVolumes().Count() > 0)
+            if (m_options.BackupTestSampleCount > 0 && m_database.GetRemoteVolumes().Any())
             {
                 m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_PostBackupTest);
                 m_result.TestResults = new TestResults(m_result);

--- a/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
+++ b/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
@@ -473,7 +473,7 @@ namespace Duplicati.Library.Main.Operation.Common
 
             if (m_options.ListVerifyUploads)
             {
-                var f = m_backend.List().Where(n => n.Name.Equals(item.RemoteFilename, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var f = m_backend.List().FirstOrDefault(n => n.Name.Equals(item.RemoteFilename, StringComparison.OrdinalIgnoreCase));
                 if (f == null)
                     throw new Exception(string.Format("List verify failed, file was not found after upload: {0}", item.RemoteFilename));
                 else if (f.Size != item.Size && f.Size >= 0)

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -139,13 +139,13 @@ namespace Duplicati.Library.Main.Operation
                     orderby n.Time descending
                     select n;
 
-                if (filelists.Count() <= 0)
+                if (!filelists.Any())
                     throw new UserInformationException("No filelists found on the remote destination", "EmptyRemoteLocation");
                 
                 if (filelistfilter != null)
                     filelists = filelistfilter(filelists).Select(x => x.Value).ToArray();
 
-                if (filelists.Count() <= 0)
+                if (!filelists.Any())
                     throw new UserInformationException("No filelists", "NoMatchingRemoteFilelists");
 
                 // If we are updating, all files should be accounted for

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -130,20 +130,20 @@ namespace Duplicati.Library.Main.Operation
 
                 if (m_options.Dryrun)
                 {
-                    if (tp.ParsedVolumes.Count() == 0 && tp.OtherVolumes.Count() > 0)
+                    if (!tp.ParsedVolumes.Any() && tp.OtherVolumes.Any())
                     {
                         if (tp.BackupPrefixes.Length == 1)
                             throw new UserInformationException(string.Format("Found no backup files with prefix {0}, but files with prefix {1}, did you forget to set the backup prefix?", m_options.Prefix, tp.BackupPrefixes[0]), "RemoteFolderEmptyWithPrefix");
                         else
                             throw new UserInformationException(string.Format("Found no backup files with prefix {0}, but files with prefixes {1}, did you forget to set the backup prefix?", m_options.Prefix, string.Join(", ", tp.BackupPrefixes)), "RemoteFolderEmptyWithPrefix");
                     }
-                    else if (tp.ParsedVolumes.Count() == 0 && tp.ExtraVolumes.Count() > 0)
+                    else if (!tp.ParsedVolumes.Any() && tp.ExtraVolumes.Any())
                     {
                         throw new UserInformationException(string.Format("No files were missing, but {0} remote files were, found, did you mean to run recreate-database?", tp.ExtraVolumes.Count()), "NoRemoteFilesMissing");
                     }
                 }
 
-                if (tp.ExtraVolumes.Count() > 0 || tp.MissingVolumes.Count() > 0 || tp.VerificationRequiredVolumes.Count() > 0)
+                if (tp.ExtraVolumes.Any() || tp.MissingVolumes.Any() || tp.VerificationRequiredVolumes.Any())
                 {
                     if (tp.VerificationRequiredVolumes.Any())
                     {

--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -218,7 +218,7 @@ namespace Duplicati.Library.Modules.Builtin
             if (paths == null || !Utility.Utility.IsClientWindows)
                 return false;
 
-            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Where(x => x.Equals(m_HyperVPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).Any();
+            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Any(x => x.Equals(m_HyperVPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
         }
 
         #endregion

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -216,7 +216,7 @@ namespace Duplicati.Library.Modules.Builtin
             if (paths == null || !Utility.Utility.IsClientWindows)
                 return false;
 
-            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Where(x => x.Equals(m_MSSQLPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).Any();
+            return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Any(x => x.Equals(m_MSSQLPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
         }
 
         #endregion

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -747,13 +747,13 @@ namespace Duplicati.Server.Database
             lock(m_lock)
             {
                 var notifications = GetNotifications();
-                var cur = notifications.Where(x => x.ID == id).FirstOrDefault();
+                var cur = notifications.FirstOrDefault(x => x.ID == id);
                 if (cur == null)
                     return false;
 
                 DeleteFromDb(typeof(Notification).Name, id);
-                Program.DataConnection.ApplicationSettings.UnackedError = notifications.Where(x => x.ID != id && x.Type == Duplicati.Server.Serialization.NotificationType.Error).Any();
-                Program.DataConnection.ApplicationSettings.UnackedWarning = notifications.Where(x => x.ID != id && x.Type == Duplicati.Server.Serialization.NotificationType.Warning).Any();
+                Program.DataConnection.ApplicationSettings.UnackedError = notifications.Any(x => x.ID != id && x.Type == Duplicati.Server.Serialization.NotificationType.Error);
+                Program.DataConnection.ApplicationSettings.UnackedWarning = notifications.Any(x => x.ID != id && x.Type == Duplicati.Server.Serialization.NotificationType.Warning);
             }
 
             System.Threading.Interlocked.Increment(ref Program.LastNotificationUpdateID);
@@ -1139,7 +1139,7 @@ namespace Duplicati.Server.Database
         private void OverwriteAndUpdateDb<T>(System.Data.IDbTransaction transaction, string deleteSql, object[] deleteArgs, IEnumerable<T> values, bool updateExisting)
         {
             var properties = GetORMFields<T>();
-            var idfield = properties.Where(x => x.Name == "ID").FirstOrDefault();
+            var idfield = properties.FirstOrDefault(x => x.Name == "ID");
             properties = properties.Where(x => x.Name != "ID").ToArray();
 
             string sql;

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -692,7 +692,7 @@ namespace Duplicati.Server
                 messageid,
                 null,
                 (n, a) => {
-                    return a.Where(x => x.BackupID == backup.ID).FirstOrDefault() ?? n;
+                    return a.FirstOrDefault(x => x.BackupID == backup.ID) ?? n;
                 }
             );
         }

--- a/Duplicati/Server/UpdatePollThread.cs
+++ b/Duplicati/Server/UpdatePollThread.cs
@@ -187,7 +187,7 @@ namespace Duplicati.Server
                                     "NewUpdateFound",
                                     null,
                                     (self, all) => {
-                                        return all.Where(x => x.Action == "update:new").FirstOrDefault() ?? self;
+                                        return all.FirstOrDefault(x => x.Action == "update:new") ?? self;
                                     }
                                 );
                     }

--- a/Duplicati/Server/WebServer/IndexHtmlHandler.cs
+++ b/Duplicati/Server/WebServer/IndexHtmlHandler.cs
@@ -66,7 +66,7 @@ namespace Duplicati.Server.WebServer
 
         private string GetPath(Uri uri)
         {
-            if (ForbiddenChars.Where(x => uri.AbsolutePath.Contains(x)).Any())
+            if (ForbiddenChars.Any(x => uri.AbsolutePath.Contains(x)))
                 throw new BadRequestException("Illegal path");
             var uripath = Uri.UnescapeDataString(uri.AbsolutePath);
             while(uripath.Length > 0 && (uripath.StartsWith("/", StringComparison.Ordinal) || uripath.StartsWith(DirSep, StringComparison.Ordinal)))

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -284,10 +284,10 @@ namespace Duplicati.Server.WebServer.RESTMethods
             {
                 // Already running
             }
-            else if (Program.WorkThread.CurrentTasks.Where(x => { 
+            else if (Program.WorkThread.CurrentTasks.Any(x => { 
                 var bn = x == null ? null : x.Backup;
                 return bn == null || bn.ID == backup.ID;
-            }).Any())
+            }))
             {
                 // Already in queue
             }
@@ -309,11 +309,11 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 info.OutputOK(new { Status = "OK", Active = true });
                 return;
             }
-            else if (Program.WorkThread.CurrentTasks.Where(x =>
+            else if (Program.WorkThread.CurrentTasks.Any(x =>
             { 
                 var bn = x == null ? null : x.Backup;
                 return bn == null || bn.ID == backup.ID;
-            }).Any())
+            }))
             {
                 info.OutputOK(new { Status = "OK", Active = true });
                 return;
@@ -539,7 +539,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                             return;
                         }
 
-                        if (Program.DataConnection.Backups.Where(x => x.Name.Equals(data.Backup.Name, StringComparison.OrdinalIgnoreCase) && x.ID != data.Backup.ID).Any())
+                        if (Program.DataConnection.Backups.Any(x => x.Name.Equals(data.Backup.Name, StringComparison.OrdinalIgnoreCase) && x.ID != data.Backup.ID))
                         {
                             info.ReportClientError("There already exists a backup with the name: " + data.Backup.Name, System.Net.HttpStatusCode.Conflict);
                             return;

--- a/Duplicati/Server/WebServer/RESTMethods/Backups.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backups.cs
@@ -113,10 +113,10 @@ namespace Duplicati.Server.WebServer.RESTMethods
                         {
                             var basename = ipx.Backup.Name;
                             var c = 0;
-                            while (c++ < 100 && Program.DataConnection.Backups.Where(x => x.Name.Equals(ipx.Backup.Name, StringComparison.OrdinalIgnoreCase)).Any())
+                            while (c++ < 100 && Program.DataConnection.Backups.Any(x => x.Name.Equals(ipx.Backup.Name, StringComparison.OrdinalIgnoreCase)))
                                 ipx.Backup.Name = basename + " (" + c.ToString() + ")";
 
-                            if (Program.DataConnection.Backups.Where(x => x.Name.Equals(ipx.Backup.Name, StringComparison.OrdinalIgnoreCase)).Any())
+                            if (Program.DataConnection.Backups.Any(x => x.Name.Equals(ipx.Backup.Name, StringComparison.OrdinalIgnoreCase)))
                             {
                                 info.BodyWriter.SetOK();
                                 info.Response.ContentType = "text/html";
@@ -204,7 +204,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
                     lock(Program.DataConnection.m_lock)
                     {
-                        if (Program.DataConnection.Backups.Where(x => x.Name.Equals(data.Backup.Name, StringComparison.OrdinalIgnoreCase)).Any())
+                        if (Program.DataConnection.Backups.Any(x => x.Name.Equals(data.Backup.Name, StringComparison.OrdinalIgnoreCase)))
                         {
                             info.ReportClientError("There already exists a backup with the name: " + data.Backup.Name, System.Net.HttpStatusCode.Conflict);
                             return;

--- a/Duplicati/Server/WebServer/RESTMethods/BugReport.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/BugReport.cs
@@ -26,7 +26,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             long id;
             long.TryParse(key, out id);
 
-            var tf = Program.DataConnection.GetTempFiles().Where(x => x.ID == id).FirstOrDefault();
+            var tf = Program.DataConnection.GetTempFiles().FirstOrDefault(x => x.ID == id);
             if (tf == null)
             {
                 info.ReportClientError("Invalid or missing bugreport id", System.Net.HttpStatusCode.NotFound);

--- a/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
@@ -55,7 +55,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 if (ix > 0)
                 {
                     var tk = path.Substring(0, ix + 1);
-                    var node = SpecialFolders.Nodes.Where(x => x.id.Equals(tk, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                    var node = SpecialFolders.Nodes.FirstOrDefault(x => x.id.Equals(tk, StringComparison.OrdinalIgnoreCase));
                     if (node != null)
                     {
                         specialpath = node.resolvedpath;

--- a/Duplicati/Server/WebServer/RESTMethods/Notification.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Notification.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 return;
             }
 
-            var el = Program.DataConnection.GetNotifications().Where(x => x.ID == id).FirstOrDefault();
+            var el = Program.DataConnection.GetNotifications().FirstOrDefault(x => x.ID == id);
             if (el == null)
                 info.ReportClientError("No such notification", System.Net.HttpStatusCode.NotFound);
             else
@@ -46,7 +46,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 return;
             }
 
-            var el = Program.DataConnection.GetNotifications().Where(x => x.ID == id).FirstOrDefault();
+            var el = Program.DataConnection.GetNotifications().FirstOrDefault(x => x.ID == id);
             if (el == null)
                 info.ReportClientError("No such notification", System.Net.HttpStatusCode.NotFound);
             else

--- a/Duplicati/Server/WebServer/RESTMethods/ServerSetting.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/ServerSetting.cs
@@ -69,7 +69,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             {
                 var settings = Program.DataConnection.Settings.ToList();
 
-                var prop = settings.Where(x => string.Equals(key, x.Name, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var prop = settings.FirstOrDefault(x => string.Equals(key, x.Name, StringComparison.OrdinalIgnoreCase));
                 if (prop == null)
                     settings.Add(prop = new Database.Setting() { Name = key, Value = info.Request.Form["data"].Value });
                 else

--- a/Duplicati/Server/WebServer/RESTMethods/Task.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Task.cs
@@ -37,7 +37,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                     return;
                 }
 
-                if (tasks.Where(x => x.TaskID == taskid).FirstOrDefault() == null)
+                if (tasks.FirstOrDefault(x => x.TaskID == taskid) == null)
                 {
                     KeyValuePair<long, Exception>[] matches;
                     lock(Program.MainLock)
@@ -75,7 +75,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 if (task != null)
                     tasks.Insert(0, task);
 
-                task = tasks.Where(x => x.TaskID == taskid).FirstOrDefault();
+                task = tasks.FirstOrDefault(x => x.TaskID == taskid);
                 if (task == null)
                 {
                     info.ReportClientError("No such task", System.Net.HttpStatusCode.NotFound);

--- a/Duplicati/Server/WebServer/RESTMethods/WebModule.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/WebModule.cs
@@ -23,7 +23,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
     {
         public void POST(string key, RequestInfo info)
         {
-            var m = Duplicati.Library.DynamicLoader.WebLoader.Modules.Where(x => x.Key.Equals(key, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            var m = Duplicati.Library.DynamicLoader.WebLoader.Modules.FirstOrDefault(x => x.Key.Equals(key, StringComparison.OrdinalIgnoreCase));
             if (m == null)
             {
                 info.ReportClientError(string.Format("No such command {0}", key), System.Net.HttpStatusCode.NotFound);

--- a/Duplicati/WindowsService/Program.cs
+++ b/Duplicati/WindowsService/Program.cs
@@ -19,9 +19,9 @@ namespace Duplicati.WindowsService
 
         public static void RealMain(string[] args)
         {
-            var install = args != null && args.Where(x => string.Equals("install", x, StringComparison.OrdinalIgnoreCase)).Any();
-            var uninstall = args != null && args.Where(x => string.Equals("uninstall", x, StringComparison.OrdinalIgnoreCase)).Any();
-            var help = args != null && args.Where(x => string.Equals("help", x, StringComparison.OrdinalIgnoreCase)).Any();
+            var install = args != null && args.Any(x => string.Equals("install", x, StringComparison.OrdinalIgnoreCase));
+            var uninstall = args != null && args.Any(x => string.Equals("uninstall", x, StringComparison.OrdinalIgnoreCase));
+            var help = args != null && args.Any(x => string.Equals("help", x, StringComparison.OrdinalIgnoreCase));
 
             if (help)
             {


### PR DESCRIPTION
This simplifies the enumeration of collections by:

1. Replacing a sequence of calls to LINQ extensions with a single call to the overload that takes a predicate.  For example, we replace instances of `collection.Where(predicate).Any()` with `collection.Any(predicate)`.  This reduces the number of enumerators that need to be created while also making the code slightly easier to read.
2. Avoiding unnecessary enumeration when we only care about whether the collection is empty or not.  For example, we replace instances of `if (collection.Count() > 0)` with `if (collection.Any())`.  This can have a positive impact on performance.