### PR TITLE
Seal method to avoid potential reference to uninitialized members

### DIFF
--- a/Duplicati/Library/AutoUpdater/SignatureReadingStream.cs
+++ b/Duplicati/Library/AutoUpdater/SignatureReadingStream.cs
@@ -174,7 +174,9 @@ namespace Duplicati.Library.AutoUpdater
             }
         }
 
-        public override long Position
+        // Since the constructor sets the Position, we seal the implementation here to prevent subclasses
+        // from potentially referencing uninitialized members.
+        public sealed override long Position
         {
             get
             {


### PR DESCRIPTION
The `SignatureReadingStream` constructor calls the `Position` property's setter.  To avoid potential references to uninitialized members, we disallow a subclass from overriding the implementation.