### PR TITLE
Change Wix installer to after-installfinalize

### DIFF
--- a/Installer/Windows/Duplicati.wxs
+++ b/Installer/Windows/Duplicati.wxs
@@ -27,7 +27,7 @@
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes" />
 
     <PropertyRef Id="WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED"/>
-    <Condition Message="The .NET Framework 4.6.2 must be installed ([WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED])">
+    <Condition Message="The .NET Framework 4.6.2 must be installed">
       <![CDATA[Installed OR WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED]]>
     </Condition>
 

--- a/Installer/Windows/Duplicati.wxs
+++ b/Installer/Windows/Duplicati.wxs
@@ -84,7 +84,7 @@
 
     <!-- Remove old versions -->
     <InstallExecuteSequence>
-      <RemoveExistingProducts Before='InstallInitialize' />
+      <RemoveExistingProducts After="InstallFinalize" />
     </InstallExecuteSequence>
 
     <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />


### PR DESCRIPTION
Wix config currently uninstalls all files and the installs all files.

The more common method is to install an upgrade and then uninstall the old version. This smartly removes any unneeded old files installed by the old installer. This is a far more efficient upgrade method.

ref: [https://docs.microsoft.com/en-us/windows/win32/msi/removeexistingproducts-action](https://docs.microsoft.com/en-us/windows/win32/msi/removeexistingproducts-action)