### PR TITLE
Fix search for ellipsis in GUI tests

### DIFF
--- a/guiTests/guiTest.py
+++ b/guiTests/guiTest.py
@@ -142,10 +142,10 @@ driver.find_element_by_link_text(BACKUP_NAME).click()
 wait_for_text(60, "//div[@class='task ng-scope']/dl[2]/dd[1]", "(took ")
 
 # Restore
-if len([n for n in driver.find_elements_by_xpath("//span[contains(text(),'Restore files ...')]") if n.is_displayed()]) == 0:
+if len([n for n in driver.find_elements_by_xpath(u"//span[contains(text(),'Restore files \u2026')]") if n.is_displayed()]) == 0:
     driver.find_element_by_link_text(BACKUP_NAME).click()
 
-[n for n in driver.find_elements_by_xpath("//span[contains(text(),'Restore files ...')]") if n.is_displayed()][0].click()
+[n for n in driver.find_elements_by_xpath(u"//span[contains(text(),'Restore files \u2026')]") if n.is_displayed()][0].click()
 driver.find_element_by_xpath("//span[contains(text(),'" + SOURCE_FOLDER + "')]")  # wait for filelist
 time.sleep(1)
 driver.find_element_by_xpath("//restore-file-picker/ul/li/div/a[2]").click()  # select root folder checkbox


### PR DESCRIPTION
The three periods were replaced by an ellipsis in revision 7ff50a30e1 (pull request #3885).