### PR TITLE
Avoid potential null reference exception

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -333,9 +333,9 @@ namespace Duplicati.GUI.TrayIcon
             m_isQuitting = true;
             if (m_rumpsProcess != null && !m_rumpsProcess.HasExited)
             {
-                m_toRumps.WriteNoWait(JsonConvert.SerializeObject(new {Action = "shutdown"}));
                 if (m_toRumps != null)
                 {
+                    m_toRumps.WriteNoWait(JsonConvert.SerializeObject(new { Action = "shutdown" }));
                     m_toRumps.Dispose();
                     m_toRumps = null;
                 }


### PR DESCRIPTION
This moves a method call inside an existing `if` statement that checks that the reference is not null.  Previously, the reference was either never null, or users were encountering a null reference exception.