### PR TITLE
Fix useless notification "Warning: Got 0 warning(s)"

### DIFF
--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -462,6 +462,8 @@ namespace Duplicati.Library.Main.Operation
                     Logging.Log.WriteInformationMessage(LOGTAG, "RestoreFailures", "Failed to restore {0} files, additionally the following files failed to download, which may be the cause:{1}{2}", fileErrors, Environment.NewLine, string.Join(Environment.NewLine, brokenFiles));
                 else if (fileErrors > 0)
                     Logging.Log.WriteInformationMessage(LOGTAG, "RestoreFailures", "Failed to restore {0} files", fileErrors);
+                else if (result.FilesRestored == 0)
+                    Logging.Log.WriteWarningMessage(LOGTAG, "NoFilesRestored", null, "Restore completed without errors but no files were restored");
 
                 // Drop the temp tables
                 database.DropRestoreTable();

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -610,7 +610,7 @@ namespace Duplicati.Library.Main
             {
                 if (Errors != null && Errors.Any())
                     return ParsedResultType.Error;
-                else if ((Warnings != null && Warnings.Any()) || FilesRestored == 0)
+                else if (Warnings != null && Warnings.Any())
                     return ParsedResultType.Warning;
                 else
                     return ParsedResultType.Success;

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -780,7 +780,7 @@ namespace Duplicati.Server
                     );
                 }
             }
-            else if (result.ParsedResult != Library.Interface.ParsedResultType.Success && (result.Warnings.Any() || result.Errors.Any()))
+            else if (result.ParsedResult != Library.Interface.ParsedResultType.Success)
             {
                 var type = result.ParsedResult == Library.Interface.ParsedResultType.Warning
                             ? NotificationType.Warning

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -780,37 +780,34 @@ namespace Duplicati.Server
                     );
                 }
             }
-            else
+            else if (result.ParsedResult != Library.Interface.ParsedResultType.Success && (result.Warnings.Any() || result.Errors.Any()))
             {
-                if (result.ParsedResult != Library.Interface.ParsedResultType.Success)
-                {
-                    var type = result.ParsedResult == Library.Interface.ParsedResultType.Warning
-                                ? NotificationType.Warning
-                                : NotificationType.Error;
+                var type = result.ParsedResult == Library.Interface.ParsedResultType.Warning
+                            ? NotificationType.Warning
+                            : NotificationType.Error;
 
-                    var title = result.ParsedResult == Library.Interface.ParsedResultType.Warning
-                                 ? (backup.IsTemporary ?
-                                    "Warning" : string.Format("Warning while running {0}", backup.Name))
-                                : (backup.IsTemporary ?
-                                   "Error" : string.Format("Error while running {0}", backup.Name));
+                var title = result.ParsedResult == Library.Interface.ParsedResultType.Warning
+                                ? (backup.IsTemporary ?
+                                "Warning" : string.Format("Warning while running {0}", backup.Name))
+                            : (backup.IsTemporary ?
+                                "Error" : string.Format("Error while running {0}", backup.Name));
 
-                    var message = result.ParsedResult == Library.Interface.ParsedResultType.Warning
-                                        ? string.Format("Got {0} warning(s) ", result.Warnings.Count())
-                                        : string.Format("Got {0} error(s) ", result.Errors.Count());
+                var message = result.ParsedResult == Library.Interface.ParsedResultType.Warning
+                                    ? string.Format("Got {0} warning(s)", result.Warnings.Count())
+                                    : string.Format("Got {0} error(s)", result.Errors.Count());
 
-                    Program.DataConnection.RegisterNotification(
-                        type,
-                        title,
-                        message,
-                        null,
-                        backup.ID,
-                        null,
-                        null,
-                        null,
-                        "backup:show-log",
-                        (n, a) => n
-                    );
-                }
+                Program.DataConnection.RegisterNotification(
+                    type,
+                    title,
+                    message,
+                    null,
+                    backup.ID,
+                    null,
+                    null,
+                    null,
+                    "backup:show-log",
+                    (n, a) => n
+                );
             }
 
             if (!backup.IsTemporary)


### PR DESCRIPTION
When a restore was made in which 0 files were restored, the Result has Success set to "Warning" and then a notification displaying "Warning: Got 0 warning(s)" appears

Another solution to avoid this was to remove the condition to return "Warning" when 0 files were restored but this could affect things that I don't know about and the problem actually belongs to the notification, so I've decided to simply show warning notifications if and only if we actually have notifications or warnings.

I don't know if this is the behavior wanted by you, just thought it would be a nice PR.