### PR TITLE
Fix Backend Google Drive Rename() method

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -21,6 +21,7 @@ using Duplicati.Library.Utility;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -369,24 +370,14 @@ namespace Duplicati.Library.Backend.GoogleDrive
                     throw new UserInformationException(string.Format(Strings.GoogleDrive.MultipleEntries(oldname, m_path)),
                                                        "GoogleDriveMultipleEntries");
 
-                var newfile = JsonConvert.DeserializeObject<GoogleDriveFolderItem>(JsonConvert.SerializeObject(files[0]));
-                newfile.title = newname;
-                newfile.parents = new GoogleDriveParentReference[] { new GoogleDriveParentReference { id = CurrentFolderId } };
-
-                var data = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(newfile));
-
-                var nf = m_oauth.GetJSONData<GoogleDriveFolderItem>(WebApi.GoogleDrive.GetUrl(files[0].id) , x =>
+                using (var cToken = new CancellationTokenSource())
                 {
-                    x.Method = "PUT";
-                    x.ContentLength = data.Length;
-                    x.ContentType = "application/json; charset=UTF-8";
-                }, x =>
-                {
-                    using (var rs = x.GetRequestStream())
-                        rs.Write(data, 0, data.Length);
-                });
+                    Stream stream = new MemoryStream();
+                    Get(oldname, stream);
+                    PutAsync(newname, stream, cToken.Token).Wait(cToken.Token);
+                    Delete(oldname);
+                }
 
-                m_filecache[newname] = new GoogleDriveFolderItem[] { nf };
                 m_filecache.Remove(oldname);
             }
             catch


### PR DESCRIPTION
While it seems the backend Rename() are not used except in the BackendTester, the Google Drive method is currently broken. 

I've changed it to just use the existing Put,Delete to effectively perform a rename. Google Drive does not have a rename api call.

> Starting run no 0
Generating file 0 (26.63 MB)
Generating file 1 (16.04 MB)
Generating file 2 (24.19 MB)
Generating file 3 (3.47 MB)
Generating file 4 (36.63 MB)
Generating file 5 (48.56 MB)
Generating file 6 (41.84 MB)
Generating file 7 (19.42 MB)
Generating file 8 (35.57 MB)
Generating file 9 (23.46 MB)
Uploading wrong files ...
Generating file 10 (1.58 KB)
Uploading file 0, 1.58 KB ...  done!
Uploading file 0, 1.58 KB ...  done!
Uploading file 9, 1.58 KB ...  done!
Uploading files ...
Uploading file 0, 26.63 MB ...  done!
Uploading file 1, 16.04 MB ...  done!
Uploading file 2, 24.19 MB ...  done!
Uploading file 3, 3.47 MB ...  done!
Uploading file 4, 36.63 MB ...  done!
Uploading file 5, 48.56 MB ...  done!
Uploading file 6, 41.84 MB ...  done!
Uploading file 7, 19.42 MB ...  done!
Uploading file 8, 35.57 MB ...  done!
Uploading file 9, 23.46 MB ...  done!
**Renaming file 1 from ap4N7jO16flba5KPV6xFKXSWmcdxZIyrns2HCl to ymerXVPwuRYRG6Yx
Unittest failed: System.Net.WebException: The remote server returned an error: (400) Bad Request**.
   at Duplicati.Library.Utility.AsyncHttpRequest.AsyncWrapper.GetResponseOrStream() in C:\Users\abc\Source\Repos\duplicati\Duplicati\Library\Utility\AsyncHttpRequest.cs:line 286
   at Duplicati.Library.Utility.AsyncHttpRequest.GetResponse() in C:\Users\abc\Source\Repos\duplicati\Duplicati\Library\Utility\AsyncHttpRequest.cs:line 168
   at Duplicati.Library.JSONWebHelper.GetResponse(AsyncHttpRequest req, Object requestdata) in C:\Users\abc\Source\Repos\duplicati\Duplicati\Library\Backend\OAuthHelper\JSONWebHelper.cs:line 379
   at Duplicati.Library.JSONWebHelper.ReadJSONResponse[T](AsyncHttpRequest req, Object requestdata) in C:\Users\abc\Source\Repos\duplicati\Duplicati\Library\Backend\OAuthHelper\JSONWebHelper.cs:line 279
   at Duplicati.Library.JSONWebHelper.GetJSONData[T](String url, Action`1 setup, Action`1 setupbodyreq) in C:\Users\abc\Source\Repos\duplicati\Duplicati\Library\Backend\OAuthHelper\JSONWebHelper.cs:line 208
   at Duplicati.Library.Backend.GoogleDrive.GoogleDrive.Rename(String oldname, String newname) in C:\Users\abc\Source\Repos\duplicati\Duplicati\Library\Backend\GoogleServices\GoogleDrive.cs:line 396
   at Duplicati.CommandLine.BackendTester.Program.Run(List`1 args, Dictionary`2 options, Boolean first) in C:\Users\abc\Source\Repos\duplicati\Duplicati\CommandLine\BackendTester\Program.cs:line 294
   at Duplicati.CommandLine.BackendTester.Program.RealMain(String[] _args) in C:\Users\abc\Source\Repos\duplicati\Duplicati\CommandLine\BackendTester\Program.cs:line 129