### PR TITLE
Remove unused members from Duplicati.GUI.TrayIcon project

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -68,11 +68,6 @@ namespace Duplicati.GUI.TrayIcon
                 // Do nothing.  Implementation needed for IMenuItem interface.
             }
 
-            public void SetEnabled(bool isEnabled)
-            {
-                m_item.Enabled = isEnabled;
-            }
-
             public void SetDefault(bool isDefault)
             {
                 // Do nothing.  Implementation needed for IMenuItem interface.

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -155,11 +155,6 @@ namespace Duplicati.GUI.TrayIcon
                 ((ImageMenuItem) m_item).Image = GetIcon(icon);
             }
             
-            public void SetEnabled(bool isEnabled)
-            {
-                m_item.Sensitive = isEnabled;
-            }
-
             public void SetDefault(bool isDefault)
             {
                 // Do nothing.  Implementation needed for TrayIconBase interface.

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -232,17 +232,6 @@ namespace Duplicati.GUI.TrayIcon
             }
         }    
 
-        public static Gtk.Image ImageToGtk(System.Drawing.Image image)
-        {
-            using (var stream = new System.IO.MemoryStream()) 
-            {
-                image.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-                stream.Position = 0;
-                Gtk.Image img = new Gtk.Image(stream);
-                return img;
-            }
-        }
-
         protected static string GetTrayIconFilename(TrayIcons icon)
         {
             switch (icon)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,6 +491,12 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
+        public void AbortTask(long id)
+        {
+            var req = new Dictionary<string, string>();
+            ExecuteAndNotify("POST", string.Format("/task/{0}/abort", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
+        }
+
         public void RunBackup(long id, bool forcefull = false)
         {
             var req = new Dictionary<string, string>();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,6 +491,12 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
+        public void DismissNotification(long id)
+        {
+            var req = new Dictionary<string, string>();
+            ExecuteAndNotify("DELETE", string.Format("/notification/{0}", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
+        }
+
         public void Dispose()
         {
             Close();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,6 +491,12 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
+        public void StopTask(long id)
+        {
+            var req = new Dictionary<string, string>();
+            ExecuteAndNotify("POST", string.Format("/task/{0}/stop", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
+        }
+
         public void AbortTask(long id)
         {
             var req = new Dictionary<string, string>();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -27,10 +27,6 @@ namespace Duplicati.GUI.TrayIcon
             public string Endpoint;
             public Dictionary<string, string> Query;
 
-            public BackgroundRequest() 
-            {
-            }
-
             public BackgroundRequest(string method, string endpoint, Dictionary<string, string> query)
             {
                 this.Method = method;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,12 +491,6 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
-        public void StopTask(long id)
-        {
-            var req = new Dictionary<string, string>();
-            ExecuteAndNotify("POST", string.Format("/task/{0}/stop", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
-        }
-
         public void AbortTask(long id)
         {
             var req = new Dictionary<string, string>();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,6 +491,14 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
+        public void RunBackup(long id, bool forcefull = false)
+        {
+            var req = new Dictionary<string, string>();
+            if (forcefull)
+                req.Add("full", "true");
+            ExecuteAndNotify("POST", string.Format("/backup/{0}/start", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
+        }
+  
         public void DismissNotification(long id)
         {
             var req = new Dictionary<string, string>();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,14 +491,6 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
-        public void RunBackup(long id, bool forcefull = false)
-        {
-            var req = new Dictionary<string, string>();
-            if (forcefull)
-                req.Add("full", "true");
-            ExecuteAndNotify("POST", string.Format("/backup/{0}/start", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
-        }
-  
         public void DismissNotification(long id)
         {
             var req = new Dictionary<string, string>();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,12 +491,6 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
-        public void AbortTask(long id)
-        {
-            var req = new Dictionary<string, string>();
-            ExecuteAndNotify("POST", string.Format("/task/{0}/abort", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
-        }
-
         public void RunBackup(long id, bool forcefull = false)
         {
             var req = new Dictionary<string, string>();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -491,12 +491,6 @@ namespace Duplicati.GUI.TrayIcon
             ExecuteAndNotify("POST", "/serverstate/resume", req);
         }
 
-        public void DismissNotification(long id)
-        {
-            var req = new Dictionary<string, string>();
-            ExecuteAndNotify("DELETE", string.Format("/notification/{0}", Library.Utility.Uri.UrlPathEncode(id.ToString())), req);
-        }
-
         public void Dispose()
         {
             Close();

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/RumpsRunner.cs
@@ -75,15 +75,6 @@ namespace Duplicati.GUI.TrayIcon
                 }
             }
 
-            public void SetEnabled(bool isEnabled)
-            {
-                if (this.Enabled != isEnabled)
-                {
-                    this.Enabled = isEnabled;
-                    m_parent.UpdateMenu(this);
-                }
-            }
-
             public void SetDefault(bool isDefault)
             {
                 if (this.Default != isDefault)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -56,7 +56,6 @@ namespace Duplicati.GUI.TrayIcon
     public interface IMenuItem
     {
         void SetDefault(bool isDefault);
-        void SetEnabled(bool isEnabled);
         void SetIcon(MenuIcons icon);
         void SetText(string text);
     }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/WinFormsRunner.cs
@@ -88,11 +88,6 @@ namespace Duplicati.GUI.TrayIcon.Windows
                 m_menu.Image = GetIcon(icon);
             }
 
-            public void SetEnabled(bool isEnabled)
-            {
-                m_menu.Enabled = isEnabled;
-            }
-
             public void SetDefault(bool value)
             {
                 m_menu.Font = new System.Drawing.Font(m_menu.Font, System.Drawing.FontStyle.Bold);


### PR DESCRIPTION
There is a lot of unused code in the source, and I think it is worth cleaning it up.  This removes unused members from the `Duplicati.GUI.TrayIcon` project.

In doing so, some inconsistent line endings were also fixed.