### PR TITLE
Improve performance of default excludes filters

### DIFF
--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -406,16 +406,19 @@ namespace Duplicati.Library.Utility
             if (string.IsNullOrWhiteSpace(filter))
                 return null;
 
-            if (filter.Length < 2 ||
-                (filter.StartsWith("[", StringComparison.Ordinal) && filter.EndsWith("]", StringComparison.Ordinal)) ||
-                (filter.StartsWith("{", StringComparison.Ordinal) && filter.EndsWith("}", StringComparison.Ordinal)))
+            if (filter.Length < 2 || (filter.StartsWith("[", StringComparison.Ordinal) && filter.EndsWith("]", StringComparison.Ordinal)))
             {
                 return new string[] { filter };
             }
-            else
+
+            if (filter.StartsWith("{", StringComparison.Ordinal) && filter.EndsWith("}", StringComparison.Ordinal))
             {
-                return filter.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                string groupName = filter.Substring(1, filter.Length - 2);
+                FilterGroup filterGroup = FilterGroups.ParseFilterList(groupName, FilterGroup.None);
+                return (filterGroup == FilterGroup.None) ? null : FilterGroups.GetFilterStrings(filterGroup);
             }
+
+            return filter.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
         }
         
         private static List<FilterEntry> Compact(IEnumerable<FilterEntry> items)


### PR DESCRIPTION
This improves the performance of the default excludes filters by not converting them to a large regex filter.  Previously, the `FilterExpression.Expand` method would forward the filter group name to the `FilterEntry` constructor, which would combine the group's patterns into one large regex filter.  This would result in a significant decrease in performance, as the regex filters are much slower than the wildcard filters.

Instead, we can first expand the filter group into its constituent patterns before presenting them to the `FilterEntry` constructor.  This preserves their wildcard nature and allows us to take advantage of faster filter matching algorithms.

This addresses issue #3395.