### PR TITLE
Fix usage statistics link

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/settings.html
+++ b/Duplicati/Server/webroot/ngax/templates/settings.html
@@ -129,7 +129,7 @@
                 <option value="crash" translate>Crashes only</option>
                 <option value="none" translate>None / disabled</option>
             </select>
-            <div class="sublabel"><p translate translate-params-link="'https://usage-reporter.duplicati.com/'">Usage reports help us improve the user experience and evaluate impact of new features. We use them to generate <external-link link="link">public usage statistics</external-link></p>
+            <div class="sublabel"><p translate>Usage reports help us improve the user experience and evaluate impact of new features. We use them to generate <external-link link="'https://usage-reporter.duplicati.com/'">{{'public usage statistics' | translate}}</external-link></p>
 
             <p translate>All usage reports are sent anonymously and do not contain any personal information. They contain information about hardware and operating system, the type of backend, backup duration, overall size of source data and similar data. They do not contain paths, filenames, usernames, passwords or similar sensitive information.</p></div>
         </div>


### PR DESCRIPTION
This fixes the usage statistics link in the Settings page of the UI.  Previously, clicking on the link would just redirect to `http://localhost:8200/ngax/index.html` instead of the usage reporter page.

This fixes issue #3334.