### PR TITLE
web-ui: log-page: fix logs not displaying on initial loading of page

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/LogController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/LogController.js
@@ -66,6 +66,7 @@ backupApp.controller('LogController', function($scope, $timeout, AppService, Log
 
                 $scope.LogData = result.current;
                 $scope.LogDataComplete = result.complete;
+                $scope.$digest();
             });
     };
     $scope.LoadMoreStoredData();


### PR DESCRIPTION
Logs were not being displayed after a successful request, this happened because the watchers for changes were not fired

Fixes #3569