### PR TITLE
Remove unnecessary use of partial keyword

### DIFF
--- a/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Duplicati.Library.Main.Database
 {
-    internal partial class LocalRecreateDatabase : LocalRestoreDatabase
+    internal class LocalRecreateDatabase : LocalRestoreDatabase
     {
         /// <summary>
         /// The tag used for logging

--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -6,7 +6,7 @@ using Duplicati.Library.Main.Volumes;
 
 namespace Duplicati.Library.Main.Database
 {
-    internal partial class LocalRestoreDatabase : LocalDatabase
+    internal class LocalRestoreDatabase : LocalDatabase
     {
         /// <summary>
         /// The tag used for logging

--- a/Duplicati/WindowsService/ProjectInstaller.cs
+++ b/Duplicati/WindowsService/ProjectInstaller.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Duplicati.WindowsService
 {
     [RunInstaller(true)]
-    public partial class ProjectInstaller : Installer
+    public class ProjectInstaller : Installer
     {
         public ProjectInstaller()
         {


### PR DESCRIPTION
These classes are defined in a single location so the `partial` keyword is unnecessary.