### PR TITLE
Ensure that dindex references correct dblock file after renames

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -79,9 +79,9 @@ namespace Duplicati.Library.Main.Operation.Backup
         public Options Options { get; }
         public BackupDatabase Database { get; }
 
-        public VolumeUploadRequest(BlockVolumeWriter blockvolume, FileEntryItem blockEntry, TemporaryIndexVolume indexVolume, Options options, BackupDatabase database)
+        public VolumeUploadRequest(BlockVolumeWriter blockVolume, FileEntryItem blockEntry, TemporaryIndexVolume indexVolume, Options options, BackupDatabase database)
         {
-            BlockVolume = blockvolume;
+            BlockVolume = blockVolume;
             BlockEntry = blockEntry;
             IndexVolume = indexVolume;
             Options = options;

--- a/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
@@ -98,14 +98,14 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                                 await database.CommitTransactionAsync("CommitAddBlockToOutputFlush");
 
-                                FileEntryItem blockEntry = CreateFileEntryForUpload(blockvolume, options);
+                                FileEntryItem blockEntry = blockvolume.CreateFileEntryForUpload(options);
 
                                 IndexVolumeWriter indexVolumeWriter = null;
                                 FileEntryItem indexEntry = null;
                                 if (indexvolume != null)
                                 {
                                     indexVolumeWriter = await indexvolume.CreateVolume(blockvolume.RemoteFilename, blockEntry.Hash, blockEntry.Size, options, database);
-                                    indexEntry = CreateFileEntryForUpload(indexVolumeWriter, options);
+                                    indexEntry = indexVolumeWriter.CreateFileEntryForUpload(options);
                                 }
 
                                 var uploadRequest = new VolumeUploadRequest(blockvolume, blockEntry, indexVolumeWriter, indexEntry);
@@ -135,15 +135,6 @@ namespace Duplicati.Library.Main.Operation.Backup
                     throw;
                 }
             });
-        }
-
-        private static FileEntryItem CreateFileEntryForUpload(VolumeWriterBase volume, Options options)
-        {
-            var fileEntry = new FileEntryItem(BackendActionType.Put, volume.RemoteFilename);
-            fileEntry.SetLocalfilename(volume.LocalFilename);
-            fileEntry.Encrypt(options);
-            fileEntry.UpdateHashAndSize(options);
-            return fileEntry;
         }
     }
 }

--- a/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
@@ -100,15 +100,14 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                                 FileEntryItem blockEntry = blockvolume.CreateFileEntryForUpload(options);
 
-                                IndexVolumeWriter indexVolumeWriter = null;
-                                FileEntryItem indexEntry = null;
+                                TemporaryIndexVolume indexVolumeCopy = null;
                                 if (indexvolume != null)
                                 {
-                                    indexVolumeWriter = await indexvolume.CreateVolume(blockvolume.RemoteFilename, blockEntry.Hash, blockEntry.Size, options, database);
-                                    indexEntry = indexVolumeWriter.CreateFileEntryForUpload(options);
+                                    indexVolumeCopy = new TemporaryIndexVolume(options);
+                                    indexvolume.CopyTo(indexVolumeCopy, false);
                                 }
 
-                                var uploadRequest = new VolumeUploadRequest(blockvolume, blockEntry, indexVolumeWriter, indexEntry);
+                                var uploadRequest = new VolumeUploadRequest(blockvolume, blockEntry, indexVolumeCopy, options, database);
                                 await self.Output.WriteAsync(uploadRequest);
 
                                 blockvolume = null;

--- a/Duplicati/Library/Main/Operation/Backup/SpillCollectorProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/SpillCollectorProcess.cs
@@ -153,15 +153,14 @@ namespace Duplicati.Library.Main.Operation.Backup
         {
             var blockEntry = target.BlockVolume.CreateFileEntryForUpload(options);
 
-            IndexVolumeWriter indexVolume = null;
-            FileEntryItem indexEntry = null;
+            TemporaryIndexVolume indexVolumeCopy = null;
             if (target.IndexVolume != null)
             {
-                indexVolume = await target.IndexVolume.CreateVolume(target.BlockVolume.RemoteFilename, blockEntry.Hash, blockEntry.Size, options, database).ConfigureAwait(false);
-                indexEntry = indexVolume.CreateFileEntryForUpload(options);
+                indexVolumeCopy = new TemporaryIndexVolume(options);
+                target.IndexVolume.CopyTo(indexVolumeCopy, false);
             }
 
-            var uploadRequest = new VolumeUploadRequest(target.BlockVolume, blockEntry, indexVolume, indexEntry);
+            var uploadRequest = new VolumeUploadRequest(target.BlockVolume, blockEntry, indexVolumeCopy, options, database);
             await outputChannel.WriteAsync(uploadRequest).ConfigureAwait(false);
         }
     }

--- a/Duplicati/Library/Main/Operation/Backup/SpillCollectorProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/SpillCollectorProcess.cs
@@ -149,25 +149,16 @@ namespace Duplicati.Library.Main.Operation.Backup
             });
         }
 
-        private static FileEntryItem CreateFileEntryForUpload(VolumeWriterBase volume, Options options)
-        {
-            var fileEntry = new FileEntryItem(BackendActionType.Put, volume.RemoteFilename);
-            fileEntry.SetLocalfilename(volume.LocalFilename);
-            fileEntry.Encrypt(options);
-            fileEntry.UpdateHashAndSize(options);
-            return fileEntry;
-        }
-
         private static async Task UploadVolumeAndIndex(SpillVolumeRequest target, IWriteChannel<IUploadRequest> outputChannel, Options options, BackupDatabase database)
         {
-            var blockEntry = CreateFileEntryForUpload(target.BlockVolume, options);
+            var blockEntry = target.BlockVolume.CreateFileEntryForUpload(options);
 
             IndexVolumeWriter indexVolume = null;
             FileEntryItem indexEntry = null;
             if (target.IndexVolume != null)
             {
                 indexVolume = await target.IndexVolume.CreateVolume(target.BlockVolume.RemoteFilename, blockEntry.Hash, blockEntry.Size, options, database).ConfigureAwait(false);
-                indexEntry = CreateFileEntryForUpload(indexVolume, options);
+                indexEntry = indexVolume.CreateFileEntryForUpload(options);
             }
 
             var uploadRequest = new VolumeUploadRequest(target.BlockVolume, blockEntry, indexVolume, indexEntry);

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Main.Operation.Common;
 
 namespace Duplicati.Library.Main.Volumes
 {
@@ -69,6 +70,15 @@ namespace Duplicati.Library.Main.Volumes
         {
             using (var sr = new StreamWriter(m_compression.CreateFile(MANIFEST_FILENAME, CompressionHint.Compressible, DateTime.UtcNow), ENCODING))
                 sr.Write(ManifestData.GetManifestInstance(m_blocksize, m_blockhash, m_filehash));
+        }
+
+        internal BackendHandler.FileEntryItem CreateFileEntryForUpload(Options options)
+        {
+            var fileEntry = new BackendHandler.FileEntryItem(BackendActionType.Put, this.RemoteFilename);
+            fileEntry.SetLocalfilename(this.LocalFilename);
+            fileEntry.Encrypt(options);
+            fileEntry.UpdateHashAndSize(options);
+            return fileEntry;
         }
 
         public void CreateFilesetFile(bool isFullBackup)


### PR DESCRIPTION
When support for parallel uploads was implemented, we overlooked a case where a failed put of a dblock file is retried with a different filename.  In this case, an instance of `TemporaryIndexVolume` was created in the `DataBlockProcessor` or `SpillCollectorProcess` prior to the attempted put.  The put would fail and then be retried with a different filename.  While the `Remotevolume` table in the database would reflect the new filename, the `TemporaryIndexVolume` (and resulting dindex file) still contained a reference to the old dblock filename.  This would cause issues in direct restores, etc., when the referenced dblock file could not be found.  

Now, the `TemporaryIndexVolume` is only created after the dblock put has completed.

This addresses issue #3932.
