### PR TITLE
Allow to use custom domain for b2 DownloadUrl #3653

### DIFF
--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -29,6 +29,7 @@ namespace Duplicati.Library.Backend.Backblaze
         private const string B2_ID_OPTION = "b2-accountid";
         private const string B2_KEY_OPTION = "b2-applicationkey";
 		private const string B2_PAGESIZE_OPTION = "b2-page-size";
+        private const string B2_DOWNLOAD_URL_OPTION = "b2-download-url";
 
 		private const string B2_CREATE_BUCKET_TYPE_OPTION = "b2-create-bucket-type";
         private const string DEFAULT_BUCKET_TYPE = "allPrivate";
@@ -40,6 +41,7 @@ namespace Duplicati.Library.Backend.Backblaze
         private readonly string m_urlencodedprefix;
         private readonly string m_bucketType;
         private readonly int m_pagesize;
+        private readonly string m_downloadUrl;
         private readonly B2AuthHelper m_helper;
         private UploadUrlResponse m_uploadUrl;
 
@@ -100,6 +102,12 @@ namespace Duplicati.Library.Backend.Backblaze
                 if (m_pagesize <= 0)
                     throw new UserInformationException(Strings.B2.InvalidPageSizeError(B2_PAGESIZE_OPTION, options[B2_PAGESIZE_OPTION]), "B2InvalidPageSize");
             }
+
+            m_downloadUrl = null;
+            if (options.ContainsKey(B2_DOWNLOAD_URL_OPTION))
+            {
+                m_downloadUrl = options[B2_DOWNLOAD_URL_OPTION];
+            }
 		}
 
         private BucketEntity Bucket
@@ -152,6 +160,16 @@ namespace Duplicati.Library.Backend.Backblaze
             throw new FileMissingException();
         }
 
+        private string DownloadUrl {
+            get {
+                if (string.IsNullOrEmpty(m_downloadUrl)) {
+                    return m_helper.DownloadUrl;
+                } else {
+                    return m_downloadUrl;
+                }
+            }
+        }
+
         public IList<ICommandLineArgument> SupportedCommands
         {
             get
@@ -163,6 +181,7 @@ namespace Duplicati.Library.Backend.Backblaze
                     new CommandLineArgument("auth-username", CommandLineArgument.ArgumentType.String, Strings.B2.AuthUsernameDescriptionShort, Strings.B2.AuthUsernameDescriptionLong),
                     new CommandLineArgument(B2_CREATE_BUCKET_TYPE_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2createbuckettypeDescriptionShort, Strings.B2.B2createbuckettypeDescriptionLong, DEFAULT_BUCKET_TYPE),
                     new CommandLineArgument(B2_PAGESIZE_OPTION, CommandLineArgument.ArgumentType.Integer, Strings.B2.B2pagesizeDescriptionShort, Strings.B2.B2pagesizeDescriptionLong, DEFAULT_PAGE_SIZE.ToString()),
+                    new CommandLineArgument(B2_DOWNLOAD_URL_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2downloadurlDescriptionShort, Strings.B2.B2downloadurlDescriptionLong),
 				});
 
             }
@@ -274,9 +293,9 @@ namespace Duplicati.Library.Backend.Backblaze
                 List();
 
             if (m_filecache != null && m_filecache.ContainsKey(remotename))
-                req = new AsyncHttpRequest(m_helper.CreateRequest(string.Format("{0}/b2api/v1/b2_download_file_by_id?fileId={1}", m_helper.DownloadUrl, Library.Utility.Uri.UrlEncode(GetFileID(remotename)))));
+                req = new AsyncHttpRequest(m_helper.CreateRequest(string.Format("{0}/b2api/v1/b2_download_file_by_id?fileId={1}", DownloadUrl, Library.Utility.Uri.UrlEncode(GetFileID(remotename)))));
             else
-                req = new AsyncHttpRequest(m_helper.CreateRequest(string.Format("{0}/{1}{2}", m_helper.DownloadUrl, m_urlencodedprefix, Library.Utility.Uri.UrlPathEncode(remotename))));
+                req = new AsyncHttpRequest(m_helper.CreateRequest(string.Format("{0}/{1}{2}", DownloadUrl, m_urlencodedprefix, Library.Utility.Uri.UrlPathEncode(remotename))));
 
             try
             {

--- a/Duplicati/Library/Backend/Backblaze/Strings.cs
+++ b/Duplicati/Library/Backend/Backblaze/Strings.cs
@@ -17,6 +17,8 @@ namespace Duplicati.Library.Backend.Strings {
         public static string B2createbuckettypeDescriptionShort { get { return LC.L(@"The bucket type used when creating a bucket"); } }
 		public static string B2pagesizeDescriptionLong { get { return LC.L(@"Use this option to set the page size for listing contents of B2 buckets. A lower number means less data, but can increase the number of Class C transaction on B2. Suggested values are between 100 and 1000"); } }
 		public static string B2pagesizeDescriptionShort { get { return LC.L(@"The size of file-listing pages"); } }
+        public static string B2downloadurlDescriptionLong { get { return LC.L(@"Change this if you want to use your custom domain to download files, and uploading will not be affected. The default download url is ""https://f00X.backblazeb2.com"""); } }
+        public static string B2downloadurlDescriptionShort { get { return LC.L(@"The base URL to use for downloading files"); } }
         public static string InvalidPageSizeError(string argname, string value) { return LC.L(@"The setting ""{0}"" is invalid for ""{1}"", it must be an integer larger than zero", value, argname); }
 	}
 }

--- a/Duplicati/Library/Backend/Backblaze/Strings.cs
+++ b/Duplicati/Library/Backend/Backblaze/Strings.cs
@@ -17,7 +17,7 @@ namespace Duplicati.Library.Backend.Strings {
         public static string B2createbuckettypeDescriptionShort { get { return LC.L(@"The bucket type used when creating a bucket"); } }
 		public static string B2pagesizeDescriptionLong { get { return LC.L(@"Use this option to set the page size for listing contents of B2 buckets. A lower number means less data, but can increase the number of Class C transaction on B2. Suggested values are between 100 and 1000"); } }
 		public static string B2pagesizeDescriptionShort { get { return LC.L(@"The size of file-listing pages"); } }
-        public static string B2downloadurlDescriptionLong { get { return LC.L(@"Change this if you want to use your custom domain to download files, and uploading will not be affected. The default download url is ""https://f00X.backblazeb2.com"""); } }
+        public static string B2downloadurlDescriptionLong { get { return LC.L(@"Change this if you want to use your custom domain to download files, and uploading will not be affected. The default download url depends on your account and looks like ""https://f00X.backblazeb2.com"""); } }
         public static string B2downloadurlDescriptionShort { get { return LC.L(@"The base URL to use for downloading files"); } }
         public static string InvalidPageSizeError(string argname, string value) { return LC.L(@"The setting ""{0}"" is invalid for ""{1}"", it must be an integer larger than zero", value, argname); }
 	}


### PR DESCRIPTION
- how custom download url can be set with option "b2-download-url"

And the option will look like this:

<img width="684" alt="image" src="https://user-images.githubusercontent.com/3804518/52513756-bc56d300-2bc1-11e9-9a6d-bec107a0916d.png">

Network-wise, the download url has been replaced as well:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/3804518/52513812-00e26e80-2bc2-11e9-81e0-76d587d41ed4.png">

