### PR TITLE
reduce backup logs page_size

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/BackupLogController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/BackupLogController.js
@@ -1,7 +1,7 @@
 backupApp.controller('BackupLogController', function($scope, $routeParams, AppUtils, LogService, BackupList, gettextCatalog) {
     $scope.BackupID = $routeParams.backupid;
-    
-    const PAGE_SIZE = 100;
+
+    const PAGE_SIZE = 15;
 
     $scope.$watch('Page', function() {
         if ($scope.Page == 'remote' && $scope.RemoteData == null)
@@ -16,10 +16,10 @@ backupApp.controller('BackupLogController', function($scope, $routeParams, AppUt
 
     $scope.formatDuration = AppUtils.formatDuration;
     $scope.formatSize = AppUtils.formatSizeString;
-    
-    $scope.Page = 'general';  
 
-    $scope.LoadMoreGeneralData = function() { 
+    $scope.Page = 'general';
+
+    $scope.LoadMoreGeneralData = function() {
         LogService.LoadMoreData('/backup/' + $scope.BackupID + '/log', $scope.GeneralData, 'ID', PAGE_SIZE)
             .then(function(result) {
                 if (!result)
@@ -29,7 +29,7 @@ backupApp.controller('BackupLogController', function($scope, $routeParams, AppUt
                 $scope.GeneralDataComplete = result.complete;
                 $scope.Backup = BackupList.lookup[$scope.BackupID];
                 for (var i in current) {
-                    try { 
+                    try {
                         current[i].Result = JSON.parse(current[i].Message);
                         current[i].Formatted = JSON.stringify(current[i].Result, null, 2);
                     }
@@ -42,19 +42,19 @@ backupApp.controller('BackupLogController', function($scope, $routeParams, AppUt
                 }
                 $scope.GeneralData = current;
                 $scope.$digest();
-            }); 
+            });
     };
-    $scope.LoadMoreRemoteData = function() { 
+    $scope.LoadMoreRemoteData = function() {
         LogService.LoadMoreData('/backup/' + $scope.BackupID + '/remotelog', $scope.RemoteData, 'ID', PAGE_SIZE)
             .then(function(result) {
                 if (!result)
                     return;
-                
+
                 $scope.RemoteData = result.current;
                 $scope.RemoteDataComplete = result.complete;
                 $scope.Backup = BackupList.lookup[$scope.BackupID];
                 $scope.$digest();
-            }); 
+            });
     };
 
     $scope.ResultIcon = function(parsedResult) {
@@ -68,7 +68,7 @@ backupApp.controller('BackupLogController', function($scope, $routeParams, AppUt
             return 'fa fa-question-circle';
         }
     }
-    
+
     $scope.LoadMoreGeneralData();
     $scope.Backup = BackupList.lookup[$scope.BackupID];
 


### PR DESCRIPTION
The log page rework is causing a few moments of browser freeze with log 45 items out of 100. With a lower number of entries it performs perfectly fine.

I don't see any obvious performance issues in the frontend, but it's also a lot of content to load at once. In this case 340KB of logs.

15 log entries is arbitrary, but it seems plenty in normal use cases.