### PR TITLE
Remove unused members from Duplicati.Library.Backend.Sia project

### DIFF
--- a/Duplicati/Library/Backend/Sia/Sia.cs
+++ b/Duplicati/Library/Backend/Sia/Sia.cs
@@ -22,10 +22,14 @@ namespace Duplicati.Library.Backend.Sia
         private readonly float m_redundancy;
         private readonly string m_authorization;
 
-        public Sia() {
-
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
+        public Sia()
+        {
         }
 
+        // ReSharper disable once UnusedMember.Global
+        // This constructor is needed by the BackendLoader.
         public Sia(string url, Dictionary<string, string> options)
         {
             var uri = new Utility.Uri(url);

--- a/Duplicati/Library/Backend/Sia/Strings.cs
+++ b/Duplicati/Library/Backend/Sia/Strings.cs
@@ -5,8 +5,6 @@ namespace Duplicati.Library.Backend.Strings
     {
         public static string DisplayName { get { return LC.L(@"Sia Decentralized Cloud"); } }
         public static string Description { get { return LC.L(@"This backend can read and write data to Sia."); } }
-        public static string SiaHostDescriptionShort { get { return LC.L(@"Sia address"); } }
-        public static string SiaHostDescriptionLong { get { return LC.L(@"Sia address, ie 127.0.0.1:9980"); } }
         public static string SiaPathDescriptionShort { get { return LC.L(@"Backup path"); } }
         public static string SiaPathDescriptionLong { get { return LC.L(@"Target path, ie /backup"); } }
         public static string SiaPasswordShort { get { return LC.L(@"Sia password"); } }


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Backend.Sia` project.

In doing so, some inconsistent line endings were also fixed.