### PR TITLE
Remove empty finally blocks

### DIFF
--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -516,15 +516,11 @@ namespace Duplicati.Library.Backend
             catch (Interface.FileMissingException) { throw; }
             catch (Interface.FolderMissingException) { throw; }
             catch { if (!useNewContext) /* retry */ doGet(remotename, stream, true); else throw; }
-            finally { }
-            try
-            {
-                byte[] copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
-                using (var fileInfo = SP.File.OpenBinaryDirect(ctx, fileurl))
-                using (var s = fileInfo.Stream)
-                    Utility.Utility.CopyStream(s, stream, true, copybuffer);
-            }
-            finally { }
+
+            byte[] copybuffer = new byte[Duplicati.Library.Utility.Utility.DEFAULT_BUFFER_SIZE];
+            using (var fileInfo = SP.File.OpenBinaryDirect(ctx, fileurl))
+            using (var s = fileInfo.Stream)
+                Utility.Utility.CopyStream(s, stream, true, copybuffer);
         }
 
         public void Put(string remotename, string filename)
@@ -554,12 +550,10 @@ namespace Duplicati.Library.Backend
             catch (Interface.FileMissingException) { throw; }
             catch (Interface.FolderMissingException) { throw; }
             catch { if (!useNewContext) /* retry */ { doPut(remotename, stream, true); return; } else throw; }
-            finally { }
 
             if (m_useBinaryDirectMode)
             {
-                try { SP.File.SaveBinaryDirect(ctx, fileurl, stream, true); }
-                finally { }
+                SP.File.SaveBinaryDirect(ctx, fileurl, stream, true);
             }
 
         }
@@ -696,7 +690,6 @@ namespace Duplicati.Library.Backend
             catch (Interface.FileMissingException) { throw; }
             catch (Interface.FolderMissingException) { throw; }
             catch { if (!useNewContext) /* retry */ doCreateFolder(true); else throw; }
-            finally { }
         }
 
         public void Delete(string remotename) { doDelete(remotename, false); }
@@ -722,7 +715,6 @@ namespace Duplicati.Library.Backend
             catch (Interface.FileMissingException) { throw; }
             catch (Interface.FolderMissingException) { throw; }
             catch { if (!useNewContext) /* retry */ doDelete(remotename, true); else throw; }
-            finally { }
         }
 
         #endregion

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -1376,25 +1376,19 @@ namespace Duplicati.Library.Main
 
         public void WaitForComplete(LocalDatabase db, System.Data.IDbTransaction transation)
         {
-            try
-            {
-                m_statwriter.BackendProgressUpdater.SetBlocking(true);
-                m_db.FlushDbMessages(db, transation);
-                if (m_lastException != null)
-                    throw m_lastException;
+            m_statwriter.BackendProgressUpdater.SetBlocking(true);
+            m_db.FlushDbMessages(db, transation);
+            if (m_lastException != null)
+                throw m_lastException;
 
-                var item = new FileEntryItem(OperationType.Terminate, null);
-                if (m_queue.Enqueue(item))
-                    item.WaitForComplete();
+            var item = new FileEntryItem(OperationType.Terminate, null);
+            if (m_queue.Enqueue(item))
+                item.WaitForComplete();
 
-                m_db.FlushDbMessages(db, transation);
+            m_db.FlushDbMessages(db, transation);
 
-                if (m_lastException != null)
-                    throw m_lastException;
-            }
-            finally
-            {
-            }
+            if (m_lastException != null)
+                throw m_lastException;
         }
 
         public void WaitForEmpty(LocalDatabase db, System.Data.IDbTransaction transation)

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -630,23 +630,17 @@ namespace Duplicati.Server.WebServer.RESTMethods
                         bool hasPaused = Program.LiveControl.State == LiveControls.LiveControlState.Paused;
                         Program.LiveControl.Pause();
 
-                        try
-                        {
-                            for(int i = 0; i < 10; i++)
-                                if (Program.WorkThread.Active)
-                                {
-                                    var t = Program.WorkThread.CurrentTask;
-                                    if (backup.Equals(t == null ? null : t.Backup))
-                                        System.Threading.Thread.Sleep(1000);
-                                    else
-                                        break;
-                                }
+                        for(int i = 0; i < 10; i++)
+                            if (Program.WorkThread.Active)
+                            {
+                                var t = Program.WorkThread.CurrentTask;
+                                if (backup.Equals(t == null ? null : t.Backup))
+                                    System.Threading.Thread.Sleep(1000);
                                 else
                                     break;
-                        }
-                        finally
-                        {
-                        }
+                            }
+                            else
+                                break;
 
                         if (Program.WorkThread.Active)
                         {


### PR DESCRIPTION
Empty `finally` blocks serve no purpose.  In cases where no exceptions are caught, we removed the `try` as well.