### PR TITLE
Include original database filename when saving database backup.

### DIFF
--- a/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
+++ b/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
@@ -255,7 +255,7 @@ namespace Duplicati.Library.SQLiteHelper
                     {
                         backupfile = System.IO.Path.Combine(
                             System.IO.Path.GetDirectoryName(sourcefile),
-                            Strings.DatabaseUpgrader.BackupFilenamePrefix + " " + (DateTime.Now + TimeSpan.FromSeconds(i * 1.5)).ToString("yyyyMMddhhmmss", System.Globalization.CultureInfo.InvariantCulture) + ".sqlite");
+                            Strings.DatabaseUpgrader.BackupFilenamePrefix + " " + System.IO.Path.GetFileNameWithoutExtension(sourcefile) + " " + (DateTime.Now + TimeSpan.FromSeconds(i * 1.5)).ToString("yyyyMMddhhmmss", System.Globalization.CultureInfo.InvariantCulture) + ".sqlite");
 
                         if (!System.IO.File.Exists(backupfile))
                             break;


### PR DESCRIPTION
As discussed on https://forum.duplicati.com/t/differens-in-database-files-what-are-they/6080/10