### PR TITLE
Use invariant culture in calls to ToLower and ToUpper

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Text;
 using Duplicati.Library.Interface;
 using System.Linq;
+using System.Globalization;
 
 namespace Duplicati.CommandLine.BackendTester
 {
@@ -158,8 +159,8 @@ namespace Duplicati.CommandLine.BackendTester
             string enabledModulesValue;
             options.TryGetValue("enable-module", out enabledModulesValue);
             options.TryGetValue("disable-module", out disabledModulesValue);
-            string[] enabledModules = enabledModulesValue == null ? new string[0] : enabledModulesValue.Trim().ToLower().Split(',');
-            string[] disabledModules = disabledModulesValue == null ? new string[0] : disabledModulesValue.Trim().ToLower().Split(',');
+            string[] enabledModules = enabledModulesValue == null ? new string[0] : enabledModulesValue.Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
+            string[] disabledModules = disabledModulesValue == null ? new string[0] : disabledModulesValue.Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
 
             List<Library.Interface.IGenericModule> loadedModules = new List<IGenericModule>();
             foreach (Library.Interface.IGenericModule m in Library.DynamicLoader.GenericLoader.Modules)

--- a/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
+++ b/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
@@ -327,7 +327,7 @@ namespace Duplicati.Library.Backend
             /*if (stream.CanSeek)
             {
                 System.Security.Cryptography.MD5 md5 = System.Security.Cryptography.MD5.Create();
-                req.Headers["ETag"] = Core.Utility.ByteArrayAsHexString(md5.ComputeHash(stream)).ToLower();
+                req.Headers["ETag"] = Core.Utility.ByteArrayAsHexString(md5.ComputeHash(stream)).ToLower(System.Globalization.CultureInfo.InvariantCulture);
                 stream.Seek(0, System.IO.SeekOrigin.Begin);
 
                 using (System.IO.Stream s = req.GetRequestStream())

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -25,6 +25,7 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Common.IO;
 using Renci.SshNet;
 using Renci.SshNet.Common;
+using System.Globalization;
 
 namespace Duplicati.Library.Backend
 {
@@ -289,10 +290,10 @@ namespace Duplicati.Library.Backend
                 string hostFingerprint = e.HostKeyName + " " + e.KeyLength.ToString() + " " + BitConverter.ToString(e.FingerPrint).Replace('-', ':');
 
                 if (string.IsNullOrEmpty(m_fingerprint))
-                    throw new Library.Utility.HostKeyException(Strings.SSHv2Backend.FingerprintNotSpecifiedManagedError(hostFingerprint.ToLower(), SSH_FINGERPRINT_OPTION, SSH_FINGERPRINT_ACCEPT_ANY_OPTION), hostFingerprint, m_fingerprint);
+                    throw new Library.Utility.HostKeyException(Strings.SSHv2Backend.FingerprintNotSpecifiedManagedError(hostFingerprint.ToLower(CultureInfo.InvariantCulture), SSH_FINGERPRINT_OPTION, SSH_FINGERPRINT_ACCEPT_ANY_OPTION), hostFingerprint, m_fingerprint);
 
                 if (!String.Equals(hostFingerprint, m_fingerprint, StringComparison.OrdinalIgnoreCase))
-                    throw new Library.Utility.HostKeyException(Strings.SSHv2Backend.FingerprintNotMatchManagedError(hostFingerprint.ToLower()), hostFingerprint, m_fingerprint);
+                    throw new Library.Utility.HostKeyException(Strings.SSHv2Backend.FingerprintNotMatchManagedError(hostFingerprint.ToLower(CultureInfo.InvariantCulture)), hostFingerprint, m_fingerprint);
                 else
                     e.CanTrust = true;
             };

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
+using System.Globalization;
 
 namespace Duplicati.Library.Main
 {
@@ -1096,7 +1097,7 @@ namespace Duplicati.Library.Main
             get
             {
                 if (m_options.ContainsKey("enable-module"))
-                    return m_options["enable-module"].Trim().ToLower().Split(',');
+                    return m_options["enable-module"].Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
                 else
                     return new string[0];
             }
@@ -1110,7 +1111,7 @@ namespace Duplicati.Library.Main
             get
             {
                 if (m_options.ContainsKey("disable-module"))
-                    return m_options["disable-module"].Trim().ToLower().Split(',');
+                    return m_options["disable-module"].Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
                 else
                     return new string[0];
             }

--- a/Duplicati/Library/Snapshots/Program.cs
+++ b/Duplicati/Library/Snapshots/Program.cs
@@ -45,7 +45,7 @@ namespace Duplicati.Library.Snapshots
                         key = args[i];
 
                     //Skip the leading --
-                    key = key.Substring(2).ToLower();
+                    key = key.Substring(2).ToLower(System.Globalization.CultureInfo.InvariantCulture);
                     if (!string.IsNullOrEmpty(value) && value.Length > 1 && value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal))
                         value = value.Substring(1, value.Length - 2);
 

--- a/Duplicati/Library/Utility/CommandLineParser.cs
+++ b/Duplicati/Library/Utility/CommandLineParser.cs
@@ -54,7 +54,7 @@ namespace Duplicati.Library.Utility
                         key = args[i];
 
                     //Skip the leading --
-                    key = key.Substring(2).ToLower();
+                    key = key.Substring(2).ToLower(System.Globalization.CultureInfo.InvariantCulture);
                     if (!string.IsNullOrEmpty(value) && value.Length > 1 && value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal))
                         value = value.Substring(1, value.Length - 2);
 

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -19,6 +19,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 namespace Duplicati.Library.Utility
 {
@@ -121,7 +122,7 @@ namespace Duplicati.Library.Utility
                 else
                 {
                     this.Type = (filter.Contains(MULTIPLE_WILDCARD) || filter.Contains(SINGLE_WILDCARD)) ? FilterType.Wildcard : FilterType.Simple;
-                    this.Filter = (!Utility.IsFSCaseSensitive && this.Type == FilterType.Wildcard) ? filter.ToUpper() : filter;
+                    this.Filter = (!Utility.IsFSCaseSensitive && this.Type == FilterType.Wildcard) ? filter.ToUpper(CultureInfo.InvariantCulture) : filter;
                     this.Regexp = new Regex(Utility.ConvertGlobbingToRegExp(filter), REGEXP_OPTIONS);
                 }
             }
@@ -266,7 +267,7 @@ namespace Duplicati.Library.Utility
                     case FilterType.Simple:
                         return string.Equals(this.Filter, path, Library.Utility.Utility.ClientFilenameStringComparison);
                     case FilterType.Wildcard:
-                        return IsWildcardMatch(!Utility.IsFSCaseSensitive ? path.ToUpper() : path, this.Filter);
+                        return IsWildcardMatch(!Utility.IsFSCaseSensitive ? path.ToUpper(CultureInfo.InvariantCulture) : path, this.Filter);
                     case FilterType.Regexp:
                     case FilterType.Group:
                         var m = this.Regexp.Match(path);

--- a/Duplicati/Library/Utility/TempFile.cs
+++ b/Duplicati/Library/Utility/TempFile.cs
@@ -32,7 +32,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The prefix applied to all temporary files
         /// </summary>
-        public static string APPLICATION_PREFIX = Utility.getEntryAssembly().FullName.Substring(0, 3).ToLower() + "-";
+        public static string APPLICATION_PREFIX = Utility.getEntryAssembly().FullName.Substring(0, 3).ToLower(System.Globalization.CultureInfo.InvariantCulture) + "-";
         
         private string m_path;
         private bool m_protect;

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -23,6 +23,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Common;
+using System.Globalization;
 
 namespace Duplicati.Library.Utility
 {
@@ -617,7 +618,7 @@ namespace Duplicati.Library.Utility
             if (string.IsNullOrEmpty(value) || value.Trim().Length == 0)
                 return System.Threading.ThreadPriority.Normal;
 
-            switch (value.ToLower().Trim())
+            switch (value.ToLower(CultureInfo.InvariantCulture).Trim())
             {
                 case "+2":
                 case "high":
@@ -656,7 +657,7 @@ namespace Duplicati.Library.Utility
                 return defaultFunc();
             }
 
-            switch (value.Trim().ToLower())
+            switch (value.Trim().ToLower(CultureInfo.InvariantCulture))
             {
                 case "1":
                 case "on":

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Duplicati.Library.Common;
@@ -21,12 +22,12 @@ namespace Duplicati.Server
         /// <summary>
         /// The name of the environment variable that holds the path to the data folder used by Duplicati
         /// </summary>
-        public static readonly string DATAFOLDER_ENV_NAME = Duplicati.Library.AutoUpdater.AutoUpdateSettings.AppName.ToUpper() + "_HOME";
+        public static readonly string DATAFOLDER_ENV_NAME = Duplicati.Library.AutoUpdater.AutoUpdateSettings.AppName.ToUpper(CultureInfo.InvariantCulture) + "_HOME";
 
         /// <summary>
         /// The environment variable that holdes the database key used to encrypt the SQLite database
         /// </summary>
-        public static readonly string DB_KEY_ENV_NAME = Duplicati.Library.AutoUpdater.AutoUpdateSettings.AppName.ToUpper() + "_DB_KEY";
+        public static readonly string DB_KEY_ENV_NAME = Duplicati.Library.AutoUpdater.AutoUpdateSettings.AppName.ToUpper(CultureInfo.InvariantCulture) + "_DB_KEY";
 
         /// <summary>
         /// Gets the folder where Duplicati data is stored

--- a/Duplicati/Server/WebServer/RESTMethods/Tags.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Tags.cs
@@ -16,6 +16,7 @@
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Duplicati.Server.WebServer.RESTMethods
@@ -30,10 +31,10 @@ namespace Duplicati.Server.WebServer.RESTMethods
                     .Union(Serializable.ServerSettings.EncryptionModules)
                     .Union(Serializable.ServerSettings.BackendModules)
                     .Union(Serializable.ServerSettings.GenericModules)
-                    select n.Key.ToLower();
+                    select n.Key.ToLower(CultureInfo.InvariantCulture);
 
             // Append all known tags
-            r = r.Union(from n in Program.DataConnection.Backups select n.Tags into p from x in p select x.ToLower());
+            r = r.Union(from n in Program.DataConnection.Backups select n.Tags into p from x in p select x.ToLower(CultureInfo.InvariantCulture));
             info.OutputOK(r);       
         }
 

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -20,6 +20,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Globalization;
 
 namespace Duplicati.UnitTest
 {
@@ -182,7 +183,7 @@ namespace Duplicati.UnitTest
                 string message = $"{value} should be parsed to true.";
 
                 Assert.IsTrue(Utility.ParseBool(value, false), message);
-                Assert.IsTrue(Utility.ParseBool(value.ToUpper(), false), message);
+                Assert.IsTrue(Utility.ParseBool(value.ToUpper(CultureInfo.InvariantCulture), false), message);
                 Assert.IsTrue(Utility.ParseBool($" {value} ", false), message);
             }
 
@@ -191,7 +192,7 @@ namespace Duplicati.UnitTest
                 string message = $"{value} should be parsed to false.";
 
                 Assert.IsFalse(Utility.ParseBool(value, true), message);
-                Assert.IsFalse(Utility.ParseBool(value.ToUpper(), true), message);
+                Assert.IsFalse(Utility.ParseBool(value.ToUpper(CultureInfo.InvariantCulture), true), message);
                 Assert.IsFalse(Utility.ParseBool($" {value} ", true), message);
             }
 


### PR DESCRIPTION
Calls to `ToLower` and `ToUpper` should typically not be sensitive to any culture.