### PR TITLE
Fix to allow creation of fedora installer.

### DIFF
--- a/Installer/fedora/Dockerfile.build
+++ b/Installer/fedora/Dockerfile.build
@@ -7,7 +7,7 @@ ENV DOCKER_BUILD_PROXY $DOCKER_BUILD_PROXY
 # Install common build tools
 RUN dnf -y install deltarpm
 RUN dnf -y upgrade
-RUN dnf -y install @"Minimal Install" @buildsys-build yum-utils rpm-sign gnupg rpmdevtools --allowerasing
+RUN dnf -y --allowerasing install @"Minimal Install" @buildsys-build yum-utils rpm-sign gnupg rpmdevtools
 
 # Install mono things
 RUN dnf -y install mono-devel gnome-sharp-devel dos2unix git nuget


### PR DESCRIPTION
Required to build the installer. Goes unnoticed if you already build the docker image and have it in your cache, but fails on new creation.