### PR TITLE
Dispose of manually iterated enumerator

### DIFF
--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -35,15 +35,17 @@ namespace Duplicati.Library.Main.Volumes
             if (metablocklisthashes != null)
             {
                 //Slightly akward, but we avoid writing if there are no entries 
-                var en = metablocklisthashes.GetEnumerator();
-                if (en.MoveNext() && !string.IsNullOrEmpty(en.Current))
+                using (var en = metablocklisthashes.GetEnumerator())
                 {
-                    m_writer.WritePropertyName("metablocklists");
-                    m_writer.WriteStartArray();
-                    m_writer.WriteValue(en.Current);
-                    while (en.MoveNext())
+                    if (en.MoveNext() && !string.IsNullOrEmpty(en.Current))
+                    {
+                        m_writer.WritePropertyName("metablocklists");
+                        m_writer.WriteStartArray();
                         m_writer.WriteValue(en.Current);
-                    m_writer.WriteEndArray();
+                        while (en.MoveNext())
+                            m_writer.WriteValue(en.Current);
+                        m_writer.WriteEndArray();
+                    }
                 }
             }
             else if (!string.IsNullOrWhiteSpace(metablockhash))

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -34,7 +34,7 @@ namespace Duplicati.Library.Main.Volumes
 
             if (metablocklisthashes != null)
             {
-                //Slightly akward, but we avoid writing if there are no entries 
+                // Slightly awkward, but we avoid writing if there are no entries.
                 using (var en = metablocklisthashes.GetEnumerator())
                 {
                     if (en.MoveNext() && !string.IsNullOrEmpty(en.Current))


### PR DESCRIPTION
The `IEnumerator<T>` interface implements `IDisposable`, so we should ensure that the enumerator is disposed of after its use.

This also fixes a minor spelling error in the associated comment.