### PR TITLE
Add support for B2 'prefix' API parameter when listing files

### DIFF
--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -320,7 +320,8 @@ namespace Duplicati.Library.Backend.Backblaze
                     string.Format("{0}/b2api/v1/b2_list_file_versions", m_helper.APIUrl),
                     new ListFilesRequest() {
                         BucketID = Bucket.BucketID,
-                    MaxFileCount = m_pagesize,
+                        MaxFileCount = m_pagesize,
+                        Prefix = m_prefix,
                         StartFileID = nextFileID,
                         StartFileName = nextFileName
                     }
@@ -506,6 +507,8 @@ namespace Duplicati.Library.Backend.Backblaze
             public string StartFileID { get; set; }
             [JsonProperty("maxFileCount")]
             public long MaxFileCount { get; set; }
+            [JsonProperty("prefix")]
+            public string Prefix { get; set; }
         }
 
         private class ListFilesResponse


### PR DESCRIPTION
Duplicati currently does not utilize the prefix parameter mentioned here:

https://www.backblaze.com/b2/docs/b2_list_file_versions.html

Using this parameter should speed up file listing operations when a single B2 bucket is used by more than one computer and/or backup job.

Lots of technical detail in ts678's excellent post here:
https://forum.duplicati.com/t/need-help-am-i-using-the-system-wrong-extremely-slow-backup-with-b2-cloud/7360/2

I believe this change should make some of the code in the subsequent foreach block unnecessary (where it checks to see if m_prefix is part of the filename), but I left it in there just to play it safe.

I have done some limited testing with good results.  Would appreciate other people testing it out.  Thanks to ts678 for doing the investigative work....