### PR TITLE
Write unwrapped exception message to JSON

### DIFF
--- a/Duplicati/Server/WebServer/RESTHandler.cs
+++ b/Duplicati/Server/WebServer/RESTHandler.cs
@@ -203,14 +203,13 @@ namespace Duplicati.Server.WebServer
                         var wex = ex;
                         while (wex is System.Reflection.TargetInvocationException && wex.InnerException != wex)
                             wex = wex.InnerException;
-                            
-
+                        
                         info.BodyWriter.WriteJsonObject(new
                         {
-                            Message = ex.Message,
-                            Type = ex.GetType().Name,
+                            Message = wex.Message,
+                            Type = wex.GetType().Name,
                             #if DEBUG
-                            Stacktrace = ex.ToString()
+                            Stacktrace = wex.ToString()
                             #endif
                         });
                         info.BodyWriter.Flush();


### PR DESCRIPTION
While the original intent was likely to write a more meaningful message to JSON, the previous implementation unwrapped the `TargetInvocationException` but neglected to use the unwrapped `Exception` when writing to JSON.