### PR TITLE
remove unnecessary write to console

### DIFF
--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -187,7 +187,7 @@ namespace Duplicati.Library.Backend
             if (errorBuilder.Length > 0) {
                 throw new Exception(errorBuilder.ToString());
             }
-            Console.Error.WriteLine(errorBuilder);
+
             return outputBuilder.ToString();
         }
 


### PR DESCRIPTION
Every rclone backend call generates an empty line. This pull removes this.