### PR TITLE
Cache Files filter group doesn't exclude Chrome files on Mac/Linux #3633

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -556,8 +556,10 @@ namespace Duplicati.Library.Utility
             }
             if (group.HasFlag(FilterGroup.CacheFiles))
             {
+                yield return FilterGroups.CreateWildcardFilter(@"*/.cache/");                
                 yield return FilterGroups.CreateWildcardFilter(@"*/.config/google-chrome/Default/Cookies");
-                yield return FilterGroups.CreateWildcardFilter(@"*/.config/google-chrome/Default/Cookies-journal");
+                yield return FilterGroups.CreateWildcardFilter(@"*/.config/google-chrome/Default/Cookies-journal");                
+
             }
             if (group.HasFlag(FilterGroup.Applications))
             {


### PR DESCRIPTION
Chrome cache files should already filtered on Mac OS X by Cache filter group. Current filter is "*/Library/Caches/" and documentation refers to "[user cache dir] ~/Library/Caches/Google/Chrome/Default".

I have added ".cache" for Linux to exclude ".cache" when Cache filter group is selected.