### PR TITLE
various GPG changes

### DIFF
--- a/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
@@ -64,9 +64,6 @@ namespace Duplicati.Library.DynamicLoader
                 if (string.IsNullOrEmpty(fileExtension))
                     throw new ArgumentNullException(nameof(fileExtension));
 
-                if (string.IsNullOrEmpty(passphrase))
-                    throw new ArgumentNullException(nameof(passphrase));
-
                 LoadInterfaces();
 
                 lock (m_lock)

--- a/Duplicati/Library/Encryption/Duplicati.Library.Encryption.csproj
+++ b/Duplicati/Library/Encryption/Duplicati.Library.Encryption.csproj
@@ -63,6 +63,10 @@
       <Project>{B68F2214-951F-4F78-8488-66E1ED3F50BF}</Project>
       <Name>Duplicati.Library.Localization</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Logging\Duplicati.Library.Logging.csproj">
+      <Project>{D10A5FC0-11B4-4E70-86AA-8AEA52BD9798}</Project>
+      <Name>Duplicati.Library.Logging</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Duplicati/Library/Encryption/GPGEncryption.cs
+++ b/Duplicati/Library/Encryption/GPGEncryption.cs
@@ -19,7 +19,6 @@
 #endregion
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.IO;
 using Duplicati.Library.Interface;
 
@@ -151,31 +150,14 @@ namespace Duplicati.Library.Encryption
                 m_decryption_args += GPG_ARMOR_OPTION;
             }
 
-            //--passphrase-fd is an option
-            m_encryption_args += " " + GPG_COMMANDLINE_STANDARD_OPTIONS;
-            m_decryption_args += " " + GPG_COMMANDLINE_STANDARD_OPTIONS;
+            var encryptOptions = options.ContainsKey(COMMANDLINE_OPTIONS_ENCRYPTION_OPTIONS) ? options[COMMANDLINE_OPTIONS_ENCRYPTION_OPTIONS] : GPG_ENCRYPTION_DEFAULT_OPTIONS;
+            var encryptCmd = options.ContainsKey(COMMANDLINE_OPTIONS_ENCRYPTION_COMMAND) ? options[COMMANDLINE_OPTIONS_ENCRYPTION_COMMAND] : GPG_ENCRYPTION_COMMAND;
+            m_encryption_args += " " + GPG_COMMANDLINE_STANDARD_OPTIONS + " " + encryptOptions +  " " + encryptCmd;
 
-            if (options.ContainsKey(COMMANDLINE_OPTIONS_ENCRYPTION_OPTIONS))
-                m_encryption_args += " " + options[COMMANDLINE_OPTIONS_ENCRYPTION_OPTIONS];
-            else
-                m_encryption_args += " " + GPG_ENCRYPTION_DEFAULT_OPTIONS;
+            var decryptOptions = options.ContainsKey(COMMANDLINE_OPTIONS_DECRYPTION_OPTIONS) ? options[COMMANDLINE_OPTIONS_DECRYPTION_OPTIONS] : GPG_DECRYPTION_DEFAULT_OPTIONS;
+            var decryptCmd = options.ContainsKey(COMMANDLINE_OPTIONS_DECRYPTION_COMMAND) ? options[COMMANDLINE_OPTIONS_DECRYPTION_COMMAND] : GPG_DECRYPTION_COMMAND;
+            m_decryption_args += " " + GPG_COMMANDLINE_STANDARD_OPTIONS + " " +  decryptOptions + " "  + decryptCmd;
 
-            if (options.ContainsKey(COMMANDLINE_OPTIONS_DECRYPTION_OPTIONS))
-                m_decryption_args += " " + options[COMMANDLINE_OPTIONS_DECRYPTION_OPTIONS];
-            else
-                m_decryption_args += " " + GPG_DECRYPTION_DEFAULT_OPTIONS;
-
-            //These are commands and thus inserted last
-
-            if (options.ContainsKey(COMMANDLINE_OPTIONS_ENCRYPTION_COMMAND))
-                m_encryption_args += " " + options[COMMANDLINE_OPTIONS_ENCRYPTION_COMMAND];
-            else
-                m_encryption_args += " " + GPG_ENCRYPTION_COMMAND;
-
-            if (options.ContainsKey(COMMANDLINE_OPTIONS_DECRYPTION_COMMAND))
-                m_decryption_args += " " + options[COMMANDLINE_OPTIONS_DECRYPTION_COMMAND];
-            else
-                m_decryption_args += " " + GPG_DECRYPTION_COMMAND;
 
             if (options.ContainsKey(COMMANDLINE_OPTIONS_PATH))
                 m_programpath = Environment.ExpandEnvironmentVariables(options[COMMANDLINE_OPTIONS_PATH]);

--- a/Duplicati/Library/Encryption/Strings.cs
+++ b/Duplicati/Library/Encryption/Strings.cs
@@ -19,7 +19,7 @@ namespace Duplicati.Library.Encryption.Strings {
         public static string GpgencryptiondisablearmorShort { get { return LC.L(@"Don't use GPG Armor"); } }
         public static string GpgencryptionencryptionswitchesLong { get { return LC.L(@"Use this switch to specify any extra options to GPG. You cannot specify the --passphrase-fd option here. The --encrypt option is always specified."); } }
         public static string GpgencryptionencryptionswitchesShort { get { return LC.L(@"Extra GPG commandline options for encryption"); } }
-        public static string GPGExecuteError(string program, string args, string message) { return LC.L(@"Failed to execute GPG at """"{0}"" {1}"": {2}", program, args, message); }
+        public static string GPGExecuteError(string program, string args, string message) { return LC.L(@"Failed to execute GPG with ""{0} {1}"": {2}", program, args, message); }
         public static string GpgprogrampathLong { get { return LC.L(@"The path to the GNU Privacy Guard program. If not supplied, Duplicati will assume that the program ""gpg"" is available in the system path."); } }
         public static string GpgprogrampathShort { get { return LC.L(@"The path to GnuPG"); } }
         public static string Gpgencryptiondisablearmordeprecated(string optionname) { return LC.L(@"This option has non-standard handling, please use the --{0} option instead.", optionname); }

--- a/Duplicati/Library/Main/Utility.cs
+++ b/Duplicati/Library/Main/Utility.cs
@@ -106,10 +106,12 @@ namespace Duplicati.Library.Main
 
         internal static void VerifyParameters(LocalDatabase db, Options options, System.Data.IDbTransaction transaction = null)
         {
-            var newDict = new Dictionary<string, string>();
-            newDict.Add("blocksize", options.Blocksize.ToString());
-            newDict.Add("blockhash", options.BlockHashAlgorithm);
-            newDict.Add("filehash", options.FileHashAlgorithm);
+            var newDict = new Dictionary<string, string>
+            {
+                { "blocksize", options.Blocksize.ToString() },
+                { "blockhash", options.BlockHashAlgorithm },
+                { "filehash", options.FileHashAlgorithm }
+            };
             var opts = db.GetDbOptions(transaction);
             
             if (options.NoEncryption)

--- a/Duplicati/Server/Database/Backup.cs
+++ b/Duplicati/Server/Database/Backup.cs
@@ -18,7 +18,6 @@
 using System;
 using Duplicati.Server.Serialization.Interface;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Linq;
 
 namespace Duplicati.Server.Database

--- a/Duplicati/Server/Database/Backup.cs
+++ b/Duplicati/Server/Database/Backup.cs
@@ -25,14 +25,14 @@ namespace Duplicati.Server.Database
     public class Backup : IBackup
     {
         // Sensitive information that may be stored in TargetUrl
-        private readonly string[] UrlPasswords = new[]{
+        private readonly string[] UrlPasswords = {
             "authid",
             "auth-password",
             "sia-password",
         };
 
         // Sensitive information that may be stored in Settings
-        private readonly string[] SettingPasswords = new[]{
+        private readonly string[] SettingPasswords = {
             "passphrase",
             "--authid",
             "--send-mail-password",
@@ -111,7 +111,7 @@ namespace Duplicati.Server.Database
         /// <summary>
         /// Gets a value indicating if this instance is not persisted to the database
         /// </summary>        
-        public bool IsTemporary { get { return ID == null ? false : ID.IndexOf("-", StringComparison.Ordinal) > 0; } }
+        public bool IsTemporary { get { return ID != null && ID.IndexOf("-", StringComparison.Ordinal) > 0; } }
 
         /// <summary>
         /// Sanitizes the backup TargetUrl from any fields in the PasswordFields list.

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -324,13 +324,22 @@ namespace Duplicati.Server.Database
             }
         }
 
-        internal Boolean IsPassphraseStored(long id)
+        internal Boolean IsUnencryptedOrPassphraseStored(long id)
         {
             lock (m_lock)
             {
+                var usesEncryption = ReadFromDb(
+                    (rd) => ConvertToBoolean(rd, 0),
+                    @"SELECT VALUE != """" FROM ""Option"" WHERE BackupID = ? AND NAME='encryption-module'", id)
+                    .FirstOrDefault();
+
+                if (!usesEncryption)
+                {
+                    return true;
+                }
+
                 return ReadFromDb(
-                    (rd) => ConvertToBoolean(rd, 0)
-                    ,
+                    (rd) => ConvertToBoolean(rd, 0),
                     @"SELECT VALUE != """" FROM ""Option"" WHERE BackupID = ? AND NAME='passphrase'", id)
                 .FirstOrDefault();
             }

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -309,7 +309,7 @@ namespace Duplicati.Server.Database
             lock(m_lock)
             {
                 var bk = ReadFromDb(
-                    (rd) => new Schedule() {
+                    (rd) => new Schedule {
                         ID = ConvertToInt64(rd, 0),
                         Tags = (ConvertToString(rd, 1) ?? "").Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
                         Time = ConvertToDateTime(rd, 2),
@@ -322,7 +322,19 @@ namespace Duplicati.Server.Database
 
                 return bk;
             }
-        }        
+        }
+
+        internal Boolean IsPassphraseStored(long id)
+        {
+            lock (m_lock)
+            {
+                return ReadFromDb(
+                    (rd) => ConvertToBoolean(rd, 0)
+                    ,
+                    @"SELECT VALUE != """" FROM ""Option"" WHERE BackupID = ? AND NAME='passphrase'", id)
+                .FirstOrDefault();
+            }
+        }
 
         internal long[] GetScheduleIDsFromTags(string[] tags)
         {

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -373,9 +373,11 @@ namespace Duplicati.Server.Database
             
             var disabled_encryption = false;
             var passphrase = string.Empty;
+            var gpgAsymmetricEncryption = false;
             if (item.Settings != null)
             {
                 foreach (var s in item.Settings)
+
                     if (string.Equals(s.Name, "--no-encryption", StringComparison.OrdinalIgnoreCase))
                         disabled_encryption = string.IsNullOrWhiteSpace(s.Value) ? true : Library.Utility.Utility.ParseBool(s.Value, false);
                     else if (string.Equals(s.Name, "passphrase", StringComparison.OrdinalIgnoreCase))
@@ -430,9 +432,12 @@ namespace Duplicati.Server.Database
                         if (!string.IsNullOrWhiteSpace(s.Value) && s.Value.Contains("-"))
                             return "The prefix cannot contain hyphens (-)";
                     }
+                    else if (string.Equals(s.Name, "--gpg-encryption-command", StringComparison.OrdinalIgnoreCase)) {
+                        gpgAsymmetricEncryption = string.Equals(s.Value, "--encrypt", StringComparison.OrdinalIgnoreCase);
+                    }
             }
 
-            if (!disabled_encryption && string.IsNullOrWhiteSpace(passphrase))
+            if (!disabled_encryption && !gpgAsymmetricEncryption && string.IsNullOrWhiteSpace(passphrase))
                 return "Missing passphrase";
 
             if (schedule != null)

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -183,18 +183,21 @@ namespace Duplicati.Server
                 filters);
         }
 
-        public static IRunnerData CreateRestoreTask(Duplicati.Server.Serialization.Interface.IBackup backup, string[] filters, DateTime time, string restoreTarget, bool overwrite, bool restore_permissions, bool skip_metadata)
+        public static IRunnerData CreateRestoreTask(Duplicati.Server.Serialization.Interface.IBackup backup, string[] filters, 
+                                                    DateTime time, string restoreTarget, bool overwrite, bool restore_permissions, 
+                                                    bool skip_metadata, string passphrase = null)
         {
-            var dict = new Dictionary<string, string>();
-            dict["time"] = Duplicati.Library.Utility.Utility.SerializeDateTime(time.ToUniversalTime());
+            var dict = new Dictionary<string, string>
+            {
+                ["time"] = Library.Utility.Utility.SerializeDateTime(time.ToUniversalTime()),
+                ["overwrite"] = overwrite? Boolean.TrueString : Boolean.FalseString,
+                ["restore-permissions"] = restore_permissions ? Boolean.TrueString : Boolean.FalseString,
+                ["skip-metadata"] = skip_metadata ? Boolean.TrueString : Boolean.FalseString,
+                ["passphrase"] = passphrase,
+                ["allow-passphrase-change"] = Boolean.TrueString
+            };
             if (!string.IsNullOrWhiteSpace(restoreTarget))
                 dict["restore-path"] = SpecialFolders.ExpandEnvironmentVariables(restoreTarget);
-            if (overwrite)
-                dict["overwrite"] = "true";
-            if (restore_permissions)
-                dict["restore-permissions"] = "true";
-            if (skip_metadata)
-                dict["skip-metadata"] = "true";
 
             return CreateTask(
                 DuplicatiOperation.Restore,

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -185,7 +185,7 @@ namespace Duplicati.Server
 
         public static IRunnerData CreateRestoreTask(Duplicati.Server.Serialization.Interface.IBackup backup, string[] filters, 
                                                     DateTime time, string restoreTarget, bool overwrite, bool restore_permissions, 
-                                                    bool skip_metadata, string passphrase = null)
+                                                    bool skip_metadata, string passphrase)
         {
             var dict = new Dictionary<string, string>
             {

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -425,7 +425,7 @@ namespace Duplicati.Server
                 try
                 {
                     var sink = new MessageSink(data.TaskID, null);
-                    Program.GenerateProgressState = () => sink.Copy();
+                    Program.GenerateProgressState = sink.Copy;
                     Program.StatusEventNotifyer.SignalNewEvent();
 
                     ((CustomRunnerTask)data).Run(sink);

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -187,7 +187,9 @@ namespace Duplicati.Server.WebServer.RESTMethods
             var input = info.Request.Form;
 
             string[] filters = parsePaths(input["paths"].Value ?? string.Empty);
-            
+
+            var passphrase = string.IsNullOrEmpty(input["passphrase"].Value) ? null : input["passphrase"].Value;
+
             var time = Duplicati.Library.Utility.Timeparser.ParseTimeInterval(input["time"].Value, DateTime.Now);
             var restoreTarget = input["restore-path"].Value;
             var overwrite = Duplicati.Library.Utility.Utility.ParseBool(input["overwrite"].Value, false);
@@ -195,7 +197,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             var permissions = Duplicati.Library.Utility.Utility.ParseBool(input["permissions"].Value, false);
             var skip_metadata = Duplicati.Library.Utility.Utility.ParseBool(input["skip-metadata"].Value, false);
 
-            var task = Runner.CreateRestoreTask(backup, filters, time, restoreTarget, overwrite, permissions, skip_metadata);
+            var task = Runner.CreateRestoreTask(backup, filters, time, restoreTarget, overwrite, permissions, skip_metadata, passphrase);
 
             Program.WorkThread.AddTask(task);
 

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -74,8 +74,10 @@ namespace Duplicati.Server.WebServer.RESTMethods
         private void ListFileSets(IBackup backup, RequestInfo info)
         {
             var input = info.Request.QueryString;
-            var extra = new Dictionary<string, string>();
-            extra["list-sets-only"] = "true";
+            var extra = new Dictionary<string, string>
+            {
+                ["list-sets-only"] = "true"
+            };
             if (input["include-metadata"].Value != null)
                 extra["list-sets-only"] = (!Library.Utility.Utility.ParseBool(input["include-metadata"].Value, false)).ToString();
             if (input["from-remote-only"].Value != null)
@@ -310,7 +312,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         private void IsActive(IBackup backup, RequestInfo info)
         {
             var t = Program.WorkThread.CurrentTask;
-            var bt = t == null ? null : t.Backup;
+            var bt = t?.Backup;
             if (bt != null && backup.ID == bt.ID)
             {
                 info.OutputOK(new { Status = "OK", Active = true });
@@ -318,7 +320,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             }
             else if (Program.WorkThread.CurrentTasks.Any(x =>
             { 
-                var bn = x == null ? null : x.Backup;
+                var bn = x?.Backup;
                 return bn == null || bn.ID == backup.ID;
             }))
             {
@@ -409,7 +411,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 info.OutputOK(new GetResponse()
                 {
                     success = true,
-                    data = new GetResponse.GetResponseData() {
+                    data = new GetResponse.GetResponseData {
                         Schedule = schedule,
                         Backup = bk,
                         DisplayNames = sourcenames

--- a/Duplicati/Server/WebServer/RESTMethods/Backups.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backups.cs
@@ -26,7 +26,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
     {
         public class AddOrUpdateBackupData
         {
-            public Boolean HasPassphraseStored { get; set;}
+            public Boolean IsUnencryptedOrPassphraseStored { get; set;}
             public Database.Schedule Schedule { get; set;}
             public Database.Backup Backup { get; set;}
         }
@@ -38,7 +38,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             var all = from n in backups
                 select new AddOrUpdateBackupData {
-                HasPassphraseStored = Program.DataConnection.IsPassphraseStored(long.Parse(n.ID)),
+                IsUnencryptedOrPassphraseStored = Program.DataConnection.IsUnencryptedOrPassphraseStored(long.Parse(n.ID)),
                 Backup = (Database.Backup)n,
                 Schedule = 
                     (from x in schedules

--- a/Duplicati/Server/WebServer/RESTMethods/Backups.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backups.cs
@@ -26,6 +26,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
     {
         public class AddOrUpdateBackupData
         {
+            public Boolean HasPassphraseStored { get; set;}
             public Database.Schedule Schedule { get; set;}
             public Database.Backup Backup { get; set;}
         }
@@ -36,7 +37,8 @@ namespace Duplicati.Server.WebServer.RESTMethods
             var backups = Program.DataConnection.Backups;
 
             var all = from n in backups
-                select new AddOrUpdateBackupData() {
+                select new AddOrUpdateBackupData {
+                HasPassphraseStored = Program.DataConnection.IsPassphraseStored(long.Parse(n.ID)),
                 Backup = (Database.Backup)n,
                 Schedule = 
                     (from x in schedules

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -50,7 +50,6 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
     $scope.$watch('RepeatPasshrase', computePassPhraseStrength);
 
     $scope.checkGpgAsymmetric = function() {
-
         if (!this.Options) {
             return false;
         }

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -49,6 +49,27 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
     $scope.$watch('Options["passphrase"]', computePassPhraseStrength);
     $scope.$watch('RepeatPasshrase', computePassPhraseStrength);
 
+    $scope.checkGpgAsymmetric = function() {
+
+        if (!this.Options) {
+            return false;
+        }
+
+        if (!('encryption-module' in this.Options)) {
+            return false;
+        }
+
+        if (!this.Options['encryption-module']) {
+            return false;
+        }
+
+        if (this.Options['encryption-module'].indexOf('gpg') < 0) {
+            return false;
+        }
+
+        return this.ExtendedOptions.includes('--gpg-encryption-command=--encrypt');
+    }
+
     $scope.generatePassphrase = function() {
         this.Options["passphrase"] = this.RepeatPasshrase = AppUtils.generatePassphrase();
         this.ShowPassphrase = true;
@@ -221,15 +242,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             return;
         }
 
-        function checkGpgAsymmetric() {
-            if ($scope.Options['encryption-module'].indexOf('gpg') < 0) {
-                return false;
-            }
-
-            return $scope.ExtendedOptions.includes('--gpg-encryption-command=--encrypt');
-        }
-
-        if (encryptionEnabled && !checkGpgAsymmetric()) {
+        if (encryptionEnabled && !$scope.checkGpgAsymmetric()) {
             if ($scope.PassphraseScore === '') {
                 DialogService.dialog(gettextCatalog.getString('Missing passphrase'), gettextCatalog.getString('You must enter a passphrase or disable encryption'));
                 $scope.CurrentStep = 0;

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -26,7 +26,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
     function computePassPhraseStrength() {
 
         var strengthMap = {
-            'x': gettextCatalog.getString("Passwords do not match"),
+            'x': gettextCatalog.getString("Passphrases do not match"),
             0: gettextCatalog.getString("Useless"),
             1: gettextCatalog.getString("Very weak"),
             2: gettextCatalog.getString("Weak"),

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -16,8 +16,8 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
     $scope.ExcludeLargeFiles = false;
 
     $scope.fileAttributes = [
-        {'name': gettextCatalog.getString('Hidden files'), 'value': 'hidden'}, 
-        {'name': gettextCatalog.getString('System files'), 'value': 'system'}, 
+        {'name': gettextCatalog.getString('Hidden files'), 'value': 'hidden'},
+        {'name': gettextCatalog.getString('System files'), 'value': 'system'},
         {'name': gettextCatalog.getString('Temporary files'), 'value': 'temporary'}
     ];
 
@@ -36,7 +36,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
 
         var passphrase = scope.Options == null ? '' : scope.Options['passphrase'];
 
-        if (scope.RepeatPasshrase != passphrase) 
+        if (scope.RepeatPasshrase != passphrase)
             scope.PassphraseScore = 'x';
         else if ((passphrase || '') == '')
             scope.PassphraseScore = '';
@@ -221,7 +221,15 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             return;
         }
 
-        if (encryptionEnabled) {
+        function checkGpgAsymmetric() {
+            if ($scope.Options['encryption-module'].indexOf('gpg') < 0) {
+                return false;
+            }
+
+            return $scope.ExtendedOptions.includes('--gpg-encryption-command=--encrypt');
+        }
+
+        if (encryptionEnabled && !checkGpgAsymmetric()) {
             if ($scope.PassphraseScore === '') {
                 DialogService.dialog(gettextCatalog.getString('Missing passphrase'), gettextCatalog.getString('You must enter a passphrase or disable encryption'));
                 $scope.CurrentStep = 0;
@@ -249,16 +257,16 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
                 }
             });
         }
-        
+
         if ($scope.KeepType == 'time') {
             resetAllRetentionOptionsExcept('keep-time');
-        
+
         } else if ($scope.KeepType == 'versions') {
             resetAllRetentionOptionsExcept('keep-versions');
-        
+
         } else if ($scope.KeepType == 'smart' || $scope.KeepType == 'custom') {
             resetAllRetentionOptionsExcept('retention-policy');
-        
+
         } else {
             resetAllRetentionOptionsExcept(); // keep none
         }
@@ -277,7 +285,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             return;
         }
 
-        if ($scope.KeepType == 'custom' && (opts['retention-policy'] || '').indexOf(':') <= 0) 
+        if ($scope.KeepType == 'custom' && (opts['retention-policy'] || '').indexOf(':') <= 0)
         {
             DialogService.dialog(gettextCatalog.getString('Invalid retention time'), gettextCatalog.getString('You must enter a valid rentention policy string'));
             $scope.CurrentStep = 4;
@@ -372,14 +380,14 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
                         $scope.CurrentStep = 0;
                     else
                         continuation();
-                });                
+                });
             }
             else if (encryptionEnabled != previousEncryptionEnabled || encryptionModule != previousEncryptionModule)
             {
                 DialogService.dialog(gettextCatalog.getString('Encryption changed'), gettextCatalog.getString('You have changed the encryption mode. This may break stuff. You are encouraged to create a new backup instead'), [gettextCatalog.getString('Cancel'), gettextCatalog.getString('Yes, I\'m brave!')], function(ix) {
                     if (ix == 1)
                         continuation();
-                });    
+                });
             }
             else
                 continuation();
@@ -417,7 +425,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             function postDb() {
                 AppService.post('/backups', result, {'headers': {'Content-Type': 'application/json'}}).then(function() {
                     $location.path('/');
-                }, AppUtils.connectionError);                                
+                }, AppUtils.connectionError);
             };
 
             function checkForExistingDb(continuation) {
@@ -506,9 +514,9 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         var dispattr = [];
         var dispmap = {};
 
-        for (var i = exclattr.length - 1; i >= 0; i--) {            
+        for (var i = exclattr.length - 1; i >= 0; i--) {
             var cmp = (exclattr[i] || '').trim().toLowerCase();
-            
+
             // Remove empty entries
             if (cmp.length == 0) {
                 exclattr.splice(i, 1);
@@ -523,7 +531,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
                         dispmap[cmp] = true;
                     }
                     exclattr.splice(i, 1);
-                    break;                    
+                    break;
                 }
             }
         }
@@ -559,7 +567,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             delete extopts[delopts[n]];
 
         $scope.ExtendedOptions = AppUtils.serializeAdvancedOptionsToArray(extopts);
-        
+
         $scope.servermodulesettings = {};
         AppUtils.extractServerModuleOptions($scope.ExtendedOptions, $scope.ServerModules, $scope.servermodulesettings, 'SupportedLocalCommands');
 
@@ -622,10 +630,10 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         if (ix > 0)
             backmodule = backmodule.substr(0, ix);
 
-        $scope.ExtendedOptionList = AppUtils.buildOptionList($scope.SystemInfo, encmodule, compmodule, backmodule);        
+        $scope.ExtendedOptionList = AppUtils.buildOptionList($scope.SystemInfo, encmodule, compmodule, backmodule);
         setupServerModules();
-        
-        AppUtils.extractServerModuleOptions($scope.ExtendedOptions, $scope.ServerModules, $scope.servermodulesettings, 'SupportedLocalCommands');        
+
+        AppUtils.extractServerModuleOptions($scope.ExtendedOptions, $scope.ServerModules, $scope.servermodulesettings, 'SupportedLocalCommands');
     };
 
     function checkAllowedDaysConfig()

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -434,16 +434,15 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
     };
 
     $scope.showInputPassphrase = function () {
-
         if (!this.Backup) {
             return false;
         }
 
-        if (!'HasPassphraseStored' in this.Backup) {
+        if (!'IsUnencryptedOrPassphraseStored' in this.Backup) {
             return false;
         }
 
-        return !this.Backup['HasPassphraseStored'];
+        return !this.Backup['IsUnencryptedOrPassphraseStored'];
     }
 
     $scope.BackupID = $routeParams.backupid;

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -8,6 +8,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
     $scope.HideFolderBrowser = true;
     $scope.RestoreLocation = 'direct';
     $scope.RestoreMode = 'overwrite';
+    $scope.passphrase = "";
 
     var filesetsBuilt = {};
     var filesetsRepaired = {};
@@ -21,7 +22,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
 
     function createGroupLabel(dt) {
         var dateStamp = function(a) { return a.getFullYear() * 10000 + a.getMonth() * 100 + a.getDate(); }
-        
+
         var now       = new Date();
         var today     = dateStamp(now);
         var yesterday = dateStamp(new Date(new Date().setDate(now.getDate()   - 1)));
@@ -30,7 +31,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
         var lastmonth = dateStamp(new Date(new Date().setMonth(now.getMonth() - 2)));
 
         var dateBuckets = [
-            {text: gettextCatalog.getString('Today'), stamp: today}, 
+            {text: gettextCatalog.getString('Today'), stamp: today},
             {text: gettextCatalog.getString('Yesterday'), stamp: yesterday},
             {text: gettextCatalog.getString('This week'), stamp: week},
             {text: gettextCatalog.getString('This month'), stamp: thismonth},
@@ -227,7 +228,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
                 function compareablePath(path) {
                     return $scope.SystemInfo.CaseSensitiveFilesystem ? path : path.toLowerCase();
                 };
-    
+
                 for(var i in filesetsBuilt[version])
                     searchNodes[i] = { Path: filesetsBuilt[version][i].Path };
 
@@ -256,7 +257,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
                                 for(var m in col.Children) {
                                     if (compareablePath(col.Children[m].Path) == compareablePath(curpath)) {
                                         found = true;
-                                        col = col.Children[m];                                    
+                                        col = col.Children[m];
                                     }
                                 }
 
@@ -335,7 +336,8 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
             'time': stamp,
             'restore-path': $scope.RestoreLocation == 'custom' ? $scope.RestorePath : null,
             'overwrite': $scope.RestoreMode == 'overwrite',
-            'permissions': $scope.RestorePermissions == null ? false : $scope.RestorePermissions
+            'permissions': $scope.RestorePermissions == null ? false : $scope.RestorePermissions,
+            'passphrase' : $scope.passphrase
         };
 
         var paths = [];
@@ -430,6 +432,19 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
         if ($scope.restore_step < 2)
             $scope.restore_step = pg;
     };
+
+    $scope.showInputPassphrase = function () {
+
+        if (!this.Backup) {
+            return false;
+        }
+
+        if (!'HasPassphraseStored' in this.Backup) {
+            return false;
+        }
+
+        return !this.Backup['HasPassphraseStored'];
+    }
 
     $scope.BackupID = $routeParams.backupid;
     $scope.IsBackupTemporary = parseInt($scope.BackupID) != $scope.BackupID;

--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -19,7 +19,7 @@
         </div>
     </div>
     <!-- .steps -->
-    
+
     <ol class="steps-legend">
         <li ng-class="{active: CurrentStep == 0}" class="step1" ng-click="CurrentStep = 0" translate>General</li>
         <li ng-class="{active: CurrentStep == 1}" class="step2" ng-click="CurrentStep = 1" translate>Destination</li>
@@ -50,15 +50,15 @@
                         </select>
                     </div>
 
-                    <div class="input encryptionhint" ng-show="(Options['encryption-module'] || '').length == 0">
+                    <div class="input encryptionhint" ng-show="!checkGpgAsymmetric() && (Options['encryption-module'] || '').length == 0">
                         <h3 class="warning" translate>We recommend that you encrypt all backups stored outside your system</h3>
                     </div>
 
-                    <div class="input password" ng-hide="(Options['encryption-module'] || '').length == 0">
+                    <div class="input password" ng-hide="checkGpgAsymmetric() || (Options['encryption-module'] || '').length == 0">
                         <label for="passphrase" translate>Passphrase</label>
                         <input type="{{ShowPassphrase ? 'text' : 'password'}}" name="passphrase" id="passphrase" ng-model="Options['passphrase']" />
                     </div>
-                    <div class="input password" ng-hide="(Options['encryption-module'] || '').length == 0">
+                    <div class="input password" ng-hide="checkGpgAsymmetric() || (Options['encryption-module'] || '').length == 0">
                         <label for="repeat-passphrase" translate>Repeat Passphrase</label>
                         <input type="{{ShowPassphrase ? 'text' : 'password'}}" name="repeat-passphrase" id="repeat-passphrase" ng-model="RepeatPasshrase"/>
 
@@ -116,7 +116,7 @@
             </form>
         </div>
         <!-- .step2 -->
-        
+
         <div class="step step3" ng-class="{active: CurrentStep == 2}">
             <form class="styled">
                 <div class="box browser">
@@ -199,7 +199,7 @@
                                         <select parse-filter-content ng-model="Backup.Filters[$index]" ng-options="item.value as item.name for item in AppUtils.filterGroups">
                                         </select>
                                     </div>
-                                    
+
                                     <a class="button" href title="{{'Remove' | translate}}" ng-click="Backup.Filters.splice($index, 1)">X</a>
                                 </li>
 
@@ -249,7 +249,7 @@
             </form>
         </div>
         <!-- .step3 -->
-        
+
         <div class="step step4" ng-class="{active: CurrentStep == 3}">
             <form class="styled">
                 <h2 translate>Schedule</h2>
@@ -288,7 +288,7 @@
                             ng-click="toggleAllowedDays(day.value)"
                           />
                           <label for="dayofweek_{{day.value}}">{{day.name}}</label>
-                        </div>                
+                        </div>
                     </div>
                 </div>
 
@@ -299,7 +299,7 @@
             </form>
         </div>
         <!-- .step4 -->
-        
+
         <div class="step step5" ng-class="{active: CurrentStep == 4}">
             <form class="styled">
                 <h2 translate>General options</h2>
@@ -343,7 +343,7 @@
                     <div class="retention-options" ng-show="KeepType == 'versions'">
                         <input type="number" ng-model="Options['keep-versions']"  min="1" />
                     </div>
-                    <div class="hint" ng-show="KeepType == 'versions'" translate>Once there are more backups than the specified number, the oldest backups are deleted.</div> 
+                    <div class="hint" ng-show="KeepType == 'versions'" translate>Once there are more backups than the specified number, the oldest backups are deleted.</div>
 
                     <div class="retention-options" ng-show="KeepType == 'time'">
                         <input type="text" class="number" parse-size-number ng-model="Options['keep-time']" />
@@ -364,7 +364,7 @@
 
                 <div ng-repeat="module in ServerModules">
                     <h2 title="{{module.Description}}">{{module.DisplayName}}</h2>
-                    
+
                     <div class="input" ng-repeat="opt in module.SupportedLocalCommands">
                         <label for="{{module.Key}}-{{opt.Name}}" title="{{opt.LongDescription}}">{{opt.ShortDescription}}</label>
                         <input type="text" title="{{opt.LongDescription}}" name="{{module.Key}}-{{opt.Name}}" id="{{module.Key}}-{{opt.Name}}" ng-model="servermodulesettings[opt.Name]" />

--- a/Duplicati/Server/webroot/ngax/templates/restore.html
+++ b/Duplicati/Server/webroot/ngax/templates/restore.html
@@ -129,7 +129,8 @@
             <div  class="input password" ng-show="showInputPassphrase()">
                 <h2 translate>Passphrase</h2>
                 <p translate>
-                    No stored passphrase available. Type a passphrase below to use for restoring your files,
+                    Backup is encrypted but no passphrase is available.
+                    Type a passphrase below to use for restoring your files,
                     or, in case of GPG encryption, leave blank to let gpg retrieve the passphrase by
                     invoking your system's keychain.
                 </p>

--- a/Duplicati/Server/webroot/ngax/templates/restore.html
+++ b/Duplicati/Server/webroot/ngax/templates/restore.html
@@ -48,7 +48,7 @@
                 <label for="restoreversion" translate>Restore from</label>
 
                 <select name="restoreversion" id="restoreversion" ng-model="RestoreVersion" ng-options="fs.Version as fs.DisplayLabel group by fs.GroupLabel for fs in Filesets | orderBy: ['Version']">
-                    
+
                 </select>
             </div>
 
@@ -101,7 +101,7 @@
 
                     <a href ng-click="HideFolderBrowser = true" style="float: right; margin-right: 10px;" translate>Manually type path</a>
                 </div>
-                
+
                 <label for="folder_path_picker" translate>Folder path</label>
                 <div class="resizable filepicker" style="clear: both;">
                     <destination-folder-picker id="folder_path_picker" ng-model="RestorePath" ng-show-hidden="ShowHiddenFolders" ng-hide-user-node="false"></destination-folder-picker>
@@ -124,14 +124,23 @@
             <div class="input checkbox leftflush">
                 <input type="checkbox" id="readwritepermissions" ng-model="RestorePermissions" />
                 <label for="readwritepermissions" translate>Restore read/write permissions</label>
-                
+            </div>
+
+            <div  class="input password" ng-show="showInputPassphrase()">
+                <h2 translate>Passphrase</h2>
+                <p translate>
+                    No stored passphrase available. Type a passphrase below to use for restoring your files,
+                    or, in case of GPG encryption, leave blank to let gpg retrieve the passphrase by
+                    invoking your system's keychain.
+                </p>
+                <input type="password" name="restore_path" id="passphrase" ng-model="passphrase"
+                placeholder="{{'Type passphrase here.' | translate}}" />
             </div>
 
             <div class="buttons">
                 <a href class="submit" ng-click="onStartRestore()" translate>Restore</a>
                 <a href class="submit" ng-click="restore_step = 0" translate>Back</a>
             </div>
-
         </div>
 
         <div ng-show="restore_step == 3 &amp;&amp; connecting == false">
@@ -144,13 +153,13 @@
             </h3>
             <div class="buttons">
                 <a href class="submit" ng-click="onClickComplete()" translate>OK</a>
-            </div>            
+            </div>
         </div>
 
         <div ng-show="connecting == true &amp;&amp; taskid != null">
             <wait-area taskid="taskid" text="ConnectionProgress" allow-cancel="true"></wait-area>
         </div>
-        
+
         <div ng-show="connecting == true &amp;&amp; taskid == null">
             {{ConnectionProgress}}
         </div>


### PR DESCRIPTION
I made some changes motivated by:
https://github.com/duplicati/duplicati/issues/3498

In particular:

- When using asymmetric GPG encryption, a passphrase is not required. 
In fact, the passphrase box disappears (this is a design decision, I'm open for discussion here :)
My argument is, Duplicati does not need to know the passphrase just to encrypt. In fact, Duplicati might not need to know the passphrase in case of GPG at all - more below)
- The UI does not complain anymore for having an empty passphrase and we don't have to use random strings such as "unused"
- Improved logging, i.e., if GPG crashes, we see it (the issue https://github.com/duplicati/duplicati/issues/3498 was afaik related to a faulty recipient option, but no error ever appeared)
- Restoring a GPG asymmetric encrypted backup set has the possibility to specify a passphrase in the second step.
- If no passphrase is supplied, then (at least on Linux), the system's keychain is invoked. Upshot: Duplicati doesn't need to store GPG's passphrase at all.
- Also restoring any other backup set gives the possibility to supply a passphrase, when Duplicati detects that no passphrase is stored. I could narrow this I guess on checking if encryption was ever used for the backup set.

There is some minimal logic in the UI checking if asymmetric GPG is active. In theory, all the above works just as well for symmetric GPG - also there the system's keychain will be invoked (on Linux). We could add a suggestion that it's not necessarily necessary to input a passphrase there, as long as the system's key chain kicks in.

Any feedback regarding corner cases I might have overlooked are more than welcome.