### PR TITLE
Remove unused members from Duplicati.Library.Backend.Mega project

### DIFF
--- a/Duplicati/Library/Backend/Mega/MegaBackend.cs
+++ b/Duplicati/Library/Backend/Mega/MegaBackend.cs
@@ -25,6 +25,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend.Mega
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class MegaBackend: IBackend, IStreamingBackend
     {
         private readonly string m_username = null;

--- a/Duplicati/Library/Backend/Mega/Strings.cs
+++ b/Duplicati/Library/Backend/Mega/Strings.cs
@@ -8,7 +8,6 @@ namespace Duplicati.Library.Backend.Strings {
         public static string AuthUsernameDescriptionShort { get { return LC.L(@"Supplies the username used to connect to the server"); } }
         public static string NoPasswordError { get { return LC.L(@"No password given"); } }
         public static string NoUsernameError { get { return LC.L(@"No username given"); } }
-        public static string NoPathError { get { return LC.L(@"No path given, cannot upload files to the root folder"); } }
         public static string Description { get { return LC.L(@"This backend can read and write data to Mega.co.nz. Allowed formats are: ""mega://folder/subfolder"""); } }
     }
 }


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.Mega` project.

In doing so, some inconsistent line endings were also fixed.