### PR TITLE
Convert regex pattern to wildcard in default excludes group

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -606,18 +606,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Creates a Regex filter
-        /// </summary>
-        /// <param name="filter">Filter text</param>
-        /// <returns>Regex filter</returns>
-        private static string CreateRegexFilter(string filter)
-        {
-            // Create a filter with the given name.
-            // However, in order to match paths correctly, the directory separators need to be normalized to match the system default.
-            return "[" + filter.Replace(FilterGroups.RegexEscapedAltDirectorySeparatorChar, FilterGroups.RegexEscapedDirectorySeparatorChar) + "]";
-        }
-
-        /// <summary>
         /// Gets a list of exclude paths from the MacOS system
         /// </summary>
         /// <returns>The list of paths to exclude on OSX backups.</returns>

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -297,7 +297,8 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"*/Google/Chrome/Safe Browsing*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/iPhoto Library/iPod Photo Cache/");
                 yield return FilterGroups.CreateWildcardFilter(@"*/Mozilla/Firefox/*cache*");
-                yield return FilterGroups.CreateRegexFilter(@".*/(cookies|permissions).sqlite(-.{3})?");
+                yield return FilterGroups.CreateWildcardFilter(@"*/cookies.sqlite-*"); // Journal for database used to store Firefox cookies between sessions
+                yield return FilterGroups.CreateWildcardFilter(@"*/permissions.sqlite-*"); // Journal for database used to store Firefox site-specific permissions
             }
 
             if (group.HasFlag(FilterGroup.TemporaryFiles))


### PR DESCRIPTION
This provides a workaround for the poor performance of the default excludes group exhibited by regex filters.  While this wildcard pattern will potentially exclude more files than the previous regex pattern, in
practice this should not often be the case.

This does not resolve the performance issue of the regex filters discussed in issue #3395.  However, I think in general we should try to avoid expensive application-specific filters since these will affect the performance for all users of the default excludes group, whether the application is present or not.

Below are some benchmarks for enumerating (using `Utility.EnumerateFileSystemEntries`) the entries in a directory that contains ~155,000 files and ~33,000 directories.  The `DefaultFilters` method represents the default filters as of revision a0af8d00c, and the `DefaultFiltersWildcardOnly` method represents the default filters as modified in this branch.  The `SingleRegexFilter` method consists of a single regex filter, and the `DualRegexFilter` consists of two regex filters.  None of the filters matched any entry in the directory being enumerated, so the number of entries being tested should be pretty consistent across the tests.

```
                     Method |     Mean |    Error |   StdDev | Scaled | ScaledSD |
--------------------------- |---------:|---------:|---------:|-------:|---------:|
                  NoFilters |  3.420 s | 0.0282 s | 0.0264 s |   0.05 |     0.00 |
             DefaultFilters | 63.868 s | 0.3148 s | 0.2790 s |   1.00 |     0.00 |
 DefaultFiltersWildcardOnly | 24.730 s | 0.3938 s | 0.3683 s |   0.39 |     0.01 |
          SingleRegexFilter | 46.562 s | 0.7440 s | 0.6959 s |   0.73 |     0.01 |
            DualRegexFilter | 86.367 s | 1.0413 s | 0.9740 s |   1.35 |     0.02 |

// * Legends *
  Mean     : Arithmetic mean of all measurements
  Error    : Half of 99.9% confidence interval
  StdDev   : Standard deviation of all measurements
  Scaled   : Mean(CurrentBenchmark) / Mean(BaselineBenchmark)
  ScaledSD : Standard deviation of ratio of distribution of [CurrentBenchmark] and [BaselineBenchmark]
  1 s      : 1 Second (1 sec)
```
The above results clearly illustrate the prohibitive cost of a regex filter.  I think [there are ways](https://github.com/duplicati/duplicati/issues/3395#issuecomment-437704755) that we can improve this, but I would need to gain more insight into why the current implementation is the way it is.
