### PR TITLE
Remove duplicate connection entries from advanced options list

### DIFF
--- a/Duplicati/Library/Modules/Builtin/HttpOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HttpOptions.cs
@@ -24,7 +24,7 @@ using System.Linq;
 
 namespace Duplicati.Library.Modules.Builtin
 {
-    public class HttpOptions : Duplicati.Library.Interface.IGenericModule, Duplicati.Library.Interface.IConnectionModule, IDisposable
+    public class HttpOptions : Duplicati.Library.Interface.IConnectionModule, IDisposable
     {
         private const string OPTION_DISABLE_EXPECT100 = "disable-expect100-continue";
         private const string OPTION_DISABLE_NAGLING = "disable-nagling";

--- a/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
@@ -655,7 +655,6 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
         }
 
         copyToList(sysinfo.GenericModules);
-        copyToList(sysinfo.ConnectionModules);
 
         if (encmodule !== false)
             copyToList(sysinfo.EncryptionModules, encmodule);


### PR DESCRIPTION
This removes duplicate connection entries from the advanced options list.  Since the `IConnectionModule` [interface](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Interface/IConnectionModule.cs#L27) implements the `IGenericModule` interface, we do not need to add the connection modules separately.

This addresses issue #2184.