### PR TITLE
Remove unused members from Duplicati.Library.Backend.FTP project

### DIFF
--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -28,6 +28,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class FTP : IBackend, IStreamingBackend
     {
         private System.Net.NetworkCredential m_userInfo;

--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -167,11 +167,6 @@ namespace Duplicati.Library.Backend
             get { return "ftp"; }
         }
 
-        public bool SupportsStreaming
-        {
-            get { return true; }
-        }
-
         private T HandleListExceptions<T>(Func<T> func, System.Net.FtpWebRequest req)
         {
             T ret = default(T);


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.FTP` project.

In doing so, some inconsistent line endings were also fixed.