### PR TITLE
Dispose backends after upload operations

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -216,7 +216,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                     }
                     catch
                     {
-                        /* As we are cancelling all threads we do not need to alert the user to any of these exceptions */
+                        // As we are cancelling all threads we do not need to alert the user to any of these exceptions.
                     }
                     finally
                     {

--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -443,7 +443,7 @@ namespace Duplicati.Library.Main.Operation.Backup
             }
         }
 
-        private class Worker
+        private class Worker : IDisposable
         {
             public Task Task;
             public IBackend Backend;
@@ -452,6 +452,12 @@ namespace Duplicati.Library.Main.Operation.Backup
             {
                 Backend = backend;
                 Task = Task.FromResult(true);
+            }
+
+            public void Dispose()
+            {
+                this.Task?.Dispose();
+                this.Backend?.Dispose();
             }
         }
     }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -400,7 +400,6 @@ namespace Duplicati.Library.Main.Operation
                     using(var backendManager = new BackendManager(m_backendurl, m_options, m_result.BackendWriter, m_database))
                     using(var filesetvolume = new FilesetVolumeWriter(m_options, m_database.OperationTimestamp))
                     using(var stats = new Backup.BackupStatsCollector(m_result))
-                    using(var bk = new Common.BackendHandler(m_options, m_backendurl, db, stats, m_result.TaskReader))
                     // Keep a reference to these channels to avoid shutdown
                     using(var uploadtarget = ChannelManager.GetChannel(Backup.Channels.BackendRequest.ForWrite))
                     {


### PR DESCRIPTION
This ensures that instances of `IBackend` are disposed of after their use in put operations.  This was previously achieved via a `BackendHandler` instance.  However, after implementing parallel uploads in pull request #3684, we neglected to ensure the disposal of the multiple backends.  This would cause some connections (e.g., SFTP) to remain open, and users could encounter a maximum connection limit.

This also removes the unused instance of `BackendHandler` in the `BackupHandler`.

This fixes issue #3808.