### PR TITLE
Add auto vacuum interval option

### DIFF
--- a/Duplicati/Library/Interface/ResultInterfaces.cs
+++ b/Duplicati/Library/Interface/ResultInterfaces.cs
@@ -142,6 +142,7 @@ namespace Duplicati.Library.Interface
         bool Dryrun { get; }
         
         ICompactResults CompactResults { get; }
+        IVacuumResults VacuumResults { get; }
         IDeleteResults DeleteResults { get; }
         IRepairResults RepairResults { get; }
     }
@@ -178,6 +179,8 @@ namespace Duplicati.Library.Interface
         long DownloadedFileSize { get; }
         long UploadedFileSize { get; }
         bool Dryrun { get; }
+
+        IVacuumResults VacuumResults { get; }
     }
     
     public interface ICreateLogDatabaseResults : IBasicResults

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -536,8 +536,8 @@ namespace Duplicati.Library.Main.Operation
                         m_database.PurgeLogData(m_options.LogRetention);
                         if (m_options.AutoVacuum)
                         {
-                            m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Vacuum_Running);
-                            m_database.Vacuum();
+                            m_result.VacuumResults = new VacuumResults(m_result);
+                            new VacuumHandler(m_options, (VacuumResults)m_result.VacuumResults).Run();
                         }
                         m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_Complete);
                         return;

--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -69,7 +69,8 @@ namespace Duplicati.Library.Main.Operation
                             db.WriteResults();
                             if (m_options.AutoVacuum)
                             {
-                                db.Vacuum();
+                                m_result.VacuumResults = new VacuumResults(m_result);
+                                new VacuumHandler(m_options, (VacuumResults)m_result.VacuumResults).Run();
                             }
                         }
                     }

--- a/Duplicati/Library/Main/Operation/VacuumHandler.cs
+++ b/Duplicati/Library/Main/Operation/VacuumHandler.cs
@@ -9,9 +9,9 @@ namespace Duplicati.Library.Main.Operation
     internal class VacuumHandler
     {
         private readonly Options m_options;
-        private readonly VacuumResult m_result;
+        private readonly VacuumResults m_result;
 
-        public VacuumHandler(Options options, VacuumResult result)
+        public VacuumHandler(Options options, VacuumResults result)
         {
             m_options = options;
             m_result = result;
@@ -24,6 +24,7 @@ namespace Duplicati.Library.Main.Operation
                 m_result.SetDatabase(db);
                 m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Vacuum_Running);
                 db.Vacuum();
+                m_result.EndTime = DateTime.UtcNow;
             }
         }
     }

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -406,6 +406,7 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("rebuild-missing-dblock-files", CommandLineArgument.ArgumentType.Boolean, Strings.Options.RebuildmissingdblockfilesShort, Strings.Options.RebuildmissingdblockfilesLong, "false"),
 
                     new CommandLineArgument("auto-compact-interval", CommandLineArgument.ArgumentType.Timespan, Strings.Options.AutoCompactIntervalShort, Strings.Options.AutoCompactIntervalLong, "0m"),
+                    new CommandLineArgument("auto-vacuum-interval", CommandLineArgument.ArgumentType.Timespan, Strings.Options.AutoVacuumIntervalShort, Strings.Options.AutoVacuumIntervalLong, "0m"),
                 });
 
                 return lst;
@@ -1803,6 +1804,20 @@ namespace Duplicati.Library.Main
         public bool AutoVacuum
         {
             get { return GetBool("auto-vacuum"); }
+        }
+
+        /// <summary>
+        /// Gets the minimum time that must elapse after last vacuum before running next automatic vacuum
+        /// </summary>
+        public TimeSpan AutoVacuumInterval
+        {
+            get
+            {
+                if (!m_options.ContainsKey("auto-vacuum-interval") || string.IsNullOrEmpty(m_options["auto-vacuum-interval"]))
+                    return TimeSpan.Zero;
+                else
+                    return Library.Utility.Timeparser.ParseTimeSpan(m_options["auto-vacuum-interval"]);
+            }
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -579,6 +579,7 @@ namespace Duplicati.Library.Main
         public override OperationMode MainOperation { get { return OperationMode.Backup; } }
 
         public ICompactResults CompactResults { get; internal set; }
+        public IVacuumResults VacuumResults { get; internal set; }
         public IDeleteResults DeleteResults { get; internal set; }
         public IRepairResults RepairResults { get; internal set; }
         public ITestResults TestResults { get; internal set; }
@@ -588,6 +589,7 @@ namespace Duplicati.Library.Main
             get
             {
                 if ((CompactResults != null && CompactResults.ParsedResult == ParsedResultType.Error) ||
+                    (VacuumResults  != null && VacuumResults.ParsedResult  == ParsedResultType.Error) ||
                     (DeleteResults  != null && DeleteResults.ParsedResult  == ParsedResultType.Error) ||
                     (RepairResults  != null && RepairResults.ParsedResult  == ParsedResultType.Error) || 
                     (TestResults    != null && TestResults.ParsedResult    == ParsedResultType.Error) ||
@@ -596,6 +598,7 @@ namespace Duplicati.Library.Main
                     return ParsedResultType.Error;
                 }
                 else if ((CompactResults != null && CompactResults.ParsedResult == ParsedResultType.Warning) ||
+                         (VacuumResults  != null && VacuumResults.ParsedResult  == ParsedResultType.Warning) ||
                          (DeleteResults  != null && DeleteResults.ParsedResult  == ParsedResultType.Warning) ||
                          (RepairResults  != null && RepairResults.ParsedResult  == ParsedResultType.Warning) ||
                          (TestResults    != null && TestResults.ParsedResult    == ParsedResultType.Warning) ||
@@ -829,6 +832,8 @@ namespace Duplicati.Library.Main
         public long UploadedFileSize { get; internal set; }
         public bool Dryrun { get; internal set; }
 
+        public IVacuumResults VacuumResults { get; internal set; }
+
         public override OperationMode MainOperation { get { return OperationMode.Compact; } }
 
         public CompactResults() : base() { }
@@ -969,8 +974,11 @@ namespace Duplicati.Library.Main
         public IEnumerable<string> Lines { get; set; }
     }
 
-    internal class VacuumResult : BasicResults, IVacuumResults
+    internal class VacuumResults : BasicResults, IVacuumResults
     {
+        public VacuumResults() : base() { }
+        public VacuumResults(BasicResults p) : base(p) { }
+
         public override OperationMode MainOperation { get { return OperationMode.Vacuum; } }
     }
 }

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -282,6 +282,8 @@ namespace Duplicati.Library.Main.Strings
 
         public static string AutoCompactIntervalShort { get { return "Minimum time between auto compactions"; } }
         public static string AutoCompactIntervalLong { get { return "The minimum amount of time that must elapse after the last compaction before another will be automatically triggered at the end of a backup job. Automatic compaction can be a long-running process and may not be desirable to run after every single backup."; } }
+        public static string AutoVacuumIntervalShort { get { return "Minimum time between auto vacuums"; } }
+        public static string AutoVacuumIntervalLong { get { return "The minimum amount of time that must elapse after the last vacuum before another will be automatically triggered at the end of a backup job. Automatic vacuum can be a long-running process and may not be desirable to run after every single backup."; } }
     }
 
     internal static class Common


### PR DESCRIPTION
Similar to https://github.com/duplicati/duplicati/pull/3832, this adds a customizable delay between automatic vacuum operations.

Reason for change: I like having auto vacuum enabled, but it can take a long time on some of my systems. Instead of turning off auto vacuum entirely I wanted to just limit how often it would run.

This uses the same approach as https://github.com/duplicati/duplicati/pull/3832 - code added to store LastVacuum information in metadata part of main database.  If the time interval has not been satisfied, the `auto-vacuum` option flag is overridden (set to "false") temporarily.

There were two situations where auto vacuum may occur that I wanted to be impacted by this code:  at end of a backup job, and after an explicit compact operation. An explicit vacuum operation is not affected (it will always run).

In a couple locations I changed a direct call to `db.Vacuum()` to instead use the VacuumHandler so that results could be properly captured so that the timestamp can be saved as metadata.  Also I renamed some members to be more consistent with other parts of the code.