### PR TITLE
Do not include Google Drive trashed items

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -449,7 +449,8 @@ namespace Duplicati.Library.Backend.GoogleDrive
             var fileQuery = new string[] {
                 string.IsNullOrEmpty(name) ? null : string.Format("title = '{0}'", EscapeTitleEntries(name)),
                 onlyFolders == null ? null : string.Format("mimeType {0}= '{1}'", onlyFolders.Value ? "" : "!", FOLDER_MIMETYPE),
-                string.Format("'{0}' in parents", EscapeTitleEntries(parentfolder))
+                string.Format("'{0}' in parents", EscapeTitleEntries(parentfolder)),
+                "trashed=false"
             };
 
             var encodedFileQuery = Library.Utility.Uri.UrlEncode(string.Join(" and ", fileQuery.Where(x => x != null)));


### PR DESCRIPTION
In Google Drive the trashed items are being included when enumerating. If a previous backup folder or files are deleted manually by the user these items prevent Duplicati form creating a new backup folder. Duplicati also see's the trashed files as being in the active backup folder.