### PR TITLE
Ensure that instances of VolumeWriterBase are disposed

### DIFF
--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -655,11 +655,9 @@ namespace Duplicati.Library.Main
                     item.IndexfileUpdated = true;
                 }
 
-                IndexVolumeWriter wr = null;
-                try
+                var hashsize = HashAlgorithmHelper.Create(m_options.BlockHashAlgorithm).HashSize / 8;
+                using (IndexVolumeWriter wr = new IndexVolumeWriter(m_options))
                 {
-                    var hashsize = HashAlgorithmHelper.Create(m_options.BlockHashAlgorithm).HashSize / 8;
-                    wr = new IndexVolumeWriter(m_options);
                     using (var rd = new IndexVolumeReader(p.CompressionModule, item.Indexfile.Item2.LocalFilename, m_options, hashsize))
                         wr.CopyFrom(rd, x => x == oldname ? newname : x);
                     item.Indexfile.Item1.Dispose();
@@ -667,15 +665,6 @@ namespace Duplicati.Library.Main
                     item.Indexfile.Item2.LocalTempfile.Dispose();
                     item.Indexfile.Item2.LocalTempfile = wr.TempFile;
                     wr.Close();
-                }
-                catch
-                {
-                    if (wr != null)
-                        try { wr.Dispose(); }
-                        catch { }
-                        finally { wr = null; }
-
-                    throw;
                 }
             }
         }

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -345,95 +345,97 @@ namespace Duplicati.Library.Main.Operation
                             }
                             else if (n.Type == RemoteVolumeType.Blocks)
                             {
-                                var w = new BlockVolumeWriter(m_options);
-                                newEntry = w;
-                                w.SetRemoteFilename(n.Name);
-                                
-                                using(var mbl = db.CreateBlockList(n.Name))
+                                using (BlockVolumeWriter w = new BlockVolumeWriter(m_options))
                                 {
-                                    //First we grab all known blocks from local files
-                                    foreach(var block in mbl.GetSourceFilesWithBlocks(m_options.Blocksize))
+                                    newEntry = w;
+                                    w.SetRemoteFilename(n.Name);
+
+                                    using (var mbl = db.CreateBlockList(n.Name))
                                     {
-                                        var hash = block.Hash;
-                                        var size = (int)block.Size;
-                                        
-                                        foreach(var source in block.Sources)
+                                        //First we grab all known blocks from local files
+                                        foreach (var block in mbl.GetSourceFilesWithBlocks(m_options.Blocksize))
                                         {
-                                            var file = source.File;
-                                            var offset = source.Offset;
-                                            
-                                            try
+                                            var hash = block.Hash;
+                                            var size = (int) block.Size;
+
+                                            foreach (var source in block.Sources)
                                             {
-                                                if (System.IO.File.Exists(file))
-                                                    using(var f = System.IO.File.OpenRead(file))
-                                                    {
-                                                        f.Position = offset;
-                                                        if (size == Library.Utility.Utility.ForceStreamRead(f, buffer, size))
+                                                var file = source.File;
+                                                var offset = source.Offset;
+
+                                                try
+                                                {
+                                                    if (System.IO.File.Exists(file))
+                                                        using (var f = System.IO.File.OpenRead(file))
                                                         {
-                                                            var newhash = Convert.ToBase64String(blockhasher.ComputeHash(buffer, 0, size));
-                                                            if (newhash == hash)
+                                                            f.Position = offset;
+                                                            if (size == Library.Utility.Utility.ForceStreamRead(f, buffer, size))
                                                             {
-                                                                if (mbl.SetBlockRestored(hash, size))
-                                                                    w.AddBlock(hash, buffer, 0, size, Duplicati.Library.Interface.CompressionHint.Default);
-                                                                break;
+                                                                var newhash = Convert.ToBase64String(blockhasher.ComputeHash(buffer, 0, size));
+                                                                if (newhash == hash)
+                                                                {
+                                                                    if (mbl.SetBlockRestored(hash, size))
+                                                                        w.AddBlock(hash, buffer, 0, size, Duplicati.Library.Interface.CompressionHint.Default);
+                                                                    break;
+                                                                }
                                                             }
                                                         }
-                                                    }
+                                                }
+                                                catch (Exception ex)
+                                                {
+                                                    Logging.Log.WriteErrorMessage(LOGTAG, "FileAccessError", ex, "Failed to access file: {0}", file);
+                                                }
+                                            }
+                                        }
+
+                                        //Then we grab all remote volumes that have the missing blocks
+                                        foreach (var vol in new AsyncDownloader(mbl.GetMissingBlockSources().ToList(), backend))
+                                        {
+                                            try
+                                            {
+                                                using (var tmpfile = vol.TempFile)
+                                                using (var f = new BlockVolumeReader(RestoreHandler.GetCompressionModule(vol.Name), tmpfile, m_options))
+                                                    foreach (var b in f.Blocks)
+                                                        if (mbl.SetBlockRestored(b.Key, b.Value))
+                                                            if (f.ReadBlock(b.Key, buffer) == b.Value)
+                                                                w.AddBlock(b.Key, buffer, 0, (int) b.Value, Duplicati.Library.Interface.CompressionHint.Default);
                                             }
                                             catch (Exception ex)
                                             {
-                                                Logging.Log.WriteErrorMessage(LOGTAG, "FileAccessError", ex, "Failed to access file: {0}", file);
+                                                Logging.Log.WriteErrorMessage(LOGTAG, "RemoteFileAccessError", ex, "Failed to access remote file: {0}", vol.Name);
                                             }
                                         }
-                                    }
-                                    
-                                    //Then we grab all remote volumes that have the missing blocks
-                                    foreach(var vol in new AsyncDownloader(mbl.GetMissingBlockSources().ToList(), backend))
-                                    {
-                                        try
-                                        {
-                                            using(var tmpfile = vol.TempFile)
-                                            using(var f = new BlockVolumeReader(RestoreHandler.GetCompressionModule(vol.Name), tmpfile, m_options))
-                                                foreach(var b in f.Blocks)
-                                                    if (mbl.SetBlockRestored(b.Key, b.Value))
-                                                        if (f.ReadBlock(b.Key, buffer) == b.Value)
-                                                            w.AddBlock(b.Key, buffer, 0, (int)b.Value, Duplicati.Library.Interface.CompressionHint.Default);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            Logging.Log.WriteErrorMessage(LOGTAG, "RemoteFileAccessError", ex, "Failed to access remote file: {0}", vol.Name);
-                                        }
-                                    }
-                                    
-                                    // If we managed to recover all blocks, NICE!
-                                    var missingBlocks = mbl.GetMissingBlocks().Count();
-                                    if (missingBlocks > 0)
-                                    {                                    
-                                        Logging.Log.WriteInformationMessage(LOGTAG, "RepairMissingBlocks", "Repair cannot acquire {0} required blocks for volume {1}, which are required by the following filesets: ", missingBlocks, n.Name);
-                                        foreach(var f in mbl.GetFilesetsUsingMissingBlocks())
-                                            Logging.Log.WriteInformationMessage(LOGTAG, "AffectedFilesetName", f.Name);
 
-                                        var recoverymsg = string.Format("If you want to continue working with the database, you can use the \"{0}\" and \"{1}\" commands to purge the missing data from the database and the remote storage.", "list-broken-files", "purge-broken-files");
-
-                                        if (!m_options.Dryrun)
+                                        // If we managed to recover all blocks, NICE!
+                                        var missingBlocks = mbl.GetMissingBlocks().Count();
+                                        if (missingBlocks > 0)
                                         {
-                                            Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", "This may be fixed by deleting the filesets and running repair again");
+                                            Logging.Log.WriteInformationMessage(LOGTAG, "RepairMissingBlocks", "Repair cannot acquire {0} required blocks for volume {1}, which are required by the following filesets: ", missingBlocks, n.Name);
+                                            foreach (var f in mbl.GetFilesetsUsingMissingBlocks())
+                                                Logging.Log.WriteInformationMessage(LOGTAG, "AffectedFilesetName", f.Name);
 
-                                            throw new UserInformationException(string.Format("Repair not possible, missing {0} blocks.\n" + recoverymsg, missingBlocks), "RepairIsNotPossible");
+                                            var recoverymsg = string.Format("If you want to continue working with the database, you can use the \"{0}\" and \"{1}\" commands to purge the missing data from the database and the remote storage.", "list-broken-files", "purge-broken-files");
+
+                                            if (!m_options.Dryrun)
+                                            {
+                                                Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", "This may be fixed by deleting the filesets and running repair again");
+
+                                                throw new UserInformationException(string.Format("Repair not possible, missing {0} blocks.\n" + recoverymsg, missingBlocks), "RepairIsNotPossible");
+                                            }
+                                            else
+                                            {
+                                                Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", recoverymsg);
+                                            }
                                         }
                                         else
                                         {
-                                            Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", recoverymsg);
-                                        }
-                                    }
-                                    else
-                                    {
-                                        if (m_options.Dryrun)
-                                            Logging.Log.WriteDryrunMessage(LOGTAG, "WouldReUploadBlockFile", "would re-upload block file {0}, with size {1}, previous size {2}", n.Name, Library.Utility.Utility.FormatSizeString(new System.IO.FileInfo(w.LocalFilename).Length), Library.Utility.Utility.FormatSizeString(n.Size));
-                                        else
-                                        {
-                                            db.UpdateRemoteVolume(w.RemoteFilename, RemoteVolumeState.Uploading, -1, null, null);
-                                            backend.Put(w);
+                                            if (m_options.Dryrun)
+                                                Logging.Log.WriteDryrunMessage(LOGTAG, "WouldReUploadBlockFile", "would re-upload block file {0}, with size {1}, previous size {2}", n.Name, Library.Utility.Utility.FormatSizeString(new System.IO.FileInfo(w.LocalFilename).Length), Library.Utility.Utility.FormatSizeString(n.Size));
+                                            else
+                                            {
+                                                db.UpdateRemoteVolume(w.RemoteFilename, RemoteVolumeState.Uploading, -1, null, null);
+                                                backend.Put(w);
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
This encloses some usages of `BlockVolumeWriter` and `IndexVolumeWriter` in `using` statements to ensure that they are disposed of after their use.