### PR TITLE
Revert hunk from 9ce1e80. Log redirect needs to be setup

### DIFF
--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -250,6 +250,9 @@ namespace Duplicati.Server
 
             try
             {
+                // Setup the log redirect
+                var logscope = Library.Logging.Log.StartScope(Program.LogHandler, null);
+
                 if (commandlineOptions.ContainsKey("log-file"))
                 {
 #if DEBUG


### PR DESCRIPTION
If the log redirect is not setup, the live logs do not work at all because the scope used is the root one, which has IsolatingScope set to true.

Reverting hunk from 9ce1e80