### PR TITLE
Use local time when checking if day is allowed

### DIFF
--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -374,10 +374,11 @@ namespace Duplicati.Server
         /// <returns>True if the backup is allowed to run, false otherwise</returns>
         private static bool IsDateAllowed(DateTime time, DayOfWeek[] allowedDays)
         {
+            var localTime = time.ToLocalTime();
             if (allowedDays == null || allowedDays.Length == 0)
                 return true;
             else
-                return Array.IndexOf<DayOfWeek>(allowedDays, time.DayOfWeek) >= 0; 
+                return Array.IndexOf<DayOfWeek>(allowedDays, localTime.DayOfWeek) >= 0; 
         }
 
     }


### PR DESCRIPTION
https://forum.duplicati.com/t/incorrect-start-time/1391/21

When using UTC time to check if a day is allowed, this causes unexpected behavior for the user because they expect to allow/disallow days on their local time, not UTC.