### PR TITLE
Show vacuum operation in status message

### DIFF
--- a/Duplicati/Library/Main/Operation/VacuumHandler.cs
+++ b/Duplicati/Library/Main/Operation/VacuumHandler.cs
@@ -22,6 +22,7 @@ namespace Duplicati.Library.Main.Operation
             using (var db = new Database.LocalDatabase(m_options.Dbpath, "Vacuum", false))
             {
                 m_result.SetDatabase(db);
+                m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Vacuum_Running);
                 db.Vacuum();
             }
         }


### PR DESCRIPTION
This is similar to a previous pull request I submitted:  https://github.com/duplicati/duplicati/pull/3743 where the vacuum operation is displayed during an auto-vacuum.

This change shows the same message when a vacuum is initiated via the API or command line.

Feedback appreciated. Thanks