### PR TITLE
Remove unused members from Duplicati.Library.Backend.Dropbox project

### DIFF
--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class Dropbox : IBackend, IStreamingBackend
     {
         private const string AUTHID_OPTION = "authid";

--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -18,10 +18,14 @@ namespace Duplicati.Library.Backend
         private readonly string m_path;
         private readonly DropboxHelper dbx;
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public Dropbox()
         {
         }
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public Dropbox(string url, Dictionary<string, string> options)
         {
             var uri = new Utility.Uri(url);

--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -339,8 +339,6 @@ namespace Duplicati.Library.Backend
         [JsonProperty(".tag")]
         public string tag { get; set; }
         public string name { get; set; }
-        public string path_lower { get; set; }
-        public string path_display { get; set; }
         public string id { get; set; }
 
         public string server_modified { get; set; }

--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -339,14 +339,19 @@ namespace Duplicati.Library.Backend
         [JsonProperty(".tag")]
         public string tag { get; set; }
         public string name { get; set; }
-        public string id { get; set; }
-
         public string server_modified { get; set; }
-        public string rev { get; set; }
         public ulong size { get; set; }
-
         public bool IsFile { get { return tag == "file"; } }
 
+        // While this is unused, the Dropbox API v2 documentation does not
+        // declare this to be optional.
+        // ReSharper disable once UnusedMember.Global
+        public string id { get; set; }
+
+        // While this is unused, the Dropbox API v2 documentation does not
+        // declare this to be optional.
+        // ReSharper disable once UnusedMember.Global
+        public string rev { get; set; }
     }
 
     public class FileMetaData : MetaData

--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -268,7 +268,7 @@ namespace Duplicati.Library.Backend
         // ReSharper disable once UnusedMember.Global
         // This is serialized into JSON and provided in the Dropbox request header.
         // A value of false indicates that the session should not be closed.
-        public bool close => false;
+        public static bool close => false;
     }
 
     public class UploadSessionAppendArg

--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -265,7 +265,10 @@ namespace Duplicati.Library.Backend
 
     public class UploadSessionStartArg
     {
-        public bool close { get; set; }
+        // ReSharper disable once UnusedMember.Global
+        // This is serialized into JSON and provided in the Dropbox request header.
+        // A value of false indicates that the session should not be closed.
+        public bool close => false;
     }
 
     public class UploadSessionAppendArg


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.Dropbox` project.

In doing so, some inconsistent line endings were also fixed.