### PR TITLE
Fix URLs in Microsoft Graph backends

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -124,7 +124,7 @@ namespace Duplicati.Library.Backend
 
             // Extract out the path to the backup root folder from the given URI.  Since this can be an expensive operation, 
             // we will cache the value using a lazy initializer.
-            this.rootPathFromURL = new Lazy<string>(() => this.GetRootPathFromUrl(url));
+            this.rootPathFromURL = new Lazy<string>(() => MicrosoftGraphBackend.NormalizeSlashes(this.GetRootPathFromUrl(url)));
         }
 
         public abstract string ProtocolKey { get; }


### PR DESCRIPTION
This fixes an issue introduced in revision f9022fec66cf33cb28e039b3046c31a111008493 ("Avoid referencing virtual members in constructor"), where the `MicrosoftGraphBackend` constructor was provided URLs with unexpected `/` characters.

This addresses issue #3460.