### PR TITLE
Fix issue with reading configuration from parameters file

### DIFF
--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -216,8 +216,9 @@ namespace Duplicati.Server
 
             if (parameterFileOption != null && !string.IsNullOrEmpty(commandlineOptions[parameterFileOption]))
             {
+                string filename = commandlineOptions[parameterFileOption];
                 commandlineOptions.Remove(parameterFileOption);
-                if (!ReadOptionsFromFile(commandlineOptions[parameterFileOption], ref filter, args, commandlineOptions))
+                if (!ReadOptionsFromFile(filename, ref filter, args, commandlineOptions))
                     return 100;
             }
 


### PR DESCRIPTION
This fixes an issue that occurred when the `--parameters-file` was passed to `Duplicati.Server.exe`.  After removing the `parameters-file` key from the command-line options `Dictionary`, we were attempting to retrieve the value for the removed key.

This fixes issue #3761.