### PR TITLE
Remove unused members from Duplicati.Library.Backend.AmazonCloudDrive project

### DIFF
--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -27,6 +27,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend.AmazonCloudDrive
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class AmzCD : IBackend, IStreamingBackend, IRenameEnabledBackend
     {
         private const string AUTHID_OPTION = "authid";

--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -68,6 +68,8 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
             m_waitUntilRemotename = new Dictionary<string, DateTime>();
         }
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public AmzCD()
         {
         }

--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -74,6 +74,8 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
         {
         }
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public AmzCD(string url, Dictionary<string, string> options)
         {
             var uri = new Utility.Uri(url);

--- a/Duplicati/Library/Backend/AmazonCloudDrive/Strings.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/Strings.cs
@@ -24,7 +24,6 @@ namespace Duplicati.Library.Backend.Strings
         public static string AuthidShort { get { return LC.L(@"The authorization code"); } }
         public static string AuthidLong(string url) { return LC.L(@"The authorization token retrieved from {0}", url); }
         public static string DisplayName { get { return LC.L(@"Amazon Cloud Drive"); } }
-        public static string MissingAuthID(string url) { return LC.L(@"You need an AuthID, you can get it from: {0}", url); }
         public static string LabelsShort { get { return LC.L(@"The labels to set"); } }
         public static string LabelsLong { get { return LC.L(@"Use this option to set labels on the files and folders created"); } }
         public static string MultipleEntries(string folder, string parent) { return LC.L(@"There is more than one item named ""{0}"" in the folder ""{1}""", folder, parent); }


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.AmazonCloudDrive` project.

In doing so, some inconsistent line endings were also fixed.