### PR TITLE
Fixed null errors when running tray with external server

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -383,15 +383,16 @@ namespace Duplicati.GUI.TrayIcon
                         switch (m_passwordSource)
                         {
                             case Program.PasswordSource.Database:
-                                Program.databaseConnection.ApplicationSettings.ReloadSettings();
+                                if (Program.databaseConnection != null)
+                                    Program.databaseConnection.ApplicationSettings.ReloadSettings();
                                 
-                                if (Program.databaseConnection.ApplicationSettings.WebserverPasswordTrayIcon != m_password)
+                                if (Program.databaseConnection != null && Program.databaseConnection.ApplicationSettings.WebserverPasswordTrayIcon != m_password)
                                     m_password = Program.databaseConnection.ApplicationSettings.WebserverPasswordTrayIcon;
                                 else
                                     hasTriedPassword = true;
                                 break;
                             case Program.PasswordSource.HostedServer:
-                                if (Server.Program.DataConnection.ApplicationSettings.WebserverPassword != m_password)
+                                if (Server.Program.DataConnection != null && Server.Program.DataConnection.ApplicationSettings.WebserverPassword != m_password)
                                     m_password = Server.Program.DataConnection.ApplicationSettings.WebserverPassword;
                                 else
                                     hasTriedPassword = true;


### PR DESCRIPTION
Added guards to prevent a null-error when attempting to connect to a password protected server without a password.