### PR TITLE
Remove unused members from Duplicati.Library.Backend.Box project

### DIFF
--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -26,6 +26,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend.Box
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class BoxBackend : IBackend, IStreamingBackend
     {
 		private static readonly string LOGTAG = Logging.Log.LogTagFromType<BoxBackend>();

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -91,10 +91,14 @@ namespace Duplicati.Library.Backend.Box
             }
         }
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public BoxBackend()
         {
         }
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public BoxBackend(string url, Dictionary<string, string> options)
         {
             var uri = new Utility.Uri(url);

--- a/Duplicati/Library/Backend/Box/Strings.cs
+++ b/Duplicati/Library/Backend/Box/Strings.cs
@@ -20,7 +20,6 @@ namespace Duplicati.Library.Backend.Strings
     internal static class Box {
         public static string Description { get { return LC.L(@"This backend can read and write data to Box.com. Supported format is ""box://folder/subfolder""."); } }
         public static string DisplayName { get { return LC.L(@"Box.com"); } }
-        public static string MissingAuthID(string url) { return LC.L(@"You need an AuthID, you can get it from: {0}", url); }
         public static string AuthidShort { get { return LC.L(@"The authorization code"); } }
         public static string AuthidLong(string url) { return LC.L(@"The authorization token retrieved from {0}", url); }
         public static string ReallydeleteShort { get { return LC.L(@"Force delete files"); } }


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.Box` project.

In doing so, some inconsistent line endings were also fixed.