### PR TITLE
Remove temporary files from backup and compact operations

### DIFF
--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -110,20 +110,19 @@ namespace Duplicati.Library.Main.Operation
                         newvolindex = new IndexVolumeWriter(m_options);
                         newvolindex.VolumeID = db.RegisterRemoteVolume(newvolindex.RemoteFilename, RemoteVolumeType.Index, RemoteVolumeState.Temporary, transaction);
                         db.AddIndexBlockLink(newvolindex.VolumeID, newvol.VolumeID, transaction);
-                        newvolindex.StartVolume(newvol.RemoteFilename);
                     }
-                    
+
                     long blocksInVolume = 0;
                     long discardedBlocks = 0;
                     long discardedSize = 0;
                     byte[] buffer = new byte[m_options.Blocksize];
                     var remoteList = db.GetRemoteVolumes().Where(n => n.State == RemoteVolumeState.Uploaded || n.State == RemoteVolumeState.Verified).ToArray();
-                    
+
                     //These are for bookkeeping
                     var uploadedVolumes = new List<KeyValuePair<string, long>>();
                     var deletedVolumes = new List<KeyValuePair<string, long>>();
                     var downloadedVolumes = new List<KeyValuePair<string, long>>();
-                    
+
                     //We start by deleting unused volumes to save space before uploading new stuff
                     var fullyDeleteable = (from v in remoteList
                                            where report.DeleteableVolumes.Contains(v.Name)
@@ -137,10 +136,11 @@ namespace Duplicati.Library.Main.Operation
 
                     if (report.ShouldCompact)
                     {
+                        newvolindex.StartVolume(newvol.RemoteFilename);
                         var volumesToDownload = (from v in remoteList
                                                  where report.CompactableVolumes.Contains(v.Name)
                                                  select (IRemoteVolume)v).ToList();
-                        
+
                         using(var q = db.CreateBlockQueryHelper(transaction))
                         {
                             foreach (var entry in new AsyncDownloader(volumesToDownload, backend))
@@ -236,13 +236,18 @@ namespace Duplicati.Library.Main.Operation
                             }
                         }
                     }
-                    
+                    else
+                    {
+                        newvolindex.Dispose();
+                        newvol.Dispose();
+                    }
+
                     deletedVolumes.AddRange(DoDelete(db, backend, deleteableVolumes, ref transaction));
                                         
                     var downloadSize = downloadedVolumes.Where(x => x.Value >= 0).Aggregate(0L, (a,x) => a + x.Value);
                     var deletedSize = deletedVolumes.Where(x => x.Value >= 0).Aggregate(0L, (a,x) => a + x.Value);
                     var uploadSize = uploadedVolumes.Where(x => x.Value >= 0).Aggregate(0L, (a,x) => a + x.Value);
-                    
+
                     m_result.DeletedFileCount = deletedVolumes.Count;
                     m_result.DownloadedFileCount = downloadedVolumes.Count;
                     m_result.UploadedFileCount = uploadedVolumes.Count;

--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -136,7 +136,7 @@ namespace Duplicati.Library.Main.Operation
 
                     if (report.ShouldCompact)
                     {
-                        newvolindex.StartVolume(newvol.RemoteFilename);
+                        newvolindex?.StartVolume(newvol.RemoteFilename);
                         var volumesToDownload = (from v in remoteList
                                                  where report.CompactableVolumes.Contains(v.Name)
                                                  select (IRemoteVolume)v).ToList();
@@ -238,7 +238,7 @@ namespace Duplicati.Library.Main.Operation
                     }
                     else
                     {
-                        newvolindex.Dispose();
+                        newvolindex?.Dispose();
                         newvol.Dispose();
                     }
 

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -150,6 +150,7 @@ namespace Duplicati.Library.Main.Volumes
         public override void Dispose()
         {
             this.Close();
+            base.Dispose();
         }
 
         public long FileCount { get { return m_filecount; } }

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -52,9 +52,6 @@ namespace Duplicati.Library.Main.Volumes
             else
                 m_localfile = new Library.Utility.TempFile();
 
-            // TODO(danstahr): This is a hack! Figure out why the file is being disposed of prematurely.
-            m_localfile.Protected = true;
-
             ResetRemoteFilename(options, timestamp);
 
             m_localFileStream = new System.IO.FileStream(m_localfile, FileMode.Create, FileAccess.Write, FileShare.Read);


### PR DESCRIPTION
This ensures removal of temporary files that were left behind in the following situations:
1. After a backup operation, a temporary file containing the `filelist.json` was left in the temporary folder.  This file remained whether or not files needed to be uploaded to the backend.
2. If the compact operation is run but [ShouldCompact](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Main/Operation/CompactHandler.cs#L138) is `false`, a few small temporary files would be left behind.
3. If the compact operation is run but [ShouldCompact](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Main/Operation/CompactHandler.cs#L138) is `true`, many temporary files (I believe containing the filelists and unencrypted blocks) would be left behind.  These files could be large in size, and would result in a user's temporary directory getting filled up.

Note that the temporary files might not be removed in cases where exceptions are thrown.  This is due to the `IDisposable` objects not being contained in `using` statements, as the variables are being reassigned inside a loop.

This addresses issue #3652, and possibly issue #3634.