### PR TITLE
Fix issue #3937 - cannot restore backup containing single file

### DIFF
--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -166,8 +166,9 @@ namespace Duplicati.Library.Main.Database
     
                     while (filecount != foundfiles && maxpath.Length > 0)
                     {
-                        cmd.SetParameterValue(0, maxpath.Length);
-                        cmd.SetParameterValue(1, maxpath);
+                        var mp = Util.AppendDirSeparator(maxpath, dirsep);
+                        cmd.SetParameterValue(0, mp.Length);
+                        cmd.SetParameterValue(1, mp);
                         
                         foundfiles = cmd.ExecuteScalarInt64(0);
 

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -19,7 +19,6 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
-using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Main.Database


### PR DESCRIPTION
Per discussion on issue https://github.com/duplicati/duplicati/issues/3937, this rolls back changes made in PR https://github.com/duplicati/duplicati/pull/3846

That PR caused an issue in the restore file selection dialog when the backup set contained only a single file, leading to an inability to restore the file.