### PR TITLE
Remove optional parameters from Controller.List overloads

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -165,7 +165,7 @@ namespace Duplicati.Library.Main
             return List(filterstring == null ? null : new string[] { filterstring }, null);
         }
 
-        public Duplicati.Library.Interface.IListResults List(IEnumerable<string> filterstrings, Library.Utility.IFilter filter = null)
+        public Duplicati.Library.Interface.IListResults List(IEnumerable<string> filterstrings, Library.Utility.IFilter filter)
         {
             return RunAction(new ListResults(), ref filter, (result) => {
                 new Operation.ListFilesHandler(m_backend, m_options, result).Run(filterstrings, filter);

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -509,7 +509,7 @@ namespace Duplicati.Server
                             }
                         case DuplicatiOperation.List:
                             {
-                                var r = controller.List(data.FilterStrings);
+                                var r = controller.List(data.FilterStrings, null);
                                 UpdateMetadata(backup, r);
                                 return r;
                             }


### PR DESCRIPTION
This removes the optional parameters from the `Controller.List` overloads.  By doing so, we avoid several issues that arise with optional parameters (default values being embedded at call sites, ambiguous overload resolution, etc.).

* For the `List(Library.Utility.IFilter filter = null)` overload, none of the usages provided a value for the `filter` parameter, so the parameter was removed.
* For the `List(IEnumerable<string> filterstrings, Library.Utility.IFilter filter = null)` overload, only one of the usages did not provide a value for the `filter` parameter.  That usage was modified to provide `null`, and the parameter is now required.

