### PR TITLE
Rename Wix installer core feature to a more meaningful name

### DIFF
--- a/Installer/Windows/Duplicati.wxs
+++ b/Installer/Windows/Duplicati.wxs
@@ -59,7 +59,7 @@
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLLOCATION" />
 
     <!-- TODO: Make expanded -->
-    <Feature Id="ProductFeature" Title="Duplicati core files" Level="1" Description="Installs the required files for Duplicati." AllowAdvertise="no" TypicalDefault="install" InstallDefault="local" Absent="disallow" ConfigurableDirectory="INSTALLLOCATION" >
+    <Feature Id="DuplicatiCore" Title="Duplicati core files" Level="1" Description="Installs the required files for Duplicati." AllowAdvertise="no" TypicalDefault="install" InstallDefault="local" Absent="disallow" ConfigurableDirectory="INSTALLLOCATION" >
       <Feature Id="DuplicatiDesktopShortCutFeature" Title="Desktop Shortcut" Level="1" Description ="Installs a shortcut to Duplicati on the desktop" Absent="allow" AllowAdvertise="no" TypicalDefault="install" InstallDefault="local">
         <ComponentRef Id="DuplicatiDesktopShortcutComponent"/>
       </Feature>


### PR DESCRIPTION
Rename from "ProductFeature" to "DuplicatiCore"

Meaningful naming is helpful when used on the command line to control features.

For example, to install the core application with no shortcuts and no autostart:

msiexec /i duplicati.msi ADDLOCAL=DuplicatiCore REMOVE=DuplicatiDesktopShortCutFeature,DuplicatiProgramMenuShortCutFeature,DuplicatiStartupShortCutFeature