### PR TITLE
Do not explicitly rethrow exceptions

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -194,7 +194,7 @@ namespace Duplicati.CommandLine.BackendTester
                     }
 
                     if (curlist == null)
-                        throw fex;
+                        throw;
                 }
 
                 foreach (Library.Interface.IFileEntry fe in curlist)

--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -178,7 +178,7 @@ namespace Duplicati.CommandLine.BackendTester
                     backend.Test();
                     curlist = backend.List();
                 }
-                catch (FolderMissingException fex)
+                catch (FolderMissingException)
                 {
                     if (autoCreateFolders)
                     {

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -447,8 +447,8 @@ namespace Duplicati.Server
                     Console.WriteLine(Strings.Program.SeriousError(mex.ToString()));
                     return 100;
                 }
-                else
-                    throw mex;
+
+                throw;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When rethrowing an exception, we should do so by simply calling `throw;` and not `throw ex;`.  The stack trace is reset with the second syntax, making debugging more difficult.