### PR TITLE
Check block size on recreate

### DIFF
--- a/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
@@ -498,8 +498,8 @@ namespace Duplicati.Library.Main.Database
                         blocksize / hashsize
                     );
 
-                var missingBlockInfo = 
-                    @"SELECT ""VolumeID"" FROM ""Block"" WHERE ""VolumeID"" < 0 ";
+                var missingBlockInfo =
+                    @"SELECT ""VolumeID"" FROM ""Block"" WHERE ""VolumeID"" < 0 AND SIZE > 0";
             
                 var missingBlocklistVolumes = string.Format(
                     @"SELECT ""VolumeID"" FROM ""Block"", (" +


### PR DESCRIPTION
As discussed in #3747 

Check the block size to avoid scavenging behavoir when Duplicati can't locate the 'empty' block which doesn't exist
