### PR TITLE
Ensure that failed put operations throw exception

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -39,6 +39,12 @@ namespace Duplicati.Library.Main.Operation.Backup
     {
         public Task<long> LastWriteSizeAsync { get { return m_tcs.Task; } }
         private readonly TaskCompletionSource<long> m_tcs = new TaskCompletionSource<long>();
+        
+        public void TrySetCanceled()
+        {
+            m_tcs.TrySetCanceled();
+        }
+        
         public void SetFlushed(long size)
         {
             m_tcs.TrySetResult(size);
@@ -171,6 +177,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 Task finishedTask = await Task.WhenAny(workers.Select(w => w.Task)).ConfigureAwait(false);
                                 if (finishedTask.IsFaulted)
                                 {
+                                    flush.TrySetCanceled();
                                     ExceptionDispatchInfo.Capture(finishedTask.Exception).Throw();
                                 }
 

--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -182,9 +182,9 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 }
 
                                 workers.RemoveAll(w => w.Task == finishedTask);
-                                flush.SetFlushed(lastSize);
                             }
                             
+                            flush.SetFlushed(lastSize);
                             uploadsInProgress = 0;
                             break;
                         }

--- a/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
@@ -69,7 +69,6 @@ namespace Duplicati.Library.Main.Operation.Backup
                             return;
                         
                         await db.UpdateRemoteVolumeAsync(filesetvolume.RemoteFilename, RemoteVolumeState.Uploading, -1, null);
-                        await db.CommitTransactionAsync("CommitUpdateRemoteVolume");
                         await self.Output.WriteAsync(new FilesetUploadRequest(filesetvolume));
                     }
                 }
@@ -78,8 +77,6 @@ namespace Duplicati.Library.Main.Operation.Backup
                     Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingLeftoverTempFile", "removing temp files, as no data needs to be uploaded");
                     await db.RemoveRemoteVolumeAsync(filesetvolume.RemoteFilename);
                 }
-
-                await db.CommitTransactionAsync("CommitUpdateRemoteVolume");
             });
         }
     }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -393,10 +393,10 @@ namespace Duplicati.Library.Main.Operation
 
                 Task parallelScanner = null;
                 Task uploaderTask = null;
+                using (var db = new Backup.BackupDatabase(m_database, m_options))
                 try
                 {
                     // Setup runners and instances here
-                    using(var db = new Backup.BackupDatabase(m_database, m_options))
                     using(var backendManager = new BackendManager(m_backendurl, m_options, m_result.BackendWriter, m_database))
                     using(var filesetvolume = new FilesetVolumeWriter(m_options, m_database.OperationTimestamp))
                     using(var stats = new Backup.BackupStatsCollector(m_result))
@@ -545,6 +545,8 @@ namespace Duplicati.Library.Main.Operation
                 }
                 catch (Exception ex)
                 {
+                    await db.RollbackTransactionAsync();
+
                     var aex = BuildException(ex, uploaderTask, parallelScanner);
                     Logging.Log.WriteErrorMessage(LOGTAG, "FatalError", ex, "Fatal error");
                     if (aex == ex)

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -355,10 +355,7 @@ namespace Duplicati.Library.Main.Operation
             // Wait for upload completion
             result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_WaitForUpload);
             await uploadtarget.WriteAsync(flushReq).ConfigureAwait(false);
-
-            // In case the uploader crashes, we grab the exception here
-            if (await Task.WhenAny(uploader, flushReq.LastWriteSizeAsync) == uploader)
-                await uploader.ConfigureAwait(false);
+            await uploader.ConfigureAwait(false);
 
             // Grab the size of the last uploaded volume
             return await flushReq.LastWriteSizeAsync;


### PR DESCRIPTION
This fixes an issue where failed Put operations would not result in an exception.  The `FlushBackend` method [uses Task.WhenAny](https://github.com/duplicati/duplicati/blob/57b28182cb714c46226645b47fa80cb3d23f1f79/Duplicati/Library/Main/Operation/BackupHandler.cs#L360) to await the first completion of the uploader task or the flush request.  Since the uploader was setting the status of the flush request in the [finally block](https://github.com/duplicati/duplicati/blob/57b28182cb714c46226645b47fa80cb3d23f1f79/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs#L180), the flush request would complete first when an exception was thrown, causing the uploader's exception to be unobserved.  To resolve this,  we check that the uploader's status is not faulted before setting the flush request status.

In order for the database transactions to be rolled back, we instantiate the `IDbTransaction` instance earlier so that the `Rollback` method is invoked in the [finally](https://github.com/duplicati/duplicati/blob/57b28182cb714c46226645b47fa80cb3d23f1f79/Duplicati/Library/Main/Operation/BackupHandler.cs#L558) block.  Otherwise, a backup version would be recorded in the database even if all the Puts failed.

This addresses issue #3673.