### PR TITLE
Use dedicated method to create symbolic links to directories on Windows

### DIFF
--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -553,10 +553,14 @@ namespace Duplicati.Library.Common.IO
             if (FileExists(symlinkfile) || DirectoryExists(symlinkfile))
                 throw new System.IO.IOException(string.Format("File already exists: {0}", symlinkfile));
 
-            Alphaleonis.Win32.Filesystem.File.CreateSymbolicLink(PrefixWithUNC(symlinkfile),
-                                                                 target,
-                                                                 asDir ? Alphaleonis.Win32.Filesystem.SymbolicLinkTarget.Directory : Alphaleonis.Win32.Filesystem.SymbolicLinkTarget.File,
-                                                                 AlphaFS.PathFormat.LongFullPath);
+            if (asDir)
+            {
+                Alphaleonis.Win32.Filesystem.Directory.CreateSymbolicLink(PrefixWithUNC(symlinkfile), target, AlphaFS.PathFormat.LongFullPath);
+            }
+            else
+            {
+                Alphaleonis.Win32.Filesystem.File.CreateSymbolicLink(PrefixWithUNC(symlinkfile), target, AlphaFS.PathFormat.LongFullPath);
+            }
 
             //Sadly we do not get a notification if the creation fails :(
             System.IO.FileAttributes attr = 0;


### PR DESCRIPTION
The [methods](http://alphafs.alphaleonis.com/doc/2.2/api/html/8863EE02.htm) that accepted a `SymbolicLinkTarget` parameter have been marked as obsolete.
