### PR TITLE
Avoid redundant calls to Util.AppendDirSeparator

### DIFF
--- a/Duplicati/Library/Snapshots/SnapshotBase.cs
+++ b/Duplicati/Library/Snapshots/SnapshotBase.cs
@@ -50,10 +50,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="errorCallback">The callback used to report errors</param>
         public IEnumerable<string> EnumerateFilesAndFolders(IEnumerable<string> sources, Utility.Utility.EnumerationFilterDelegate callback, Utility.Utility.ReportAccessError errorCallback)
         {
-            // Add trailing slashes to folders
-            var sanitizedSources = sources.Select(x => DirectoryExists(x) ? Util.AppendDirSeparator(x) : x).ToList();
-
-            return sanitizedSources.SelectMany(
+            return sources.SelectMany(
                 s => Utility.Utility.EnumerateFileSystemEntries(s, callback, ListFolders, ListFiles, GetAttributes, errorCallback)
             );
         }

--- a/Duplicati/Library/Snapshots/SnapshotBase.cs
+++ b/Duplicati/Library/Snapshots/SnapshotBase.cs
@@ -50,9 +50,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="errorCallback">The callback used to report errors</param>
         public IEnumerable<string> EnumerateFilesAndFolders(IEnumerable<string> sources, Utility.Utility.EnumerationFilterDelegate callback, Utility.Utility.ReportAccessError errorCallback)
         {
-            return sources.SelectMany(
-                s => Utility.Utility.EnumerateFileSystemEntries(s, callback, ListFolders, ListFiles, GetAttributes, errorCallback)
-            );
+            return sources.SelectMany(s => Utility.Utility.EnumerateFileSystemEntries(s, callback, ListFolders, ListFiles, GetAttributes, errorCallback));
         }
         
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -215,7 +215,7 @@ namespace Duplicati.Library.Utility
 
                 while (lst.Count > 0)
                 {
-                    var f = Util.AppendDirSeparator(lst.Pop());
+                    var f = lst.Pop();
 
                     yield return f;
 

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -198,7 +198,6 @@ namespace Duplicati.Library.Utility
                 rootpath = Util.AppendDirSeparator(rootpath);
                 try
                 {
-
                     var attr = attributeReader?.Invoke(rootpath) ?? FileAttributes.Directory;
                     if (callback(rootpath, rootpath, attr))
                         lst.Push(rootpath);


### PR DESCRIPTION
This removes some redundant calls to `Util.AppendDirSeparator`.  Since the `Utility.EnumerateFileSystemEntries` method always calls `Util.AppendDirSeparator` before pushing a folder name onto the stack, we do not need to do so when providing the collection of sources, or when popping an entry from the stack.