### PR TITLE
Fix quota reporting with Google Drive backend

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -340,7 +340,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
                 try
                 {
                     GoogleDriveAboutResponse about = this.GetAboutInfo();
-                    return new QuotaInfo(about.quotaBytesTotal ?? -1, about.quotaBytesUsed ?? -1);
+                    return new QuotaInfo(about.quotaBytesTotal ?? -1, about.quotaBytesTotal - about.quotaBytesUsed ?? -1);
                 }
                 catch
                 {


### PR DESCRIPTION
This fixes a bug in how the `GoogleDrive` backend reports quota values.  The second argument to `QuotaInfo` is the amount of free space.  However, we were previously providing the amount of space used. 
 This resulted in brand new backups to an empty Google Drive reporting a quota exceeded error.  Subsequent backups would then run without error.