### PR TITLE
Remove unused empty methods and empty statements

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -165,25 +165,9 @@ namespace Duplicati.GUI.TrayIcon
             ShowStatusWindow();
         }
 
-        protected void OnWizardClicked()
-        {
-        }
-        
-        protected void OnOptionsClicked()
-        {
-        }
-        
-        protected void OnStopClicked()
-        {
-        }
-
         protected void OnQuitClicked()
         {
             Exit();
-        }
-
-        protected void OnThrottleClicked()
-        {
         }
 
         protected void OnPauseClicked()

--- a/Duplicati/Library/AutoUpdater/AutoUpdateSettings.cs
+++ b/Duplicati/Library/AutoUpdater/AutoUpdateSettings.cs
@@ -106,7 +106,7 @@ namespace Duplicati.Library.AutoUpdater
                 if (UsesAlternateURLs)
                     return Environment.GetEnvironmentVariable(string.Format(UPDATEURL_ENVNAME_TEMPLATE, AppName)).Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                 else
-                    return ReadResourceText(UPDATE_URL, OEM_UPDATE_URL).Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);; 
+                    return ReadResourceText(UPDATE_URL, OEM_UPDATE_URL).Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
         }
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -145,7 +145,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
                 if (string.IsNullOrWhiteSpace(token))
                     break;
                 url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.Uri.UrlEncode(m_prefix), token);
-            };
+            }
         }
 
         public void Put(string remotename, string filename)

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCommon.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCommon.cs
@@ -161,7 +161,7 @@ namespace Duplicati.Library.Backend.GoogleServices
                     var chunkSize = Math.Min(UPLOAD_CHUNK_SIZE, stream.Length - offset);
 
                     req.ContentLength = chunkSize;
-                    req.Headers["Content-Range"] = string.Format("bytes {0}-{1}/{2}", offset, offset + chunkSize - 1, stream.Length);;
+                    req.Headers["Content-Range"] = string.Format("bytes {0}-{1}/{2}", offset, offset + chunkSize - 1, stream.Length);
 
                     // Upload the remaining data
                     var areq = new AsyncHttpRequest(req);

--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -135,7 +135,7 @@ namespace Duplicati.Library.Backend
 #endif
                         // append the new data to the data already read-in
                         outputBuilder.Append(e.Data);
-                    };
+                    }
                 }
             );  
 

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -625,7 +625,7 @@ namespace Duplicati.Library.Main.Database
             {
                 get
                 {
-                    return m_reader.ConvertValueToInt64(1);;
+                    return m_reader.ConvertValueToInt64(1);
                 }
             }
 

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -87,10 +87,6 @@ namespace Duplicati.Library.Main.Volumes
             }
         }
 
-        private void VerifyManifest()
-        {
-        }
-
         public virtual void Dispose()
         {
             if (m_disposeCompression && m_compression != null)

--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -63,6 +63,7 @@ namespace Duplicati.Library.Modules.Builtin
 
         public void Configure(IDictionary<string, string> commandlineOptions)
         {
+            // Do nothing.  Implementation needed for IGenericModule interface.
         }
 
         #endregion

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -64,6 +64,7 @@ namespace Duplicati.Library.Modules.Builtin
 
         public void Configure(IDictionary<string, string> commandlineOptions)
         {
+            // Do nothing.  Implementation needed for IGenericModule interface.
         }
 
         #endregion

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -308,6 +308,7 @@ namespace Duplicati.Server
             }
             public void WriteMessage(Library.Logging.LogEntry entry)
             {
+                // Do nothing.  Implementation needed for ILogDestination interface.
             }
 
             public Duplicati.Library.Main.IBackendProgress BackendProgress

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -199,10 +199,6 @@ namespace Duplicati.UnitTest
                     throw new Exception("Failed during final remote verification");
 
         }
-
-        protected void DeleteExistingData()
-        {
-        }
     }
 }
 


### PR DESCRIPTION
This removes some unused empty methods and empty statements (extra semicolons).  The remaining empty methods are implementations of `Dispose`, which will need to be looked at more carefully to determine if the empty implementation is correct.