### PR TITLE
Remove unused variable that caused compiler warning

### DIFF
--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
@@ -77,7 +77,7 @@ namespace Duplicati.Library
             {
                 return await this.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException($"HTTP timeout {this.Timeout} exceeded.");
             }


### PR DESCRIPTION
This removes an unused variable that was causing a compiler warning.