### PR TITLE
Fix error in POST requests with empty form

### DIFF
--- a/Duplicati/Server/WebServer/RESTHandler.cs
+++ b/Duplicati/Server/WebServer/RESTHandler.cs
@@ -164,7 +164,7 @@ namespace Duplicati.Server.WebServer
                     ((IRESTMethodPUT)mod).PUT(key, info);
                 else if (method == HttpServer.Method.Post && mod is IRESTMethodPOST)
                 {
-                    if (info.Request.Form == HttpServer.HttpForm.EmptyForm)
+                    if (info.Request.Form == HttpServer.HttpForm.EmptyForm || info.Request.Form == HttpServer.HttpInput.Empty)
                     {
                         var r = info.Request.GetType().GetMethod("AssignForm", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance, null, new Type[] { typeof(HttpServer.HttpForm) }, null);
                         r.Invoke(info.Request, new object[] { new HttpServer.HttpForm(info.Request.QueryString) });


### PR DESCRIPTION
Sometimes `info.Request.Form`, which is of type `HttpForm`, is empty and has a value of `HttpInput.Empty` instead of `HttpForm.EmptyForm`. Because of that, the check to see if the form was empty before trying to add items did not return true. 