### PR TITLE
Copy AlphaVSS dlls for debug build

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
@@ -443,8 +443,10 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
+    <PostBuildEvent>if "$(ConfigurationName)"=="Debug" (
+  xcopy /Y  "%25USERPROFILE%25\.nuget\packages\alphavss\1.4.0\build\net45\AlphaVSS.*.dll" "$(TargetDir)\alphavss\"
+  xcopy /Y  "%25USERPROFILE%25\.nuget\packages\alphavss\1.4.0\lib\net45\AlphaVSS.*.dll" "$(TargetDir)\alphavss\"
+)</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\..\..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
The AlphaVSS dll's are not copied when building. The release build .sh script handles this for releases.

This PR will cause the dll's to be copied only for the debug build so that AlphaVSS can be tested in debug.
