### PR TITLE
Remove unused members from Duplicati.Library.Backend.Rclone project

### DIFF
--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -32,6 +32,8 @@ using System.Threading.Tasks;
 
 namespace Duplicati.Library.Backend
 {
+    // ReSharper disable once UnusedMember.Global
+    // This class is instantiated dynamically in the BackendLoader.
     public class Rclone : IBackend
     {
         private const string OPTION_LOCAL_REPO = "rclone-local-repository";

--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -95,11 +95,6 @@ namespace Duplicati.Library.Backend
             get { return "rclone"; }
         }
 
-        public bool SupportsStreaming
-        {
-            get { return false; }
-        }
-
         private async Task<string> RcloneCommandExecuter(String command, String arguments, CancellationToken cancelToken)
         {
             StringBuilder outputBuilder = new StringBuilder();


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.Rclone` project.

In doing so, some inconsistent line endings were also fixed.