### PR TITLE
Remove unused members from Duplicati.Library.Backend.SharePoint project

### DIFF
--- a/Duplicati/Library/Backend/SharePoint/OneDriveForBusinessBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/OneDriveForBusinessBackend.cs
@@ -33,6 +33,8 @@ namespace Duplicati.Library.Backend
     /// moves away from SharePoint as OD4B base, this allows to reimplement it without breaking existing
     /// configurations...
     /// </summary>
+    // ReSharper disable once UnusedMember.Global
+    // This constructor is needed by the BackendLoader.
     public class OneDriveForBusinessBackend : SharePointBackend
     {
         public override string ProtocolKey

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -95,11 +95,6 @@ namespace Duplicati.Library.Backend
             get { return Strings.SharePoint.Description; }
         }
 
-        public virtual bool SupportsStreaming
-        {
-            get { return true; }
-        }
-
         public virtual IList<ICommandLineArgument> SupportedCommands
         {
             get


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.SharePoint` project.

In doing so, some inconsistent line endings were also fixed.