### PR TITLE
Test that retention policy is a valid pattern

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -297,7 +297,10 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
             return;
         }
 
-        if ($scope.KeepType == 'custom' && (opts['retention-policy'] || '').indexOf(':') <= 0)
+        var retentionPolicy = (opts['retention-policy'] || '');
+        var valid_chars = /^((\d+[shDWMY]|U):(\d+[shDWMY]|U),?)+$/;
+        var valid_commas = /^(\d*\w:\d*\w,)*\d*\w:\d*\w$/;
+        if ($scope.KeepType == 'custom' && (retentionPolicy.indexOf(':') <= 0 || valid_chars.test(retentionPolicy) == false || valid_commas.test(retentionPolicy) == false))
         {
             DialogService.dialog(gettextCatalog.getString('Invalid retention time'), gettextCatalog.getString('You must enter a valid rentention policy string'));
             $scope.CurrentStep = 4;

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -300,7 +300,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         var retentionPolicy = (opts['retention-policy'] || '');
         var valid_chars = /^((\d+[shDWMY]|U):(\d+[shDWMY]|U),?)+$/;
         var valid_commas = /^(\d*\w:\d*\w,)*\d*\w:\d*\w$/;
-        if ($scope.KeepType == 'custom' && (retentionPolicy.indexOf(':') <= 0 || valid_chars.test(retentionPolicy) == false || valid_commas.test(retentionPolicy) == false))
+        if ($scope.KeepType == 'custom' && (retentionPolicy.indexOf(':') <= 0 || valid_chars.test(retentionPolicy) === false || valid_commas.test(retentionPolicy) === false))
         {
             DialogService.dialog(gettextCatalog.getString('Invalid retention time'), gettextCatalog.getString('You must enter a valid rentention policy string'));
             $scope.CurrentStep = 4;


### PR DESCRIPTION
Fixes #3774 

I decided to put the logic in javascript instead of the server since we already do so much validation there.

The pattern `^((\d+[shDWMY]|U):(\d+[shDWMY]|U),?)+$` ensures a valid pattern. 
It expects one or more repeats of the sub-pattern:
1. Expects two sections divided by `:`
2. Expects first section to either be `U` or `<one or more numbers><one valid letter>`
3. Expects second section to either be `U` or `<one or more numbers><one valid letter>`
4. Allows a trailing comma after each repeat

It's only possible to make an invalid pattern in two ways, 
1. Without any commas, e.g. `1W:1D4W:1W3Y:1M`
2. With a trailing comma, e.g. `1D:U,`. 

A second regex pattern fixes these cases `^(\d*\w:\d*\w,)*\d*\w:\d*\w$`.
Requiring 0 or more cases with commas after them, but only one case without a comma at the end of the line.