### PR TITLE
Avoid potential null reference exception

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -314,9 +314,9 @@ namespace Duplicati.Library.Main.Operation
                         }
                     }
                 }
+                
+                m_result.BackendWriter.AssignedQuotaSpace = m_options.QuotaSize;
             }
-
-            m_result.BackendWriter.AssignedQuotaSpace = m_options.QuotaSize;
         }
 
         public void Run(string[] sources, Library.Utility.IFilter filter)


### PR DESCRIPTION
This line of code immediately follows an `if` statement that checks if the reference is not `null`.  As such, the statement should probably be included in the block as well.