### PR TITLE
Fixed incorrect escaping of pipe characters

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1385,7 +1385,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// Special characters that needs to be escaped on Linux
         /// </summary>
-        private static readonly Regex COMMANDLINE_ESCAPED_LINUX = new Regex(@"[""|$|`|\\|!]");
+        private static readonly Regex COMMANDLINE_ESCAPED_LINUX = new Regex(@"[""$`\\!]");
 
         /// <summary>
         /// Wraps a single argument in quotes suitable for the passing on the commandline


### PR DESCRIPTION
Based on forum discussion, the regexp is incorrect:
https://forum.duplicati.com/t/bug-regular-expression-filter-operator-or-does-not-work-inside-parenthesis/7950/21