### PR TITLE
Improve logging during database recreation

### DIFF
--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -188,13 +188,18 @@ namespace Duplicati.Library.Main.Operation
                                 backend.WaitForComplete(restoredb, null);
                                 m_result.EndTime = DateTime.UtcNow;
                                 return;
-                            }    
-                        
+                            }
+
                             progress++;
                             if (filelistWork.Count == 1 && m_options.RepairOnlyPaths)
+                            {
                                 m_result.OperationProgressUpdater.UpdateProgress(0.5f);
+                            }
                             else
+                            {
                                 m_result.OperationProgressUpdater.UpdateProgress(((float)progress / filelistWork.Count()) * (m_options.RepairOnlyPaths ? 1f : 0.2f));
+                                Logging.Log.WriteVerboseMessage(LOGTAG, "ProcessingFilelistVolumes", "Processing filelist volume {0} of {1}", progress, filelistWork.Count);
+                            }
 
                             using(var tmpfile = entry.TempFile)
                             {
@@ -341,6 +346,7 @@ namespace Duplicati.Library.Main.Operation
 
                                 progress++;
                                 m_result.OperationProgressUpdater.UpdateProgress((((float)progress / indexfiles.Count) * 0.5f) + 0.2f);
+                                Logging.Log.WriteVerboseMessage(LOGTAG, "ProcessingIndexlistVolumes", "Processing indexlist volume {0} of {1}", progress, indexfiles.Count);
 
                                 using(var tmpfile = sf.TempFile)
                                 {
@@ -456,6 +462,7 @@ namespace Duplicati.Library.Main.Operation
 
                                     progress++;
                                     m_result.OperationProgressUpdater.UpdateProgress((((float)progress / lst.Count) * 0.1f) + 0.7f + (i * 0.1f));
+                                    Logging.Log.WriteVerboseMessage(LOGTAG, "ProcessingBlocklistVolumes", "Phase {0} of 3, processing blocklist volume {1} of {2}", (i + 1), progress, lst.Count);
 
                                     var volumeid = restoredb.GetRemoteVolumeID(sf.Name);
 


### PR DESCRIPTION
This adds "X of Y" type messages to the verbose logging mechanism while processing files during database recreation. It makes it easier to see how far along the process is.