### PR TITLE
Remove unused members from Duplicati.Library.Backend.Jottacloud project

### DIFF
--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -395,8 +395,6 @@ namespace Duplicati.Library.Backend
             return CreateRequest(method, url, queryparams);
         }
 
-        #region IStreamingBackend Members
-
         public string[] DNSName
         {
             get { return new string[] { new Uri(JFS_ROOT).Host, new Uri(JFS_ROOT_UPLOAD).Host }; }
@@ -577,7 +575,5 @@ namespace Duplicati.Library.Backend
                 catch { }
             }
         }
-
-        #endregion
     }
 }

--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -397,11 +397,6 @@ namespace Duplicati.Library.Backend
 
         #region IStreamingBackend Members
 
-        public bool SupportsStreaming
-        {
-            get { return true; }
-        }
-
         public string[] DNSName
         {
             get { return new string[] { new Uri(JFS_ROOT).Host, new Uri(JFS_ROOT_UPLOAD).Host }; }

--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -26,6 +26,8 @@ using System.Threading;
 using System.Threading.Tasks;
 namespace Duplicati.Library.Backend
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class Jottacloud : IBackend, IStreamingBackend
     {
         private const string JFS_ROOT = "https://jfs.jottacloud.com/jfs";


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.Jottacloud` project.

This also removes a misleading `region` tag, which enclosed more members than described.