### PR TITLE
Fix issues with XML documentation

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphTypes.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphTypes.cs
@@ -4,14 +4,13 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-/// <summary>
-/// Types are based on definitions from:
-/// https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/onedrive
-/// 
-/// Note that some classes don't have the full set of properties defined, particularly if they don't seem like they are needed.
-/// </summary>
 namespace Duplicati.Library.Backend.MicrosoftGraph
 {
+    /// Types are based on definitions from:
+    /// https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/onedrive
+    ///
+    /// Note that some classes don't have the full set of properties defined, particularly if they don't seem like they are needed.
+
     public class Identity
     {
         [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphTypes.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphTypes.cs
@@ -64,7 +64,7 @@ namespace Duplicati.Library.Backend.MicrosoftGraph
 
         /// <summary>
         /// Note: OneDrive and OneDrive for Business don't allow the following characters in file names:
-        ///   " * : < > ? / \ |
+        ///   &quot; * : &lt; &gt; ? / \ |
         /// https://support.office.com/en-us/article/Invalid-file-names-and-file-types-in-OneDrive-OneDrive-for-Business-and-SharePoint-64883a5d-228e-48f5-b3d2-eb39e07630fa
         /// If appears it also follows the Windows conventions for handling leading and trailing spaces,
         /// meaning the ASCII space character is trimmed off of both the front and back of the file name:

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -159,7 +159,6 @@ namespace Duplicati.Library.Modules.Builtin
         /// </summary>
         private bool m_isConfigured;
         /// <summary>
-        /// <summary>
         /// The mail subject
         /// </summary>
         private string m_subject;

--- a/Duplicati/Library/Utility/Win32.cs
+++ b/Duplicati/Library/Utility/Win32.cs
@@ -209,7 +209,7 @@ namespace Duplicati.Library.Utility
         /// <param name="processInformationLength">Process information length.</param>
         /// <param name="returnLength">The size of the result.</param>
         [DllImport("ntdll.dll", SetLastError = true)]
-        public static extern int NtQueryInformationProcess(IntPtr hProcess, PROCESS_INFORMATION_CLASS processInformationClass, ref IO_PRIORITY_HINT processInformation, int processInformationLength, IntPtr returnlen);
+        public static extern int NtQueryInformationProcess(IntPtr hProcess, PROCESS_INFORMATION_CLASS processInformationClass, ref IO_PRIORITY_HINT processInformation, int processInformationLength, IntPtr returnLength);
 
         /// <summary>
         /// Sets the priority class for the specified process. This value together with the priority value of each thread of the process determines each thread's base priority level.


### PR DESCRIPTION
This fixes a few trivial issues with the XML documentation:
- Remove XML tags and move comment that was not placed before a valid language element.
- Escape invalid XML characters.
- Rename method parameter (using camel-case to match surrounding style) to match XML documentation.
- Remove extra XML tag.
