### PR TITLE
Replace write-only properties

### DIFF
--- a/Duplicati/CommandLine/ConsoleOutput.cs
+++ b/Duplicati/CommandLine/ConsoleOutput.cs
@@ -40,9 +40,7 @@ namespace Duplicati.CommandLine
         }
     
         #region IMessageSink implementation
-        
-        public IBackendProgress BackendProgress { get; set; }
-        
+       
         private IOperationProgress m_operationProgress;
         public IOperationProgress OperationProgress
         {
@@ -91,6 +89,11 @@ namespace Duplicati.CommandLine
                             break;
                     }
                 }
+        }
+
+        public void SetBackendProgress(IBackendProgress progress)
+        {
+            // Not implemented.
         }
 
         public void WriteMessage(Library.Logging.LogEntry entry)

--- a/Duplicati/CommandLine/ConsoleOutput.cs
+++ b/Duplicati/CommandLine/ConsoleOutput.cs
@@ -79,7 +79,7 @@ namespace Duplicati.CommandLine
 
         public void SetBackendProgress(IBackendProgress progress)
         {
-            // Not implemented.
+            // Do nothing.  Implementation needed for IMessageSink interface.
         }
 
         public void SetOperationProgress(IOperationProgress progress)

--- a/Duplicati/CommandLine/ConsoleOutput.cs
+++ b/Duplicati/CommandLine/ConsoleOutput.cs
@@ -42,21 +42,8 @@ namespace Duplicati.CommandLine
         #region IMessageSink implementation
        
         private IOperationProgress m_operationProgress;
-        public IOperationProgress OperationProgress
-        {
-            get { return m_operationProgress; }
-            set 
-            { 
-                if (m_operationProgress != null)
-                    m_operationProgress.PhaseChanged -= InvokePhaseChanged;
-                    
-                m_operationProgress = value; 
-                
-                if (value != null)
-                    m_operationProgress.PhaseChanged += InvokePhaseChanged;
-            }
-        }
-        
+        public IOperationProgress OperationProgress => m_operationProgress;
+
         private void InvokePhaseChanged(OperationPhase p1, OperationPhase p2)
         {
             if (PhaseChanged != null)
@@ -94,6 +81,17 @@ namespace Duplicati.CommandLine
         public void SetBackendProgress(IBackendProgress progress)
         {
             // Not implemented.
+        }
+
+        public void SetOperationProgress(IOperationProgress progress)
+        {
+            if (m_operationProgress != null)
+                m_operationProgress.PhaseChanged -= InvokePhaseChanged;
+
+            m_operationProgress = progress;
+
+            if (progress != null)
+                m_operationProgress.PhaseChanged += InvokePhaseChanged;
         }
 
         public void WriteMessage(Library.Logging.LogEntry entry)

--- a/Duplicati/CommandLine/ConsoleOutput.cs
+++ b/Duplicati/CommandLine/ConsoleOutput.cs
@@ -38,11 +38,10 @@ namespace Duplicati.CommandLine
             this.VerboseErrors = Library.Utility.Utility.ParseBoolOption(options, "debug-output");
             this.FullResults = Library.Utility.Utility.ParseBoolOption(options, "full-results");
         }
-    
+
         #region IMessageSink implementation
-       
-        private IOperationProgress m_operationProgress;
-        public IOperationProgress OperationProgress => m_operationProgress;
+
+        public IOperationProgress OperationProgress { get; private set; }
 
         private void InvokePhaseChanged(OperationPhase p1, OperationPhase p2)
         {
@@ -85,13 +84,13 @@ namespace Duplicati.CommandLine
 
         public void SetOperationProgress(IOperationProgress progress)
         {
-            if (m_operationProgress != null)
-                m_operationProgress.PhaseChanged -= InvokePhaseChanged;
+            if (OperationProgress != null)
+                this.OperationProgress.PhaseChanged -= InvokePhaseChanged;
 
-            m_operationProgress = progress;
+            OperationProgress = progress;
 
             if (progress != null)
-                m_operationProgress.PhaseChanged += InvokePhaseChanged;
+                this.OperationProgress.PhaseChanged += InvokePhaseChanged;
         }
 
         public void WriteMessage(Library.Logging.LogEntry entry)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/AppIndicatorRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/AppIndicatorRunner.cs
@@ -47,44 +47,39 @@ namespace Duplicati.GUI.TrayIcon
             Gtk.Application.Run();
         }
         
-        
         protected override void SetMenu (IEnumerable<IMenuItem> items)
         {
             base.SetMenu(items);
             m_appIndicator.Menu = m_popupMenu;
         }
         
-        protected override TrayIcons Icon 
+        protected override void SetIcon(TrayIcons icon)
         {
-            set 
-            {
-                m_appIndicator.IconName = GetTrayIconFilename(value);
+            m_appIndicator.IconName = GetTrayIconFilename(icon);
 
-                switch(value)
-                {
-                    case TrayIcons.Paused:
-                        m_appIndicator.IconDesc = "Paused";
-                        break;
-                    case TrayIcons.Running:
-                        m_appIndicator.IconDesc = "Running";
-                        break;
-                    case TrayIcons.IdleError:
-                        m_appIndicator.IconDesc = "Error";
-                        break;
-                    case TrayIcons.RunningError:
-                        m_appIndicator.IconDesc = "Running";
-                        break;
-                    case TrayIcons.PausedError:
-                        m_appIndicator.IconDesc = "Paused";
-                        break;
-                    case TrayIcons.Idle:
-                    default:
-                        m_appIndicator.IconDesc = "Ready";
-                        break;
-                }
+            switch (icon)
+            {
+                case TrayIcons.Paused:
+                    m_appIndicator.IconDesc = "Paused";
+                    break;
+                case TrayIcons.Running:
+                    m_appIndicator.IconDesc = "Running";
+                    break;
+                case TrayIcons.IdleError:
+                    m_appIndicator.IconDesc = "Error";
+                    break;
+                case TrayIcons.RunningError:
+                    m_appIndicator.IconDesc = "Running";
+                    break;
+                case TrayIcons.PausedError:
+                    m_appIndicator.IconDesc = "Paused";
+                    break;
+                case TrayIcons.Idle:
+                default:
+                    m_appIndicator.IconDesc = "Ready";
+                    break;
             }
         }
-
     }
 }
 #endif

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -65,7 +65,7 @@ namespace Duplicati.GUI.TrayIcon
 
             public void SetIcon(MenuIcons icons)
             {
-                // Not implemented.
+                // Do nothing.  Implementation needed for IMenuItem interface.
             }
 
             public void SetEnabled(bool isEnabled)
@@ -75,7 +75,7 @@ namespace Duplicati.GUI.TrayIcon
 
             public void SetDefault(bool isDefault)
             {
-                // Not implemented.
+                // Do nothing.  Implementation needed for IMenuItem interface.
             }
             #endregion
         }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -58,10 +58,9 @@ namespace Duplicati.GUI.TrayIcon
             }
             
             #region IMenuItem implementation
-            public string Text {
-                set {
-                    m_item.Title = value;
-                }
+            public void SetText(string text)
+            {
+                m_item.Title = text;
             }
 
             public Duplicati.GUI.TrayIcon.MenuIcons Icon {

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -68,16 +68,14 @@ namespace Duplicati.GUI.TrayIcon
                 }
             }
 
-            public void SetEnabled(bool enabled)
+            public void SetEnabled(bool isEnabled)
             {
-                m_item.Enabled = enabled;
+                m_item.Enabled = isEnabled;
             }
 
-            public bool Default
+            public void SetDefault(bool isDefault)
             {
-                set
-                {
-                }
+                // Not implemented.
             }
             #endregion
         }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -63,9 +63,9 @@ namespace Duplicati.GUI.TrayIcon
                 m_item.Title = text;
             }
 
-            public Duplicati.GUI.TrayIcon.MenuIcons Icon {
-                set {
-                }
+            public void SetIcon(MenuIcons icons)
+            {
+                // Not implemented.
             }
 
             public void SetEnabled(bool isEnabled)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -189,14 +189,6 @@ namespace Duplicati.GUI.TrayIcon
                 action();
         }
 
-        protected override Duplicati.GUI.TrayIcon.TrayIcons Icon 
-        {
-            set 
-            {
-                m_statusItem.Image = GetIcon(value);
-            }
-        }
-
         protected override Duplicati.GUI.TrayIcon.IMenuItem CreateMenuItem (string text, Duplicati.GUI.TrayIcon.MenuIcons icon, Action callback, System.Collections.Generic.IList<Duplicati.GUI.TrayIcon.IMenuItem> subitems)
         {
             return new MenuItemWrapper(text, callback, subitems);
@@ -214,7 +206,12 @@ namespace Duplicati.GUI.TrayIcon
                     0, 0, 0, null, 0, 0, 0), true);
             }
         }
-        
+
+        protected override void SetIcon(TrayIcons icon)
+        {
+            m_statusItem.Image = GetIcon(icon);
+        }
+
         protected override void SetMenu(System.Collections.Generic.IEnumerable<Duplicati.GUI.TrayIcon.IMenuItem> items)
         {
             m_statusItem.Menu = new NSMenu();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -68,10 +68,9 @@ namespace Duplicati.GUI.TrayIcon
                 }
             }
 
-            public bool Enabled {
-                set {
-                    m_item.Enabled = value;
-                }
+            public void SetEnabled(bool enabled)
+            {
+                m_item.Enabled = enabled;
             }
 
             public bool Default

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -150,9 +150,9 @@ namespace Duplicati.GUI.TrayIcon
                 ((Gtk.Label) m_item.Child).Text = text;
             }
             
-            public MenuIcons Icon
+            public void SetIcon(MenuIcons icon)
             {
-                set { ((ImageMenuItem)m_item).Image = GetIcon(value); }
+                ((ImageMenuItem) m_item).Image = GetIcon(icon);
             }
             
             public void SetEnabled(bool isEnabled)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -162,7 +162,7 @@ namespace Duplicati.GUI.TrayIcon
 
             public void SetDefault(bool isDefault)
             {
-                // Not implemented.
+                // Do nothing.  Implementation needed for TrayIconBase interface.
             }
         }
         

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -155,14 +155,14 @@ namespace Duplicati.GUI.TrayIcon
                 set { ((ImageMenuItem)m_item).Image = GetIcon(value); }
             }
             
-            public void SetEnabled(bool enabled)
+            public void SetEnabled(bool isEnabled)
             {
-                m_item.Sensitive = enabled;
+                m_item.Sensitive = isEnabled;
             }
 
-            public bool Default
+            public void SetDefault(bool isDefault)
             {
-                set { }
+                // Not implemented.
             }
         }
         

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -155,10 +155,9 @@ namespace Duplicati.GUI.TrayIcon
                 set { ((ImageMenuItem)m_item).Image = GetIcon(value); }
             }
             
-            public bool Enabled
+            public void SetEnabled(bool enabled)
             {
-                get { return m_item.Sensitive; }
-                set { m_item.Sensitive = value; }
+                m_item.Sensitive = enabled;
             }
 
             public bool Default

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -305,15 +305,13 @@ namespace Duplicati.GUI.TrayIcon
             
             return _images[icon];
         }
-        
-        protected override TrayIcons Icon 
+
+        protected override void SetIcon(TrayIcons icon)
         {
-            set 
-            {
-                m_trayIcon.Pixbuf = GetIcon(value);
-            }
+            m_trayIcon.Pixbuf = GetIcon(icon);
         }
-        
+       
+
         protected override void SetMenu (IEnumerable<IMenuItem> items)
         {
             m_popupMenu = new Menu();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -145,10 +145,9 @@ namespace Duplicati.GUI.TrayIcon
             }
             */
             
-            public string Text
+            public void SetText(string text)
             {
-                get { return ((Gtk.Label)m_item.Child).Text; }
-                set { ((Gtk.Label)m_item.Child).Text = value; }
+                ((Gtk.Label) m_item.Child).Text = text;
             }
             
             public MenuIcons Icon

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/IBrowserWindow.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/IBrowserWindow.cs
@@ -8,6 +8,6 @@ namespace Duplicati.GUI.TrayIcon
     public interface IBrowserWindow
     {
         void SetTitle(string title);
-        WindowIcons Icon { set; }
+        void SetIcon(WindowIcons icon);
     }
 }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/IBrowserWindow.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/IBrowserWindow.cs
@@ -7,7 +7,7 @@ namespace Duplicati.GUI.TrayIcon
 {
     public interface IBrowserWindow
     {
-        string Title { set; }
+        void SetTitle(string title);
         WindowIcons Icon { set; }
     }
 }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -66,16 +66,12 @@ namespace Duplicati.GUI.TrayIcon
                 }
             }
 
-            public MenuIcons Icon
+            public void SetIcon(MenuIcons icon)
             {
-                get { return m_icon; }
-                set
+                if (m_icon != icon)
                 {
-                    if (m_icon != value)
-                    {
-                        m_icon = value;
-                        m_parent.UpdateMenu(this);
-                    }
+                    m_icon = icon;
+                    m_parent.UpdateMenu(this);
                 }
             }
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -57,18 +57,15 @@ namespace Duplicati.GUI.TrayIcon
             public IList<MenuItemWrapper> Subitems { get; private set; }
             
             #region IMenuItem implementation
-            public string Text
+            public void SetText(string text)
             {
-                get { return m_text; }
-                set
+                if (m_text != text)
                 {
-                    if (m_text != value)
-                    {
-                        m_text = value;
-                        m_parent.UpdateMenu(this);
-                    }
+                    m_text = text;
+                    m_parent.UpdateMenu(this);
                 }
             }
+
             public MenuIcons Icon
             {
                 get { return m_icon; }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -315,15 +315,6 @@ namespace Duplicati.GUI.TrayIcon
             return m_images[icon];
         }
 
-        protected override Duplicati.GUI.TrayIcon.TrayIcons Icon 
-        {
-            set 
-            {
-                m_lastIcon = value;
-                m_toRumps.WriteNoWait(JsonConvert.SerializeObject(new {Action = "seticon", Image = GetIcon(value)}));
-            }
-        }
-
         protected override Duplicati.GUI.TrayIcon.IMenuItem CreateMenuItem (string text, Duplicati.GUI.TrayIcon.MenuIcons icon, Action callback, System.Collections.Generic.IList<Duplicati.GUI.TrayIcon.IMenuItem> subitems)
         {
             return new MenuItemWrapper(this, text, callback, subitems);
@@ -346,6 +337,12 @@ namespace Duplicati.GUI.TrayIcon
                 m_rumpsProcess = null;
             }
 
+        }
+
+        protected override void SetIcon(TrayIcons icon)
+        {
+            m_lastIcon = icon;
+            m_toRumps.WriteNoWait(JsonConvert.SerializeObject(new { Action = "seticon", Image = GetIcon(icon) }));
         }
 
         protected override void SetMenu(System.Collections.Generic.IEnumerable<Duplicati.GUI.TrayIcon.IMenuItem> items)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -78,18 +78,16 @@ namespace Duplicati.GUI.TrayIcon
                     }
                 }
             }
-            public bool Enabled
+
+            public void SetEnabled(bool enabled)
             {
-                get { return m_enabled; }
-                set
+                if (m_enabled != enabled)
                 {
-                    if (m_enabled != value)
-                    {
-                        m_enabled = value;
-                        m_parent.UpdateMenu(this);
-                    }
+                    m_enabled = enabled;
+                    m_parent.UpdateMenu(this);
                 }
             }
+
             public bool Default
             {
                 get { return m_default; }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -79,25 +79,21 @@ namespace Duplicati.GUI.TrayIcon
                 }
             }
 
-            public void SetEnabled(bool enabled)
+            public void SetEnabled(bool isEnabled)
             {
-                if (m_enabled != enabled)
+                if (m_enabled != isEnabled)
                 {
-                    m_enabled = enabled;
+                    m_enabled = isEnabled;
                     m_parent.UpdateMenu(this);
                 }
             }
 
-            public bool Default
+            public void SetDefault(bool isDefault)
             {
-                get { return m_default; }
-                set
+                if (m_default != isDefault)
                 {
-                    if (m_default != value)
-                    {
-                        m_default = value;
-                        m_parent.UpdateMenu(this);
-                    }
+                    m_default = isDefault;
+                    m_parent.UpdateMenu(this);
                 }
             }
             #endregion

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -55,10 +55,10 @@ namespace Duplicati.GUI.TrayIcon
     
     public interface IMenuItem
     {
-        string Text { set; }
         MenuIcons Icon { set; }
         bool Enabled { set; }
         bool Default { set; }
+        void SetText(string text);
     }
     
     public abstract class TrayIconBase : IDisposable
@@ -208,13 +208,13 @@ namespace Duplicati.GUI.TrayIcon
                 if (status.ProgramState == LiveControlState.Running)
                 {
                     m_pauseMenu.Icon = MenuIcons.Pause;
-                    m_pauseMenu.Text = "Pause";
+                    m_pauseMenu.SetText("Pause");
                     m_stateIsPaused = false;
                 }
                 else
                 {
                     m_pauseMenu.Icon = MenuIcons.Resume;
-                    m_pauseMenu.Text = "Resume";
+                    m_pauseMenu.SetText("Resume");
                     m_stateIsPaused = true;
                 }
             });

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -56,8 +56,8 @@ namespace Duplicati.GUI.TrayIcon
     public interface IMenuItem
     {
         MenuIcons Icon { set; }
-        bool Default { set; }
-        void SetEnabled(bool enabled);
+        void SetDefault(bool isDefault);
+        void SetEnabled(bool isEnabled);
         void SetText(string text);
     }
     
@@ -142,7 +142,7 @@ namespace Duplicati.GUI.TrayIcon
         protected IEnumerable<IMenuItem> BuildMenu() 
         {
             var tmp = CreateMenuItem("Open", MenuIcons.Status, OnStatusClicked, null);
-            tmp.Default = true;
+            tmp.SetDefault(true);
             return new IMenuItem[] {
                 tmp,
                 m_pauseMenu = CreateMenuItem("Pause", MenuIcons.Pause, OnPauseClicked, null ),

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -156,7 +156,7 @@ namespace Duplicati.GUI.TrayIcon
             if (window != null)
             {
                 window.Icon = WindowIcons.Regular;
-                window.Title = "Duplicati status";
+                window.SetTitle("Duplicati status");
             }
         }
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -155,7 +155,7 @@ namespace Duplicati.GUI.TrayIcon
             var window = ShowUrlInWindow(Program.Connection.StatusWindowURL);
             if (window != null)
             {
-                window.Icon = WindowIcons.Regular;
+                window.SetIcon(WindowIcons.Regular);
                 window.SetTitle("Duplicati status");
             }
         }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -90,11 +90,11 @@ namespace Duplicati.GUI.TrayIcon
             action();
         }
         
-        protected abstract TrayIcons Icon { set; }
-        
         protected abstract IMenuItem CreateMenuItem(string text, MenuIcons icon, Action callback, IList<IMenuItem> subitems);
         
         protected abstract void Exit();
+
+        protected abstract void SetIcon(TrayIcons icon);
         
         protected abstract void SetMenu(IEnumerable<IMenuItem> items);
 
@@ -184,23 +184,23 @@ namespace Duplicati.GUI.TrayIcon
                 switch(status.SuggestedStatusIcon)
                 {
                     case SuggestedStatusIcon.Active:
-                        Icon = TrayIcons.Running;
+                        this.SetIcon(TrayIcons.Running);
                         break;
                     case SuggestedStatusIcon.ActivePaused:
-                        Icon = TrayIcons.Paused;
+                        this.SetIcon(TrayIcons.Paused);
                         break;
                     case SuggestedStatusIcon.ReadyError:
-                        Icon = TrayIcons.IdleError;
+                        this.SetIcon(TrayIcons.IdleError);
                         break;
                     case SuggestedStatusIcon.ReadyWarning:
-                        Icon = TrayIcons.IdleError;
+                        this.SetIcon(TrayIcons.IdleError);
                         break;
                     case SuggestedStatusIcon.Paused:
-                        Icon = TrayIcons.Paused;
+                        this.SetIcon(TrayIcons.Paused);
                         break;
                     case SuggestedStatusIcon.Ready:
                     default:    
-                        Icon = TrayIcons.Idle;
+                        this.SetIcon(TrayIcons.Idle);
                         break;
                     
                 }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -55,9 +55,9 @@ namespace Duplicati.GUI.TrayIcon
     
     public interface IMenuItem
     {
-        MenuIcons Icon { set; }
         void SetDefault(bool isDefault);
         void SetEnabled(bool isEnabled);
+        void SetIcon(MenuIcons icon);
         void SetText(string text);
     }
     
@@ -207,13 +207,13 @@ namespace Duplicati.GUI.TrayIcon
     
                 if (status.ProgramState == LiveControlState.Running)
                 {
-                    m_pauseMenu.Icon = MenuIcons.Pause;
+                    m_pauseMenu.SetIcon(MenuIcons.Pause);
                     m_pauseMenu.SetText("Pause");
                     m_stateIsPaused = false;
                 }
                 else
                 {
-                    m_pauseMenu.Icon = MenuIcons.Resume;
+                    m_pauseMenu.SetIcon(MenuIcons.Resume);
                     m_pauseMenu.SetText("Resume");
                     m_stateIsPaused = true;
                 }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -56,8 +56,8 @@ namespace Duplicati.GUI.TrayIcon
     public interface IMenuItem
     {
         MenuIcons Icon { set; }
-        bool Enabled { set; }
         bool Default { set; }
+        void SetEnabled(bool enabled);
         void SetText(string text);
     }
     

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
@@ -83,10 +83,9 @@ namespace Duplicati.GUI.TrayIcon.Windows
                 m_menu.Text = text;
             }
 
-            public MenuIcons Icon {
-                set {
-                    m_menu.Image = GetIcon(value);
-                }
+            public void SetIcon(MenuIcons icon)
+            {
+                m_menu.Image = GetIcon(icon);
             }
 
             public void SetEnabled(bool isEnabled)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
@@ -78,10 +78,9 @@ namespace Duplicati.GUI.TrayIcon.Windows
             }
 
             #region IMenuItem implementation
-            public string Text {
-                set {
-                    m_menu.Text = value;
-                }
+            public void SetText(string text)
+            {
+                m_menu.Text = text;
             }
 
             public MenuIcons Icon {

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
@@ -89,10 +89,9 @@ namespace Duplicati.GUI.TrayIcon.Windows
                 }
             }
 
-            public bool Enabled {
-                set {
-                    m_menu.Enabled = value;
-                }
+            public void SetEnabled(bool enabled)
+            {
+                m_menu.Enabled = enabled;
             }
 
             public bool Default {

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
@@ -169,34 +169,7 @@ namespace Duplicati.GUI.TrayIcon.Windows
             m_trayIcon.Visible = true;
             Application.Run();
         }
-
-        protected override TrayIcons Icon {
-            set {
-                switch (value)
-                {
-                    case TrayIcons.IdleError:
-                        m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.ErrorIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
-                        break;
-                    case TrayIcons.Paused:
-                        m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.PauseIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
-                        break;
-                    case TrayIcons.PausedError:
-                        m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.PauseIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
-                        break;
-                    case TrayIcons.Running:
-                        m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.WorkingIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
-                        break;
-                    case TrayIcons.RunningError:
-                        m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.WorkingIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
-                        break;
-                    case TrayIcons.Idle:
-                    default:
-                        m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.NormalIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
-                        break;
-                }
-            }
-        }
-
+       
         protected override IMenuItem CreateMenuItem (string text, MenuIcons icon, Action callback, IList<IMenuItem> subitems)
         {
             return new MenuItemWrapper(text, icon, callback, subitems);
@@ -225,6 +198,32 @@ namespace Duplicati.GUI.TrayIcon.Windows
         protected override void Exit ()
         {
             Application.Exit();
+        }
+
+        protected override void SetIcon(TrayIcons icon)
+        {
+            switch (icon)
+            {
+                case TrayIcons.IdleError:
+                    m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.ErrorIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
+                    break;
+                case TrayIcons.Paused:
+                    m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.PauseIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
+                    break;
+                case TrayIcons.PausedError:
+                    m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.PauseIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
+                    break;
+                case TrayIcons.Running:
+                    m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.WorkingIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
+                    break;
+                case TrayIcons.RunningError:
+                    m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.WorkingIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
+                    break;
+                case TrayIcons.Idle:
+                default:
+                    m_trayIcon.Icon = ImageLoader.LoadIcon(ImageLoader.NormalIcon, System.Windows.Forms.SystemInformation.SmallIconSize);
+                    break;
+            }
         }
 
         protected override void SetMenu (System.Collections.Generic.IEnumerable<IMenuItem> items)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
@@ -89,15 +89,14 @@ namespace Duplicati.GUI.TrayIcon.Windows
                 }
             }
 
-            public void SetEnabled(bool enabled)
+            public void SetEnabled(bool isEnabled)
             {
-                m_menu.Enabled = enabled;
+                m_menu.Enabled = isEnabled;
             }
 
-            public bool Default {
-                set {
-                    m_menu.Font = new System.Drawing.Font(m_menu.Font, System.Drawing.FontStyle.Bold);
-                }
+            public void SetDefault(bool value)
+            {
+                m_menu.Font = new System.Drawing.Font(m_menu.Font, System.Drawing.FontStyle.Bold);
             }
             #endregion
         }

--- a/Duplicati/Library/Interface/ResultInterfaces.cs
+++ b/Duplicati/Library/Interface/ResultInterfaces.cs
@@ -55,15 +55,15 @@ namespace Duplicati.Library.Interface
 
     public interface IParsedBackendStatistics : IBackendStatstics
     {
-        long UnknownFileSize { get; }
-        long UnknownFileCount { get; }
-        long KnownFileCount { get; }
-        long KnownFileSize { get; }
-        DateTime LastBackupDate { get; }
-        long BackupListCount { get; }
-        long TotalQuotaSpace { get; }
-        long FreeQuotaSpace { get; }
-        long AssignedQuotaSpace { get; }
+        long UnknownFileSize { get; set; }
+        long UnknownFileCount { get; set; }
+        long KnownFileCount { get; set; }
+        long KnownFileSize { get; set; }
+        DateTime LastBackupDate { get; set; }
+        long BackupListCount { get; set; }
+        long TotalQuotaSpace { get; set; }
+        long FreeQuotaSpace { get; set; }
+        long AssignedQuotaSpace { get; set; }
     }
 
     public interface IBackendStatsticsReporter

--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -40,12 +40,12 @@ namespace Duplicati.Library.Main
         /// </summary>
         /// <value>The backend progress update object</value>
         void SetBackendProgress(IBackendProgress progress);
-        
+
         /// <summary>
         /// Sets the operation progress update object
         /// </summary>
         /// <value>The operation progress update object</value>
-        IOperationProgress OperationProgress { set; }
+        void SetOperationProgress(IOperationProgress progress);
     }
 
     /// <summary>
@@ -88,13 +88,10 @@ namespace Duplicati.Library.Main
                 s.SetBackendProgress(progress);
         }
 
-        public IOperationProgress OperationProgress
+        public void SetOperationProgress(IOperationProgress progress)
         {
-            set
-            {
-                foreach (var s in m_sinks)
-                    s.OperationProgress = value;
-            }
+            foreach (var s in m_sinks)
+                s.SetOperationProgress(progress);
         }
 
         public void BackendEvent(BackendActionType action, BackendEventType type, string path, long size)

--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Library.Main
         /// Sets the backend progress update object
         /// </summary>
         /// <value>The backend progress update object</value>
-        IBackendProgress BackendProgress { set; }
+        void SetBackendProgress(IBackendProgress progress);
         
         /// <summary>
         /// Sets the operation progress update object
@@ -82,13 +82,10 @@ namespace Duplicati.Library.Main
             m_sinks = na;
         }
 
-        public IBackendProgress BackendProgress
+        public void SetBackendProgress(IBackendProgress progress)
         {
-            set
-            {
-                foreach (var s in m_sinks)
-                    s.BackendProgress = value;
-            }
+            foreach (var s in m_sinks)
+                s.SetBackendProgress(progress);
         }
 
         public IOperationProgress OperationProgress

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -25,18 +25,8 @@ using Newtonsoft.Json;
 
 namespace Duplicati.Library.Main
 {
-    internal interface IBackendWriter
+    internal interface IBackendWriter : IParsedBackendStatistics
     {
-        long UnknownFileSize { set; }
-        long UnknownFileCount { set; }
-        long KnownFileCount { set; }
-        long KnownFileSize { set; }
-        DateTime LastBackupDate { set; }
-        long BackupListCount { set; }
-        long TotalQuotaSpace { set; }
-        long FreeQuotaSpace { set; }
-        long AssignedQuotaSpace { set; }
-
         bool ReportedQuotaError { get; set; }
         bool ReportedQuotaWarning { get; set; }
 

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -59,7 +59,7 @@ namespace Duplicati.Library.Main
     internal interface ISetCommonOptions
     {
         DateTime EndTime { get; set; }
-        DateTime BeginTime { set; }
+        DateTime BeginTime { get; set; }
 
         void SetDatabase(LocalDatabase db);
 

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -240,7 +240,7 @@ namespace Duplicati.Library.Main
                 m_messageSink = value;
                 if (value != null)
                 {
-                    m_messageSink.OperationProgress = this.OperationProgressUpdater;
+                    m_messageSink.SetOperationProgress(this.OperationProgressUpdater);
                     m_messageSink.SetBackendProgress(this.BackendProgressUpdater);
                 }
             }

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -241,7 +241,7 @@ namespace Duplicati.Library.Main
                 if (value != null)
                 {
                     m_messageSink.OperationProgress = this.OperationProgressUpdater;
-                    m_messageSink.BackendProgress = this.BackendProgressUpdater;
+                    m_messageSink.SetBackendProgress(this.BackendProgressUpdater);
                 }
             }
         }

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -60,11 +60,10 @@ namespace Duplicati.Library.Main
     {
         DateTime EndTime { get; set; }
         DateTime BeginTime { get; set; }
+        IMessageSink MessageSink { get; set; }
+        OperationMode MainOperation { get; }
 
         void SetDatabase(LocalDatabase db);
-
-        OperationMode MainOperation { get; }
-        IMessageSink MessageSink { set; }
     }
 
     internal class BackendWriter : BasicResults, IBackendWriter, IBackendStatstics, IParsedBackendStatistics

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -328,10 +328,6 @@ namespace Duplicati.Library.Utility
                     default: throw new NotSupportedException();
                 }
             }
-
-            public override long Position
-            { set { if (value == this.Position) return; else throw new NotSupportedException(); } }
-
         }
 
 

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -316,18 +316,15 @@ namespace Duplicati.Server
                     m_backendProgress = progress;
             }
 
+            public void SetOperationProgress(Library.Main.IOperationProgress progress)
+            {
+                lock (m_lock)
+                    m_operationProgress = progress;
+            }
+
             public void WriteMessage(Library.Logging.LogEntry entry)
             {
                 // Do nothing.  Implementation needed for ILogDestination interface.
-            }
-           
-            public Duplicati.Library.Main.IOperationProgress OperationProgress
-            {
-                set
-                {
-                    lock(m_lock)
-                        m_operationProgress = value;
-                }
             }
             #endregion
         }

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -309,19 +309,18 @@ namespace Duplicati.Server
                     }
                 }
             }
+
+            public void SetBackendProgress(Library.Main.IBackendProgress progress)
+            {
+                lock (m_lock)
+                    m_backendProgress = progress;
+            }
+
             public void WriteMessage(Library.Logging.LogEntry entry)
             {
                 // Do nothing.  Implementation needed for ILogDestination interface.
             }
-
-            public Duplicati.Library.Main.IBackendProgress BackendProgress
-            {
-                set
-                {
-                    lock(m_lock)
-                        m_backendProgress = value;
-                }
-            }
+           
             public Duplicati.Library.Main.IOperationProgress OperationProgress
             {
                 set


### PR DESCRIPTION
Write-only properties present a peculiar API and can be confusing.  This is evidenced by several implementations that actually provided a getter that was never used.  These write-only properties have been replaced by methods, which more clearly convey the write-only semantics, or made writable in cases where all implementations already provided a getter.