### PR TITLE
Ensure that failed put operations throw exception

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -39,6 +39,12 @@ namespace Duplicati.Library.Main.Operation.Backup
     {
         public Task<long> LastWriteSizeAsync { get { return m_tcs.Task; } }
         private readonly TaskCompletionSource<long> m_tcs = new TaskCompletionSource<long>();
+        
+        public void TrySetCanceled()
+        {
+            m_tcs.TrySetCanceled();
+        }
+        
         public void SetFlushed(long size)
         {
             m_tcs.TrySetResult(size);
@@ -171,6 +177,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 Task finishedTask = await Task.WhenAny(workers.Select(w => w.Task)).ConfigureAwait(false);
                                 if (finishedTask.IsFaulted)
                                 {
+                                    flush.TrySetCanceled();
                                     ExceptionDispatchInfo.Capture(finishedTask.Exception).Throw();
                                 }
 

--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -40,14 +40,14 @@ namespace Duplicati.Library.Main.Operation.Backup
         public Task<long> LastWriteSizeAsync { get { return m_tcs.Task; } }
         private readonly TaskCompletionSource<long> m_tcs = new TaskCompletionSource<long>();
         
-        public void TrySetCanceled()
-        {
-            m_tcs.TrySetCanceled();
-        }
-        
         public void SetFlushed(long size)
         {
             m_tcs.TrySetResult(size);
+        }
+        
+        public void TrySetCanceled()
+        {
+            m_tcs.TrySetCanceled();
         }
     }
 

--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -182,9 +182,9 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 }
 
                                 workers.RemoveAll(w => w.Task == finishedTask);
-                                flush.SetFlushed(lastSize);
                             }
                             
+                            flush.SetFlushed(lastSize);
                             uploadsInProgress = 0;
                             break;
                         }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -355,10 +355,7 @@ namespace Duplicati.Library.Main.Operation
             // Wait for upload completion
             result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_WaitForUpload);
             await uploadtarget.WriteAsync(flushReq).ConfigureAwait(false);
-
-            // In case the uploader crashes, we grab the exception here
-            if (await Task.WhenAny(uploader, flushReq.LastWriteSizeAsync) == uploader)
-                await uploader.ConfigureAwait(false);
+            await uploader.ConfigureAwait(false);
 
             // Grab the size of the last uploaded volume
             return await flushReq.LastWriteSizeAsync;


### PR DESCRIPTION
This fixes an issue where failed Put operations would not result in an exception.  The `FlushBackend` method [uses Task.WhenAny](https://github.com/duplicati/duplicati/blob/57b28182cb714c46226645b47fa80cb3d23f1f79/Duplicati/Library/Main/Operation/BackupHandler.cs#L360) to await the first completion of the uploader task or the flush request.  Since the uploader was setting the status of the flush request in the [finally block](https://github.com/duplicati/duplicati/blob/57b28182cb714c46226645b47fa80cb3d23f1f79/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs#L180), the flush request would complete first when an exception was thrown, causing the uploader's exception to be unobserved.  To resolve this,  we check that the uploader's status is not faulted before setting the flush request status.

Previous behavior (as of revision e885f214b0595b63a0b4354e3a6442808a5e4e2a):

* For larger uploads (those that satisfy [uploadsInProgress >= m_maxConcurrentUploads](https://github.com/duplicati/duplicati/blob/e885f214b0595b63a0b4354e3a6442808a5e4e2a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs#L187)), failed Puts do result in an error (this appears to have been due to changes in pull request #3684 (thanks @seantempleton)).  The UI shows "Last successful backup: Never".  However, when attempting to restore, a backup version (with files) appears to exist, but restores will fail.

  The next successful backup runs without error.  However, we encounter a warning
  
  ```
  Expected there to be a temporary fileset for synthetic filelist (1, duplicati-20190407T022849Z.dlist.zip.aes), but none was found?
  ```
  The UI shows a nonzero backup size, but 0 backup versions and no versions appear in the resore list. The backend contains `dblock` and `dindex` files, but no `dlist` files.

  A subsequent successful backup then uploads the `dlist` file, a backup version appears in the UI and restore list, and restores work without issues.

* For smaller uploads (those that do not satisfy [uploadsInProgress >= m_maxConcurrentUploads](https://github.com/duplicati/duplicati/blob/e885f214b0595b63a0b4354e3a6442808a5e4e2a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs#L187)), failed Puts **do not result in an error**.  The UI shows "0 bytes / 0 versions", and no versions appear in the restore list.

  The next successful backup runs without error, a backup version appears in the UI and restores list, and restores work without issues.

This fix makes the behavior for smaller uploads consistent with that of larger ones.  Failed Puts result in an error and the UI shows "Last successful backup: Never".  However, when attempting to restore, a backup version (with files) will appear to exist, but restores will fail.

The next successful backup runs without error.  However, we will encounter a warning
```
Expected there to be a temporary fileset for synthetic filelist (1, duplicati-20190407T022849Z.dlist.zip.aes), but none was found?
```
The UI shows a nonzero backup size with 1 version, and restores work without issues.

The problem with the misleading version appearing in the database when the Puts fail is a separate issue that we'll have to look into later.  However, we can at least ensure that the failed Puts result in an error that can be observed by the user.

Fixes #3673.