### PR TITLE
run-script-example.*: change option --volsize to --dblock-size

### DIFF
--- a/Duplicati/Library/Modules/Builtin/run-script-example.bat
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.bat
@@ -153,11 +153,11 @@ GOTO end
 
 :ON_BEFORE_BACKUP
 REM Check if volsize is either not set, or set to 50mb
-IF "%DUPLICATI__dblock-_size%" == "" GOTO SET_VOLSIZE
-IF "%DUPLICATI__dblock-_size%" == "50mb" GOTO SET_VOLSIZE
+IF "%DUPLICATI__dblock_size%" == "" GOTO SET_VOLSIZE
+IF "%DUPLICATI__dblock_size%" == "50mb" GOTO SET_VOLSIZE
 
 REM We write this to stderr, and it will show up as a warning in the logfile
-echo Not setting volumesize, it was already set to %DUPLICATI__dblock-_size% 1>&2
+echo Not setting volumesize, it was already set to %DUPLICATI__dblock_size% 1>&2
 GOTO end
 
 :SET_VOLSIZE

--- a/Duplicati/Library/Modules/Builtin/run-script-example.bat
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.bat
@@ -142,7 +142,7 @@ GOTO end
 :ON_BEFORE
 
 REM If the operation is a backup starting, 
-REM then we check if the --volsize option is unset
+REM then we check if the --dblock-size option is unset
 REM or 50mb, and change it to 25mb, otherwise we 
 REM leave it alone
 
@@ -162,7 +162,7 @@ GOTO end
 
 :SET_VOLSIZE
 REM Write the option to stdout to change it
-echo --volsize=25mb
+echo --dblock-size=25mb
 GOTO end
 
 

--- a/Duplicati/Library/Modules/Builtin/run-script-example.bat
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.bat
@@ -153,11 +153,11 @@ GOTO end
 
 :ON_BEFORE_BACKUP
 REM Check if volsize is either not set, or set to 50mb
-IF "%DUPLICATI__volsize%" == "" GOTO SET_VOLSIZE
-IF "%DUPLICATI__volsize%" == "50mb" GOTO SET_VOLSIZE
+IF "%DUPLICATI__dblock-_size%" == "" GOTO SET_VOLSIZE
+IF "%DUPLICATI__dblock-_size%" == "50mb" GOTO SET_VOLSIZE
 
 REM We write this to stderr, and it will show up as a warning in the logfile
-echo Not setting volumesize, it was already set to %DUPLICATI__volsize% 1>&2
+echo Not setting volumesize, it was already set to %DUPLICATI__dblock-_size% 1>&2
 GOTO end
 
 :SET_VOLSIZE

--- a/Duplicati/Library/Modules/Builtin/run-script-example.sh
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.sh
@@ -139,13 +139,13 @@ then
 	
 	if [ "$OPERATIONNAME" == "Backup" ]
 	then
-		if [ "$DUPLICATI__volsize" == "" ] || ["$DUPLICATI__volsize" == "50mb"]
+		if [ "$DUPLICATI__dblock-_size" == "" ] || ["$DUPLICATI__dblock-_size" == "50mb"]
 		then
 			# Write the option to stdout to change it
 			echo "--dblock-size=25mb"
 		else
 			# We write this to stderr, and it will show up as a warning in the logfile
-			echo "Not setting volumesize, it was already set to $DUPLICATI__volsize" >&2
+			echo "Not setting volumesize, it was already set to $DUPLICATI__dblock-_size" >&2
 		fi
 	else
 		# This will be ignored

--- a/Duplicati/Library/Modules/Builtin/run-script-example.sh
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.sh
@@ -139,13 +139,13 @@ then
 	
 	if [ "$OPERATIONNAME" == "Backup" ]
 	then
-		if [ "$DUPLICATI__dblock-_size" == "" ] || ["$DUPLICATI__dblock-_size" == "50mb"]
+		if [ "$DUPLICATI__dblock_size" == "" ] || ["$DUPLICATI__dblock_size" == "50mb"]
 		then
 			# Write the option to stdout to change it
 			echo "--dblock-size=25mb"
 		else
 			# We write this to stderr, and it will show up as a warning in the logfile
-			echo "Not setting volumesize, it was already set to $DUPLICATI__dblock-_size" >&2
+			echo "Not setting volumesize, it was already set to $DUPLICATI__dblock_size" >&2
 		fi
 	else
 		# This will be ignored

--- a/Duplicati/Library/Modules/Builtin/run-script-example.sh
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.sh
@@ -133,7 +133,7 @@ LOCALPATH=$DUPLICATI__LOCALPATH
 if [ "$EVENTNAME" == "BEFORE" ]
 then
 	# If the operation is a backup starting, 
-	# then we check if the --volsize option is unset
+	# then we check if the --dblock-size option is unset
 	# or 50mb, and change it to 25mb, otherwise we 
 	# leave it alone
 	
@@ -142,7 +142,7 @@ then
 		if [ "$DUPLICATI__volsize" == "" ] || ["$DUPLICATI__volsize" == "50mb"]
 		then
 			# Write the option to stdout to change it
-			echo "--volsize=25mb"
+			echo "--dblock-size=25mb"
 		else
 			# We write this to stderr, and it will show up as a warning in the logfile
 			echo "Not setting volumesize, it was already set to $DUPLICATI__volsize" >&2


### PR DESCRIPTION
The option --volsize is changed to --dblock-size to fix the examples.