### PR TITLE
Remove redundant calls to ToString

### DIFF
--- a/Duplicati/CommandLine/ConsoleLogTarget.cs
+++ b/Duplicati/CommandLine/ConsoleLogTarget.cs
@@ -72,9 +72,9 @@ namespace Duplicati.CommandLine
                     return;
                 
                 if (entry.Level == LogMessageType.Error)
-                    m_stderr.WriteLine(entry.ToString());
+                    m_stderr.WriteLine(entry);
                 else
-                    m_stdout.WriteLine(entry.ToString());
+                    m_stdout.WriteLine(entry);
             }
             else
             {


### PR DESCRIPTION
This removes a few unnecessary calls to `ToString`.