### PR TITLE
Improve creation and deletion of test data

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,11 +14,6 @@ build:
     verbosity: minimal
 test_script:
     - ps: |
-        Start-FileDownload https://s3.amazonaws.com/duplicati-test-file-hosting/DSMCBE.zip
-
-        7z x DSMCBE.zip -otestdata
-        mkdir .\testData\data
-
         nuget install OpenCover -Version 4.6.166 -OutputDirectory packages
         nuget install coveralls.net -Version 0.6.0 -OutputDirectory packages
         nuget install NUnit.Runners -Version 3.4.0 -OutputDirectory packages

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ test_script:
             .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe `
             -register:user `
             -target:.\packages\NUnit.ConsoleRunner.3.4.0\tools\nunit3-console.exe `
-            "-targetargs:""$elem"" /framework:net-4.5 /result:""$testResultsFile""" `
+            "-targetargs:""$elem"" /framework:net-4.5 /where:cat!=BulkData /result:""$testResultsFile""" `
             "-filter:+[Duplicati.Library.Main]* -[UnitTest]*" `
             -output:opencover.xml `
             -returntargetcode `

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ test_script:
             .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe `
             -register:user `
             -target:.\packages\NUnit.ConsoleRunner.3.4.0\tools\nunit3-console.exe `
-            "-targetargs:""$elem"" /framework:net-4.5 /where:cat!=BulkData /result:""$testResultsFile""" `
+            "-targetargs:""$elem"" /framework:net-4.5 /result:""$testResultsFile""" `
             "-filter:+[Duplicati.Library.Main]* -[UnitTest]*" `
             -output:opencover.xml `
             -returntargetcode `

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -96,6 +96,7 @@ namespace Duplicati.UnitTest
         {
             Directory.CreateDirectory(this.DATAFOLDER);
             Directory.CreateDirectory(this.TARGETFOLDER);
+            Directory.CreateDirectory(this.RESTOREFOLDER);
         }
 
         [TearDown]
@@ -108,6 +109,10 @@ namespace Duplicati.UnitTest
             if (Directory.Exists(this.TARGETFOLDER))
             {
                 Directory.Delete(this.TARGETFOLDER, true);
+            }
+            if (Directory.Exists(this.RESTOREFOLDER))
+            {
+                Directory.Delete(this.RESTOREFOLDER, true);
             }
             if (File.Exists(this.LOGFILE))
             {

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -85,6 +85,12 @@ namespace Duplicati.UnitTest
             this.TearDown();
         }
 
+        [OneTimeTearDown]
+        public virtual void OneTimeTearDown()
+        {
+            // No-op by default.
+        }
+
         [SetUp]
         public void SetUp()
         {

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -79,6 +79,12 @@ namespace Duplicati.UnitTest
             if (DEBUG_OUTPUT)
                 Console.SetOut(TestContext.Progress);
 
+            this.RemoveSourceData();
+        }
+
+        [OneTimeTearDown]
+        public void RemoveSourceData()
+        {
             ProgressWriteLine("Deleting backup data and log...");
             if (Directory.Exists(DATAFOLDER))
                 Directory.Delete(DATAFOLDER, true);
@@ -90,7 +96,6 @@ namespace Duplicati.UnitTest
             if (Directory.Exists(TARGETFOLDER))
                 Directory.Delete(TARGETFOLDER, true);
         }
-
 
         protected virtual Dictionary<string, string> TestOptions
         {

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -87,14 +87,8 @@ namespace Duplicati.UnitTest
         [OneTimeTearDown]
         public void RemoveSourceData()
         {
-            if (Directory.Exists(DATAFOLDER))
-                Directory.Delete(DATAFOLDER, true);
-            if (Directory.Exists(TARGETFOLDER))
-                Directory.Delete(TARGETFOLDER, true);
-            if (File.Exists(LOGFILE))
-                File.Delete(LOGFILE);
-            if (File.Exists(DBFILE))
-                File.Delete(DBFILE);
+            if (Directory.Exists(BASEFOLDER))
+                Directory.Delete(BASEFOLDER, true);
         }
 
         protected virtual Dictionary<string, string> TestOptions

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -74,23 +74,23 @@ namespace Duplicati.UnitTest
         }
 
         [OneTimeSetUp]
-        public virtual void PrepareSourceData()
+        public virtual void OneTimeSetUp()
         {
             if (DEBUG_OUTPUT)
                 Console.SetOut(TestContext.Progress);
 
-            this.RemoveSourceData();
+            this.OneTimeTearDown();
         }
 
         [OneTimeTearDown]
-        public void RemoveSourceData()
+        public void OneTimeTearDown()
         {
             if (Directory.Exists(BASEFOLDER))
                 Directory.Delete(BASEFOLDER, true);
         }
 
         [SetUp]
-        public void CleanTargetDataDirectory()
+        public void SetUp()
         {
             Directory.CreateDirectory(this.DATAFOLDER);
             Directory.CreateDirectory(this.TARGETFOLDER);

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -79,7 +79,11 @@ namespace Duplicati.UnitTest
             if (DEBUG_OUTPUT)
                 Console.SetOut(TestContext.Progress);
 
-            this.OneTimeTearDown();
+            if (Directory.Exists(BASEFOLDER))
+            {
+                Directory.Delete(BASEFOLDER, true);
+            }
+            Directory.CreateDirectory(BASEFOLDER);
         }
 
         [OneTimeTearDown]

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -83,6 +83,7 @@ namespace Duplicati.UnitTest
 
             Directory.CreateDirectory(BASEFOLDER);
             this.TearDown();
+            this.OneTimeTearDown();
         }
 
         [OneTimeTearDown]

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -81,20 +81,8 @@ namespace Duplicati.UnitTest
                 Console.SetOut(TestContext.Progress);
             }
 
-            if (Directory.Exists(BASEFOLDER))
-            {
-                Directory.Delete(BASEFOLDER, true);
-            }
             Directory.CreateDirectory(BASEFOLDER);
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            if (Directory.Exists(BASEFOLDER))
-            {
-                Directory.Delete(BASEFOLDER, true);
-            }
+            this.TearDown();
         }
 
         [SetUp]

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -85,12 +85,10 @@ namespace Duplicati.UnitTest
         [OneTimeTearDown]
         public void RemoveSourceData()
         {
-            ProgressWriteLine("Deleting backup data and log...");
             if (Directory.Exists(DATAFOLDER))
                 Directory.Delete(DATAFOLDER, true);
             if (File.Exists(LOGFILE))
                 File.Delete(LOGFILE);
-            ProgressWriteLine("Deleting older data");
             if (File.Exists(DBFILE))
                 File.Delete(DBFILE);
             if (Directory.Exists(TARGETFOLDER))

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -100,7 +100,7 @@ namespace Duplicati.UnitTest
         }
 
         [TearDown]
-        public void TearDown()
+        public virtual void TearDown()
         {
             if (Directory.Exists(this.DATAFOLDER))
             {

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -80,8 +80,6 @@ namespace Duplicati.UnitTest
                 Console.SetOut(TestContext.Progress);
 
             this.RemoveSourceData();
-            Directory.CreateDirectory(DATAFOLDER);
-            Directory.CreateDirectory(TARGETFOLDER);
         }
 
         [OneTimeTearDown]
@@ -89,6 +87,34 @@ namespace Duplicati.UnitTest
         {
             if (Directory.Exists(BASEFOLDER))
                 Directory.Delete(BASEFOLDER, true);
+        }
+
+        [SetUp]
+        public void CleanTargetDataDirectory()
+        {
+            Directory.CreateDirectory(this.DATAFOLDER);
+            Directory.CreateDirectory(this.TARGETFOLDER);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(this.DATAFOLDER))
+            {
+                Directory.Delete(this.DATAFOLDER, true);
+            }
+            if (Directory.Exists(this.TARGETFOLDER))
+            {
+                Directory.Delete(this.TARGETFOLDER, true);
+            }
+            if (File.Exists(this.LOGFILE))
+            {
+                File.Delete(this.LOGFILE);
+            }
+            if (File.Exists(this.DBFILE))
+            {
+                File.Delete(this.DBFILE);
+            }
         }
 
         protected virtual Dictionary<string, string> TestOptions

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -89,12 +89,12 @@ namespace Duplicati.UnitTest
         {
             if (Directory.Exists(DATAFOLDER))
                 Directory.Delete(DATAFOLDER, true);
+            if (Directory.Exists(TARGETFOLDER))
+                Directory.Delete(TARGETFOLDER, true);
             if (File.Exists(LOGFILE))
                 File.Delete(LOGFILE);
             if (File.Exists(DBFILE))
                 File.Delete(DBFILE);
-            if (Directory.Exists(TARGETFOLDER))
-                Directory.Delete(TARGETFOLDER, true);
         }
 
         protected virtual Dictionary<string, string> TestOptions

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -80,6 +80,8 @@ namespace Duplicati.UnitTest
                 Console.SetOut(TestContext.Progress);
 
             this.RemoveSourceData();
+            Directory.CreateDirectory(DATAFOLDER);
+            Directory.CreateDirectory(TARGETFOLDER);
         }
 
         [OneTimeTearDown]

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -77,7 +77,9 @@ namespace Duplicati.UnitTest
         public virtual void OneTimeSetUp()
         {
             if (DEBUG_OUTPUT)
+            {
                 Console.SetOut(TestContext.Progress);
+            }
 
             if (Directory.Exists(BASEFOLDER))
             {
@@ -90,7 +92,9 @@ namespace Duplicati.UnitTest
         public void OneTimeTearDown()
         {
             if (Directory.Exists(BASEFOLDER))
+            {
                 Directory.Delete(BASEFOLDER, true);
+            }
         }
 
         [SetUp]

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -28,7 +28,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void Run10kNoProgress()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => { 
                 opts["disable-file-scanner"] = "true"; 
             });
@@ -38,7 +37,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void Run10k()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10);
         }
 
@@ -46,7 +44,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void Run10mb()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => { 
                 opts["blocksize"] = "10mb";
             });
@@ -56,7 +53,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void Run100k()
         {
-            PrepareSourceData();
             RunCommands(1024 * 100);
         }
 
@@ -64,7 +60,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void Run12345_1()
         {
-            PrepareSourceData();
             RunCommands(12345);
         }
 
@@ -72,7 +67,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void Run12345_2()
         {
-            PrepareSourceData();
             RunCommands(12345, 1024 * 1024 * 10);
         }
 
@@ -80,7 +74,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunNoMetadata()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => {
                 opts["skip-metadata"] = "true";
             });
@@ -91,7 +84,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunMD5()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => {
                 opts["block-hash-algorithm"] = "MD5";
                 opts["file-hash-algorithm"] = "MD5";
@@ -102,7 +94,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunSHA384()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => {
                 opts["block-hash-algorithm"] = "SHA384";
                 opts["file-hash-algorithm"] = "SHA384";
@@ -113,7 +104,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunMixedBlockFile_1()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => {
                 opts["block-hash-algorithm"] = "MD5";
                 opts["file-hash-algorithm"] = "SHA1";
@@ -124,7 +114,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunMixedBlockFile_2()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => {
                 opts["block-hash-algorithm"] = "MD5";
                 opts["file-hash-algorithm"] = "SHA256";
@@ -135,7 +124,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunNoIndexFiles()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => {
                 opts["index-file-policy"] = "None";
             });
@@ -145,7 +133,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunSlimIndexFiles()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts => {
                 opts["index-file-policy"] = "Lookup";
             });
@@ -155,7 +142,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunQuickTimestamps()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts =>
             {
                 opts["check-filetime-only"] = "true";
@@ -166,7 +152,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunFullScan()
         {
-            PrepareSourceData();
             RunCommands(1024 * 10, modifyOptions: opts =>
             {
                 opts["disable-filetime-check"] = "true";

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -24,14 +24,6 @@ namespace Duplicati.UnitTest
 {
     public class BorderTests : BasicSetupHelper
     {
-        public override void PrepareSourceData()
-        {
-            base.PrepareSourceData();
-
-            Directory.CreateDirectory(DATAFOLDER);
-            Directory.CreateDirectory(TARGETFOLDER);
-        }
-
         [Test]
         [Category("Border")]
         public void Run10kNoProgress()

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -300,10 +300,6 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual((filenames.Count * 3) + 1, r.Files.Count());
             }
 
-            if (Directory.Exists(RESTOREFOLDER))
-                Directory.Delete(RESTOREFOLDER, true);
-            Directory.CreateDirectory(RESTOREFOLDER);
-
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { restore_path = RESTOREFOLDER, no_local_blocks = true }), null))
             {
                 var r = c.Restore(null);

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -24,6 +24,18 @@ namespace Duplicati.UnitTest
 {
     public class BorderTests : BasicSetupHelper
     {
+        private readonly string recreatedDatabaseFile = Path.Combine(BASEFOLDER, "recreated-database.sqlite");
+
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            if (File.Exists(this.recreatedDatabaseFile))
+            {
+                File.Delete(this.recreatedDatabaseFile);
+            }
+        }
+
         [Test]
         [Category("Border")]
         public void Run10kNoProgress()
@@ -264,11 +276,7 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual((filenames.Count * 3) + 1, r.Files.Count());
             }
 
-            var newdb = Path.Combine(Path.GetDirectoryName(DBFILE), Path.ChangeExtension(Path.GetFileNameWithoutExtension(DBFILE) + "-recreated", Path.GetExtension(DBFILE)));
-            if (File.Exists(newdb))
-                File.Delete(newdb);
-
-            testopts["dbpath"] = newdb;
+            testopts["dbpath"] = this.recreatedDatabaseFile;
 
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
                 c.Repair();

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 
 namespace Duplicati.UnitTest
 {
@@ -42,6 +43,20 @@ namespace Duplicati.UnitTest
                     orderby x
                     select x;
             }
+        }
+
+        public override void PrepareSourceData()
+        {
+            base.PrepareSourceData();
+            
+            const string filename = "data.zip";
+            string tempZipFile = Path.Combine(BASEFOLDER, filename);
+            using (WebClient client = new WebClient())
+            {
+                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{filename}", tempZipFile);
+            }
+            
+            System.IO.Compression.ZipFile.ExtractToDirectory(tempZipFile, BASEFOLDER);
         }
 
         [Test]

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -36,6 +36,7 @@ namespace Duplicati.UnitTest
         protected readonly string SOURCEFOLDER = Path.Combine(BASEFOLDER, "data");
 
         private readonly string zipFilename = "data.zip";
+        private string zipFilepath => Path.Combine(BASEFOLDER, this.zipFilename);
 
         protected virtual IEnumerable<string> SourceDataFolders
         {
@@ -52,13 +53,12 @@ namespace Duplicati.UnitTest
         {
             base.OneTimeSetUp();
             
-            string tempZipFile = Path.Combine(BASEFOLDER, this.zipFilename);
             using (WebClient client = new WebClient())
             {
-                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{this.zipFilename}", tempZipFile);
+                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{this.zipFilename}", this.zipFilepath);
             }
             
-            System.IO.Compression.ZipFile.ExtractToDirectory(tempZipFile, BASEFOLDER);
+            System.IO.Compression.ZipFile.ExtractToDirectory(this.zipFilepath, BASEFOLDER);
         }
 
         public override void OneTimeTearDown()
@@ -67,11 +67,9 @@ namespace Duplicati.UnitTest
             {
                 Directory.Delete(this.SOURCEFOLDER, true);
             }
-            
-            string zipFile = Path.Combine(BASEFOLDER, this.zipFilename);
-            if (File.Exists(zipFile))
+            if (File.Exists(this.zipFilepath))
             {
-                File.Delete(zipFile);
+                File.Delete(this.zipFilepath);
             }
         }
 

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -29,10 +29,13 @@ namespace Duplicati.UnitTest
         /// The log tag
         /// </summary>
         private static readonly string LOGTAG = Library.Logging.Log.LogTagFromType<CommandLineOperationsTests>();
+        
         /// <summary>
         /// The folder that contains all the source data which the test is based on
         /// </summary>
         protected readonly string SOURCEFOLDER = Path.Combine(BASEFOLDER, "data");
+
+        private readonly string zipFilename = "data.zip";
 
         protected virtual IEnumerable<string> SourceDataFolders
         {
@@ -49,14 +52,27 @@ namespace Duplicati.UnitTest
         {
             base.OneTimeSetUp();
             
-            const string filename = "data.zip";
-            string tempZipFile = Path.Combine(BASEFOLDER, filename);
+            string tempZipFile = Path.Combine(BASEFOLDER, this.zipFilename);
             using (WebClient client = new WebClient())
             {
-                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{filename}", tempZipFile);
+                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{this.zipFilename}", tempZipFile);
             }
             
             System.IO.Compression.ZipFile.ExtractToDirectory(tempZipFile, BASEFOLDER);
+        }
+
+        public override void OneTimeTearDown()
+        {
+            if (Directory.Exists(this.SOURCEFOLDER))
+            {
+                Directory.Delete(this.SOURCEFOLDER, true);
+            }
+            
+            string zipFile = Path.Combine(BASEFOLDER, this.zipFilename);
+            if (File.Exists(zipFile))
+            {
+                File.Delete(zipFile);
+            }
         }
 
         [Test]

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -45,9 +45,9 @@ namespace Duplicati.UnitTest
             }
         }
 
-        public override void PrepareSourceData()
+        public override void OneTimeSetUp()
         {
-            base.PrepareSourceData();
+            base.OneTimeSetUp();
             
             const string filename = "data.zip";
             string tempZipFile = Path.Combine(BASEFOLDER, filename);

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -174,9 +174,6 @@ namespace Duplicati.UnitTest
             datafolders = Directory.EnumerateDirectories(DATAFOLDER);
             var rf = datafolders.Skip(datafolders.Count() - 2).First();
 
-            if (Directory.Exists(RESTOREFOLDER))
-                Directory.Delete(RESTOREFOLDER, true);
-
             ProgressWriteLine("Partial restore of {0} ...", Path.GetFileName(rf));
             using(new Library.Logging.Timer(LOGTAG, "PartialRestore", "Partial restore"))
                 Duplicati.CommandLine.Program.RealMain((new string[] { "restore", target, rf + "*", "--restore-path=\"" + RESTOREFOLDER + "\"" }.Union(opts)).ToArray());
@@ -185,8 +182,7 @@ namespace Duplicati.UnitTest
             using (new Library.Logging.Timer(LOGTAG, "VerifiationOfPartialRestore", "Verification of partial restored files"))
                 TestUtils.VerifyDir(rf, RESTOREFOLDER, true);
 
-            if (Directory.Exists(RESTOREFOLDER))
-                Directory.Delete(RESTOREFOLDER, true);
+            Directory.Delete(RESTOREFOLDER, true);
 
             ProgressWriteLine("Partial restore of {0} without local db...", Path.GetFileName(rf));
             using(new Library.Logging.Timer(LOGTAG, "PartialRestoreWithoutLocalDb", "Partial restore without local db"))
@@ -196,8 +192,7 @@ namespace Duplicati.UnitTest
             using (new Library.Logging.Timer(LOGTAG, "VerificationOfPartialRestore", "Verification of partial restored files"))
                 TestUtils.VerifyDir(rf, RESTOREFOLDER, true);
             
-            if (Directory.Exists(RESTOREFOLDER))
-                Directory.Delete(RESTOREFOLDER, true);
+            Directory.Delete(RESTOREFOLDER, true);
 
             ProgressWriteLine("Full restore ...");
             using(new Library.Logging.Timer(LOGTAG, "FullRestore", "Full restore"))
@@ -208,8 +203,7 @@ namespace Duplicati.UnitTest
                 foreach(var s in Directory.EnumerateDirectories(DATAFOLDER))
                     TestUtils.VerifyDir(s, Path.Combine(RESTOREFOLDER, Path.GetFileName(s)), true);
 
-            if (Directory.Exists(RESTOREFOLDER))
-                Directory.Delete(RESTOREFOLDER, true);
+            Directory.Delete(RESTOREFOLDER, true);
 
             ProgressWriteLine("Full restore without local db...");
             using(new Library.Logging.Timer(LOGTAG, "FullRestoreWithoutDb", "Full restore without local db"))

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -197,11 +197,6 @@ namespace Duplicati.UnitTest
             using (new Library.Logging.Timer(LOGTAG, "TestRemoteData", "Test remote data"))
                 if (Duplicati.CommandLine.Program.RealMain((new string[] { "test", target, "all" }.Union(opts)).ToArray()) != 0)
                     throw new Exception("Failed during final remote verification");
-
-            foreach (var datafolder in datafolders)
-            {
-                Directory.Delete(datafolder, true);
-            }
         }
     }
 }

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -44,12 +44,6 @@ namespace Duplicati.UnitTest
             }
         }
 
-        [OneTimeSetUp]
-        public override void PrepareSourceData()
-        {
-            base.PrepareSourceData();
-        }
-
         [Test]
         [Category("BulkData")]
         [Category("BulkNormal")]

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -64,8 +64,6 @@ namespace Duplicati.UnitTest
         [Category("BulkNormal")]
         public void RunCommands()
         {
-            if (Directory.Exists(DATAFOLDER))
-                PrepareSourceData();
             DoRunCommands(TARGETFOLDER);
         }
 
@@ -74,8 +72,6 @@ namespace Duplicati.UnitTest
         [Category("BulkNoSize")]
         public void RunCommandsWithoutSize()
         {
-            if (Directory.Exists(DATAFOLDER))
-                PrepareSourceData();
             DoRunCommands(new SizeOmittingBackend().ProtocolKey + "://" + TARGETFOLDER);
         }
 

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -33,6 +33,7 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SVNCheckoutsTest.cs" />

--- a/Duplicati/UnitTest/FilterTest.cs
+++ b/Duplicati/UnitTest/FilterTest.cs
@@ -26,14 +26,6 @@ namespace Duplicati.UnitTest
 {
     public class FilterTest : BasicSetupHelper
     {
-        public override void PrepareSourceData()
-        {
-            base.PrepareSourceData();
-
-            Directory.CreateDirectory(DATAFOLDER);
-            Directory.CreateDirectory(TARGETFOLDER);
-        }
-
         [Test]
         [Category("Filter")]
         public void TestEmptyFolderExclude()

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -19,18 +19,15 @@ using System.Linq;
 using System.IO;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Reflection;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.UnitTest
 {
-    public class GeneralBlackBoxTesting
+    public class GeneralBlackBoxTesting : BasicSetupHelper
     {
-        private static readonly string SOURCE_FOLDERS =
-            Path.Combine(
-                string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("UNITTEST_BASEFOLDER"))
-                ? Path.Combine(Library.Utility.Utility.HOME_PATH, "duplicati_testdata")
-                : Environment.GetEnvironmentVariable("UNITTEST_BASEFOLDER")
-            , "DSMCBE");
+        private static readonly string SOURCE_FOLDERS = Path.Combine(BASEFOLDER, "DSMCBE");
 
         protected IEnumerable<string> TestFolders
         {
@@ -62,6 +59,21 @@ namespace Duplicati.UnitTest
                 return x == "x" ? null : x;
             }
         }
+
+        public override void PrepareSourceData()
+        {
+            base.PrepareSourceData();
+            
+            const string filename = "DSMCBE.zip";
+            string tempZipFile = Path.Combine(BASEFOLDER, filename);
+            using (WebClient client = new WebClient())
+            {
+                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{filename}", tempZipFile);
+            }
+            
+            System.IO.Compression.ZipFile.ExtractToDirectory(tempZipFile, BASEFOLDER);
+        }
+
         [Test]
         [Category("SVNData")]
         public void TestWithSVNShort()

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -92,6 +92,7 @@ namespace Duplicati.UnitTest
         {
             SVNCheckoutTest.RunTest(TestFolders.Take(5).ToArray(), TestOptions, TestTarget);
         }
+        
         [Test]
         [Category("SVNDataLong")]
         public void TestWithSVNLong()

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -28,6 +28,7 @@ namespace Duplicati.UnitTest
     public class GeneralBlackBoxTesting : BasicSetupHelper
     {
         private static readonly string SOURCE_FOLDERS = Path.Combine(BASEFOLDER, "DSMCBE");
+        private readonly string zipFilename = "DSMCBE.zip";
 
         protected IEnumerable<string> TestFolders
         {
@@ -64,14 +65,27 @@ namespace Duplicati.UnitTest
         {
             base.OneTimeSetUp();
             
-            const string filename = "DSMCBE.zip";
-            string tempZipFile = Path.Combine(BASEFOLDER, filename);
+            string tempZipFile = Path.Combine(BASEFOLDER, this.zipFilename);
             using (WebClient client = new WebClient())
             {
-                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{filename}", tempZipFile);
+                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{this.zipFilename}", tempZipFile);
             }
             
             System.IO.Compression.ZipFile.ExtractToDirectory(tempZipFile, BASEFOLDER);
+        }
+
+        public override void OneTimeTearDown()
+        {
+            if (Directory.Exists(SOURCE_FOLDERS))
+            {
+                Directory.Delete(SOURCE_FOLDERS, true);
+            }
+
+            string zipFile = Path.Combine(BASEFOLDER, this.zipFilename);
+            if (File.Exists(zipFile))
+            {
+                File.Delete(zipFile);
+            }
         }
 
         [Test]

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -29,6 +29,7 @@ namespace Duplicati.UnitTest
     {
         private static readonly string SOURCE_FOLDERS = Path.Combine(BASEFOLDER, "DSMCBE");
         private readonly string zipFilename = "DSMCBE.zip";
+        private string zipFilepath => Path.Combine(BASEFOLDER, this.zipFilename);
 
         protected IEnumerable<string> TestFolders
         {
@@ -65,13 +66,12 @@ namespace Duplicati.UnitTest
         {
             base.OneTimeSetUp();
             
-            string tempZipFile = Path.Combine(BASEFOLDER, this.zipFilename);
             using (WebClient client = new WebClient())
             {
-                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{this.zipFilename}", tempZipFile);
+                client.DownloadFile($"https://s3.amazonaws.com/duplicati-test-file-hosting/{this.zipFilename}", this.zipFilepath);
             }
             
-            System.IO.Compression.ZipFile.ExtractToDirectory(tempZipFile, BASEFOLDER);
+            System.IO.Compression.ZipFile.ExtractToDirectory(this.zipFilepath, BASEFOLDER);
         }
 
         public override void OneTimeTearDown()
@@ -80,11 +80,9 @@ namespace Duplicati.UnitTest
             {
                 Directory.Delete(SOURCE_FOLDERS, true);
             }
-
-            string zipFile = Path.Combine(BASEFOLDER, this.zipFilename);
-            if (File.Exists(zipFile))
+            if (File.Exists(this.zipFilepath))
             {
-                File.Delete(zipFile);
+                File.Delete(this.zipFilepath);
             }
         }
 

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -43,7 +43,7 @@ namespace Duplicati.UnitTest
             }
         }
 
-        protected Dictionary<string, string> TestOptions
+        protected override Dictionary<string, string> TestOptions
         {
             get
             {

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -60,9 +60,9 @@ namespace Duplicati.UnitTest
             }
         }
 
-        public override void PrepareSourceData()
+        public override void OneTimeSetUp()
         {
-            base.PrepareSourceData();
+            base.OneTimeSetUp();
             
             const string filename = "DSMCBE.zip";
             string tempZipFile = Path.Combine(BASEFOLDER, filename);

--- a/Duplicati/UnitTest/Issue1410.cs
+++ b/Duplicati/UnitTest/Issue1410.cs
@@ -24,15 +24,6 @@ namespace Duplicati.UnitTest
 {
     public class Issue1410 : BasicSetupHelper
     {
-        [OneTimeSetUp]
-        public override void PrepareSourceData()
-        {
-            base.PrepareSourceData();
-
-            Directory.CreateDirectory(DATAFOLDER);
-            Directory.CreateDirectory(TARGETFOLDER);
-        }
-
         [Test]
         [Category("Targeted")]
         public void RunCommands()

--- a/Duplicati/UnitTest/Issue1723.cs
+++ b/Duplicati/UnitTest/Issue1723.cs
@@ -22,15 +22,6 @@ namespace Duplicati.UnitTest
 {
 	public class Issue1723 : BasicSetupHelper
 	{
-        [OneTimeSetUp]
-		public override void PrepareSourceData()
-		{
-			base.PrepareSourceData();
-
-			Directory.CreateDirectory(DATAFOLDER);
-			Directory.CreateDirectory(TARGETFOLDER);
-		}
-
 		[Test]
         [Category("Targeted")]
 		public void RunCommands()

--- a/Duplicati/UnitTest/PurgeTesting.cs
+++ b/Duplicati/UnitTest/PurgeTesting.cs
@@ -30,8 +30,6 @@ namespace Duplicati.UnitTest
         [Category("Purge")]
         public void PurgeTest()
         {
-            PrepareSourceData();
-
             var blocksize = 1024 * 10;
             var basedatasize = 0;
 
@@ -157,8 +155,6 @@ namespace Duplicati.UnitTest
         [Category("Purge")]
         public void PurgeBrokenFilesTest()
         {
-            PrepareSourceData();
-
             var blocksize = 1024 * 10;
             var basedatasize = 0;
 

--- a/Duplicati/UnitTest/PurgeTesting.cs
+++ b/Duplicati/UnitTest/PurgeTesting.cs
@@ -26,14 +26,6 @@ namespace Duplicati.UnitTest
 {
     public class PurgeTesting : BasicSetupHelper
     {
-        public override void PrepareSourceData()
-        {
-            base.PrepareSourceData();
-
-            Directory.CreateDirectory(DATAFOLDER);
-            Directory.CreateDirectory(TARGETFOLDER);
-        }
-
         [Test]
         [Category("Purge")]
         public void PurgeTest()

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -30,8 +30,6 @@ namespace Duplicati.UnitTest
         [Category("Border")]
         public void RunScriptBefore()
         {
-            PrepareSourceData();
-
             var blocksize = 10 * 1024;
             var options = TestOptions;
             options["blocksize"] = blocksize.ToString() + "b";

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -26,14 +26,6 @@ namespace Duplicati.UnitTest
 {
     public class RunScriptTests : BasicSetupHelper
     {
-        public override void PrepareSourceData()
-        {
-            base.PrepareSourceData();
-
-            Directory.CreateDirectory(DATAFOLDER);
-            Directory.CreateDirectory(TARGETFOLDER);
-        }
-
         [Test]
         [Category("Border")]
         public void RunScriptBefore()

--- a/build.sh
+++ b/build.sh
@@ -38,15 +38,7 @@ list_dir .
 
 if [ ! -d ~/tmp ]; then mkdir ~/tmp; fi
 if [ ! -d ~/download ]; then mkdir ~/download; fi
-if [ ! -d ~/download/svn ]; then mkdir ~/download/svn; fi
 if [ ! -d ~/download/bulk ]; then mkdir ~/download/bulk; fi
-
-if [ "$CATEGORY" == "SVNData" ] || [ "$CATEGORY" == "SVNDataLong" ]; then
-    # test if zip file exists and contains no errors
-    unzip -t ~/download/svn/DSMCBE.zip &> /dev/null || \
-    wget --progress=dot:giga "https://s3.amazonaws.com/duplicati-test-file-hosting/DSMCBE.zip" -O ~/download/svn/DSMCBE.zip
-    list_dir ~/download/svn
-fi
 
 if [ "$CATEGORY" == "BulkNormal" ] || [ "$CATEGORY" == "BulkNoSize" ];  then
     # test if zip file exists and contains no errors
@@ -56,12 +48,6 @@ if [ "$CATEGORY" == "BulkNormal" ] || [ "$CATEGORY" == "BulkNoSize" ];  then
 fi
 
 rm -rf ~/duplicati_testdata && mkdir ~/duplicati_testdata
-
-if [ "$CATEGORY" == "SVNData" ] || [ "$CATEGORY" == "SVNDataLong" ]; then
-    mkdir ~/duplicati_testdata/DSMCBE
-    unzip -q ~/download/svn/DSMCBE.zip -d ~/duplicati_testdata/
-    list_dir ~/duplicati_testdata/DSMCBE
-fi
 
 if [ "$CATEGORY" == "BulkNormal" ] || [ "$CATEGORY" == "BulkNoSize" ]; then
     mkdir ~/duplicati_testdata/data

--- a/build.sh
+++ b/build.sh
@@ -32,32 +32,9 @@ msbuild /p:Configuration=Release Duplicati.sln
 cp -r ./Duplicati/Server/webroot ./Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/webroot
 echo "travis_fold:end:build_duplicati"
 
-# download and extract testdata
-echo "travis_fold:start:download_extract_testdata"
-list_dir .
-
-if [ ! -d ~/tmp ]; then mkdir ~/tmp; fi
-if [ ! -d ~/download ]; then mkdir ~/download; fi
-if [ ! -d ~/download/bulk ]; then mkdir ~/download/bulk; fi
-
-if [ "$CATEGORY" == "BulkNormal" ] || [ "$CATEGORY" == "BulkNoSize" ];  then
-    # test if zip file exists and contains no errors
-    unzip -t ~/download/bulk/data.zip &> /dev/null || \
-    wget --progress=dot:giga "https://s3.amazonaws.com/duplicati-test-file-hosting/data.zip" -O ~/download/bulk/data.zip
-    list_dir ~/download/bulk
-fi
-
 rm -rf ~/duplicati_testdata && mkdir ~/duplicati_testdata
-
-if [ "$CATEGORY" == "BulkNormal" ] || [ "$CATEGORY" == "BulkNoSize" ]; then
-    mkdir ~/duplicati_testdata/data
-    unzip -q ~/download/bulk/data.zip -d ~/duplicati_testdata/
-    list_dir ~/duplicati_testdata/data
-fi
-
 chown -R $TESTUSER ~/duplicati_testdata/
 chmod -R 755 ~/duplicati_testdata
-echo "travis_fold:end:download_extract_testdata"
 
 # run unit tests
 echo "travis_fold:start:unit_test"


### PR DESCRIPTION
This improves how we handle the creation and deletion of test data.  Previously, the data were basically handled separately by each test class.  Now, we make use of setup and teardown methods to create and clean up the test data as necessary.

We also moved the downloading of external test data (`data.zip` and `DSMCBE.zip`) out of the AppVeyor and Travis configuration files and into a setup method.  This allows users to more easily run all of the tests locally.

Note that AppVeyor is still configured to ignore the `BulkData` tests.  While the 60 minute time limit no longer appears to be an issue for us, the `data.zip` file contains paths that are longer than what is supported by Windows (see issue #3863).

