### PR TITLE
Add workaround for bug in Mono HttpClient

### DIFF
--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
@@ -31,6 +31,19 @@ namespace Duplicati.Library
 
         private readonly OAuthHttpMessageHandler m_authenticator;
 
+        static OAuthHttpClient()
+        {
+            // There is a regression in some versions of Mono (6.0) where an HttpClient
+            // with a BaseAddress cannot make requests to URLs that begin with '/'.
+            // https://github.com/mono/mono/issues/14630
+            // https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/.
+            if (Utility.Utility.IsMono)
+            {
+                FieldInfo field = typeof(System.Uri).GetField("useDotNetRelativeOrAbsolute", BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+                field?.SetValue(null, true);
+            }
+        }
+
         public OAuthHttpClient(string authid, string protocolKey)
             : this(CreateMessageHandler(authid, protocolKey))
         {


### PR DESCRIPTION
This adds a workaround for a regression in Mono 6.0 where an `HttpClient` with a `BaseAddress` cannot make requests to URLs that begin with `/`.

This addresses issue #3852.

It's unclear how setting this environment variable affects other environments.  We should consider the following test cases using the Microsoft OneDrive (or SharePoint) backend with:

- [x] Linux and Mono 6.0
- [ ] Linux and Mono 5.*
- [ ] Mac OS and Mono 6.0
- [ ] Mac OS and Mono 5.*
- [ ] Windows

The other option is to require the users to set the environment variable themselves.