### PR TITLE
Fix travis complaint about build.sh not being executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,8 @@ jobs:
           access_key: $SAUCE_ACCESS_KEY
 
 before_install:
-      - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+  - chmod +x ./build.sh # make the script executable if it already is not
+  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 script:
   - ./build.sh ${CATEGORY} ${TRAVIS_BUILD_DIR}


### PR DESCRIPTION
Sometimes Travis will complain about build.sh not being executable. I keep needing to add this to every new branch.

The echo line is not changed, just moved to the left.