### PR TITLE
Remove condition that always evaluates to true

### DIFF
--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -260,7 +260,7 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
                     );
                     SetWaitUntil(null, DateTime.Now + m_delayTimeSpan);
                 }
-                else if (self != null && self.Count > 1)
+                else if (self.Count > 1)
                     throw new UserInformationException(Strings.AmzCD.MultipleEntries(p, "/" + string.Join("/", curpath)), "AmzCDMultipleEntries");
                 else
                     parent = self.Data.First();


### PR DESCRIPTION
This removes a condition that always evaluates to `true`.  The corresponding `if` condition guarantees that this line will only be reached if `self` is not `null`.