### PR TITLE
Remove unused GetFilesetID method

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -528,11 +528,6 @@ namespace Duplicati.Library.Main.Database
             }
         }
 
-        public long GetFilesetID(DateTime restoretime, long[] versions)
-        {
-            return GetFilesetIDs(restoretime, versions).First();
-        }
-
         public IEnumerable<long> GetFilesetIDs(DateTime restoretime, long[] versions)
         {
             if (restoretime.Kind == DateTimeKind.Unspecified)


### PR DESCRIPTION
The last reference was removed in revision cbc18970d5 ("Re-applied the path-storage fix as the merge failed somehow").