### PR TITLE
Consolidate duplicated DateTime utility methods

### DIFF
--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -645,7 +645,7 @@ namespace Duplicati.Library.Main.Database
         
         private long GetPreviousFilesetID(System.Data.IDbCommand cmd, DateTime timestamp, long filesetid)
         {
-            var lastFilesetId = cmd.ExecuteScalarInt64(@"SELECT ""ID"" FROM ""Fileset"" WHERE ""Timestamp"" < ? AND ""ID"" != ? ORDER BY ""Timestamp"" DESC ", -1, NormalizeDateTimeToEpochSeconds(timestamp), filesetid);                
+            var lastFilesetId = cmd.ExecuteScalarInt64(@"SELECT ""ID"" FROM ""Fileset"" WHERE ""Timestamp"" < ? AND ""ID"" != ? ORDER BY ""Timestamp"" DESC ", -1, Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(timestamp), filesetid);                
             return lastFilesetId;
         }
 

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -153,21 +153,9 @@ namespace Duplicati.Library.Main.Database
             m_result = result;
         }
         
-        /// <summary>
-        /// Normalizes a DateTime instance floor'ed to seconds and in UTC
-        /// </summary>
-        /// <returns>The normalised date time</returns>
-        /// <param name="input">The input time</param>
-        public static DateTime NormalizeDateTime(DateTime input)
-        {
-            var ticks = input.ToUniversalTime().Ticks;
-            ticks -= ticks % TimeSpan.TicksPerSecond;
-            return new DateTime(ticks, DateTimeKind.Utc);
-        }
-        
         public static long NormalizeDateTimeToEpochSeconds(DateTime input)
         {
-            return (long)Math.Floor((NormalizeDateTime(input) - Library.Utility.Utility.EPOCH).TotalSeconds);
+            return (long)Math.Floor((Library.Utility.Utility.NormalizeDateTime(input) - Library.Utility.Utility.EPOCH).TotalSeconds);
         }
         
         /// <summary>

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -96,7 +96,7 @@ namespace Duplicati.Library.Main.Database
                 m_connection.Open();
 
             using (var cmd = m_connection.CreateCommand())
-                m_operationid = cmd.ExecuteScalarInt64( @"INSERT INTO ""Operation"" (""Description"", ""Timestamp"") VALUES (?, ?); SELECT last_insert_rowid();", -1, operation, NormalizeDateTimeToEpochSeconds(OperationTimestamp));
+                m_operationid = cmd.ExecuteScalarInt64( @"INSERT INTO ""Operation"" (""Description"", ""Timestamp"") VALUES (?, ?); SELECT last_insert_rowid();", -1, operation, Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(OperationTimestamp));
         }
         
         private LocalDatabase(System.Data.IDbConnection connection)
@@ -151,11 +151,6 @@ namespace Duplicati.Library.Main.Database
         internal void SetResult(BasicResults result)
         {
             m_result = result;
-        }
-        
-        public static long NormalizeDateTimeToEpochSeconds(DateTime input)
-        {
-            return (long)Math.Floor((Library.Utility.Utility.NormalizeDateTime(input) - Library.Utility.Utility.EPOCH).TotalSeconds);
         }
         
         /// <summary>
@@ -224,7 +219,7 @@ namespace Duplicati.Library.Main.Database
 
                     query.Append(singleTimeMatch ? @" ""Timestamp"" = ?" : @" ""Timestamp"" <= ?");
                     // Make sure the resolution is the same (i.e. no milliseconds)
-                    args.Add(NormalizeDateTimeToEpochSeconds(time));
+                    args.Add(Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(time));
                     hasTime = true;
                 }
 
@@ -327,7 +322,7 @@ namespace Duplicati.Library.Main.Database
         {
             m_insertremotelogCommand.Transaction = transaction;
             m_insertremotelogCommand.SetParameterValue(0, m_operationid);
-            m_insertremotelogCommand.SetParameterValue(1, NormalizeDateTimeToEpochSeconds(DateTime.UtcNow));
+            m_insertremotelogCommand.SetParameterValue(1, Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(DateTime.UtcNow));
             m_insertremotelogCommand.SetParameterValue(2, operation);
             m_insertremotelogCommand.SetParameterValue(3, path);
             m_insertremotelogCommand.SetParameterValue(4, data);
@@ -344,7 +339,7 @@ namespace Duplicati.Library.Main.Database
         {
             m_insertlogCommand.Transaction = transaction;
             m_insertlogCommand.SetParameterValue(0, m_operationid);
-            m_insertlogCommand.SetParameterValue(1, NormalizeDateTimeToEpochSeconds(DateTime.UtcNow));
+            m_insertlogCommand.SetParameterValue(1, Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(DateTime.UtcNow));
             m_insertlogCommand.SetParameterValue(2, type);
             m_insertlogCommand.SetParameterValue(3, message);
             m_insertlogCommand.SetParameterValue(4, exception == null ? null : exception.ToString());
@@ -1272,7 +1267,7 @@ ORDER BY
             using (var tr = new TemporaryTransactionWrapper(m_connection, transaction))
             {
                 cmd.Transaction = tr.Parent;                
-                var id = cmd.ExecuteScalarInt64(@"INSERT INTO ""Fileset"" (""OperationID"", ""Timestamp"", ""VolumeID"") VALUES (?, ?, ?); SELECT last_insert_rowid();", -1, m_operationid, NormalizeDateTimeToEpochSeconds(timestamp), volumeid);
+                var id = cmd.ExecuteScalarInt64(@"INSERT INTO ""Fileset"" (""OperationID"", ""Timestamp"", ""VolumeID"") VALUES (?, ?, ?); SELECT last_insert_rowid();", -1, m_operationid, Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(timestamp), volumeid);
                 tr.Commit();
                 return id;
             }
@@ -1329,7 +1324,7 @@ ORDER BY
             using(var tr = m_connection.BeginTransaction())
             using(var cmd = m_connection.CreateCommand(tr))
             {
-                var t = NormalizeDateTimeToEpochSeconds(threshold);
+                var t = Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(threshold);
                 cmd.ExecuteNonQuery(@"DELETE FROM ""LogData"" WHERE ""Timestamp"" < ?", t);
                 cmd.ExecuteNonQuery(@"DELETE FROM ""RemoteOperation"" WHERE ""Timestamp"" < ?", t);
 

--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -76,7 +76,7 @@ namespace Duplicati.Library.Main.Database
                     string q = string.Join(",", Enumerable.Repeat("?", sliceLen));
 
                     //First we remove unwanted entries
-                    deleted += cmd.ExecuteNonQuery(@"DELETE FROM ""Fileset"" WHERE ""Timestamp"" IN (" + q + @") ", toDelete.Skip(sliceStart).Take(sliceLen).Select(x => NormalizeDateTimeToEpochSeconds(x)).Cast<object>().ToArray());
+                    deleted += cmd.ExecuteNonQuery(@"DELETE FROM ""Fileset"" WHERE ""Timestamp"" IN (" + q + @") ", toDelete.Skip(sliceStart).Take(sliceLen).Select(Library.Utility.Utility.NormalizeDateTimeToEpochSeconds).Cast<object>().ToArray());
                 }
 
                 if (deleted != toDelete.Length)

--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -189,7 +189,7 @@ namespace Duplicati.Library.Main.Database
 
             using(var cmd = m_connection.CreateCommand())
             {
-                var filesetIds = GetFilesetIDs(NormalizeDateTime(restoretime), versions).ToList();
+                var filesetIds = GetFilesetIDs(Library.Utility.Utility.NormalizeDateTime(restoretime), versions).ToList();
                 while(filesetIds.Count > 0)
                 {
                     var filesetId = filesetIds[0];

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -942,9 +942,9 @@ namespace Duplicati.Library.Utility
         }
         
         /// <summary>
-        /// Normalizes a DateTime instance floor'ed to seconds and in UTC
+        /// Normalizes a DateTime instance by converting to UTC and flooring to seconds.
         /// </summary>
-        /// <returns>The normalised date time</returns>
+        /// <returns>The normalized date time</returns>
         /// <param name="input">The input time</param>
         public static DateTime NormalizeDateTime(DateTime input)
         {

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -940,7 +940,19 @@ namespace Duplicati.Library.Utility
 
                 ENVIRONMENT_VARIABLE_MATCHER_WINDOWS.Replace(str, m => Regex.Escape(lookup(m.Groups["name"].Value)));
         }
-
+        
+        /// <summary>
+        /// Normalizes a DateTime instance floor'ed to seconds and in UTC
+        /// </summary>
+        /// <returns>The normalised date time</returns>
+        /// <param name="input">The input time</param>
+        public static DateTime NormalizeDateTime(DateTime input)
+        {
+            var ticks = input.ToUniversalTime().Ticks;
+            ticks -= ticks % TimeSpan.TicksPerSecond;
+            return new DateTime(ticks, DateTimeKind.Utc);
+        }
+        
         /// <summary>
         /// The format string for a DateTime
         /// </summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -953,6 +953,11 @@ namespace Duplicati.Library.Utility
             return new DateTime(ticks, DateTimeKind.Utc);
         }
         
+        public static long NormalizeDateTimeToEpochSeconds(DateTime input)
+        {
+            return (long) Math.Floor((NormalizeDateTime(input) - EPOCH).TotalSeconds);
+        }
+        
         /// <summary>
         /// The format string for a DateTime
         /// </summary>

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -941,18 +941,6 @@ namespace Duplicati.Server.Database
             return tempfile.ID;
         }
 
-        /// <summary>
-        /// Normalizes a DateTime instance floor'ed to seconds and in UTC
-        /// </summary>
-        /// <returns>The normalised date time</returns>
-        /// <param name="input">The input time</param>
-        public static DateTime NormalizeDateTime(DateTime input)
-        {
-            var ticks = input.ToUniversalTime().Ticks;
-            ticks -= ticks % TimeSpan.TicksPerSecond;
-            return new DateTime(ticks, DateTimeKind.Utc);
-        }
-
         public void PurgeLogData(DateTime purgeDate)
         {
             var t = NormalizeDateTimeToEpochSeconds(purgeDate);
@@ -972,7 +960,7 @@ namespace Duplicati.Server.Database
         
         private static long NormalizeDateTimeToEpochSeconds(DateTime input)
         {
-            return (long)Math.Floor((NormalizeDateTime(input) - Library.Utility.Utility.EPOCH).TotalSeconds);
+            return (long)Math.Floor((Library.Utility.Utility.NormalizeDateTime(input) - Library.Utility.Utility.EPOCH).TotalSeconds);
         }
         
         private static DateTime ConvertToDateTime(System.Data.IDataReader rd, int index)

--- a/Duplicati/Server/Database/Connection.cs
+++ b/Duplicati/Server/Database/Connection.cs
@@ -52,7 +52,7 @@ namespace Duplicati.Server.Database
                 ((System.Data.IDbDataParameter)m_errorcmd.Parameters[0]).Value = id;
                 ((System.Data.IDbDataParameter)m_errorcmd.Parameters[1]).Value = message;
                 ((System.Data.IDbDataParameter)m_errorcmd.Parameters[2]).Value = ex?.ToString();
-                ((System.Data.IDbDataParameter)m_errorcmd.Parameters[3]).Value = NormalizeDateTimeToEpochSeconds(DateTime.UtcNow);
+                ((System.Data.IDbDataParameter)m_errorcmd.Parameters[3]).Value = Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(DateTime.UtcNow);
                 m_errorcmd.ExecuteNonQuery();
             }
         }
@@ -626,9 +626,9 @@ namespace Duplicati.Server.Database
                         @"INSERT INTO ""Schedule"" (""Tags"", ""Time"", ""Repeat"", ""LastRun"", ""Rule"") VALUES (?,?,?,?,?)",
                     (n) => new object[] {
                         string.Join(",", n.Tags),
-                        NormalizeDateTimeToEpochSeconds(n.Time),
+                        Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(n.Time),
                         n.Repeat,
-                        NormalizeDateTimeToEpochSeconds(n.LastRun),
+                        Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(n.LastRun),
                         n.Rule ?? "",
                         update ? (object)item.ID : null
                     });
@@ -943,7 +943,7 @@ namespace Duplicati.Server.Database
 
         public void PurgeLogData(DateTime purgeDate)
         {
-            var t = NormalizeDateTimeToEpochSeconds(purgeDate);
+            var t = Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(purgeDate);
 
             using(var tr = m_connection.BeginTransaction())
             using(var cmd = m_connection.CreateCommand())
@@ -956,11 +956,6 @@ namespace Duplicati.Server.Database
 
                 tr.Commit();
             }
-        }
-        
-        private static long NormalizeDateTimeToEpochSeconds(DateTime input)
-        {
-            return (long)Math.Floor((Library.Utility.Utility.NormalizeDateTime(input) - Library.Utility.Utility.EPOCH).TotalSeconds);
         }
         
         private static DateTime ConvertToDateTime(System.Data.IDataReader rd, int index)
@@ -1162,7 +1157,7 @@ namespace Duplicati.Server.Database
                     if (x.PropertyType.IsEnum)
                         val = val.ToString();
                     else if (x.PropertyType == typeof(DateTime))
-                        val = NormalizeDateTimeToEpochSeconds((DateTime)val);
+                        val = Library.Utility.Utility.NormalizeDateTimeToEpochSeconds((DateTime)val);
 
                     return val;                    
                 }).ToArray();

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -202,6 +202,19 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Utility")]
+        public void NormalizeDateTime()
+        {
+            DateTime baseDateTime = new DateTime(2000, 1, 2, 3, 4, 5);
+            DateTime baseDateTimeUTC = baseDateTime.ToUniversalTime();
+            Assert.AreEqual(baseDateTimeUTC, Utility.NormalizeDateTime(baseDateTime.AddMilliseconds(1)));
+            Assert.AreEqual(baseDateTimeUTC, Utility.NormalizeDateTime(baseDateTime.AddMilliseconds(500)));
+            Assert.AreEqual(baseDateTimeUTC, Utility.NormalizeDateTime(baseDateTime.AddMilliseconds(999)));
+            Assert.AreEqual(baseDateTimeUTC.AddSeconds(-1), Utility.NormalizeDateTime(baseDateTime.AddMilliseconds(-1)));
+            Assert.AreEqual(baseDateTimeUTC.AddSeconds(1), Utility.NormalizeDateTime(baseDateTime.AddSeconds(1.9)));
+        }
+
+        [Test]
+        [Category("Utility")]
         public void ParseBool()
         {
             string[] expectTrue = { "1", "on", "true", "yes" };

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -212,7 +212,20 @@ namespace Duplicati.UnitTest
             Assert.AreEqual(baseDateTimeUTC.AddSeconds(-1), Utility.NormalizeDateTime(baseDateTime.AddMilliseconds(-1)));
             Assert.AreEqual(baseDateTimeUTC.AddSeconds(1), Utility.NormalizeDateTime(baseDateTime.AddSeconds(1.9)));
         }
-
+        
+        [Test]
+        [Category("Utility")]
+        public void NormalizeDateTimeToEpochSeconds()
+        {
+            DateTime baseDateTime = new DateTime(2000, 1, 2, 3, 4, 5);
+            long epochSeconds = (long) (baseDateTime.ToUniversalTime() - Utility.EPOCH).TotalSeconds;
+            Assert.AreEqual(epochSeconds, Utility.NormalizeDateTimeToEpochSeconds(baseDateTime.AddMilliseconds(1)));
+            Assert.AreEqual(epochSeconds, Utility.NormalizeDateTimeToEpochSeconds(baseDateTime.AddMilliseconds(500)));
+            Assert.AreEqual(epochSeconds, Utility.NormalizeDateTimeToEpochSeconds(baseDateTime.AddMilliseconds(999)));
+            Assert.AreEqual(epochSeconds - 1, Utility.NormalizeDateTimeToEpochSeconds(baseDateTime.AddMilliseconds(-1)));
+            Assert.AreEqual(epochSeconds + 1, Utility.NormalizeDateTimeToEpochSeconds(baseDateTime.AddSeconds(1.9)));
+        }
+        
         [Test]
         [Category("Utility")]
         public void ParseBool()


### PR DESCRIPTION
This consolidates the duplicated `NormalizeDateTime` and `NormalizeDateTimeToEpochSeconds` methods by creating a single implementation in the `Utility` class.  We also added some simple unit tests to verify the behaviors.