### PR TITLE
Fix negative bytes to go issue

### DIFF
--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -379,18 +379,13 @@ namespace Duplicati.Library.Main
             {
                 m_curfilename = filename;
                 m_curfilesize = size;
-                Logging.Log.WriteInformationMessage("DEBUG-TEMP", "DEBUG-TEMP", "StartFile - setting m_curfileoffset = 0, currently = {0}", m_curfileoffset);
-                m_curfileoffset = 0;
             }
         }
         
         public void UpdateFileProgress(long offset)
         {
             lock (m_lock)
-            {
-                Logging.Log.WriteInformationMessage("DEBUG-TEMP", "DEBUG-TEMP", "UpdateFileProgress - setting m_curfileoffset = {0}, currently = {1}", offset, m_curfileoffset);
                 m_curfileoffset = offset;
-            }
         }
         
         public void UpdatefileCount(long filecount, long filesize, bool done)
@@ -409,7 +404,6 @@ namespace Duplicati.Library.Main
             {
                 m_filesprocessed = count;
                 m_filesizeprocessed = size;
-                Logging.Log.WriteInformationMessage("DEBUG-TEMP", "DEBUG-TEMP", "UpdatefilesProcessed - setting m_curfileoffset = 0, currently = {0}", m_curfileoffset);
                 m_curfileoffset = 0;
             }
         }

--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -405,6 +405,7 @@ namespace Duplicati.Library.Main
             {
                 m_filesprocessed = count;
                 m_filesizeprocessed = size;
+                m_curfileoffset = 0;
             }
         }
         

--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -375,7 +375,7 @@ namespace Duplicati.Library.Main
         
         public void StartFile(string filename, long size)
         {
-            lock (m_lock)
+            lock(m_lock)
             {
                 m_curfilename = filename;
                 m_curfilesize = size;
@@ -384,7 +384,7 @@ namespace Duplicati.Library.Main
         
         public void UpdateFileProgress(long offset)
         {
-            lock (m_lock)
+            lock(m_lock)
                 m_curfileoffset = offset;
         }
         
@@ -400,7 +400,7 @@ namespace Duplicati.Library.Main
         
         public void UpdatefilesProcessed(long count, long size)
         {
-            lock (m_lock)
+            lock(m_lock)
             {
                 m_filesprocessed = count;
                 m_filesizeprocessed = size;

--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -375,18 +375,22 @@ namespace Duplicati.Library.Main
         
         public void StartFile(string filename, long size)
         {
-            lock(m_lock)
+            lock (m_lock)
             {
                 m_curfilename = filename;
                 m_curfilesize = size;
+                Logging.Log.WriteInformationMessage("DEBUG-TEMP", "DEBUG-TEMP", "StartFile - setting m_curfileoffset = 0, currently = {0}", m_curfileoffset);
                 m_curfileoffset = 0;
             }
         }
         
         public void UpdateFileProgress(long offset)
         {
-            lock(m_lock)
+            lock (m_lock)
+            {
+                Logging.Log.WriteInformationMessage("DEBUG-TEMP", "DEBUG-TEMP", "UpdateFileProgress - setting m_curfileoffset = {0}, currently = {1}", offset, m_curfileoffset);
                 m_curfileoffset = offset;
+            }
         }
         
         public void UpdatefileCount(long filecount, long filesize, bool done)
@@ -401,10 +405,11 @@ namespace Duplicati.Library.Main
         
         public void UpdatefilesProcessed(long count, long size)
         {
-            lock(m_lock)
+            lock (m_lock)
             {
                 m_filesprocessed = count;
                 m_filesizeprocessed = size;
+                Logging.Log.WriteInformationMessage("DEBUG-TEMP", "DEBUG-TEMP", "UpdatefilesProcessed - setting m_curfileoffset = 0, currently = {0}", m_curfileoffset);
                 m_curfileoffset = 0;
             }
         }


### PR DESCRIPTION
Under certain circumstances the bytes to go will be shown as negative:

![dbc696f948ba515d252bb040ff869eb6a16e6bde](https://user-images.githubusercontent.com/39164691/62406424-8f77ed00-b560-11e9-9586-59e04b1ba5fd.png)

This seems to happen most notably when backing up a large file that is a significant portion of the total backup set size.  It is easiest to reproduce if you create a new backup set and choose a single large file to back up.

After some testing it appears the root cause is that `m_filesizeprocessed` is incremented when the file is done being processed, but some time may pass before `m_curfileoffset` is set back to zero.  If the status bar updates during this brief time window, the size of the file is counted twice when the `sizeleft` value is calucated in `AppUtils.js`:

`var sizeleft = $scope.state.lastPgEvent.TotalFileSize - $scope.state.lastPgEvent.ProcessedFileSize - $scope.state.lastPgEvent.CurrentFileoffset;`

This can result in `sizeleft` being a negative number if, as stated above, the file being counted twice is a significant portion (over 50%) of the total backup set size.   Even if it is not significant, it still results in an incorrect calculation.

My proposed solution is to immediately set `m_curfileoffset` to zero when `UpdatefilesProcessed` is called in `ProgressHandler.cs:72`.

In my testing it seems to work well.