### PR TITLE
Remove unnecessary method overloads in Utility class

### DIFF
--- a/Duplicati/Library/Compression/FileArchiveDirectory.cs
+++ b/Duplicati/Library/Compression/FileArchiveDirectory.cs
@@ -133,7 +133,7 @@ namespace Duplicati.Library.Compression
         /// </summary>
         public long Size
         {
-            get { return Utility.Utility.GetDirectorySize(m_folder, null); }
+            get { return Utility.Utility.GetDirectorySize(m_folder); }
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -513,11 +513,10 @@ namespace Duplicati.Library.Utility
         /// Calculates the size of files in a given folder
         /// </summary>
         /// <param name="folder">The folder to examine</param>
-        /// <param name="filter">A filter to apply</param>
         /// <returns>The combined size of all files that match the filter</returns>
-        public static long GetDirectorySize(string folder, IFilter filter)
+        public static long GetDirectorySize(string folder)
         {
-            return EnumerateFolders(folder, filter).Sum((path) => new FileInfo(path).Length);
+            return EnumerateFolders(folder).Sum((path) => new FileInfo(path).Length);
         }
 
 

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -130,7 +130,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full filenames</returns>
         public static IEnumerable<string> EnumerateFiles(string basepath)
         {
-            return EnumerateFiles(basepath, null);
+            return EnumerateFileSystemEntries(basepath).Where(x => !x.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
         }
 
         /// <summary>
@@ -153,18 +153,6 @@ namespace Duplicati.Library.Utility
         public static IEnumerable<string> EnumerateFileSystemEntries(string basepath)
         {
             return EnumerateFileSystemEntries(basepath, (IFilter)null);
-        }
-
-        /// <summary>
-        /// Returns a list of all files found in the given folder.
-        /// The search is recursive.
-        /// </summary>
-        /// <param name="basepath">The folder to look in</param>
-        /// <param name="filter">The filter to apply.</param>
-        /// <returns>A list of the full filenames</returns>
-        public static IEnumerable<string> EnumerateFiles(string basepath, IFilter filter)
-        {
-            return EnumerateFileSystemEntries(basepath, filter).Where(x => !x.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -141,7 +141,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full paths</returns>
         public static IEnumerable<string> EnumerateFolders(string basepath)
         {
-            return EnumerateFolders(basepath, null);
+            return EnumerateFileSystemEntries(basepath).Where(x => x.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
         }
 
         /// <summary>
@@ -165,18 +165,6 @@ namespace Duplicati.Library.Utility
         public static IEnumerable<string> EnumerateFiles(string basepath, IFilter filter)
         {
             return EnumerateFileSystemEntries(basepath, filter).Where(x => !x.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
-        }
-
-        /// <summary>
-        /// Returns a list of folder names found in the given folder.
-        /// The search is recursive.
-        /// </summary>
-        /// <param name="basepath">The folder to look in</param>
-        /// <param name="filter">The filter to apply.</param>
-        /// <returns>A list of the full paths</returns>
-        public static IEnumerable<string> EnumerateFolders(string basepath, IFilter filter)
-        {
-            return EnumerateFileSystemEntries(basepath, filter).Where(x => x.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -152,7 +152,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full filenames and foldernames. Foldernames ends with the directoryseparator char</returns>
         public static IEnumerable<string> EnumerateFileSystemEntries(string basepath)
         {
-            return EnumerateFileSystemEntries(basepath, (rootpath, path, attributes) => true);
+            return EnumerateFileSystemEntries(basepath, (rootpath, path, attributes) => true, SystemIO.IO_OS.GetDirectories, Directory.GetFiles, null);
         }
 
         /// <summary>
@@ -176,18 +176,6 @@ namespace Duplicati.Library.Utility
         /// <param name="path">The path that produced the error</param>
         /// <param name="ex">The exception for the error</param>
         public delegate void ReportAccessError(string rootpath, string path, Exception ex);
-
-        /// <summary>
-        /// Returns a list of all files found in the given folder.
-        /// The search is recursive.
-        /// </summary>
-        /// <param name="rootpath">The folder to look in</param>
-        /// <param name="callback">The function to call with the filenames</param>
-        /// <returns>A list of the full filenames</returns>
-        public static IEnumerable<string> EnumerateFileSystemEntries(string rootpath, EnumerationFilterDelegate callback)
-        {
-            return EnumerateFileSystemEntries(rootpath, callback, SystemIO.IO_OS.GetDirectories, Directory.GetFiles, null);
-        }
 
         /// <summary>
         /// Returns a list of all files found in the given folder.

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -152,15 +152,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full filenames and foldernames. Foldernames ends with the directoryseparator char</returns>
         public static IEnumerable<string> EnumerateFileSystemEntries(string basepath)
         {
-            IFilter filter = new FilterExpression();
-            return EnumerateFileSystemEntries(basepath, (rootpath, path, attributes) => {
-                if (!filter.Matches(path, out var result, out _))
-                {
-                    result = true;
-                }
-
-                return result;
-            });
+            return EnumerateFileSystemEntries(basepath, (rootpath, path, attributes) => true);
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -152,22 +152,12 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full filenames and foldernames. Foldernames ends with the directoryseparator char</returns>
         public static IEnumerable<string> EnumerateFileSystemEntries(string basepath)
         {
-            return EnumerateFileSystemEntries(basepath, (IFilter)null);
-        }
-
-        /// <summary>
-        /// Returns a list of all files and subfolders found in the given folder.
-        /// The search is recursive.
-        /// </summary>
-        /// <param name="basepath">The folder to look in.</param>
-        /// <param name="filter">The filter to apply.</param>
-        /// <returns>A list of the full filenames and foldernames. Foldernames ends with the directoryseparator char</returns>
-        public static IEnumerable<string> EnumerateFileSystemEntries(string basepath, IFilter filter)
-        {
-            filter = filter ?? new FilterExpression();
+            IFilter filter = new FilterExpression();
             return EnumerateFileSystemEntries(basepath, (rootpath, path, attributes) => {
                 if (!filter.Matches(path, out var result, out _))
+                {
                     result = true;
+                }
 
                 return result;
             });

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -194,21 +194,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A list of the full filenames</returns>
         public static IEnumerable<string> EnumerateFileSystemEntries(string rootpath, EnumerationFilterDelegate callback)
         {
-            return EnumerateFileSystemEntries(rootpath, callback, SystemIO.IO_OS.GetDirectories, Directory.GetFiles);
-        }
-
-        /// <summary>
-        /// Returns a list of all files found in the given folder.
-        /// The search is recursive.
-        /// </summary>
-        /// <param name="rootpath">The folder to look in</param>
-        /// <param name="callback">The function to call with the filenames</param>
-        /// <param name="folderList">A function to call that lists all folders in the supplied folder</param>
-        /// <param name="fileList">A function to call that lists all files in the supplied folder</param>
-        /// <returns>A list of the full filenames</returns>
-        public static IEnumerable<string> EnumerateFileSystemEntries(string rootpath, EnumerationFilterDelegate callback, FileSystemInteraction folderList, FileSystemInteraction fileList)
-        {
-            return EnumerateFileSystemEntries(rootpath, callback, folderList, fileList, null);
+            return EnumerateFileSystemEntries(rootpath, callback, SystemIO.IO_OS.GetDirectories, Directory.GetFiles, null);
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -451,7 +451,6 @@ namespace Duplicati.Library.Utility
             return EnumerateFolders(folder).Sum((path) => new FileInfo(path).Length);
         }
 
-
         /// <summary>
         /// Some streams can return a number that is less than the requested number of bytes.
         /// This is usually due to fragmentation, and is solved by issuing a new read.


### PR DESCRIPTION
The `Utility` class contained many method overloads for enumerating filesystem entries using a provided filter.  However, many of these methods were only invoked with a `null` (empty) filter.  Removing these unnecessary members reduces the amount of clutter in the `Utility` class.