### PR TITLE
fix bug in GetLargestPrefix() which adds an ending slash to file name

### DIFF
--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -163,9 +163,8 @@ namespace Duplicati.Library.Main.Database
     
                     while (filecount != foundfiles && maxpath.Length > 0)
                     {
-                        var mp = Platform.IsClientPosix ? Util.AppendDirSeparator(maxpath, dirsep) : maxpath;
-                        cmd.SetParameterValue(0, mp.Length);
-                        cmd.SetParameterValue(1, mp);
+                        cmd.SetParameterValue(0, maxpath.Length);
+                        cmd.SetParameterValue(1, maxpath);
                         
                         foundfiles = cmd.ExecuteScalarInt64(0);
 

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -163,17 +163,9 @@ namespace Duplicati.Library.Main.Database
     
                     while (filecount != foundfiles && maxpath.Length > 0)
                     {
-                        if (Platform.IsClientWindows)
-                        {
-                            cmd.SetParameterValue(0, maxpath.Length);
-                            cmd.SetParameterValue(1, maxpath);
-                        }
-                        else
-                        {
-                            var mp = Util.AppendDirSeparator(maxpath, dirsep);
-                            cmd.SetParameterValue(0, mp.Length);
-                            cmd.SetParameterValue(1, mp);
-                        }
+                        var mp = Platform.IsClientPosix ? Util.AppendDirSeparator(maxpath, dirsep) : maxpath;
+                        cmd.SetParameterValue(0, mp.Length);
+                        cmd.SetParameterValue(1, mp);
                         
                         foundfiles = cmd.ExecuteScalarInt64(0);
 

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -19,6 +19,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
+using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Main.Database
@@ -162,9 +163,18 @@ namespace Duplicati.Library.Main.Database
     
                     while (filecount != foundfiles && maxpath.Length > 0)
                     {
-                        cmd.SetParameterValue(0, maxpath.Length);
-                        cmd.SetParameterValue(1, maxpath);
-
+                        if (Platform.IsClientWindows)
+                        {
+                            cmd.SetParameterValue(0, maxpath.Length);
+                            cmd.SetParameterValue(1, maxpath);
+                        }
+                        else
+                        {
+                            var mp = Util.AppendDirSeparator(maxpath, dirsep);
+                            cmd.SetParameterValue(0, mp.Length);
+                            cmd.SetParameterValue(1, mp);
+                        }
+                        
                         foundfiles = cmd.ExecuteScalarInt64(0);
 
                         if (filecount != foundfiles)

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -162,11 +162,11 @@ namespace Duplicati.Library.Main.Database
     
                     while (filecount != foundfiles && maxpath.Length > 0)
                     {
-                        var mp = Util.AppendDirSeparator(maxpath, dirsep);
-                        cmd.SetParameterValue(0, mp.Length);
-                        cmd.SetParameterValue(1, mp);
+                        cmd.SetParameterValue(0, maxpath.Length);
+                        cmd.SetParameterValue(1, maxpath);
+
                         foundfiles = cmd.ExecuteScalarInt64(0);
-    
+
                         if (filecount != foundfiles)
                         {
                             var oldlen = maxpath.Length;
@@ -190,8 +190,8 @@ namespace Duplicati.Library.Main.Database
 
                         return roots.Concat(rootsUNC).Select(x => GetLargestPrefix(filter, x).First()).Distinct().ToArray();
                     }
-    
-                    return 
+
+                    return
                         new IFileversion[] {
                             new FileversionFixed { Path = maxpath == "" ? "" : Util.AppendDirSeparator(maxpath, dirsep) }
                         };


### PR DESCRIPTION
Do not apply AppendDirSeparator() to files.

For the section of code which handles files, AppendDirSeparator() is being applied to files when it should n't be at all. This results in all file paths to have an ending slash. This adjusted path causes the sql query to have 0 results.

For example:
GetLargestPrefix() would change D:\\myfiles\\photo1.jpg to be D:\\myfiles\\photo1.jpg\\

When the adjusted path is searched in the database it has 0 hits.

When debugging this can be tested by hitting the Restore and getting the file list for an existing backup job in the GUI.