### PR TITLE
Fix invalid regex pattern

### DIFF
--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -391,7 +391,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The regular expression that matches %20 type values in a querystring
         /// </summary>
-        private static System.Text.RegularExpressions.Regex RE_NUMBER = new System.Text.RegularExpressions.Regex(@"(\%(?<number>([0-9]|[a-f]|[A-F]){2}))|(\+)|(\%u(?<number>([0-9]|[a-f]|[A-F]){2,4,6,8}))", System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static System.Text.RegularExpressions.Regex RE_NUMBER = new System.Text.RegularExpressions.Regex(@"(\%(?<number>([0-9]|[a-f]|[A-F]){2}))|(\+)|(\%u(?<number>([0-9]|[a-f]|[A-F]){4}))", System.Text.RegularExpressions.RegexOptions.Compiled);
 
         /// <summary>
         /// Decodes a URL, like System.Web.HttpUtility.UrlDecode


### PR DESCRIPTION
This was introduced as part of revision b8199ad1c4 to resolve issues #1063 and #1085.  However, the regex pattern was invalid.  This reverts the pattern to the previous value, which seems more appropriate
since most non-standard encodings are of the form `%uxxxx` where `xxxx` is a 4 byte hex string representing a UTF-16 code.

https://en.wikipedia.org/wiki/Percent-encoding#Non-standard_implementations

This fixes issue #3737.