### PR TITLE
Added folder .Cache for filter group Cache on Linux

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -556,6 +556,7 @@ namespace Duplicati.Library.Utility
             }
             if (group.HasFlag(FilterGroup.CacheFiles))
             {
+                yield return FilterGroups.CreateWildcardFilter(@"*/.cache/");
                 yield return FilterGroups.CreateWildcardFilter(@"*/.config/google-chrome/Default/Cookies");
                 yield return FilterGroups.CreateWildcardFilter(@"*/.config/google-chrome/Default/Cookies-journal");
             }


### PR DESCRIPTION
I have added ".cache" for Linux to exclude ".cache" when Cache filter group is selected.