### PR TITLE
Ensure that filelist is always included in dlist files

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
@@ -62,9 +62,6 @@ namespace Duplicati.Library.Main.Operation.Backup
                             return;
 
                         await db.WriteFilesetAsync(filesetvolume, filesetid);
-
-                        filesetvolume.AddFilelistFile();
-
                         filesetvolume.Close();
 
                         if (!await taskreader.ProgressAsync)

--- a/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
@@ -88,7 +88,6 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                 var prevId = prevs.Length == 0 ? -1 : prevs.Last();
 
-                    FilesetVolumeWriter fsw = null;
                     try
                     {
                         var s = 1;
@@ -104,40 +103,33 @@ namespace Duplicati.Library.Main.Operation.Backup
                             fileTime = incompleteSet.Value + TimeSpan.FromSeconds(++s);
                         }
 
-                        fsw = new FilesetVolumeWriter(options, fileTime);
-                        fsw.VolumeID = await database.RegisterRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeType.Files, RemoteVolumeState.Temporary);
+                        using (FilesetVolumeWriter fsw = new FilesetVolumeWriter(options, fileTime))
+                        {
+                            fsw.VolumeID = await database.RegisterRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeType.Files, RemoteVolumeState.Temporary);
 
-                        if (!string.IsNullOrEmpty(options.ControlFiles))
-                            foreach(var p in options.ControlFiles.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
-                                fsw.AddControlFile(p, options.GetCompressionHintFromFilename(p));
+                            if (!string.IsNullOrEmpty(options.ControlFiles))
+                                foreach (var p in options.ControlFiles.Split(new char[] {System.IO.Path.PathSeparator}, StringSplitOptions.RemoveEmptyEntries))
+                                    fsw.AddControlFile(p, options.GetCompressionHintFromFilename(p));
 
-                        fsw.AddFilelistFile();
+                            var newFilesetID = await database.CreateFilesetAsync(fsw.VolumeID, fileTime);
+                            await database.LinkFilesetToVolumeAsync(newFilesetID, fsw.VolumeID);
+                            await database.AppendFilesFromPreviousSetAsync(null, newFilesetID, prevId, fileTime);
 
-                        var newFilesetID = await database.CreateFilesetAsync(fsw.VolumeID, fileTime);
-                        await database.LinkFilesetToVolumeAsync(newFilesetID, fsw.VolumeID);
-                        await database.AppendFilesFromPreviousSetAsync(null, newFilesetID, prevId, fileTime);
+                            await database.WriteFilesetAsync(fsw, newFilesetID);
 
-                        await database.WriteFilesetAsync(fsw, newFilesetID);
+                            if (!await taskreader.ProgressAsync)
+                                return;
 
-                        if (!await taskreader.ProgressAsync)
-                            return;
-                        
-                        await database.UpdateRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeState.Uploading, -1, null);
-                        await database.CommitTransactionAsync("CommitUpdateFilelistVolume");
-                        await self.UploadChannel.WriteAsync(new FilesetUploadRequest(fsw));
-                        fsw = null;
+                            await database.UpdateRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeState.Uploading, -1, null);
+                            await database.CommitTransactionAsync("CommitUpdateFilelistVolume");
+                            await self.UploadChannel.WriteAsync(new FilesetUploadRequest(fsw));
+                        }
                     }
                     catch
                     {
                         await database.RollbackTransactionAsync();
                         throw;
                     }
-                    finally
-                    {
-                        if (fsw != null)
-                            try { fsw.Dispose(); }
-                        catch { fsw = null; }
-                    }                          
                 }
             );
         }

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -132,6 +132,7 @@ namespace Duplicati.Library.Main.Volumes
         {
             if (m_streamwriter != null)
             {
+                this.AddFilelistFile();
                 m_writer.Close();
                 m_streamwriter.Dispose();
                 m_streamwriter = null;
@@ -140,14 +141,11 @@ namespace Duplicati.Library.Main.Volumes
             base.Close();
         }
 
-        public void AddFilelistFile()
+        private void AddFilelistFile()
         {
-            if (m_streamwriter != null)
-            {
-                m_writer.WriteEndArray();
-                m_writer.Flush();
-                m_streamwriter.Flush();
-            }
+            m_writer.WriteEndArray();
+            m_writer.Flush();
+            m_streamwriter.Flush();
 
             using (Stream sr = m_compression.CreateFile(FILELIST, CompressionHint.Compressible, DateTime.UtcNow))
             {


### PR DESCRIPTION
This fixes a regression introduced around revisions e0899a2a91 and 3b5af1cf01, where the filelist was not written by all usages of the `FilesetVolumeWriter` (these revisions did fix an issue with including the control-files).  Previously, one would have to invoke `AddFilelistFile` with each usage.  Now, we simply do so when the `FilesetVolumeWriter` is closed.

We also modified the `UploadSyntheticFilelist` class so that the usage of the `FilesetVolumeWriter` is contained in a `using` statement, which will ensure that it is disposed.

This fixes issue #3924.