### PR TITLE
Add cache-busting for html/js/css files at each new Duplicati version

### DIFF
--- a/BuildTools/UpdateVersionStamp/Program.cs
+++ b/BuildTools/UpdateVersionStamp/Program.cs
@@ -19,6 +19,9 @@ namespace UpdateVersionStamp
             FILEMAP.Add("AssemblyInfo.cs", new Regex(@"(\[assembly\: AssemblyVersion\(\""" + versionre + @"""\)\])|(\[assembly\: AssemblyFileVersion\(\""" + versionre + @"\""\)\])|(\[assembly\: AssemblyFileVersionAttribute\(\""" + versionre + @"\""\)\])"));
             FILEMAP.Add("UpgradeData.wxi", new Regex(@"\<\?define ProductVersion\=\""" + versionre + @"\"" \?\>"));
             FILEMAP.Add("AssemblyRedirects.xml", new Regex(@"newVersion\=\""" + versionre + @"\"""));
+            FILEMAP.Add("index.html", new Regex(@"\?v\=" + versionre));
+            FILEMAP.Add("login.html", new Regex(@"\?v\=" + versionre));
+            FILEMAP.Add("app.js", new Regex(@"\?v\=" + versionre));
         }
         
         private class Options

--- a/Duplicati/Server/webroot/index.html
+++ b/Duplicati/Server/webroot/index.html
@@ -48,8 +48,8 @@
 
 </script>
 
-    <script type="text/javascript" src="oem/root/index/oem.js" ></script>
-    <link rel="stylesheet" type="text/css" href="oem/root/index/oem.css" />
+    <script type="text/javascript" src="oem/root/index/oem.js?v=2.0.0.7" ></script>
+    <link rel="stylesheet" type="text/css" href="oem/root/index/oem.css?v=2.0.0.7" />
 
 </head>
 

--- a/Duplicati/Server/webroot/login.html
+++ b/Duplicati/Server/webroot/login.html
@@ -8,11 +8,11 @@
     
     <script type="text/javascript" src="login/jquery-2.0.3.min.js"></script>
     <script type="text/javascript" src="login/cryptojs.js"></script>
-    <script type="text/javascript" src="login/login.js"></script>
-    <link rel="stylesheet" type="text/css" href="login/login.css" />
+    <script type="text/javascript" src="login/login.js?v=2.0.0.7"></script>
+    <link rel="stylesheet" type="text/css" href="login/login.css?v=2.0.0.7" />
 
-    <script type="text/javascript" src="oem/root/login/oem.js" ></script>
-    <link rel="stylesheet" type="text/css" href="oem/root/login/oem.css" />
+    <script type="text/javascript" src="oem/root/login/oem.js?v=2.0.0.7" ></script>
+    <link rel="stylesheet" type="text/css" href="oem/root/login/oem.css?v=2.0.0.7" />
 </head>
 
 <body>

--- a/Duplicati/Server/webroot/ngax/index.html
+++ b/Duplicati/Server/webroot/ngax/index.html
@@ -26,10 +26,10 @@
     <meta name="theme-color" content="#ffffff">
 
     <link rel="stylesheet" type="text/css" href="styles/smoothness/jquery-ui.min.css">
-    <link rel="stylesheet" type="text/css" href="styles/style.css">
-    <link rel="stylesheet" type="text/css" href="styles/themes.css">
-    <link rel="stylesheet" type="text/css" href="../oem/ngax/styles/oem.css" />
-    <link rel="stylesheet" type="text/css" href="../customized/customized.css" />
+    <link rel="stylesheet" type="text/css" href="styles/style.css?v=2.0.0.7">
+    <link rel="stylesheet" type="text/css" href="styles/themes.css?v=2.0.0.7">
+    <link rel="stylesheet" type="text/css" href="../oem/ngax/styles/oem.css?v=2.0.0.7" />
+    <link rel="stylesheet" type="text/css" href="../customized/customized.css?v=2.0.0.7" />
 
     <script type="text/javascript" src="scripts/libs/oldbrowsersupport.js"></script>
     <script type="text/javascript" src="scripts/libs/cryptojs.js"></script>
@@ -56,70 +56,70 @@
 
     <script type="text/javascript" src="scripts/libs/angular-gettext.min.js"></script>
 
-    <script type="text/javascript" src="scripts/app.js"></script>
-    <script type="text/javascript" src="scripts/menu.js"></script>
+    <script type="text/javascript" src="scripts/app.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/menu.js?v=2.0.0.7"></script>
 
-    <script type="text/javascript" src="scripts/angular-gettext-cli_compiled_js_output.js"></script>
+    <script type="text/javascript" src="scripts/angular-gettext-cli_compiled_js_output.js?v=2.0.0.7"></script>
 
-    <script type="text/javascript" src="scripts/services/AppUtils.js"></script>
-    <script type="text/javascript" src="scripts/services/BrandingService.js"></script>
-    <script type="text/javascript" src="scripts/services/BackupList.js"></script>
-    <script type="text/javascript" src="scripts/services/AppService.js"></script>
-    <script type="text/javascript" src="scripts/services/ServerStatus.js"></script>
-    <script type="text/javascript" src="scripts/services/SystemInfo.js"></script>
-    <script type="text/javascript" src="scripts/services/EditUriBackendConfig.js"></script>
-    <script type="text/javascript" src="scripts/services/EditUriBuiltins.js"></script>
-    <script type="text/javascript" src="scripts/services/NotificationService.js"></script>
-    <script type="text/javascript" src="scripts/services/DialogService.js"></script>
-    <script type="text/javascript" src="scripts/services/EditBackupService.js"></script>
-    <script type="text/javascript" src="scripts/services/CaptchaService.js"></script>
+    <script type="text/javascript" src="scripts/services/AppUtils.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/BrandingService.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/BackupList.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/AppService.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/ServerStatus.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/SystemInfo.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/EditUriBackendConfig.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/EditUriBuiltins.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/NotificationService.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/DialogService.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/EditBackupService.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/services/CaptchaService.js?v=2.0.0.7"></script>
 
-    <script type="text/javascript" src="scripts/controllers/AppController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/AboutController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/StateController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/SystemSettingsController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/HomeController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/EditBackupController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/RestoreController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/RestoreDirectController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/LogController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/ExportController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/ImportController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/UpdateChangelogController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/DialogController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/LocalDatabaseController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/DeleteController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/CaptchaController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/RestoreWizardController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/AddWizardController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/PauseController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/CommandlineController.js"></script>
-    <script type="text/javascript" src="scripts/controllers/ThrottleController.js"></script>
+    <script type="text/javascript" src="scripts/controllers/AppController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/AboutController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/StateController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/SystemSettingsController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/HomeController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/EditBackupController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/RestoreController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/RestoreDirectController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/LogController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/ExportController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/ImportController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/UpdateChangelogController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/DialogController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/LocalDatabaseController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/DeleteController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/CaptchaController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/RestoreWizardController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/AddWizardController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/PauseController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/CommandlineController.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/controllers/ThrottleController.js?v=2.0.0.7"></script>
 
-    <script type="text/javascript" src="scripts/filters/timeremaining.js"></script>
-    <script type="text/javascript" src="scripts/filters/highlight.js"></script>
-    <script type="text/javascript" src="scripts/filters/parsetimestamp.js"></script>
-    <script type="text/javascript" src="scripts/filters/moment.js"></script>
+    <script type="text/javascript" src="scripts/filters/timeremaining.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/filters/highlight.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/filters/parsetimestamp.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/filters/moment.js?v=2.0.0.7"></script>
 
-    <script type="text/javascript" src="scripts/directives/backupEditUri.js"></script>
-    <script type="text/javascript" src="scripts/directives/sourceFolderPicker.js"></script>
-    <script type="text/javascript" src="scripts/directives/targetFolderPicker.js"></script>
-    <script type="text/javascript" src="scripts/directives/parseFilterType.js"></script>
-    <script type="text/javascript" src="scripts/directives/parseSizeNumber.js"></script>
-    <script type="text/javascript" src="scripts/directives/parseAdvancedOption.js"></script>
-    <script type="text/javascript" src="scripts/directives/stringArrayAsText.js"></script>
-    <script type="text/javascript" src="scripts/directives/waitArea.js"></script>
-    <script type="text/javascript" src="scripts/directives/restoreFilePicker.js"></script>
-    <script type="text/javascript" src="scripts/directives/keyboardHandlers.js"></script>
-    <script type="text/javascript" src="scripts/directives/notificationArea.js"></script>
-    <script type="text/javascript" src="scripts/directives/progressBar.js"></script>
-    <script type="text/javascript" src="scripts/directives/advancedOptionsEditor.js"></script>
-    <script type="text/javascript" src="scripts/directives/timeFormatFixer.js"></script>
-    <script type="text/javascript" src="scripts/directives/externalLink.js"></script>
+    <script type="text/javascript" src="scripts/directives/backupEditUri.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/sourceFolderPicker.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/targetFolderPicker.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/parseFilterType.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/parseSizeNumber.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/parseAdvancedOption.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/stringArrayAsText.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/waitArea.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/restoreFilePicker.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/keyboardHandlers.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/notificationArea.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/progressBar.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/advancedOptionsEditor.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/timeFormatFixer.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="scripts/directives/externalLink.js?v=2.0.0.7"></script>
 
-    <script type="text/javascript" src="../package/ngax/package.js"></script>
-    <script type="text/javascript" src="../oem/ngax/scripts/oem.js"></script>
-    <script type="text/javascript" src="../customized/customized.js"></script>
+    <script type="text/javascript" src="../package/ngax/package.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="../oem/ngax/scripts/oem.js?v=2.0.0.7"></script>
+    <script type="text/javascript" src="../customized/customized.js?v=2.0.0.7"></script>
 
 </head>
 <body class="theme-{{active_theme}}">

--- a/Duplicati/Server/webroot/ngax/scripts/app.js
+++ b/Duplicati/Server/webroot/ngax/scripts/app.js
@@ -11,80 +11,80 @@ var backupApp = angular.module(
 );
 
 backupApp.constant('appConfig', {
-    login_url: '/login.html'
+    login_url: '/login.html?v=2.0.0.7'
 });
 
 backupApp.config(['$routeProvider',
     function($routeProvider) {
         $routeProvider.
             when('/home', {
-                templateUrl: 'templates/home.html'
+                templateUrl: 'templates/home.html?v=2.0.0.7'
             }).
             when('/add', {
-                templateUrl: 'templates/addoredit.html'
+                templateUrl: 'templates/addoredit.html?v=2.0.0.7'
             }).
             when('/add-import', {
-                templateUrl: 'templates/addoredit.html'
+                templateUrl: 'templates/addoredit.html?v=2.0.0.7'
             }).
             when('/restorestart', {
-                templateUrl: 'templates/restorewizard.html'
+                templateUrl: 'templates/restorewizard.html?v=2.0.0.7'
             }).
             when('/addstart', {
-                templateUrl: 'templates/addwizard.html'
+                templateUrl: 'templates/addwizard.html?v=2.0.0.7'
             }).
             when('/edit/:backupid', {
-                templateUrl: 'templates/addoredit.html'
+                templateUrl: 'templates/addoredit.html?v=2.0.0.7'
             }).
             when('/restoredirect', {
-                templateUrl: 'templates/restoredirect.html'
+                templateUrl: 'templates/restoredirect.html?v=2.0.0.7'
             }).
             when('/restoredirect-import', {
-                templateUrl: 'templates/restoredirect.html'
+                templateUrl: 'templates/restoredirect.html?v=2.0.0.7'
             }).
             when('/restore/:backupid', {
-                templateUrl: 'templates/restore.html'
+                templateUrl: 'templates/restore.html?v=2.0.0.7'
             }).
             when('/settings', {
-                templateUrl: 'templates/settings.html'
+                templateUrl: 'templates/settings.html?v=2.0.0.7'
             }).
             when('/about', {
-                templateUrl: 'templates/about.html'
+                templateUrl: 'templates/about.html?v=2.0.0.7'
             }).
             when('/delete/:backupid', {
-                templateUrl: 'templates/delete.html'
+                templateUrl: 'templates/delete.html?v=2.0.0.7'
             }).
             when('/log/:backupid', {
-                templateUrl: 'templates/log.html'
+                templateUrl: 'templates/log.html?v=2.0.0.7'
             }).
             when('/log', {
-                templateUrl: 'templates/log.html'
+                templateUrl: 'templates/log.html?v=2.0.0.7'
             }).
             when('/updatechangelog', {
-                templateUrl: 'templates/updatechangelog.html'
+                templateUrl: 'templates/updatechangelog.html?v=2.0.0.7'
             }).
             when('/export/:backupid', {
-                templateUrl: 'templates/export.html'
+                templateUrl: 'templates/export.html?v=2.0.0.7'
             }).
             when('/import', {
-                templateUrl: 'templates/import.html'
+                templateUrl: 'templates/import.html?v=2.0.0.7'
             }).
             when('/restore-import', {
-                templateUrl: 'templates/import.html'
+                templateUrl: 'templates/import.html?v=2.0.0.7'
             }).
             when('/localdb/:backupid', {
-                templateUrl: 'templates/localdatabase.html'
+                templateUrl: 'templates/localdatabase.html?v=2.0.0.7'
             }).
             when('/commandline', {
-                templateUrl: 'templates/commandline.html'
+                templateUrl: 'templates/commandline.html?v=2.0.0.7'
             }).
             when('/commandline/:backupid', {
-                templateUrl: 'templates/commandline.html'
+                templateUrl: 'templates/commandline.html?v=2.0.0.7'
             }).
             when('/commandline/view/:viewid', {
-                templateUrl: 'templates/commandline.html'
+                templateUrl: 'templates/commandline.html?v=2.0.0.7'
             }).
             otherwise({
-                templateUrl: 'templates/home.html'
+                templateUrl: 'templates/home.html?v=2.0.0.7'
                 //redirectTo: '/home'
         });
 }]);


### PR DESCRIPTION
Everytime a new release is built using `build-release.sh`, the script will execute `UpdateVersionStamp` which will take care of updating the version numbers for the correct version

Closes #3481 