### PR TITLE
Show vacuum progress in status message

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -537,6 +537,7 @@ namespace Duplicati.Library.Main.Operation
                         m_database.PurgeLogData(m_options.LogRetention);
                         if (m_options.AutoVacuum)
                         {
+                            m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Vacuum_Running);
                             m_database.Vacuum();
                         }
                         m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_Complete);

--- a/Duplicati/Library/Main/OperationPhase.cs
+++ b/Duplicati/Library/Main/OperationPhase.cs
@@ -46,6 +46,7 @@ namespace Duplicati.Library.Main
         Restore_Complete,
 
         Recreate_Running,
+        Vacuum_Running,
         Verify_Running,
 
         BugReport_Running,

--- a/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
@@ -54,6 +54,7 @@ backupApp.service('ServerStatus', function($rootScope, $timeout, AppService, App
             'Restore_PostRestoreVerify': gettextCatalog.getString('Verifying restored files ...'),
             'Restore_Complete': gettextCatalog.getString('Restore complete!'),
             'Recreate_Running': gettextCatalog.getString('Recreating database ...'),
+            'Vacuum_Running': gettextCatalog.getString('Vacuuming database ...'),
             'Repair_Running': gettextCatalog.getString('Repairing database ...'),
             'Verify_Running': gettextCatalog.getString('Verifying files ...'),
             'BugReport_Running': gettextCatalog.getString('Creating bug report ...'),


### PR DESCRIPTION
I have a pretty large database and I use the auto-vacuum option.  I noticed that during the vacuum step (which takes several minutes) the main Duplicati status message would still read "verifying files" or similar.

This was an attempt to have it show when the database is being vacuumed after a backup operation.  Seems to work.

What do you all think?

BTW, I am not sure how to handle the localization files. Also there are a couple other locations in the code where a vacuum operation may be triggered that I didn't touch.