### PR TITLE
Make description an optional field for backups

### DIFF
--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -518,7 +518,7 @@ namespace Duplicati.Server.Database
                            
                             return new object[] {
                                 n.Name,
-                                n.Description,
+                                n.Description == null ? "" : n.Description, // Description is optional but the column is set to NOT NULL, an additional check is welcome
                                 string.Join(",", n.Tags ?? new string[0]),
                                 n.TargetURL,
                                 update ? (object)item.ID : (object)n.DBPath 

--- a/Duplicati/Server/Database/Database schema/6. Add Description to Backup.sql
+++ b/Duplicati/Server/Database/Database schema/6. Add Description to Backup.sql
@@ -1,1 +1,1 @@
-﻿ALTER TABLE "Backup" ADD COLUMN "Description" TEXT NULL;
+﻿ALTER TABLE "Backup" ADD COLUMN "Description" TEXT NOT NULL DEFAULT '';

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -221,7 +221,6 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             return;
         }
 
-
         if (encryptionEnabled) {
             if ($scope.PassphraseScore === '') {
                 DialogService.dialog(gettextCatalog.getString('Missing passphrase'), gettextCatalog.getString('You must enter a passphrase or disable encryption'));
@@ -486,6 +485,13 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
 
         var filters = $scope.Backup.Filters;
         $scope.Backup.Filters = [];
+
+        // If Description is anything other than a string, we are either creating a new
+        // backup or something went wrong when retrieving an existing one
+        // Either way we should set it to an empty string
+        if (typeof $scope.Backup.Description !== 'string') {
+            $scope.Backup.Description = '';
+        }
 
         $scope.Backup.Sources = $scope.Backup.Sources || [];
 

--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -40,7 +40,7 @@
                         <input type="text" name="name" id="name" ng-model="Backup.Name" placeholder="{{'My Photos' | translate}}" />
                     </div>
                     <div class="input textarea">
-                        <label for="description" translate>Description</label>
+                        <label for="description" translate>Description (optional)</label>
                         <textarea name="description" id="description" ng-model="Backup.Description"></textarea>
                     </div>
                     <div class="input select" ng-hide="SystemInfo.EncryptionModules.length == 0">

--- a/Duplicati/Server/webroot/ngax/templates/home.html
+++ b/Duplicati/Server/webroot/ngax/templates/home.html
@@ -13,10 +13,12 @@
                 </a>
 
                 <dl class="taskmenu" ng-show="$parent.TaskMenuID == item.Backup.ID">
-                    <dt translate>Description:</dt>
-                    <dd>
-                        {{item.Backup.Description}}
-                    </dd>
+                    <span ng-show="item.Backup.Description">
+                        <dt translate>Description:</dt>
+                        <dd>
+                            {{item.Backup.Description}}
+                        </dd>
+                    </span>
 
                     <dt translate>Operations:</dt>
                     <dd>


### PR DESCRIPTION
Checks whether it has been set and acts accordingly to avoid exceptions

Update migration to initialize all existent rows to Description=''.

Note that after some research, default values for TEXT columns were not
supported by MySQL a few years ago, however Duplicati uses SQLite
which seems to fully support this feature. If not, a workaround is to use:

```
ALTER TABLE "Backup" ADD COLUMN "Description" TEXT NULL;
UPDATE "Backup" SET "Description"='' WHERE "Description" IS NULL;
ALTER TABLE "Backup" ALTER COLUMN "Description" TEXT NOT NULL;
```

Closes #3428 and #3433 