### PR TITLE
Remove unused members from Duplicati.Library.Backend.GoogleServices project

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GCSConfig.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GCSConfig.cs
@@ -21,6 +21,8 @@ using System.Linq;
 
 namespace Duplicati.Library.Backend.GoogleServices
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the ServerSettings.
     public class GCSConfig : IWebModule
     {
         private const ConfigType DEFAULT_CONFIG_TYPE = ConfigType.Locations;

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -28,6 +28,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend.GoogleCloudStorage
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class GoogleCloudStorage : IBackend, IStreamingBackend, IRenameEnabledBackend
     {
         private const string AUTHID_OPTION = "authid";

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -77,24 +77,15 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         private class ListBucketResponse
         {
-            public string kind { get; set; }
             public string nextPageToken { get; set; }
             public BucketResourceItem[] items { get; set; }
         }
 
         private class BucketResourceItem
         {
-            public string kind { get; set; }
-            public string id { get; set; }
-            public string selfLink { get; set; }
             public string name { get; set; }
-            public string contentType { get; set; }
             public DateTime? updated { get; set; }
-            public string storageClass { get; set; }
             public long? size { get; set; }
-            public string md5Hash { get; set; }
-
-            public string mediaLink { get; set; }
         }
 
         private class CreateBucketRequest

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -79,7 +79,6 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         {
             public string kind { get; set; }
             public string nextPageToken { get; set; }
-            public string[] prefixes { get; set; }
             public BucketResourceItem[] items { get; set; }
         }
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -29,6 +29,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend.GoogleDrive
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class GoogleDrive : IBackend, IStreamingBackend, IQuotaEnabledBackend, IRenameEnabledBackend
     {
         private const string AUTHID_OPTION = "authid";

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -409,70 +409,38 @@ namespace Duplicati.Library.Backend.GoogleDrive
 
         private class GoogleDriveParentReference
         {
-            public string kind { get; set; }
             public string id { get; set; }
-            public string selfLink { get; set; }
-            public string parentLink { get; set; }
-            public bool? isRoot { get; set; }
         }
 
         private class GoogleDriveListResponse
         {
-            public string kind { get; set; }
-            public string etag { get; set; }
-            public string selfLink { get; set; }
             public string nextPageToken { get; set; }
-            public string nextLink { get; set; }
             public GoogleDriveFolderItem[] items { get; set; }
         }
 
         private class GoogleDriveFolderItemLabels
         {
-            public bool starred { get; set; }
             public bool hidden { get; set; }
-            public bool thrashed { get; set; }
-            public bool restricted { get; set; }
-            public bool viewed { get; set; }
         }
 
         private class GoogleDriveFolderItem
         {
-            public string kind { get; set; }
             public string id { get; set; }
-            public string etag { get; set; }
-            public string selfLink { get; set; }
             public string title { get; set; }
             public string description { get; set; }
             public string mimeType { get; set; }
-
             public GoogleDriveFolderItemLabels labels { get; set; }
-
             public DateTime? createdDate { get; set; }
             public DateTime? modifiedDate { get; set; }
-
-            public string downloadUrl { get; set; }
-
-            public string originalFilename { get; set; }
-            public string md5Checksum { get; set; }
             public long? fileSize { get; set; }
-            public long? quotaBytesUsed { get; set; }
-
             public string teamDriveId { get; set; }
-
             public GoogleDriveParentReference[] parents { get; set; }
         }
 
         private class GoogleDriveAboutResponse
         {
-            public string kind { get; set; }
-            public string etag { get; set; }
-            public string selfLink { get; set; }
-            public string name { get; set; }
             public long? quotaBytesTotal { get; set; }
             public long? quotaBytesUsed { get; set; }
-            public long? quotaBytesUsedAggregate { get; set; }
-            public long? quotaBytesUsedInTrash { get; set; }
-            public string quotaType { get; set; }
             public string rootFolderId { get; set; }
         }
 

--- a/Duplicati/Library/Backend/GoogleServices/Strings.cs
+++ b/Duplicati/Library/Backend/GoogleServices/Strings.cs
@@ -38,12 +38,10 @@ namespace Duplicati.Library.Backend.Strings
     }
 
     internal static class GoogleDrive {
-        public static string CaptchaRequiredError(string url) { return LC.L(@"The account access has been blocked by Google, please visit this URL and unlock it: {0}", url); }
         public static string Description { get { return LC.L(@"This backend can read and write data to Google Drive. Supported format is ""googledrive://folder/subfolder""."); } }
         public static string AuthidShort { get { return LC.L(@"The authorization code"); } }
         public static string AuthidLong(string url) { return LC.L(@"The authorization token retrieved from {0}", url); }
         public static string DisplayName { get { return LC.L(@"Google Drive"); } }
-        public static string MissingAuthID(string url) { return LC.L(@"You need an AuthID, you can get it from: {0}", url); }
         public static string MultipleEntries(string folder, string parent) { return LC.L(@"There is more than one item named ""{0}"" in the folder ""{1}""", folder, parent); }
         public static string TeamDriveIdShort { get { return LC.L("Team drive ID"); } }
         public static string TeamDriveIdLong { get { return LC.L("This option sets the team drive to use. Leaving it empty uses the personal drive"); } }

--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -167,11 +167,6 @@ namespace Duplicati.Library.Backend.WebApi
             });
         }
 
-        public static string RenameUrl(string fileId)
-        {
-            return FileQueryUrl(Uri.UrlPathEncode(fileId));
-        }
-
         public static string DeleteUrl(string fileId, string teamDriveId)
         {
             return FileQueryUrl(Uri.UrlPathEncode(fileId), AddTeamDriveParam(teamDriveId));


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.GoogleServices` project.

In doing so, some inconsistent line endings were also fixed.