### PR TITLE
Constrain generic type to be a class to allow for null comparison

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -479,12 +479,12 @@ namespace Duplicati.Library.Backend
             return this.SendRequest<T>(HttpMethod.Get, url);
         }
 
-        protected T Post<T>(string url, T body)
+        protected T Post<T>(string url, T body) where T : class
         {
             return this.SendRequest(HttpMethod.Post, url, body);
         }
 
-        protected T Patch<T>(string url, T body)
+        protected T Patch<T>(string url, T body) where T : class
         {
             return this.SendRequest(PatchMethod, url, body);
         }
@@ -495,7 +495,7 @@ namespace Duplicati.Library.Backend
             return this.SendRequest<T>(request);
         }
 
-        private T SendRequest<T>(HttpMethod method, string url, T body)
+        private T SendRequest<T>(HttpMethod method, string url, T body) where T : class
         {
             var request = new HttpRequestMessage(method, url);
             if (body != null)

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -498,7 +498,7 @@ namespace Duplicati.Library.Backend
         private T SendRequest<T>(HttpMethod method, string url, T body)
         {
             var request = new HttpRequestMessage(method, url);
-            if (!Object.Equals(body, default(T)))
+            if (body != null)
             {
                 request.Content = this.PrepareContent(body);
             }


### PR DESCRIPTION
This reverts the changes made in pull request #3414, and adds a constraint to ensure that a generic type parameter is a `class`.  The `SendRequest` method performs a comparison between an object of type `T` and `null`.  While there are no use cases currently where the generic type is a value type, we should constrain the generic type to be a `class` so that the comparison remains meaningful. 
