### PR TITLE
Improve some unittest handling

### DIFF
--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -123,6 +123,10 @@ namespace Duplicati.UnitTest
             {
                 File.Delete(this.DBFILE);
             }
+            if (File.Exists($"{this.DBFILE}-journal"))
+            {
+                File.Delete($"{this.DBFILE}-journal");
+            }
         }
 
         protected virtual Dictionary<string, string> TestOptions

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -105,8 +105,9 @@ namespace Duplicati.UnitTest
                 var foldername = Path.GetFileName(n);
                 var targetfolder = Path.Combine(DATAFOLDER, foldername);
                 ProgressWriteLine("Adding folder {0} to source", foldername);
-                TestUtils.CopyDirectoryRecursive(n, targetfolder);
 
+                Directory.Move(n, targetfolder);
+                
                 var size = Directory.EnumerateFiles(targetfolder, "*", SearchOption.AllDirectories).Select(x => new FileInfo(x).Length).Sum();
 
                 ProgressWriteLine("Running backup with {0} data added ...", Duplicati.Library.Utility.Utility.FormatSizeString(size));

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -20,10 +20,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Duplicati.UnitTest
 {

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -58,7 +58,7 @@ namespace Duplicati.UnitTest
         {
             base.OneTimeSetUp();
 
-            if (!File.Exists($@"{BASEFOLDER}\{zipAlternativeFilename}"))
+            if (!File.Exists(zipAlternativeFilepath))
             {
                 var url = $"{S3_URL}{this.zipFilename}";
                 DownloadS3FileIfNewer(zipFilepath, url);

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -34,9 +34,6 @@
       <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SVNCheckoutsTest.cs" />

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -34,6 +34,9 @@
       <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SVNCheckoutsTest.cs" />


### PR DESCRIPTION
Currently the data.zip is not functional for some tests on Windows. 

- This PR adds the ability of a dev to use a alternative data.zip for testing. To use an alternative filename the file "data-alternative.zip" for it to be automatically used.

- The downloading of data.zip will only occur if the local file is missing or the remote data.zip file has been updated. 

- The CommandLineOperationsTests use the data.zip file which is very large rather than recursively copy the files, we'll move the directories instead. Each test sets everything up again.