### PR TITLE
Remove unused members from Duplicati.Library.Backend.AzureBlob project

### DIFF
--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -78,11 +78,6 @@ namespace Duplicati.Library.Backend.AzureBlob
             get { return "azure"; }
         }
 
-        public bool SupportsStreaming
-        {
-            get { return true; }
-        }
-
         public IEnumerable<IFileEntry> List()
         {
             return _azureBlob.ListContainerEntries();

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -32,10 +32,14 @@ namespace Duplicati.Library.Backend.AzureBlob
     {
         private readonly AzureBlobWrapper _azureBlob;
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public AzureBlobBackend()
         {
         }
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public AzureBlobBackend(string url, Dictionary<string, string> options)
         {
             var uri = new Utility.Uri(url);

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -26,6 +26,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend.AzureBlob
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class AzureBlobBackend : IStreamingBackend
     {
         private readonly AzureBlobWrapper _azureBlob;

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
@@ -92,14 +92,6 @@ namespace Duplicati.Library.Backend.AzureBlob
             _container.GetBlockBlobReference(keyName).DownloadToStream(target);
         }
 
-        public Task AddFileObject(string keyName, string localfile, CancellationToken cancelToken)
-        {
-            using (var fs = File.Open(localfile, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                return AddFileStream(keyName, fs, cancelToken);
-            }
-        }
-
         public virtual async Task AddFileStream(string keyName, Stream source, CancellationToken cancelToken)
         {
             await _container.GetBlockBlobReference(keyName).UploadFromStreamAsync(source, cancelToken);

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
@@ -92,11 +92,6 @@ namespace Duplicati.Library.Backend.AzureBlob
             _container.GetBlockBlobReference(keyName).DownloadToStream(target);
         }
 
-        public void GetFileObject(string keyName, string localfile)
-        {
-            _container.GetBlockBlobReference(keyName).DownloadToFile(localfile, FileMode.Create);
-        }
-
         public Task AddFileObject(string keyName, string localfile, CancellationToken cancelToken)
         {
             using (var fs = File.Open(localfile, FileMode.Open, FileAccess.Read, FileShare.Read))


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.AzureBlob` project.

In doing so, some inconsistent line endings were also fixed.