### PR TITLE
Fix parameter file alias

### DIFF
--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -155,7 +155,7 @@ namespace Duplicati.CommandLine
             }
 
             // try and parse all parameter file aliases
-            foreach (string parameterOption in new[] { "parameters-file", "parameters-file", "parameterfile" })
+            foreach (string parameterOption in new[] { "parameters-file", "parameter-file", "parameterfile" })
             {
                 if (options.ContainsKey(parameterOption) && !string.IsNullOrEmpty(options[parameterOption]))
                 {


### PR DESCRIPTION
The code that parsed the parameter file aliases was improved in pull request #3229.  In doing so, we accidentally omitted one of the previously accepted aliases.  The allowed aliases were `parameters-file`, `parameter-file`, and `parameterfile`.