### PR TITLE
Fix tempfile date comparison to use UTC

### DIFF
--- a/Duplicati/Library/Utility/TempFile.cs
+++ b/Duplicati/Library/Utility/TempFile.cs
@@ -113,7 +113,7 @@ namespace Duplicati.Library.Utility
             foreach(var e in GetApplicationTempFiles())
                 try
                 {
-                    if (DateTime.Now > (System.IO.File.GetLastWriteTimeUtc(e) + expires))
+                    if (DateTime.UtcNow > (System.IO.File.GetLastWriteTimeUtc(e) + expires))
                         System.IO.File.Delete(e);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Currently the temp file dates are pulled as UTC and a comparison is made between .Now and the UTC date.

We'll now compare UTC to UTC otherwise the comparison if off by hours.

This isn't a big problem but it can easily cause confusion to a user or more importantly a developer when files are not removed when they should be.