### PR TITLE
Fix GTK notification icons

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -354,7 +354,7 @@ namespace Duplicati.GUI.TrayIcon
                     break;
             }
 
-            var notification = new Notifications.Notification(title, message, Stock.Info);
+            var notification = new Notifications.Notification(title, message, icon);
             notification.Show();
         }
 


### PR DESCRIPTION
Previously, the `icon` variable was unused and the information icon was always displayed. Now, we display different icons for information, warning, and error notifications.

Information:
![Information](https://user-images.githubusercontent.com/17345532/56334002-6cf5cb80-614b-11e9-8b14-ff408724bd12.png)

Warning:
![Warning](https://user-images.githubusercontent.com/17345532/56334005-71ba7f80-614b-11e9-8cc4-b8630f441fd4.png)

Error:
![Error](https://user-images.githubusercontent.com/17345532/56334008-75e69d00-614b-11e9-8283-1e52adb79b40.png)
