### PR TITLE
Add round-trip tests for importing and exporting backup configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ jobs:
     - env: CATEGORY=UriUtility
     - env: CATEGORY=WebApi
     - env: CATEGORY=IO
+    - env: CATEGORY=ImportExport
 
     - env: CATEGORY=GUI
       addons:

--- a/Duplicati/ConfigurationImporter/Program.cs
+++ b/Duplicati/ConfigurationImporter/Program.cs
@@ -14,8 +14,6 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using Duplicati.Library.SQLiteHelper;
-using Duplicati.Server;
 using Duplicati.Server.Serializable;
 using Duplicati.Server.WebServer.RESTMethods;
 using System;

--- a/Duplicati/ConfigurationImporter/Program.cs
+++ b/Duplicati/ConfigurationImporter/Program.cs
@@ -42,29 +42,9 @@ namespace Duplicati.CommandLine.ConfigurationImporter
                 throw new ArgumentException($"Invalid import-metadata argument.  {ConfigurationImporter.usageString}");
             }
             bool importMetadata = Duplicati.Library.Utility.Utility.ParseBool(importMetadataString, false);
-
-            // This removes the ID and DBPath from the backup configuration.
-            ImportExportStructure importedStructure = Backups.LoadConfiguration(configurationFile, importMetadata, () => ConfigurationImporter.ReadPassword($"Password for {configurationFile}: "));
-
             Dictionary<string, string> advancedOptions = Duplicati.Library.Utility.CommandLineParser.ExtractOptions(new List<string>(args.Skip(2)));
 
-            // This will create the Duplicati-server.sqlite database file if it doesn't exist.
-            Duplicati.Server.Database.Connection connection = Program.GetDatabaseConnection(advancedOptions);
-
-            if (connection.Backups.Any(x => x.Name.Equals(importedStructure.Backup.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new InvalidOperationException($"A backup with the name {importedStructure.Backup.Name} already exists.");
-            }
-
-            string error = connection.ValidateBackup(importedStructure.Backup, importedStructure.Schedule);
-            if (!string.IsNullOrWhiteSpace(error))
-            {
-                throw new InvalidOperationException(error);
-            }
-
-            // This creates a new ID and DBPath.
-            connection.AddOrUpdateBackupAndSchedule(importedStructure.Backup, importedStructure.Schedule);
-
+            ImportExportStructure importedStructure = Backups.ImportBackup(configurationFile, importMetadata, () => ConfigurationImporter.ReadPassword($"Password for {configurationFile}: "), advancedOptions);
             Console.WriteLine($"Imported \"{importedStructure.Backup.Name}\" with ID {importedStructure.Backup.ID} and local database at {importedStructure.Backup.DBPath}.");
         }
 

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -146,31 +146,13 @@ namespace Duplicati.Server.WebServer.RESTMethods
             else
             {
                 var passphrase = info.Request.QueryString["passphrase"].Value;
-                var ipx = Program.DataConnection.PrepareBackupForExport(backup);
+                byte[] data = Backup.ExportToJSON(backup, passphrase);
 
-                byte[] data;
-                using(var ms = new System.IO.MemoryStream())
-                using(var sw = new System.IO.StreamWriter(ms))
-                {
-                    Serializer.SerializeJson(sw, ipx, true);
-
-                    if (!string.IsNullOrWhiteSpace(passphrase))
-                    {
-                        ms.Position = 0;
-                        using(var ms2 = new System.IO.MemoryStream())
-                        using(var m = new Duplicati.Library.Encryption.AESEncryption(passphrase, new Dictionary<string, string>()))
-                        {
-                            m.Encrypt(ms, ms2);
-                            data = ms2.ToArray();
-                        }
-                    }
-                    else
-                        data = ms.ToArray();
-                }
-
-                var filename = Library.Utility.Uri.UrlEncode(backup.Name) + "-duplicati-config.json";
+                string filename = Library.Utility.Uri.UrlEncode(backup.Name) + "-duplicati-config.json";
                 if (!string.IsNullOrWhiteSpace(passphrase))
+                {
                     filename += ".aes";
+                }
 
                 info.Response.ContentLength = data.Length;
                 info.Response.AddHeader("Content-Disposition", string.Format("attachment; filename={0}", filename));
@@ -180,6 +162,39 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 info.Response.SendHeaders();
                 info.Response.SendBody(data);
             }
+        }
+
+        public static byte[] ExportToJSON(IBackup backup, string passphrase)
+        {
+            Serializable.ImportExportStructure ipx = Program.DataConnection.PrepareBackupForExport(backup);
+
+            byte[] data;
+            using (MemoryStream ms = new System.IO.MemoryStream())
+            {
+                using (StreamWriter sw = new System.IO.StreamWriter(ms))
+                {
+                    Serializer.SerializeJson(sw, ipx, true);
+
+                    if (!string.IsNullOrWhiteSpace(passphrase))
+                    {
+                        ms.Position = 0;
+                        using (MemoryStream ms2 = new System.IO.MemoryStream())
+                        {
+                            using (Library.Encryption.AESEncryption m = new Duplicati.Library.Encryption.AESEncryption(passphrase, new Dictionary<string, string>()))
+                            {
+                                m.Encrypt(ms, ms2);
+                                data = ms2.ToArray();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        data = ms.ToArray();
+                    }
+                }
+            }
+                       
+            return data;
         }
 
         private void RestoreFiles(IBackup backup, RequestInfo info)

--- a/Duplicati/Server/WebServer/RESTMethods/Backups.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backups.cs
@@ -146,7 +146,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             return importedStructure;
         }
 
-        public static Serializable.ImportExportStructure LoadConfiguration(string filename, bool importMetadata, Func<string> getPassword)
+        private static Serializable.ImportExportStructure LoadConfiguration(string filename, bool importMetadata, Func<string> getPassword)
         {
             Serializable.ImportExportStructure ipx;
 

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -54,6 +54,7 @@
     <Compile Include="WebApiTests.cs" />
     <Compile Include="RunScriptTests.cs" />
     <Compile Include="IOTests.cs" />
+    <Compile Include="ImportExportTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Duplicati/UnitTest/ImportExportTests.cs
+++ b/Duplicati/UnitTest/ImportExportTests.cs
@@ -42,6 +42,7 @@ namespace Duplicati.UnitTest
             }
             catch
             {
+                // If there's an exception, let the OS deal with cleaning up the temp folder.
             }
         }
 

--- a/Duplicati/UnitTest/ImportExportTests.cs
+++ b/Duplicati/UnitTest/ImportExportTests.cs
@@ -1,0 +1,99 @@
+﻿//  Copyright (C) 2019, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+using Duplicati.Server.Database;
+using Duplicati.Server.Serialization.Interface;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Duplicati.UnitTest
+{
+    public class ImportExportTests
+    {
+        private string serverDatafolder;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            this.serverDatafolder = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(this.serverDatafolder);
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            try
+            {
+                Directory.Delete(this.serverDatafolder, true);
+            }
+            catch
+            {
+            }
+        }
+
+        [Test]
+        [Category("ImportExport")]
+        public void RoundTrip()
+        {
+            Dictionary<string, string> metadata = new Dictionary<string, string> { { "SourceFilesCount", "1" } };
+            IBackup CreateBackup(string name)
+            {
+                return new Backup
+                {
+                    Description = "Mock Backup Description",
+                    Filters = new IFilter[0],
+                    ID = "1",
+                    Metadata = metadata,
+                    Name = name,
+                    Settings = new[] { new Setting { Name = "passphrase", Value = "12345" } },
+                    Sources = new[] { "Mock Backup Source" },
+                    Tags = new[] { "Tags" },
+                    TargetURL = "file:///mock_backup_target"
+                };
+            }
+
+            Dictionary<string, string> advancedOptions = new Dictionary<string, string> { { "server-datafolder", this.serverDatafolder } };
+            using (Duplicati.Server.Program.DataConnection = Duplicati.Server.Program.GetDatabaseConnection(advancedOptions))
+            {
+                string unencryptedWithoutMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
+                File.WriteAllBytes(unencryptedWithoutMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("unencrypted without metadata"), null));
+                Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(unencryptedWithoutMetadata, false, () => null, advancedOptions);
+                Assert.AreEqual(1, Duplicati.Server.Program.DataConnection.Backups.Length);
+                Assert.AreEqual(0, Duplicati.Server.Program.DataConnection.Backups[0].Metadata.Count);
+
+                string unencryptedWithMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
+                File.WriteAllBytes(unencryptedWithMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("unencrypted with metadata"), null));
+                Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(unencryptedWithMetadata, true, () => null, advancedOptions);
+                Assert.AreEqual(2, Duplicati.Server.Program.DataConnection.Backups.Length);
+                Assert.AreEqual(metadata.Count, Duplicati.Server.Program.DataConnection.Backups[1].Metadata.Count);
+
+                string encryptedWithoutMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
+                string passphrase = "abcde";
+                File.WriteAllBytes(encryptedWithoutMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("encrypted without metadata"), passphrase));
+                Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(encryptedWithoutMetadata, false, () => passphrase, advancedOptions);
+                Assert.AreEqual(3, Duplicati.Server.Program.DataConnection.Backups.Length);
+                Assert.AreEqual(0, Duplicati.Server.Program.DataConnection.Backups[2].Metadata.Count);
+
+                string encryptedWithMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
+                File.WriteAllBytes(encryptedWithMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("encrypted with metadata"), passphrase));
+                Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(encryptedWithMetadata, true, () => passphrase, advancedOptions);
+                Assert.AreEqual(4, Duplicati.Server.Program.DataConnection.Backups.Length);
+                Assert.AreEqual(metadata.Count, Duplicati.Server.Program.DataConnection.Backups[3].Metadata.Count);
+            }
+        }
+    }
+}

--- a/Duplicati/UnitTest/ImportExportTests.cs
+++ b/Duplicati/UnitTest/ImportExportTests.cs
@@ -17,6 +17,7 @@
 using Duplicati.Server.Database;
 using Duplicati.Server.Serialization.Interface;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -98,6 +99,9 @@ namespace Duplicati.UnitTest
                 Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(encryptedWithMetadata, true, () => passphrase, advancedOptions);
                 Assert.AreEqual(4, Duplicati.Server.Program.DataConnection.Backups.Length);
                 Assert.AreEqual(metadata.Count, Duplicati.Server.Program.DataConnection.Backups[3].Metadata.Count);
+
+                // Encrypted file, incorrect passphrase.
+                Assert.Throws(Is.InstanceOf<Exception>(), () => Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(encryptedWithMetadata, true, () => passphrase + " ", advancedOptions));
             }
         }
     }

--- a/Duplicati/UnitTest/ImportExportTests.cs
+++ b/Duplicati/UnitTest/ImportExportTests.cs
@@ -70,18 +70,21 @@ namespace Duplicati.UnitTest
             Dictionary<string, string> advancedOptions = new Dictionary<string, string> { { "server-datafolder", this.serverDatafolder } };
             using (Duplicati.Server.Program.DataConnection = Duplicati.Server.Program.GetDatabaseConnection(advancedOptions))
             {
+                // Unencrypted file, don't import metadata.
                 string unencryptedWithoutMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
                 File.WriteAllBytes(unencryptedWithoutMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("unencrypted without metadata"), null));
                 Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(unencryptedWithoutMetadata, false, () => null, advancedOptions);
                 Assert.AreEqual(1, Duplicati.Server.Program.DataConnection.Backups.Length);
                 Assert.AreEqual(0, Duplicati.Server.Program.DataConnection.Backups[0].Metadata.Count);
 
+                // Unencrypted file, import metadata.
                 string unencryptedWithMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
                 File.WriteAllBytes(unencryptedWithMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("unencrypted with metadata"), null));
                 Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(unencryptedWithMetadata, true, () => null, advancedOptions);
                 Assert.AreEqual(2, Duplicati.Server.Program.DataConnection.Backups.Length);
                 Assert.AreEqual(metadata.Count, Duplicati.Server.Program.DataConnection.Backups[1].Metadata.Count);
 
+                // Encrypted file, don't import metadata.
                 string encryptedWithoutMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
                 string passphrase = "abcde";
                 File.WriteAllBytes(encryptedWithoutMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("encrypted without metadata"), passphrase));
@@ -89,6 +92,7 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(3, Duplicati.Server.Program.DataConnection.Backups.Length);
                 Assert.AreEqual(0, Duplicati.Server.Program.DataConnection.Backups[2].Metadata.Count);
 
+                // Encrypted file, import metadata.
                 string encryptedWithMetadata = Path.Combine(this.serverDatafolder, Path.GetRandomFileName());
                 File.WriteAllBytes(encryptedWithMetadata, Server.WebServer.RESTMethods.Backup.ExportToJSON(CreateBackup("encrypted with metadata"), passphrase));
                 Duplicati.Server.WebServer.RESTMethods.Backups.ImportBackup(encryptedWithMetadata, true, () => passphrase, advancedOptions);


### PR DESCRIPTION
This adds a unit test to verify the ability to import and export backup configurations.  To do so, we extracted some key functionality to methods that can be tested in isolation.