### PR TITLE
Fix incorrect reference to database path

### DIFF
--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -594,7 +594,7 @@ namespace Duplicati.Server
                                 if (Library.Utility.Utility.ParseBoolOption(data.ExtraOptions, "delete-local-db"))
                                 {
                                     string dbpath;
-                                    options.TryGetValue("db-path", out dbpath);
+                                    options.TryGetValue("dbpath", out dbpath);
 
                                     if (!string.IsNullOrWhiteSpace(dbpath) && System.IO.File.Exists(dbpath))
                                         System.IO.File.Delete(dbpath);


### PR DESCRIPTION
This fixes an issue where the wrong key was used to access the options `Dictionary`, which caused the local database to not be deleted when deleting a backup configuration.

This addresses issue #3072.