### PR TITLE
Fix pause and resume, and check for cancel while uploading

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -253,6 +253,10 @@ namespace Duplicati.Library.Main.Operation.Backup
             {
                 // Timeout exception is expected and handled
             }
+            catch (TaskCanceledException)
+            {
+                // Either the read will be tried again or uploads have been canceled
+            }
 
             return null;
         }

--- a/Duplicati/Library/Main/Operation/Backup/FileProgressThrottler.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FileProgressThrottler.cs
@@ -30,6 +30,7 @@ namespace Duplicati.Library.Main.Operation.Backup
         private readonly object m_Lock = new object();
         private readonly StatsCollector m_Stats;
         private long m_MaxBytesPerSecond;
+        private bool m_Paused;
         private long m_TotalSize;
 
         public FileProgressThrottler(StatsCollector stats, long maxBytesPerSecond)
@@ -46,6 +47,16 @@ namespace Duplicati.Library.Main.Operation.Backup
                 if (f != null)
                     f.Done = true;
             }
+        }
+
+        public void Pause()
+        {
+            m_Paused = true;
+        }
+
+        public void Resume()
+        {
+            m_Paused = false;
         }
 
         public void Run(CancellationToken cancelToken)
@@ -148,6 +159,9 @@ namespace Duplicati.Library.Main.Operation.Backup
                 await Task.Delay(1000).ConfigureAwait(false);
                 if (cancelToken.IsCancellationRequested)
                     return;
+
+                if (m_Paused)
+                    continue;
 
                 lock (m_Lock)
                 {

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -31,8 +31,6 @@ using Duplicati.Library.Utility;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Common;
 using Duplicati.Library.Logging;
-using Duplicati.Library.Main.Operation.Backup;
-using Duplicati.Library.Main.Operation.Common;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -429,7 +427,8 @@ namespace Duplicati.Library.Main.Operation
                     {
                         long filesetid;
                         var counterToken = new CancellationTokenSource();
-                        var uploader = new Backup.BackendUploader(() => DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions), m_options, db, m_result.TaskReader, stats);
+                        Func<IBackend> backendFactory = () => DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions);
+                        var uploader = new Backup.BackendUploader(backendFactory, m_options, db, m_result.TaskReader, stats, m_result.OperationProgressUpdater);
                         using (var snapshot = GetSnapshot(sources, m_options))
                         {
                             try

--- a/Duplicati/Library/Main/OperationPhase.cs
+++ b/Duplicati/Library/Main/OperationPhase.cs
@@ -59,7 +59,9 @@ namespace Duplicati.Library.Main
         PurgeFiles_Compact,
         PurgeFiles_Complete,
 
+        Paused,
+        Paused_WaitForUpload,
+
         Error
     }
 }
-

--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -313,6 +313,8 @@ namespace Duplicati.Library.Main
         /// Occurs when the phase has changed
         /// </summary>
         event PhaseChangedDelegate PhaseChanged;
+
+        OperationPhase CurrentPhase { get; }
     }
     
     /// <summary>
@@ -334,9 +336,10 @@ namespace Duplicati.Library.Main
     
     internal class OperationProgressUpdater : IOperationProgressUpdaterAndReporter
     {
+        public OperationPhase CurrentPhase { get; private set; }
+
         private readonly object m_lock = new object();
         
-        private OperationPhase m_phase;
         private float m_progress;
         private string m_curfilename;
         private long m_curfilesize;
@@ -357,8 +360,8 @@ namespace Duplicati.Library.Main
             OperationPhase prev_phase;
             lock(m_lock)
             {
-                prev_phase = m_phase;
-                m_phase = phase;
+                prev_phase = CurrentPhase;
+                CurrentPhase = phase;
                 m_curfilename = null;
                 m_curfilesize = 0;
                 m_curfileoffset = 0;
@@ -426,7 +429,7 @@ namespace Duplicati.Library.Main
         {
             lock(m_lock)
             {
-                phase = m_phase;
+                phase = CurrentPhase;
                 filesize = m_filesize;
                 progress = m_progress;
                 filesprocessed = m_filesprocessed;

--- a/Duplicati/Server/webroot/ngax/index.html
+++ b/Duplicati/Server/webroot/ngax/index.html
@@ -175,9 +175,13 @@
                                       </div>
                                     </div>
                                 </span>
-                                <span ng-show="StopReqId == activeTaskID">
+
+                                <span ng-show="StopReqId == activeTaskID &amp;&amp; stopEvent == 'stopaftercurrentfile'">
                                     <strong translate>Stopping after the current file:</strong> {{activeBackup.Backup.Name}}
                                 </span>
+                                <span ng-show="StopReqId == activeTaskID &amp;&amp; stopEvent == 'stopnow'">
+                                    <strong translate>Stopping backup ...</strong>
+                                </span>                                
                             </span>
                             <span ng-show="activeBackup == null">
                                 <strong ng-hide="StopReqId == activeTaskID" translate>Running task:</strong>

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
@@ -67,6 +67,11 @@ backupApp.controller('StateController', function($scope, $timeout, ServerStatus,
             {
                 pg = 1;
             }
+            else if ($scope.state.lastPgEvent != null && $scope.state.lastPgEvent.Phase == 'Paused_WaitForUpload')
+            {
+                var speed_txt = ($scope.state.lastPgEvent.BackendSpeed < 0) ? "" : " at "+AppUtils.formatSizeString($scope.state.lastPgEvent.BackendSpeed)+"/s";
+                text = text + speed_txt;    
+            }
             else if ($scope.state.lastPgEvent.OverallProgress > 0) {
                 pg = $scope.state.lastPgEvent.OverallProgress;
             }
@@ -91,10 +96,12 @@ backupApp.controller('StateController', function($scope, $timeout, ServerStatus,
             {
                 AppService.post('/task/' + taskId + '/stopaftercurrentfile');
                 $scope.StopReqId = taskId;
+                $scope.stopEvent = 'stopaftercurrentfile';
             }
             else if (ix == 1) {
                 AppService.post('/task/' + taskId + '/stopnow');
                 $scope.StopReqId = taskId;
+                $scope.stopEvent = 'stopnow';
             }
         };
 

--- a/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
@@ -22,7 +22,8 @@ backupApp.service('ServerStatus', function($rootScope, $timeout, AppService, App
         updateReady: false,
         updateDownloadProgress: 0,
         proposedSchedule: [],
-        schedulerQueueIds: []
+        schedulerQueueIds: [],
+        stopEvent: ''
     };
 
     this.state = state;
@@ -42,6 +43,7 @@ backupApp.service('ServerStatus', function($rootScope, $timeout, AppService, App
             'Backup_VerificationUpload': gettextCatalog.getString('Uploading verification file …'),
             'Backup_PostBackupVerify': gettextCatalog.getString('Verifying backend data …'),
             'Backup_Complete': gettextCatalog.getString('Backup complete!'),
+            'Backup_StopNow': gettextCatalog.getString('Stopping backup ...'),
             'Restore_Begin': gettextCatalog.getString('Starting restore …'),
             'Restore_RecreateDatabase': gettextCatalog.getString('Rebuilding local database …'),
             'Restore_PreRestoreVerify': gettextCatalog.getString('Verifying remote data …'),
@@ -64,6 +66,8 @@ backupApp.service('ServerStatus', function($rootScope, $timeout, AppService, App
             'PurgeFiles_Process,': gettextCatalog.getString('Purging files …'),
             'PurgeFiles_Compact,': gettextCatalog.getString('Compacting remote data …'),
             'PurgeFiles_Complete,': gettextCatalog.getString('Purging files complete!'),
+            'Paused': gettextCatalog.getString('Paused'),
+            'Paused_WaitForUpload': gettextCatalog.getString('Pausing, waiting for uploads to finish'),
             'Error': gettextCatalog.getString('Error!')
         };
     };


### PR DESCRIPTION
The BasicResults class was not calling Pause or Resume on
m_taskController. m_taskController is the instance of ITaskReader that
is passed to all of the worker classes that use it to check if they
should pause or stop.

Changed the BackendUploader to check TransferProgressAsync instead of
ProgressAsync, as the transfer function is meant for the worker that is
uploading files.

Added two new phases, Paused and Paused_WaitForUpload. These are used
to inform the user about the state of the operation when a pause has been requested.
The current transfer rate will display while waiting for uploads to finish.

The BackendUploader will now periodically timeout waiting for input (files ready
to upload) and will check if a pause is requested. It will then wait for all
current uploads to finish and signal to the IOperationProgressUpdater
that the phase should be changed to Paused.

This also helps when using "Stop Now" as the BackendUploader will check if a cancel is requested while uploads are currently in progress, and then cancel the uploads rather than waiting for them to finish.


Fixes #3565 