### PR TITLE
Revert to alphabetic db names

### DIFF
--- a/Duplicati/Library/Main/DatabaseLocator.cs
+++ b/Duplicati/Library/Main/DatabaseLocator.cs
@@ -199,7 +199,7 @@ namespace Duplicati.Library.Main
 
             System.Text.StringBuilder backupName = new System.Text.StringBuilder();
             for (var i = 0; i < 10; i++)
-                backupName.Append(rnd.Next('A', 'Z' + 1));
+                backupName.Append((char)rnd.Next('A', 'Z' + 1));
 
             return backupName.ToString();
         }


### PR DESCRIPTION
Fixed an issue where the randomly generated database names were numeric instead of alphabetic.

This has no impact on existing database, as the names are stored once generated.