### PR TITLE
Fix Duplicati shutdown issue on Synology

### DIFF
--- a/Installer/Synology/scripts/start-stop-status
+++ b/Installer/Synology/scripts/start-stop-status
@@ -68,7 +68,7 @@ DaemonStop() {
 	DaemonStatus
 	if [ $? == 1 ]; then
 		echo "Stopping ${PACKAGE_NAME_SIMPLE}."
-		kill -- -$(ps -o pgid= $(cat "$PID_FILE") | grep -o '[0-9]*')
+		pkill -P $(cat "$PID_FILE")
 		rm -f "$PID_FILE"
 		
 		rm -f /usr/local/etc/nginx/conf.d/dsm.duplicati.conf

--- a/Installer/Synology/scripts/start-stop-status
+++ b/Installer/Synology/scripts/start-stop-status
@@ -68,7 +68,7 @@ DaemonStop() {
 	DaemonStatus
 	if [ $? == 1 ]; then
 		echo "Stopping ${PACKAGE_NAME_SIMPLE}."
-		kill $(cat "$PID_FILE");
+		kill -- -$(ps -o pgid= $(cat "$PID_FILE") | grep -o '[0-9]*')
 		rm -f "$PID_FILE"
 		
 		rm -f /usr/local/etc/nginx/conf.d/dsm.duplicati.conf


### PR DESCRIPTION
The current Synology start-stop-status does not properly shut down Duplicati.  It terminates only the main process but not the child processes.

Example processes before Duplicati is stopped via Synology Package Manager:

```
bash-4.3# ps ax | grep Dup
15236 ?        Sl     0:00 mono /volume1/@appstore/Duplicati/Duplicati.Server.exe
15242 ?        Sl     0:01 /volume1/@appstore/Mono/usr/local/bin/mono-sgen /volume1/@appstore/Duplicati/Duplicati.Server.exe
```

After telling Duplicati to stop, only PID 15236 is terminated.  PID 15242 remains, and this causes problems if you try to start Duplicati again.  This issue also causes problems when people try to upgrade as a stop/start cycle is needed in such a case.

With this change the script will look up the process group ID (PGID) of the main PID and issue a kill command to that whole group.  This will ensure the child processes are also shut down.