### PR TITLE
Fixed extraction of destination folder path from URI

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -271,7 +271,7 @@ backupApp.service('EditUriBuiltins', function(AppService, AppUtils, SystemInfo, 
             var ix = scope.uri.indexOf('?');
             if (ix < 0)
                 ix = scope.uri.location;
-            scope.Path = scope.uri.substr(scope.uri.indexOf('://') + 3, ix);
+            scope.Path = scope.uri.substring(scope.uri.indexOf('://') + 3, ix);
         } else {
             var dirsep = '/';
             var newScopePath = scope.Server;


### PR DESCRIPTION
The extraction of the destination folder path from the URI was incorrectly returning superfluous characters after the ? in the URI because of the use of substr (length based) rather than substring (position based).