### PR TITLE
Fix implementation of ThrottledStream.Write

### DIFF
--- a/Duplicati/Library/Utility/ThrottledStream.cs
+++ b/Duplicati/Library/Utility/ThrottledStream.cs
@@ -147,9 +147,9 @@ namespace Duplicati.Library.Utility
         }
 
 		/// <summary>
-		/// Write the specified buffer, offset and count.
+		/// Write from a buffer to this stream.
 		/// </summary>
-		/// <param name="buffer">The buffer to write to.</param>
+		/// <param name="buffer">The buffer to read from.</param>
 		/// <param name="offset">The offset into the buffer.</param>
 		/// <param name="count">The number of bytes to write.</param>
         public override void Write(byte[] buffer, int offset, int count)

--- a/Duplicati/Library/Utility/ThrottledStream.cs
+++ b/Duplicati/Library/Utility/ThrottledStream.cs
@@ -116,9 +116,9 @@ namespace Duplicati.Library.Utility
         }
 
 		/// <summary>
-		/// Read the specified buffer, offset and count.
+		/// Read from this stream into a buffer.
 		/// </summary>
-		/// <param name="buffer">The buffer to read from.</param>
+		/// <param name="buffer">The buffer to write to.</param>
 		/// <param name="offset">The offset into the buffer.</param>
 		/// <param name="count">The number of bytes to read.</param>
         public override int Read(byte[] buffer, int offset, int count)

--- a/Duplicati/Library/Utility/ThrottledStream.cs
+++ b/Duplicati/Library/Utility/ThrottledStream.cs
@@ -153,7 +153,8 @@ namespace Duplicati.Library.Utility
 		/// <param name="offset">The offset into the buffer.</param>
 		/// <param name="count">The number of bytes to write.</param>
         public override void Write(byte[] buffer, int offset, int count)
-        {
+		{
+			int bytesWritten = 0;
 			while (count > 0)
 			{
                 // To avoid excessive waiting, the delay will wait at most 2 seconds,
@@ -161,10 +162,10 @@ namespace Duplicati.Library.Utility
                 UpdateLimits();
 				var chunksize = (int)Math.Min(count, m_writespeed <= 0 ? count : m_writespeed * 2);
 				DelayIfRequired(ref m_writespeed, chunksize, ref m_last_write_sample, ref m_current_write_counter, ref m_current_write_speed);
-				m_basestream.Write(buffer, offset, chunksize);
+				m_basestream.Write(buffer, offset + bytesWritten, chunksize);
 
 				m_current_write_counter += chunksize;
-
+				bytesWritten += chunksize;
 				count -= chunksize;
 			}
         }

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
+using System.IO;
 
 namespace Duplicati.UnitTest
 {
@@ -202,6 +203,38 @@ namespace Duplicati.UnitTest
                 Assert.IsTrue(Utility.ParseBool(value, returnsTrue));
                 Assert.IsFalse(Utility.ParseBool(value, false));
                 Assert.IsFalse(Utility.ParseBool(value, returnsFalse));
+            }
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void ThrottledStreamWrite()
+        {
+            byte[] initialBuffer = {0x10, 0x20, 0x30, 0x40, 0x50};
+            byte[] source = {0x60, 0x70, 0x80, 0x90};
+            const int offset = 1;
+            const int bytesToWrite = 3;
+
+            using (MemoryStream baseStream = new MemoryStream(initialBuffer))
+            {
+                const int readSpeed = 1;
+                const int writeSpeed = 1;
+
+                ThrottledStream throttledStream = new ThrottledStream(baseStream, readSpeed, writeSpeed);
+                throttledStream.Write(source, offset, bytesToWrite);
+
+                byte[] result = baseStream.ToArray();
+                for (int k = 0; k < result.Length; k++)
+                {
+                    if (k < bytesToWrite)
+                    {
+                        Assert.AreEqual(source[offset + k], result[k]);
+                    }
+                    else
+                    {
+                        Assert.AreEqual(initialBuffer[k], result[k]);
+                    }
+                }
             }
         }
     }

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -226,11 +226,7 @@ namespace Duplicati.UnitTest
 
                 for (int k = 0; k < destinationBuffer.Length; k++)
                 {
-                    if (k < offset)
-                    {
-                        Assert.AreEqual(default(byte), destinationBuffer[k]);
-                    }
-                    else if (k < offset + bytesToRead)
+                    if (offset <= k && k < offset + bytesToRead)
                     {
                         Assert.AreEqual(sourceBuffer[k - offset], destinationBuffer[k]);
                     }

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -208,6 +208,42 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Utility")]
+        public static void ThrottledStreamRead()
+        {
+            byte[] sourceBuffer = {0x10, 0x20, 0x30, 0x40, 0x50};
+            byte[] destinationBuffer = new byte[sourceBuffer.Length + 1];
+            const int offset = 1;
+            const int bytesToRead = 3;
+
+            using (MemoryStream baseStream = new MemoryStream(sourceBuffer))
+            {
+                const int readSpeed = 1;
+                const int writeSpeed = 1;
+
+                ThrottledStream throttledStream = new ThrottledStream(baseStream, readSpeed, writeSpeed);
+                int bytesRead = throttledStream.Read(destinationBuffer, offset, bytesToRead);
+                Assert.AreEqual(bytesToRead, bytesRead);
+
+                for (int k = 0; k < destinationBuffer.Length; k++)
+                {
+                    if (k < offset)
+                    {
+                        Assert.AreEqual(default(byte), destinationBuffer[k]);
+                    }
+                    else if (k < offset + bytesToRead)
+                    {
+                        Assert.AreEqual(sourceBuffer[k - offset], destinationBuffer[k]);
+                    }
+                    else
+                    {
+                        Assert.AreEqual(default(byte), destinationBuffer[k]);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        [Category("Utility")]
         public static void ThrottledStreamWrite()
         {
             byte[] initialBuffer = {0x10, 0x20, 0x30, 0x40, 0x50};


### PR DESCRIPTION
This fixes an issue with the `ThrottledStream.Write` method, where the offset into the source buffer was not advanced properly.  Prior to revision 0190a9994e, the `DelayIfRequired` method would increment the offset variable to advance through the buffer.  When we modified the implementation in revision 0190a9994e, we may have forgotten to modify the offset accordingly.  

We also add unit tests for `ThrottledStream.Write` as well as `ThrottedStream.Read` (see issue #3787, which was fixed in pull request #3802).

This might fix issue #3782.