### PR TITLE
Auto compact interval

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.Main
             Library.UsageReporter.Reporter.Report("USE_COMPRESSION", m_options.CompressionModule);
             Library.UsageReporter.Reporter.Report("USE_ENCRYPTION", m_options.EncryptionModule);
 
-            if (!m_options.NoAutoCompact && (m_lastcompact > DateTime.MinValue) && (m_lastcompact.Add(m_options.AutoCompactInterval) >= DateTime.Now))
+            if (!m_options.NoAutoCompact && (m_lastcompact > DateTime.MinValue) && (m_lastcompact.Add(m_options.AutoCompactInterval) > DateTime.Now))
             {
                 Logging.Log.WriteInformationMessage(LOGTAG, "CompactResults", "Skipping auto compaction until {0}", m_lastcompact.Add(m_options.AutoCompactInterval));
                 m_options.RawOptions["no-auto-compact"] = "true";

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -117,9 +117,9 @@ namespace Duplicati.Library.Main
             Library.UsageReporter.Reporter.Report("USE_COMPRESSION", m_options.CompressionModule);
             Library.UsageReporter.Reporter.Report("USE_ENCRYPTION", m_options.EncryptionModule);
 
-            if (!m_options.NoAutoCompact && (m_lastcompact > DateTime.MinValue) && (m_lastcompact.Add(m_options.AutoCompactInterval) > DateTime.Now))
+            if (!m_options.NoAutoCompact && (m_lastcompact > DateTime.MinValue) && (m_lastcompact.Add(m_options.AutoCompactInterval) >= DateTime.Now))
             {
-                Logging.Log.WriteInformationMessage(LOGTAG, "CompactResults", "AutoCompactInterval not satisfied, skipping auto compaction for this backup");
+                Logging.Log.WriteInformationMessage(LOGTAG, "CompactResults", "Skipping auto compaction until {0}", m_lastcompact.Add(m_options.AutoCompactInterval));
                 m_options.RawOptions["no-auto-compact"] = "true";
             }
 

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -83,11 +83,6 @@ namespace Duplicati.Library.Main
         private ControllerMultiLogTarget m_logTarget;
 
         /// <summary>
-        /// Time of last compact operation
-        /// </summary>
-        private DateTime m_lastcompact;
-
-        /// <summary>
         /// Constructs a new interface for performing backup and restore operations
         /// </summary>
         /// <param name="backend">The url for the backend to use</param>
@@ -117,9 +112,9 @@ namespace Duplicati.Library.Main
             Library.UsageReporter.Reporter.Report("USE_COMPRESSION", m_options.CompressionModule);
             Library.UsageReporter.Reporter.Report("USE_ENCRYPTION", m_options.EncryptionModule);
 
-            if (!m_options.NoAutoCompact && (m_lastcompact > DateTime.MinValue) && (m_lastcompact.Add(m_options.AutoCompactInterval) > DateTime.Now))
+            if (!m_options.NoAutoCompact && (LastCompact > DateTime.MinValue) && (LastCompact.Add(m_options.AutoCompactInterval) > DateTime.Now))
             {
-                Logging.Log.WriteInformationMessage(LOGTAG, "CompactResults", "Skipping auto compaction until {0}", m_lastcompact.Add(m_options.AutoCompactInterval));
+                Logging.Log.WriteInformationMessage(LOGTAG, "CompactResults", "Skipping auto compaction until {0}", LastCompact.Add(m_options.AutoCompactInterval));
                 m_options.RawOptions["no-auto-compact"] = "true";
             }
 
@@ -1108,11 +1103,10 @@ namespace Duplicati.Library.Main
             set { m_options.MaxDownloadPrSecond = value; }
         }
 
-        public DateTime LastCompact
-        {
-            get { return m_lastcompact; }
-            set { m_lastcompact = value; }
-        }
+        /// <summary>
+        /// Time of last compact operation
+        /// </summary>
+        public DateTime LastCompact { get; set; }
 
         #region IDisposable Members
 

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -405,7 +405,7 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("restore-symlink-metadata", CommandLineArgument.ArgumentType.Boolean, Strings.Options.RestoresymlinkmetadataShort, Strings.Options.RestoresymlinkmetadataLong, "false"),
                     new CommandLineArgument("rebuild-missing-dblock-files", CommandLineArgument.ArgumentType.Boolean, Strings.Options.RebuildmissingdblockfilesShort, Strings.Options.RebuildmissingdblockfilesLong, "false"),
 
-                    new CommandLineArgument("auto-compact-interval", CommandLineArgument.ArgumentType.Timespan, Strings.Options.AutoCompactIntervalShort, Strings.Options.AutoCompactIntervalLong, "0s"),
+                    new CommandLineArgument("auto-compact-interval", CommandLineArgument.ArgumentType.Timespan, Strings.Options.AutoCompactIntervalShort, Strings.Options.AutoCompactIntervalLong, "0m"),
                 });
 
                 return lst;

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -405,6 +405,7 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("restore-symlink-metadata", CommandLineArgument.ArgumentType.Boolean, Strings.Options.RestoresymlinkmetadataShort, Strings.Options.RestoresymlinkmetadataLong, "false"),
                     new CommandLineArgument("rebuild-missing-dblock-files", CommandLineArgument.ArgumentType.Boolean, Strings.Options.RebuildmissingdblockfilesShort, Strings.Options.RebuildmissingdblockfilesLong, "false"),
 
+                    new CommandLineArgument("auto-compact-interval", CommandLineArgument.ArgumentType.Timespan, Strings.Options.AutoCompactIntervalShort, Strings.Options.AutoCompactIntervalLong, "0s"),
                 });
 
                 return lst;
@@ -1632,6 +1633,20 @@ namespace Duplicati.Library.Main
         public bool NoAutoCompact
         {
             get { return Library.Utility.Utility.ParseBoolOption(m_options, "no-auto-compact"); }
+        }
+
+        /// <summary>
+        /// Gets the minimum time that must elapse after last compaction before running next automatic compaction
+        /// </summary>
+        public TimeSpan AutoCompactInterval
+        {
+            get
+            {
+                if (!m_options.ContainsKey("auto-compact-interval") || string.IsNullOrEmpty(m_options["auto-compact-interval"]))
+                    return TimeSpan.Zero;
+                else
+                    return Library.Utility.Timeparser.ParseTimeSpan(m_options["auto-compact-interval"]);
+            }
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -279,6 +279,9 @@ namespace Duplicati.Library.Main.Strings
         public static string ProfilealldatabasequeriesLong { get { return LC.L("To improve performance of the backups, frequent database queries are not logged by default. Enable this option to log all database queries, and remember to set either --{0}={2} or --{1}={2} to report the additional log data", "console-log-level", "log-file-log-level", nameof(Logging.LogMessageType.Profiling)); } }
         public static string RebuildmissingdblockfilesShort { get { return "Rebuild dblock files when missing"; } }
         public static string RebuildmissingdblockfilesLong { get { return "If dblock files are missing from the destination, you can attempt to rebuild them using local source data. However, since the local data may have changed, it may not be possible to retrieve all the required data and the process may be slow. Use this option to attempt to rebuild missing dblock files."; } }
+
+        public static string AutoCompactIntervalShort { get { return "Minimum time between auto compactions"; } }
+        public static string AutoCompactIntervalLong { get { return "The minimum amount of time that must elapse after the last compaction before another will be automatically triggered at the end of a backup job. Automatic compaction can be a long-running process and may not be desirable to run after every single backup."; } }
     }
 
     internal static class Common

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -701,6 +701,16 @@ namespace Duplicati.Server
             );
         }
 
+        private static void UpdateLastCompactMetadata(Duplicati.Server.Serialization.Interface.IBackup backup, Duplicati.Library.Interface.ICompactResults r)
+        {
+            if (r != null)
+            {
+                backup.Metadata["LastCompactDuration"] = r.Duration.ToString();
+                backup.Metadata["LastCompactStarted"] = Library.Utility.Utility.SerializeDateTime(r.BeginTime.ToUniversalTime());
+                backup.Metadata["LastCompactFinished"] = Library.Utility.Utility.SerializeDateTime(r.EndTime.ToUniversalTime());
+            }
+        }
+
         private static void UpdateMetadata(Duplicati.Server.Serialization.Interface.IBackup backup, Duplicati.Library.Interface.IParsedBackendStatistics r)
         {
             if (r != null)
@@ -727,14 +737,6 @@ namespace Duplicati.Server
                 backup.Metadata["LastRestoreFinished"] = Library.Utility.Utility.SerializeDateTime(result.EndTime.ToUniversalTime());
             }
 
-            if (result is Duplicati.Library.Interface.ICompactResults)
-            {
-                var r = (Duplicati.Library.Interface.ICompactResults)result;
-                backup.Metadata["LastCompactDuration"] = r.Duration.ToString();
-                backup.Metadata["LastCompactStarted"] = Library.Utility.Utility.SerializeDateTime(r.BeginTime.ToUniversalTime());
-                backup.Metadata["LastCompactFinished"] = Library.Utility.Utility.SerializeDateTime(r.EndTime.ToUniversalTime());
-            }
-
             if (result is Duplicati.Library.Interface.IParsedBackendStatistics)
             {
                 var r = (Duplicati.Library.Interface.IParsedBackendStatistics)result;
@@ -748,6 +750,9 @@ namespace Duplicati.Server
                     UpdateMetadata(backup, (Duplicati.Library.Interface.IParsedBackendStatistics)r.BackendStatistics);
             }
 
+            if (result is Duplicati.Library.Interface.ICompactResults)
+                UpdateLastCompactMetadata(backup, (Duplicati.Library.Interface.ICompactResults)result);
+
             if (result is Duplicati.Library.Interface.IBackupResults)
             {
                 var r = (Duplicati.Library.Interface.IBackupResults)result;
@@ -759,7 +764,7 @@ namespace Duplicati.Server
                 backup.Metadata["LastBackupDuration"] = r.Duration.ToString();
 
                 if (r.CompactResults != null)
-                    UpdateMetadata(backup, r.CompactResults);
+                    UpdateLastCompactMetadata(backup, r.CompactResults);
 
                 if (r.FilesWithError > 0 || r.Warnings.Any() || r.Errors.Any())
                 {


### PR DESCRIPTION
This adds a customizable delay between automatic compactions.

Reason for change: On a couple of my systems the compaction effort takes a long time. Specifically the GetWastedSpaceReport SQL query that takes over 1 hour on my NAS (it has a lot of data and not a very powerful CPU).  I thought it might be useful to have auto compaction run only once a week on these systems.

High level overview of changes:

Runner.cs - added code so that Last Compaction time is stored in the main database (metadata)
Controller.cs - overrides no-auto-compact flag temporarily (sets it to "true") if auto-compact-interval has not been satisfied

It works as expected on two of my test systems.

Feedback appreciated. Not sure if Controller.cs Backup() is the best place to do this check, or if temporarily overriding no-auto-compact is the best approach.