### PR TITLE
Fix typo in async property name

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -37,7 +37,7 @@ namespace Duplicati.Library.Main.Operation.Backup
 
     internal class FlushRequest : IUploadRequest
     {
-        public Task<long> LastWriteSizeAync { get { return m_tcs.Task; } }
+        public Task<long> LastWriteSizeAsync { get { return m_tcs.Task; } }
         private readonly TaskCompletionSource<long> m_tcs = new TaskCompletionSource<long>();
         public void SetFlushed(long size)
         {

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -357,11 +357,11 @@ namespace Duplicati.Library.Main.Operation
             await uploadtarget.WriteAsync(flushReq).ConfigureAwait(false);
 
             // In case the uploader crashes, we grab the exception here
-            if (await Task.WhenAny(uploader, flushReq.LastWriteSizeAync) == uploader)
+            if (await Task.WhenAny(uploader, flushReq.LastWriteSizeAsync) == uploader)
                 await uploader.ConfigureAwait(false);
 
             // Grab the size of the last uploaded volume
-            return await flushReq.LastWriteSizeAync;
+            return await flushReq.LastWriteSizeAsync;
         }
 
         private async Task RunAsync(string[] sources, Library.Utility.IFilter filter)


### PR DESCRIPTION
This renames the `FlushRequest.LastWriteSizeAync` property to `FlushRequest.LastWriteSizeAsync`.