### PR TITLE
Fix spelling error in log message identifier

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/FileBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FileBlockProcessor.cs
@@ -69,7 +69,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                                     if (res.Item1)
                                         return res.Item2;
 
-                                    Logging.Log.WriteWarningMessage(FILELOGTAG, "UnexpextedMetadataLookup", null, "Metadata was reported as not changed, but still requires being added?\nHash: {0}, Length: {1}, ID: {2}, Path: {3}", e.MetaHashAndSize.FileHash, e.MetaHashAndSize.Blob.Length, res.Item2, e.Path);
+                                    Logging.Log.WriteWarningMessage(FILELOGTAG, "UnexpectedMetadataLookup", null, "Metadata was reported as not changed, but still requires being added?\nHash: {0}, Length: {1}, ID: {2}, Path: {3}", e.MetaHashAndSize.FileHash, e.MetaHashAndSize.Blob.Length, res.Item2, e.Path);
                                     e.MetadataChanged = true;
                                 }
 


### PR DESCRIPTION
This fixes a small typo in a log message identifier.