### PR TITLE
Run PRAGMA optimize when closing database connection

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Text;
 using System.IO;
@@ -1358,7 +1359,20 @@ ORDER BY
             if (ShouldCloseConnection && m_connection != null)
             {
                 if (m_connection.State == System.Data.ConnectionState.Open)
+                {
+                    using (IDbTransaction transaction = m_connection.BeginTransaction())
+                    {
+                        using (IDbCommand command = m_connection.CreateCommand(transaction))
+                        {
+                            // SQLite recommends that PRAGMA optimize is run just before closing each database connection.
+                            command.ExecuteNonQuery("PRAGMA optimize");
+                            transaction.Commit();
+                        }
+                    }
+
                     m_connection.Close();
+                }
+
                 m_connection.Dispose();
             }
 


### PR DESCRIPTION
It's [recommended](https://sqlite.org/pragma.html#pragma_optimize) that PRAGMA optimize be run just before closing each database connection.  Some users have been running this manually and experiencing significant improvements in performance (see [here](https://forum.duplicati.com/t/verifying-backend-data/348/65) and [here](https://forum.duplicati.com/t/verifying-backend-data-forever/5324/32)).

It seems that the bulk of the performance benefit is obtained when `PRAGMA optimize` decides that `ANALYZE` should be run and the `sqlite_stat1` table of statistics is created.  In this case, one user has seen a query that used to take 15 hours [improve](https://github.com/duplicati/duplicati/issues/3745#issuecomment-486113014) to 6 seconds.

[Initial testing](https://github.com/duplicati/duplicati/issues/3745#issuecomment-486498026) seems to indicate that running `PRAGMA optimize` externally (e.g., in sqlitebrowser) does not run `ANALYZE`.  However, the changes in this pull request do appear to create the `sqlite_stat1` table on both existing and new backup configurations.

I would prefer to start with only running `PRAGMA optimize` (letting it decide when to run `ANALYZE`) and see if it improves performance.  If not, we can later decide to do something more sophisticated and run ANALYZE at an appropriate time.

This addresses issue #3745.