### PR TITLE
Fix index files not being created for full dblock files

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
@@ -102,7 +102,7 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                                 IndexVolumeWriter indexVolumeWriter = null;
                                 FileEntryItem indexEntry = null;
-                                if (indexVolumeWriter != null)
+                                if (indexvolume != null)
                                 {
                                     indexVolumeWriter = await indexvolume.CreateVolume(blockvolume.RemoteFilename, blockEntry.Hash, blockEntry.Size, options, database);
                                     indexEntry = CreateFileEntryForUpload(indexVolumeWriter, options);


### PR DESCRIPTION
As part of the parallel upload changes a bug slipped in where a check was
being made if the index volume writer exists before creating said index
volume writer to actually create the index file. Fixed by changing the
test to check if the temporary index volume exists and then creating
the writer for the index file.

Fixes #3703 