### PR TITLE
Fix progress bar issue

### DIFF
--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -307,7 +307,7 @@ namespace Duplicati.Library.Main
         /// <param name="filename">Filename.</param>
         /// <param name="filesize">Filesize.</param>
         /// <param name="fileoffset">Fileoffset.</param>
-        void UpdateFile(out string filename, out long filesize, out long fileoffset);
+        void UpdateFile(out string filename, out long filesize, out long fileoffset, out bool filecomplete);
         
         /// <summary>
         /// Occurs when the phase has changed
@@ -341,6 +341,7 @@ namespace Duplicati.Library.Main
         private string m_curfilename;
         private long m_curfilesize;
         private long m_curfileoffset;
+        private bool m_curfilecomplete;
         
         private long m_filesprocessed;
         private long m_filesizeprocessed;
@@ -361,6 +362,7 @@ namespace Duplicati.Library.Main
                 m_curfilename = null;
                 m_curfilesize = 0;
                 m_curfileoffset = 0;
+                m_curfilecomplete = false;
             }
             
             if (prev_phase != phase && PhaseChanged != null)
@@ -379,6 +381,8 @@ namespace Duplicati.Library.Main
             {
                 m_curfilename = filename;
                 m_curfilesize = size;
+                m_curfileoffset = 0;
+                m_curfilecomplete = false;
             }
         }
         
@@ -404,7 +408,7 @@ namespace Duplicati.Library.Main
             {
                 m_filesprocessed = count;
                 m_filesizeprocessed = size;
-                m_curfileoffset = 0;
+                m_curfilecomplete = true;
             }
         }
         
@@ -438,13 +442,14 @@ namespace Duplicati.Library.Main
         /// <param name="filename">Filename.</param>
         /// <param name="filesize">Filesize.</param>
         /// <param name="fileoffset">Fileoffset.</param>
-        public void UpdateFile(out string filename, out long filesize, out long fileoffset)
+        public void UpdateFile(out string filename, out long filesize, out long fileoffset, out bool filecomplete)
         {
             lock(m_lock)
             {
                 filename = m_curfilename;
                 filesize = m_curfilesize;
                 fileoffset = m_curfileoffset;
+                filecomplete = m_curfilecomplete;
             }
         }
     }

--- a/Duplicati/Server/Duplicati.Server.Serialization/Interface/IProgressEventData.cs
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Interface/IProgressEventData.cs
@@ -20,6 +20,7 @@ namespace Duplicati.Server.Serialization.Interface
         string CurrentFilename { get; }
         long CurrentFilesize { get; }
         long CurrentFileoffset { get; }
+        bool CurrentFilecomplete { get; }
         
         string Phase { get; }
         float OverallProgress { get; }

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -223,6 +223,7 @@ namespace Duplicati.Server
                 internal string m_currentFilename;
                 internal long m_currentFilesize;
                 internal long m_currentFileoffset;
+                internal bool m_currentFilecomplete;
 
                 internal Duplicati.Library.Main.OperationPhase m_phase;
                 internal float m_overallProgress;
@@ -255,6 +256,7 @@ namespace Duplicati.Server
                 public string CurrentFilename { get { return m_currentFilename; } }
                 public long CurrentFilesize { get { return m_currentFilesize; } }
                 public long CurrentFileoffset { get { return m_currentFileoffset; } }
+                public bool CurrentFilecomplete { get { return m_currentFilecomplete; } }
                 public string Phase { get { return  m_phase.ToString(); } }
                 public float OverallProgress { get { return m_overallProgress; } }
                 public long ProcessedFileCount { get { return m_processedFileCount; } }
@@ -283,7 +285,7 @@ namespace Duplicati.Server
                         m_backendProgress.Update(out m_state.m_backendAction, out m_state.m_backendPath, out m_state.m_backendFileSize, out m_state.m_backendFileProgress, out m_state.m_backendSpeed, out m_state.m_backendIsBlocking);
                     if (m_operationProgress != null)
                     {
-                        m_operationProgress.UpdateFile(out m_state.m_currentFilename, out m_state.m_currentFilesize, out m_state.m_currentFileoffset);
+                        m_operationProgress.UpdateFile(out m_state.m_currentFilename, out m_state.m_currentFilesize, out m_state.m_currentFileoffset, out m_state.m_currentFilecomplete);
                         m_operationProgress.UpdateOverall(out m_state.m_phase, out m_state.m_overallProgress, out m_state.m_processedFileCount, out m_state.m_processedFileSize, out m_state.m_totalFileCount, out m_state.m_totalFileSize, out m_state.m_stillCounting);
                     }
 

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
@@ -34,9 +34,10 @@ backupApp.controller('StateController', function($scope, $timeout, ServerStatus,
                     text = gettextCatalog.getString('Counting ({{files}} files found, {{size}})', { files: $scope.state.lastPgEvent.TotalFileCount, size: AppUtils.formatSizeString($scope.state.lastPgEvent.TotalFileSize) });
                     pg = 0;
                 } else {
+                    var xxx = ($scope.state.lastPgEvent.CurrentFilecomplete) ? 0 : $scope.state.lastPgEvent.CurrentFileoffset;
                     var filesleft = $scope.state.lastPgEvent.TotalFileCount - $scope.state.lastPgEvent.ProcessedFileCount;
-                    var sizeleft = $scope.state.lastPgEvent.TotalFileSize - $scope.state.lastPgEvent.ProcessedFileSize - $scope.state.lastPgEvent.CurrentFileoffset;
-                    pg = ($scope.state.lastPgEvent.ProcessedFileSize + $scope.state.lastPgEvent.CurrentFileoffset) / $scope.state.lastPgEvent.TotalFileSize;
+                    var sizeleft = $scope.state.lastPgEvent.TotalFileSize - $scope.state.lastPgEvent.ProcessedFileSize - xxx;
+                    pg = ($scope.state.lastPgEvent.ProcessedFileSize + xxx) / $scope.state.lastPgEvent.TotalFileSize;
 
                     if ($scope.state.lastPgEvent.ProcessedFileCount == 0)
                         pg = 0;

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/StateController.js
@@ -34,10 +34,10 @@ backupApp.controller('StateController', function($scope, $timeout, ServerStatus,
                     text = gettextCatalog.getString('Counting ({{files}} files found, {{size}})', { files: $scope.state.lastPgEvent.TotalFileCount, size: AppUtils.formatSizeString($scope.state.lastPgEvent.TotalFileSize) });
                     pg = 0;
                 } else {
-                    var xxx = ($scope.state.lastPgEvent.CurrentFilecomplete) ? 0 : $scope.state.lastPgEvent.CurrentFileoffset;
+                    var unaccountedbytes = ($scope.state.lastPgEvent.CurrentFilecomplete) ? 0 : $scope.state.lastPgEvent.CurrentFileoffset;
                     var filesleft = $scope.state.lastPgEvent.TotalFileCount - $scope.state.lastPgEvent.ProcessedFileCount;
-                    var sizeleft = $scope.state.lastPgEvent.TotalFileSize - $scope.state.lastPgEvent.ProcessedFileSize - xxx;
-                    pg = ($scope.state.lastPgEvent.ProcessedFileSize + xxx) / $scope.state.lastPgEvent.TotalFileSize;
+                    var sizeleft = $scope.state.lastPgEvent.TotalFileSize - $scope.state.lastPgEvent.ProcessedFileSize - unaccountedbytes;
+                    pg = ($scope.state.lastPgEvent.ProcessedFileSize + unaccountedbytes) / $scope.state.lastPgEvent.TotalFileSize;
 
                     if ($scope.state.lastPgEvent.ProcessedFileCount == 0)
                         pg = 0;


### PR DESCRIPTION
PR https://github.com/duplicati/duplicati/pull/3847 fixed a problem with the main progress bar, but introduced unwanted behavior in the per-file progress meter.  It would cause the per-file progress meter to drop back to zero at file completion, which was mostly noticeable on the final file:

![Capture](https://user-images.githubusercontent.com/39164691/65013156-c9157500-d8ce-11e9-9a4a-dd1291bffd7a.PNG)

This PR undoes the previous changes and implements a new fix.  It uses a new variable to track whether the current file is complete or not (`m_currentFilecomplete`). The javascript portion checks this variable to determine if `m_currentFileoffset` is already added in the total processed file size value or not.

With this fix `m_currentFileoffset` is not double-counted which used to cause the main progress bar to show negative in some situations, yet we still see the current file showing 100% when complete:

![Untitled](https://user-images.githubusercontent.com/39164691/65013393-cff0b780-d8cf-11e9-8d09-ce20ca8f18d5.png)