### PR TITLE
Update Travis build to use Ubuntu 18.04.2 LTS (Bionic Beaver)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: csharp
 solution: Duplicati.sln
 dotnet: 2.0.0


### PR DESCRIPTION
This updates the Travis build to use Ubuntu 18.04.2 LTS (Bionic Beaver).  For some reason, we started to encounter "Unable to locate package dotnet-sdk-2.0.0" errors.  Updating the distribution (recommended [here](https://travis-ci.community/t/dotnet-core-2-2/1216/19)) appears to resolve the issue.