### PR TITLE
Fix issue 3308 - deletion of too many Filesets

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -64,11 +64,23 @@ namespace Duplicati.Library.Main.Database
             {
                 cmd.Transaction = transaction;
 
-                string q = String.Join(",", Enumerable.Repeat("?", toDelete.Length));
-                        
-                //First we remove unwanted entries
-                var deleted = cmd.ExecuteNonQuery(@"DELETE FROM ""Fileset"" WHERE ""Timestamp"" IN (" + q + @") ", toDelete.Select(x => NormalizeDateTimeToEpochSeconds(x)).Cast<object>().ToArray());
-    
+                var deleted = 0;
+
+                //Process array in slices to prevent exceeding SQLITE_MAX_VARIABLE_NUMBER (default 999)
+                const int SLICE_SIZE = 128;
+                for (int sliceStart = 0; sliceStart < toDelete.Length; sliceStart += SLICE_SIZE)
+                {
+                    int sliceEnd = Math.Min(toDelete.Length, sliceStart + SLICE_SIZE) - 1;
+                    int sliceLen = sliceEnd - sliceStart + 1;
+
+                    string q = string.Join(",", Enumerable.Repeat("?", sliceLen));
+
+                    Logging.Log.WriteInformationMessage("TEMP-DEBUG", "TEMP-DEBUG", "total {0}, sliceStart {1}, sliceEnd {2}, sliceLen {3}", toDelete.Length, sliceStart, sliceEnd, sliceLen);
+
+                    //First we remove unwanted entries
+                    deleted += cmd.ExecuteNonQuery(@"DELETE FROM ""Fileset"" WHERE ""Timestamp"" IN (" + q + @") ", toDelete.Skip(sliceStart).Take(sliceLen).Select(x => NormalizeDateTimeToEpochSeconds(x)).Cast<object>().ToArray());
+                }
+
                 if (deleted != toDelete.Length)
                     throw new Exception(string.Format("Unexpected number of deleted filesets {0} vs {1}", deleted, toDelete.Length));
     

--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -75,8 +75,6 @@ namespace Duplicati.Library.Main.Database
 
                     string q = string.Join(",", Enumerable.Repeat("?", sliceLen));
 
-                    Logging.Log.WriteInformationMessage("TEMP-DEBUG", "TEMP-DEBUG", "total {0}, sliceStart {1}, sliceEnd {2}, sliceLen {3}", toDelete.Length, sliceStart, sliceEnd, sliceLen);
-
                     //First we remove unwanted entries
                     deleted += cmd.ExecuteNonQuery(@"DELETE FROM ""Fileset"" WHERE ""Timestamp"" IN (" + q + @") ", toDelete.Skip(sliceStart).Take(sliceLen).Select(x => NormalizeDateTimeToEpochSeconds(x)).Cast<object>().ToArray());
                 }


### PR DESCRIPTION
See issue https://github.com/duplicati/duplicati/issues/3308

Currently Duplicati will fail if adjusting retention policy that results in >999 filesets needing to be deleted.  This change processes the deletions in batches to avoid this problem.