### PR TITLE
Unwrap TargetInvocationExceptions while preserving stack trace

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -19,6 +19,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Common.IO;
@@ -1025,9 +1026,13 @@ namespace Duplicati.Library.AutoUpdater
                 }
 
                 if (tex.InnerException != null)
-                    throw tex.InnerException;
-                else
-                    throw;
+                {
+                    // Unwrap exceptions for nicer display.  The ExceptionDispatchInfo class allows us to
+                    // rethrow an exception without changing the stack trace.
+                    ExceptionDispatchInfo.Capture(tex.InnerException).Throw();
+                }
+                
+                throw;
             }
         }
 

--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -24,6 +24,7 @@ using Duplicati.Library.Interface;
 using System.Collections.Specialized;
 using System.Web;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 
 namespace Duplicati.Library.DynamicLoader
 {
@@ -96,9 +97,12 @@ namespace Duplicati.Library.DynamicLoader
                     }
                     catch (System.Reflection.TargetInvocationException tex)
                     {
-                        // Unwrap exceptions for nicer display
                         if (tex.InnerException != null)
-                            throw new Exception("Unwrapped TargetInvocationException", tex.InnerException);
+                        {
+                            // Unwrap exceptions for nicer display.  The ExceptionDispatchInfo class allows us to
+                            // rethrow an exception without changing the stack trace.
+                            ExceptionDispatchInfo.Capture(tex.InnerException).Throw();
+                        }
 
                         throw;
                     }


### PR DESCRIPTION
This unwraps some `TargetInvocationExceptions` by using the `ExceptionDispatchInfo` class.  This allows us to provide the user with a more meaningful error message while preserving the stack trace of the originating exception.

As an example, exceptions thrown in the backend constructors are currently presented to the user as:
![image](https://user-images.githubusercontent.com/17345532/54797966-9df9e380-4c13-11e9-80b3-21f779b26695.png)

With these changes, a more meaningful message is provided:
![image](https://user-images.githubusercontent.com/17345532/54798060-0943b580-4c14-11e9-963c-2e5933a37587.png)


