### PR TITLE
Remove condition that is always true

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/List.cs
+++ b/Duplicati/CommandLine/RecoveryTool/List.cs
@@ -76,7 +76,7 @@ namespace Duplicati.CommandLine.RecoveryTool
                     bool result;
                     Library.Utility.IFilter evfilter;
                     bool match = filter.Matches(f.Path, out result, out evfilter);
-                    if (!match || (match && result))
+                    if (!match || result)
                         yield return f;
                 }
         }


### PR DESCRIPTION
This removes a condition in an `if` statement that always evaluates to `true`.