### PR TITLE
Only create passphrase option if passphrase is provided

### DIFF
--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -193,11 +193,12 @@ namespace Duplicati.Server
                 ["overwrite"] = overwrite? Boolean.TrueString : Boolean.FalseString,
                 ["restore-permissions"] = restore_permissions ? Boolean.TrueString : Boolean.FalseString,
                 ["skip-metadata"] = skip_metadata ? Boolean.TrueString : Boolean.FalseString,
-                ["passphrase"] = passphrase,
                 ["allow-passphrase-change"] = Boolean.TrueString
             };
             if (!string.IsNullOrWhiteSpace(restoreTarget))
                 dict["restore-path"] = SpecialFolders.ExpandEnvironmentVariables(restoreTarget);
+            if (!(passphrase is null))
+                dict["passphrase"] = passphrase;
 
             return CreateTask(
                 DuplicatiOperation.Restore,


### PR DESCRIPTION
This fixes an issue introduced in revision f7800e8a2bd where passphrase-less restore operations from the UI would result in the following exception:
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.ArgumentException: Empty passphrase not allowed
Parameter name: passphrase
```
This addresses issue #3542.