### PR TITLE
Remove unused RecreateDatabase method

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -232,18 +232,6 @@ namespace Duplicati.Library.Main
             });
         }
 
-        public Duplicati.Library.Interface.IRecreateDatabaseResults RecreateDatabase(string targetpath, Library.Utility.IFilter filter = null)
-        {
-            var t = new string[] { string.IsNullOrEmpty(targetpath) ? m_options.Dbpath : targetpath };
-
-            var filelistfilter = Operation.RestoreHandler.FilterNumberedFilelist(m_options.Time, m_options.Version);
-
-            return RunAction(new RecreateDatabaseResults(), ref t, ref filter, (result) => {
-                using(var h = new Operation.RecreateDatabaseHandler(m_backend, m_options, result))
-                    h.Run(t[0], filter, filelistfilter);
-            });
-        }
-
         public Duplicati.Library.Interface.IRecreateDatabaseResults UpdateDatabaseWithVersions(Library.Utility.IFilter filter = null)
         {
             var filelistfilter = Operation.RestoreHandler.FilterNumberedFilelist(m_options.Time, m_options.Version, singleTimeMatch: true);


### PR DESCRIPTION
It appears that the `Controller.RecreateDatabase` method was unused.  I was unable to find any usages, and was still able to recreate the local database from the UI.  It looks like the last usage was removed in revision e4f1d4106a99db724d105c88b4e88409f758158b.