### PR TITLE
Remove unused members from Duplicati.Library.Backend.File project

### DIFF
--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -28,6 +28,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class File : IBackend, IStreamingBackend, IQuotaEnabledBackend, IRenameEnabledBackend
     {
         private const string OPTION_DESTINATION_MARKER = "alternate-destination-marker";

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -165,11 +165,6 @@ namespace Duplicati.Library.Backend
             get { return "file"; }
         }
 
-        public bool SupportsStreaming
-        {
-            get { return true; }
-        }
-
         public IEnumerable<IFileEntry> List()
         {
             PreAuthenticate();

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -284,11 +284,6 @@ namespace Duplicati.Library.Backend
 
         #endregion
 
-        public static bool PreAuthenticate(string path, string username, string password, bool forceReauth)
-        {
-            return Win32.PreAuthenticate(path, username, password, forceReauth);
-        }
-
         private System.IO.DriveInfo GetDrive()
         {
             string root;


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.File` project.

In doing so, some inconsistent line endings were also fixed.

There are a lot of unused members in the `Win32` class that I did not remove since I'm guessing that they are required by `mpr.dll` (I don't have a Windows machine to test this).