### PR TITLE
Remove unused local variables

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -910,7 +910,7 @@ namespace Duplicati.Library.Main
                         {
                             // Try to get attributes. Returns -1 if source doesn't exist, otherwise throws an exception.
                             // In this case, it is irrelevant to use fileinfo or directoryinfo to retrieve attributes.
-                            var attributes = fi.Attributes;
+                            var unused = fi.Attributes;
                         }
                         catch (UnauthorizedAccessException ex)
                         {

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -175,7 +175,7 @@ namespace Duplicati.Library.Main.Operation
             using(new Logging.Timer(LOGTAG, "BackupMainOperation", "BackupMainOperation"))
             {
                 // Make sure the CompressionHints table is initialized, otherwise all workers will initialize it
-                var tb = options.CompressionHints.Count;
+                var unused = options.CompressionHints.Count;
 
                 Task all;
                 using(new ChannelScope())

--- a/Duplicati/Library/Modules/Builtin/ResultSerialization/JsonFormatSerializer.cs
+++ b/Duplicati/Library/Modules/Builtin/ResultSerialization/JsonFormatSerializer.cs
@@ -87,8 +87,6 @@ namespace Duplicati.Library.Modules.Builtin.ResultSerialization
 
         public string SerializeResults(IBasicResults result)
         {
-            var basicResult = result;
-
             return JsonConvert.SerializeObject(
                 result,
                 new JsonSerializerSettings()

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -254,7 +254,7 @@ namespace Duplicati.Server
             try
             {
                 // Setup the log redirect
-                var logscope = Library.Logging.Log.StartScope(Program.LogHandler, null);
+                Library.Logging.Log.StartScope(Program.LogHandler, null);
 
                 if (commandlineOptions.ContainsKey("log-file"))
                 {


### PR DESCRIPTION
This removes a few unused local variables.  For cases where a property reference cannot be removed, we rename the local variable to better indicate that it is unused.