### PR TITLE
Avoid potential comparison of value type with null

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -498,7 +498,7 @@ namespace Duplicati.Library.Backend
         private T SendRequest<T>(HttpMethod method, string url, T body)
         {
             var request = new HttpRequestMessage(method, url);
-            if (body != null)
+            if (!Object.Equals(body, default(T)))
             {
                 request.Content = this.PrepareContent(body);
             }


### PR DESCRIPTION
While there aren't currently any cases where the generic type is a value type, this will make the code slightly more robust to future implementations.