### PR TITLE
Mark fields that don't need to be reassigned as readonly

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -25,7 +25,7 @@ namespace Duplicati.GUI.TrayIcon
 {
     public class GtkRunner : TrayIconBase
     {
-        private static string m_svgfolder;
+        private static readonly string m_svgfolder;
 
         /// <summary>
         /// Static constructor that ensures the Gtk environment is initialized
@@ -46,9 +46,9 @@ namespace Duplicati.GUI.TrayIcon
         
         private class MenuItemWrapper : IMenuItem
         {
-            private MenuItem m_item;
-            private System.Action m_callback;
-            private static Dictionary<MenuIcons, Gtk.Image> _icons = new Dictionary<MenuIcons, Gtk.Image>();
+            private readonly MenuItem m_item;
+            private readonly System.Action m_callback;
+            private static readonly Dictionary<MenuIcons, Gtk.Image> _icons = new Dictionary<MenuIcons, Gtk.Image>();
             
             public MenuItem MenuItem { get { return m_item; } }
 
@@ -164,7 +164,7 @@ namespace Duplicati.GUI.TrayIcon
         protected StatusIcon m_trayIcon;
         protected Menu m_popupMenu;
         
-        protected static Dictionary<TrayIcons, Pixbuf> _images = new Dictionary<TrayIcons, Pixbuf>();
+        protected static readonly Dictionary<TrayIcons, Pixbuf> _images = new Dictionary<TrayIcons, Pixbuf>();
 
         protected override void Exit ()
         {

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -23,9 +23,9 @@ namespace Duplicati.GUI.TrayIcon
 
         private class BackgroundRequest
         {
-            public string Method;
-            public string Endpoint;
-            public Dictionary<string, string> Query;
+            public readonly string Method;
+            public readonly string Endpoint;
+            public readonly Dictionary<string, string> Query;
 
             public BackgroundRequest(string method, string endpoint, Dictionary<string, string> query)
             {
@@ -226,8 +226,8 @@ namespace Duplicati.GUI.TrayIcon
 
         private class SaltAndNonce
         {
-            public string Salt = null;
-            public string Nonce = null;
+            public readonly string Salt = null;
+            public readonly string Nonce = null;
         }
 
         private SaltAndNonce GetSaltAndNonce()

--- a/Duplicati/Library/AutoUpdater/AutoUpdateSettings.cs
+++ b/Duplicati/Library/AutoUpdater/AutoUpdateSettings.cs
@@ -24,7 +24,7 @@ namespace Duplicati.Library.AutoUpdater
 {
     public static class AutoUpdateSettings
     {
-        private static Dictionary<string, string> _cache = new Dictionary<string, string>();
+        private static readonly Dictionary<string, string> _cache = new Dictionary<string, string>();
         private const string APP_NAME = "AutoUpdateAppName.txt";
         private const string UPDATE_URL = "AutoUpdateURL.txt";
         private const string UPDATE_KEY = "AutoUpdateSignKey.txt";

--- a/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
+++ b/Duplicati/Library/Backend/AmazonCloudDrive/AmzCD.cs
@@ -60,7 +60,7 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
         private readonly TimeSpan m_delayTimeSpan;
 
         private static readonly object m_waitUntilLock;
-        private static Dictionary<string, DateTime> m_waitUntilAuthId;
+        private static readonly Dictionary<string, DateTime> m_waitUntilAuthId;
         private static Dictionary<string, DateTime> m_waitUntilRemotename;
 
         static AmzCD()
@@ -310,7 +310,7 @@ namespace Duplicati.Library.Backend.AmazonCloudDrive
             throw new FileMissingException();
         }
         
-        private static System.Text.RegularExpressions.Regex FILTERS_VALUE_ESCAPECHAR = new System.Text.RegularExpressions.Regex(@"[+\-&|!(){}\[\]^'""~*?:\\ ]", System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static readonly System.Text.RegularExpressions.Regex FILTERS_VALUE_ESCAPECHAR = new System.Text.RegularExpressions.Regex(@"[+\-&|!(){}\[\]^'""~*?:\\ ]", System.Text.RegularExpressions.RegexOptions.Compiled);
 
         public static string EscapeFiltersValue(string value)
         {

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -46,7 +46,7 @@ namespace Duplicati.Library.Backend
 
         private readonly byte[] m_copybuffer = new byte[Utility.Utility.DEFAULT_BUFFER_SIZE];
 
-        private static ISystemIO systemIO = SystemIO.IO_OS;
+        private static readonly ISystemIO systemIO = SystemIO.IO_OS;
 
         public File()
         {

--- a/Duplicati/Library/Backend/OAuthHelper/JSONWebHelper.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/JSONWebHelper.cs
@@ -429,8 +429,8 @@ namespace Duplicati.Library
 
         protected class HeaderPart
         {
-            public byte[] Header;
-            public MultipartItem Part;
+            public readonly byte[] Header;
+            public readonly MultipartItem Part;
 
             public HeaderPart(byte[] header, MultipartItem part)
             {

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -32,7 +32,7 @@ namespace Duplicati.Library.Backend
 {
     public class S3 : IBackend, IStreamingBackend, IRenameEnabledBackend
     {
-        private static string LOGTAG = Logging.Log.LogTagFromType<S3>();
+        private static readonly string LOGTAG = Logging.Log.LogTagFromType<S3>();
 
         public const string RRS_OPTION = "s3-use-rrs";
         public const string STORAGECLASS_OPTION = "s3-storage-class";

--- a/Duplicati/Library/Backend/S3/S3Wrapper.cs
+++ b/Duplicati/Library/Backend/S3/S3Wrapper.cs
@@ -33,11 +33,11 @@ namespace Duplicati.Library.Backend
     /// </summary>
     public class S3Wrapper : IDisposable
     {
-        private static string LOGTAG = Logging.Log.LogTagFromType<S3Wrapper>();
+        private static readonly string LOGTAG = Logging.Log.LogTagFromType<S3Wrapper>();
         private const int ITEM_LIST_LIMIT = 1000;
 
-        protected string m_locationConstraint;
-        protected string m_storageClass;
+        protected readonly string m_locationConstraint;
+        protected readonly string m_storageClass;
         protected AmazonS3Client m_client;
 
         public readonly string DNSHost;

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -58,12 +58,12 @@ namespace Duplicati.Library.Common.IO
 
         private class FileSystemAccess
         {
-            public FileSystemRights Rights;
-            public AccessControlType ControlType;
-            public string SID;
-            public bool Inherited;
-            public InheritanceFlags Inheritance;
-            public PropagationFlags Propagation;
+            public readonly FileSystemRights Rights;
+            public readonly AccessControlType ControlType;
+            public readonly string SID;
+            public readonly bool Inherited;
+            public readonly InheritanceFlags Inheritance;
+            public readonly PropagationFlags Propagation;
 
             public FileSystemAccess()
             {

--- a/Duplicati/Library/Localization/LocalizationService.cs
+++ b/Duplicati/Library/Localization/LocalizationService.cs
@@ -32,7 +32,7 @@ namespace Duplicati.Library.Localization
         /// <summary>
         /// The cache of services
         /// </summary>
-        private static Dictionary<CultureInfo, ILocalizationService> Services = new Dictionary<CultureInfo, ILocalizationService>();
+        private static readonly Dictionary<CultureInfo, ILocalizationService> Services = new Dictionary<CultureInfo, ILocalizationService>();
 
         /// <summary>
         /// The key for accessing logical context
@@ -61,7 +61,7 @@ namespace Duplicati.Library.Localization
         /// <summary>
         /// A non-translating service
         /// </summary>
-        private static ILocalizationService InvariantService = new MockLocalizationService();
+        private static readonly ILocalizationService InvariantService = new MockLocalizationService();
 
         /// <summary>
         /// Gets a localization provider with the default language

--- a/Duplicati/Library/Localization/MoLocalizationService.cs
+++ b/Duplicati/Library/Localization/MoLocalizationService.cs
@@ -40,7 +40,7 @@ namespace Duplicati.Library.Localization
         /// </summary>
         public const string LOCALIZATIONDIR_ENVNAME = "LOCALIZATION_FOLDER";
 
-        private static string LOCALIZATIONDIR_VALUE =
+        private static readonly string LOCALIZATIONDIR_VALUE =
             string.IsNullOrWhiteSpace(AppDomain.CurrentDomain.GetData(LOCALIZATIONDIR_ENVNAME) as string)
                   ? Environment.GetEnvironmentVariable(LOCALIZATIONDIR_ENVNAME)
                   : AppDomain.CurrentDomain.GetData(LOCALIZATIONDIR_ENVNAME) as string;
@@ -48,7 +48,7 @@ namespace Duplicati.Library.Localization
         /// <summary>
         /// Path to search for extra .mo files in
         /// </summary>
-        public static string[] SearchPaths =
+        public static readonly string[] SearchPaths =
             string.IsNullOrWhiteSpace(LOCALIZATIONDIR_VALUE)
                 ? new string[] { Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) }
                 : (LOCALIZATIONDIR_VALUE).Split(new char[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
@@ -57,7 +57,7 @@ namespace Duplicati.Library.Localization
         /// <summary>
         /// Assembly to look for .mo files in
         /// </summary>
-        public static Assembly SearchAssembly = Assembly.GetExecutingAssembly();
+        public static readonly Assembly SearchAssembly = Assembly.GetExecutingAssembly();
 
         /// <summary>
         /// Regular expression to match a locale from a filename

--- a/Duplicati/Library/Logging/LogEntry.cs
+++ b/Duplicati/Library/Logging/LogEntry.cs
@@ -43,7 +43,7 @@ namespace Duplicati.Library.Logging
         /// <summary>
         /// The message level
         /// </summary>
-        public LogMessageType Level;
+        public readonly LogMessageType Level;
 
         /// <summary>
         /// The filter tag for the message

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -67,7 +67,7 @@ namespace Duplicati.Library.Main
             /// <summary>
             /// The current operation this entry represents
             /// </summary>
-            public OperationType Operation;
+            public readonly OperationType Operation;
             /// <summary>
             /// The name of the remote file
             /// </summary>
@@ -113,7 +113,7 @@ namespace Duplicati.Library.Main
             /// True if an exception ultimately kills the handler,
             /// false if the item is returned with an exception
             /// </summary>
-            public bool ExceptionKillsHandler;
+            public readonly bool ExceptionKillsHandler;
             /// <summary>
             /// A flag indicating if the file is a extra metadata file
             /// that has no entry in the database

--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -109,10 +109,10 @@ namespace Duplicati.Library.Main.Database
 
         private struct VolumeUsage
         {
-            public string Name;
-            public long DataSize;
-            public long WastedSize;
-            public long CompressedSize;
+            public readonly string Name;
+            public readonly long DataSize;
+            public readonly long WastedSize;
+            public readonly long CompressedSize;
             
             public VolumeUsage(string name, long datasize, long wastedsize, long compressedsize)
             {

--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -15,7 +15,7 @@ namespace Duplicati.Library.Main.Database
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(LocalRestoreDatabase));
 
-        protected string m_temptabsetguid = Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
+        protected readonly string m_temptabsetguid = Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
         protected string m_tempfiletable;
         protected string m_tempblocktable;
         protected string m_fileprogtable;

--- a/Duplicati/Library/Main/Database/LocalTestDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalTestDatabase.cs
@@ -164,8 +164,8 @@ namespace Duplicati.Library.Main.Database
         
         private abstract class Basiclist : IDisposable
         {
-              protected System.Data.IDbConnection m_connection;
-              protected string m_volumename;
+              protected readonly System.Data.IDbConnection m_connection;
+              protected readonly string m_volumename;
               protected string m_tablename;
               protected System.Data.IDbTransaction m_transaction;
               protected System.Data.IDbCommand m_insertCommand;

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -58,7 +58,7 @@ namespace Duplicati.Library.Main.Operation
 
         private readonly BackupResults m_result;
 
-        public CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        public readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
         public BackupHandler(string backendurl, Options options, BackupResults results)
         {

--- a/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
+++ b/Duplicati/Library/Main/Operation/Common/BackendHandler.cs
@@ -49,7 +49,7 @@ namespace Duplicati.Library.Main.Operation.Common
             /// <summary>
             /// The current operation this entry represents
             /// </summary>
-            public BackendActionType Operation;
+            public readonly BackendActionType Operation;
             /// <summary>
             /// The name of the remote file
             /// </summary>

--- a/Duplicati/Library/Main/Operation/Common/DatabaseCommon.cs
+++ b/Duplicati/Library/Main/Operation/Common/DatabaseCommon.cs
@@ -34,9 +34,9 @@ namespace Duplicati.Library.Main.Operation.Common
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<DatabaseCommon>();
 
-        protected LocalDatabase m_db;
+        protected readonly LocalDatabase m_db;
         protected System.Data.IDbTransaction m_transaction;
-        protected Options m_options;
+        protected readonly Options m_options;
 
         public DatabaseCommon(LocalDatabase db, Options options)
             : base()

--- a/Duplicati/Library/Main/Operation/Common/SingleRunner.cs
+++ b/Duplicati/Library/Main/Operation/Common/SingleRunner.cs
@@ -27,8 +27,8 @@ namespace Duplicati.Library.Main.Operation.Common
     /// </summary>
     internal abstract class SingleRunner : IDisposable
     {
-        protected AsyncLock m_lock = new AsyncLock();
-        protected CancellationTokenSource m_workerSource = new CancellationTokenSource();
+        protected readonly AsyncLock m_lock = new AsyncLock();
+        protected readonly CancellationTokenSource m_workerSource = new CancellationTokenSource();
 
         protected async Task<T> DoRunOnMain<T>(Func<Task<T>> method)
         {

--- a/Duplicati/Library/Main/Operation/Common/StatsCollector.cs
+++ b/Duplicati/Library/Main/Operation/Common/StatsCollector.cs
@@ -24,7 +24,7 @@ namespace Duplicati.Library.Main.Operation.Common
     /// </summary>
     internal class StatsCollector : SingleRunner, IDisposable
     {
-        protected IBackendWriter m_bw;
+        protected readonly IBackendWriter m_bw;
 
         public StatsCollector(IBackendWriter bw)
         {

--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -30,9 +30,9 @@ namespace Duplicati.Library.Main.Operation
         /// The tag used for logging
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<CompactHandler>();
-        protected string m_backendurl;
-        protected Options m_options;
-        protected CompactResults m_result;
+        protected readonly string m_backendurl;
+        protected readonly Options m_options;
+        protected readonly CompactResults m_result;
         
         public CompactHandler(string backend, Options options, CompactResults result)
         {

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -37,8 +37,8 @@ namespace Duplicati.Library.Main.Operation
         private static readonly string LOGTAG_RETENTION = LOGTAG + ":RetentionPolicy";
 
         private readonly DeleteResults m_result;
-        protected string m_backendurl;
-        protected Options m_options;
+        protected readonly string m_backendurl;
+        protected readonly Options m_options;
     
         public DeleteHandler(string backend, Options options, DeleteResults result)
         {

--- a/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
@@ -28,9 +28,9 @@ namespace Duplicati.Library.Main.Operation
         /// The tag used for logging
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(ListBrokenFilesHandler));
-        protected string m_backendurl;
-        protected Options m_options;
-        protected ListBrokenFilesResults m_result;
+        protected readonly string m_backendurl;
+        protected readonly Options m_options;
+        protected readonly ListBrokenFilesResults m_result;
 
         public ListBrokenFilesHandler(string backend, Options options, ListBrokenFilesResults result)
         {

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -27,9 +27,9 @@ namespace Duplicati.Library.Main.Operation
         /// The tag used for logging
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(PurgeBrokenFilesHandler));
-        protected string m_backendurl;
-        protected Options m_options;
-        protected PurgeBrokenFilesResults m_result;
+        protected readonly string m_backendurl;
+        protected readonly Options m_options;
+        protected readonly PurgeBrokenFilesResults m_result;
 
         public PurgeBrokenFilesHandler(string backend, Options options, PurgeBrokenFilesResults result)
         {

--- a/Duplicati/Library/Main/Operation/PurgeFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeFilesHandler.cs
@@ -28,9 +28,9 @@ namespace Duplicati.Library.Main.Operation
         /// The tag used for logging
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<PurgeFilesHandler>();
-        protected string m_backendurl;
-        protected Options m_options;
-        protected PurgeFilesResults m_result;
+        protected readonly string m_backendurl;
+        protected readonly Options m_options;
+        protected readonly PurgeFilesResults m_result;
 
         public PurgeFilesHandler(string backend, Options options, PurgeFilesResults result)
         {

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -198,9 +198,9 @@ namespace Duplicati.Library.Main
         /// </summary>
         protected readonly object m_lock = new object();
 
-        protected Dictionary<string, string> m_options;
+        protected readonly Dictionary<string, string> m_options;
 
-        protected List<KeyValuePair<bool, Library.Interface.IGenericModule>> m_loadedModules = new List<KeyValuePair<bool, IGenericModule>>();
+        protected readonly List<KeyValuePair<bool, Library.Interface.IGenericModule>> m_loadedModules = new List<KeyValuePair<bool, IGenericModule>>();
 
         /// <summary>
         /// Lookup table for compression hints

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -196,7 +196,7 @@ namespace Duplicati.Library.Main
         protected readonly BasicResults m_parent;
         protected System.Threading.Thread m_callerThread;
         protected readonly object m_lock = new object();
-        protected Queue<DbMessage> m_dbqueue;
+        protected readonly Queue<DbMessage> m_dbqueue;
 
         private TaskControlState m_controlState = TaskControlState.Run;
         private readonly System.Threading.ManualResetEvent m_pauseEvent = new System.Threading.ManualResetEvent(true);
@@ -221,9 +221,9 @@ namespace Duplicati.Library.Main
 
         public abstract OperationMode MainOperation { get; }
 
-        protected Library.Utility.FileBackedStringList m_messages;
-        protected Library.Utility.FileBackedStringList m_warnings;
-        protected Library.Utility.FileBackedStringList m_errors;
+        protected readonly Library.Utility.FileBackedStringList m_messages;
+        protected readonly Library.Utility.FileBackedStringList m_warnings;
+        protected readonly Library.Utility.FileBackedStringList m_errors;
         protected Library.Utility.FileBackedStringList m_retryAttempts;
         
         protected IMessageSink m_messageSink;
@@ -243,7 +243,7 @@ namespace Duplicati.Library.Main
             }
         }
 
-        protected internal IOperationProgressUpdaterAndReporter m_operationProgressUpdater;
+        protected internal readonly IOperationProgressUpdaterAndReporter m_operationProgressUpdater;
         internal IOperationProgressUpdaterAndReporter OperationProgressUpdater
         {
             get
@@ -255,7 +255,7 @@ namespace Duplicati.Library.Main
             }
         }
 
-        protected internal IBackendProgressUpdaterAndReporter m_backendProgressUpdater;
+        protected internal readonly IBackendProgressUpdaterAndReporter m_backendProgressUpdater;
         internal IBackendProgressUpdaterAndReporter BackendProgressUpdater
         {
             get
@@ -353,7 +353,7 @@ namespace Duplicati.Library.Main
         [JsonProperty(PropertyName = "Errors")]
         public IEnumerable<string> LimitedErrors { get { return Errors?.Take(SERIALIZATION_LIMIT); } }
 
-        protected Operation.Common.TaskControl m_taskController;
+        protected readonly Operation.Common.TaskControl m_taskController;
         public Operation.Common.ITaskReader TaskReader { get { return m_taskController; } }
 
         protected BasicResults()
@@ -378,7 +378,7 @@ namespace Duplicati.Library.Main
             this.m_parent = p;
         }
 
-        protected IBackendStatstics m_backendStatistics;
+        protected readonly IBackendStatstics m_backendStatistics;
         public IBackendStatstics BackendStatistics
         {
             get

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -8,7 +8,7 @@ namespace Duplicati.Library.Main.Volumes
 {
     public class FilesetVolumeWriter : VolumeWriterBase
     {
-        private MemoryStream m_memorystream;
+        private readonly MemoryStream m_memorystream;
         private StreamWriter m_streamwriter;
         private readonly JsonWriter m_writer;
         private long m_filecount;

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -11,7 +11,7 @@ namespace Duplicati.Library.Main.Volumes
     {
         public bool IsFullBackup { get; set; }
 
-        protected bool m_disposeCompression = false;
+        protected readonly bool m_disposeCompression = false;
         protected ICompression m_compression;
         protected Stream m_stream;
         

--- a/Duplicati/Library/Snapshots/Win32USN.cs
+++ b/Duplicati/Library/Snapshots/Win32USN.cs
@@ -45,17 +45,17 @@ namespace Duplicati.Library.Snapshots
             /// stamped with a new identifier in the course of its existence. 
             /// The NTFS file system uses this identifier for an integrity check.
             /// </summary>
-            public long UsnJournalID;
+            public readonly long UsnJournalID;
 
             /// <summary>
             /// The number of first record that can be read from the journal.
             /// </summary>
-            public long FirstUsn;
+            public readonly long FirstUsn;
 
             /// <summary>
             /// The number of next record to be written to the journal.
             /// </summary>
-            public long NextUsn;
+            public readonly long NextUsn;
 
             /// <summary>
             /// The first record that was written into the journal for this journal instance. 
@@ -65,26 +65,26 @@ namespace Duplicati.Library.Snapshots
             /// In this case, LowestValidUsn may indicate a discontinuity in the journal, in which changes 
             /// to some or all files or directories on the volume may have occurred that are not recorded in the change journal.
             /// </summary>
-            public long LowestValidUsn;
+            public readonly long LowestValidUsn;
 
             /// <summary>
             /// The largest USN that the change journal supports. An administrator must delete 
             /// the change journal as the value of NextUsn approaches this value.
             /// </summary>
-            public long MaxUsn;
+            public readonly long MaxUsn;
 
             /// <summary>
             /// The target maximum size for the change journal, in bytes. The change journal can grow larger 
             /// than this value, but it is then truncated at the next NTFS file system checkpoint to less than this value.
             /// </summary>
-            public long MaximumSize;
+            public readonly long MaximumSize;
 
             /// <summary>
             /// The number of bytes of disk memory added to the end and removed from the beginning of the change 
             /// journal each time memory is allocated or deallocated. In other words, allocation and deallocation
             /// take place in units of this size. An integer multiple of a cluster size is a reasonable value for this member.
             /// </summary>
-            public long AllocationDelta;    //DWORDLONG AllocationDelta
+            public readonly long AllocationDelta;    //DWORDLONG AllocationDelta
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -101,19 +101,19 @@ namespace Duplicati.Library.Snapshots
         [StructLayout(LayoutKind.Sequential)]
         public struct USN_RECORD_V2
         {
-            public uint RecordLength;
-            public ushort MajorVersion;
-            public ushort MinorVersion;
-            public ulong FileReferenceNumber;
-            public ulong ParentFileReferenceNumber;
-            public long Usn;
-            public long TimeStamp;  // strictly, this is a LARGE_INTEGER in C
-            public USNReason Reason;
-            public uint SourceInfo;
-            public uint SecurityId;
-            public FileAttributes FileAttributes;
-            public ushort FileNameLength;
-            public ushort FileNameOffset;
+            public readonly uint RecordLength;
+            public readonly ushort MajorVersion;
+            public readonly ushort MinorVersion;
+            public readonly ulong FileReferenceNumber;
+            public readonly ulong ParentFileReferenceNumber;
+            public readonly long Usn;
+            public readonly long TimeStamp;  // strictly, this is a LARGE_INTEGER in C
+            public readonly USNReason Reason;
+            public readonly uint SourceInfo;
+            public readonly uint SecurityId;
+            public readonly FileAttributes FileAttributes;
+            public readonly ushort FileNameLength;
+            public readonly ushort FileNameOffset;
             // immediately after the FileNameOffset comes an array of WCHARs containing the FileName
         }
 
@@ -128,16 +128,16 @@ namespace Duplicati.Library.Snapshots
         [StructLayout(LayoutKind.Sequential)]
         public struct BY_HANDLE_FILE_INFORMATION
         {
-            public uint FileAttributes;
+            public readonly uint FileAttributes;
             public System.Runtime.InteropServices.ComTypes.FILETIME CreationTime;
             public System.Runtime.InteropServices.ComTypes.FILETIME LastAccessTime;
             public System.Runtime.InteropServices.ComTypes.FILETIME LastWriteTime;
-            public uint VolumeSerialNumber;
-            public uint FileSizeHigh;
-            public uint FileSizeLow;
-            public uint NumberOfLinks;
-            public uint FileIndexHigh;
-            public uint FileIndexLow;
+            public readonly uint VolumeSerialNumber;
+            public readonly uint FileSizeHigh;
+            public readonly uint FileSizeLow;
+            public readonly uint NumberOfLinks;
+            public readonly uint FileIndexHigh;
+            public readonly uint FileIndexLow;
         }
         #endregion
 

--- a/Duplicati/Library/Utility/CallContextSettings.cs
+++ b/Duplicati/Library/Utility/CallContextSettings.cs
@@ -225,7 +225,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The settings that are stored in the call context, which are not serializable
         /// </summary>
-        private static Dictionary<string, T> _settings = new Dictionary<string, T>();
+        private static readonly Dictionary<string, T> _settings = new Dictionary<string, T>();
 
         /// <summary>
         /// The context setting types that are used and need their private setting key

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -308,7 +308,7 @@ namespace Duplicati.Library.Utility
         /// <summary> Common base class for reader and writer. </summary>
         private abstract class LinkedSubStream : Stream
         {
-            protected DirectStreamLink m_linkStream;
+            protected readonly DirectStreamLink m_linkStream;
             protected LinkedSubStream(DirectStreamLink linkStream)
             { this.m_linkStream = linkStream; }
 

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -93,7 +93,7 @@ namespace Duplicati.Library.Utility
             // Since we might need to get the regex for a particular filter group multiple times
             // (e.g., when combining multiple FilterExpressions together, which discards the existing FilterEntries and recreates them from the Filter representations),
             // and since they don't change (and compiling them isn't a super cheap operation), we keep a cache of the ones we've built for re-use.
-            private static Dictionary<FilterGroup, Regex> filterGroupRegexCache = new Dictionary<FilterGroup, Regex>();
+            private static readonly Dictionary<FilterGroup, Regex> filterGroupRegexCache = new Dictionary<FilterGroup, Regex>();
 
             /// <summary>
             /// Initializes a new instance of the <see cref="T:Duplicati.Library.Utility.FilterExpression.FilterEntry"/> struct.
@@ -469,7 +469,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// A cache for computing the fallback strategy for a filter
         /// </summary>
-        private static Dictionary<IFilter, Tuple<bool, bool>> _matchFallbackLookup = new Dictionary<IFilter, Tuple<bool, bool>>();
+        private static readonly Dictionary<IFilter, Tuple<bool, bool>> _matchFallbackLookup = new Dictionary<IFilter, Tuple<bool, bool>>();
 
         /// <summary>
         /// The lock object for protecting access to the lookup table

--- a/Duplicati/Library/Utility/TempFile.cs
+++ b/Duplicati/Library/Utility/TempFile.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Library.Utility
 #if DEBUG
         //In debug mode, we track the creation of temporary files, and encode the generating method into the name
         private static readonly object m_lock = new object();
-        private static Dictionary<string, System.Diagnostics.StackTrace> m_fileTrace = new Dictionary<string, System.Diagnostics.StackTrace>();
+        private static readonly Dictionary<string, System.Diagnostics.StackTrace> m_fileTrace = new Dictionary<string, System.Diagnostics.StackTrace>();
 
         public static System.Diagnostics.StackTrace GetStackTraceForTempFile(string filename)
         {

--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -35,7 +35,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// A very lax version of a URL parser
         /// </summary>
-        private static System.Text.RegularExpressions.Regex URL_PARSER = new System.Text.RegularExpressions.Regex(@"(?<scheme>[^:]+)://(((?<username>[^\:\?/]+)(\:(?<password>[^@\:\?/]*))?\@))?((?<hostname>[^/\?\:]+)(\:(?<port>\d+))?)?((?<path>[^\?]*))?(\?(?<query>.+))?");
+        private static readonly System.Text.RegularExpressions.Regex URL_PARSER = new System.Text.RegularExpressions.Regex(@"(?<scheme>[^:]+)://(((?<username>[^\:\?/]+)(\:(?<password>[^@\:\?/]*))?\@))?((?<hostname>[^/\?\:]+)(\:(?<port>\d+))?)?((?<path>[^\?]*))?(\?(?<query>.+))?");
 
         /// <summary>
         /// The URL scheme, e.g. http
@@ -336,7 +336,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The regular expression that matches %20 type values in a querystring
         /// </summary>
-        private static System.Text.RegularExpressions.Regex RE_ESCAPECHAR = new System.Text.RegularExpressions.Regex(@"[^0-9a-zA-Z\-_]", System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static readonly System.Text.RegularExpressions.Regex RE_ESCAPECHAR = new System.Text.RegularExpressions.Regex(@"[^0-9a-zA-Z\-_]", System.Text.RegularExpressions.RegexOptions.Compiled);
 
         /// <summary>
         /// Encodes a URL, like System.Web.HttpUtility.UrlEncode
@@ -391,7 +391,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The regular expression that matches %20 type values in a querystring
         /// </summary>
-        private static System.Text.RegularExpressions.Regex RE_NUMBER = new System.Text.RegularExpressions.Regex(@"(\%(?<number>([0-9]|[a-f]|[A-F]){2}))|(\+)|(\%u(?<number>([0-9]|[a-f]|[A-F]){4}))", System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static readonly System.Text.RegularExpressions.Regex RE_NUMBER = new System.Text.RegularExpressions.Regex(@"(\%(?<number>([0-9]|[a-f]|[A-F]){2}))|(\+)|(\%u(?<number>([0-9]|[a-f]|[A-F]){4}))", System.Text.RegularExpressions.RegexOptions.Compiled);
 
         /// <summary>
         /// Decodes a URL, like System.Web.HttpUtility.UrlDecode
@@ -436,7 +436,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The regular expression that matches a=b type values in a querystring
         /// </summary>
-        private static System.Text.RegularExpressions.Regex RE_URLPARAM = new System.Text.RegularExpressions.Regex(@"(?<key>[^\=\&]+)(\=(?<value>[^\&]*))?", System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static readonly System.Text.RegularExpressions.Regex RE_URLPARAM = new System.Text.RegularExpressions.Regex(@"(?<key>[^\=\&]+)(\=(?<value>[^\&]*))?", System.Text.RegularExpressions.RegexOptions.Compiled);
 
         /// <summary>
         /// Parses the query string.

--- a/Duplicati/Library/Utility/UrlUtility.cs
+++ b/Duplicati/Library/Utility/UrlUtility.cs
@@ -29,7 +29,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The file path to the system browser selected
         /// </summary>
-        public static string SystemBrowser = null;
+        public static readonly string SystemBrowser = null;
 
         /// <summary>
         /// A delegate for handing error messages

--- a/Duplicati/License/LicenseEntry.cs
+++ b/Duplicati/License/LicenseEntry.cs
@@ -31,7 +31,7 @@ namespace Duplicati.License
         /// <summary>
         /// The component title
         /// </summary>
-        public string Title;
+        public readonly string Title;
         /// <summary>
         /// The homepage of the component
         /// </summary>
@@ -39,7 +39,7 @@ namespace Duplicati.License
         /// <summary>
         /// The license for the component
         /// </summary>
-        public string License;
+        public readonly string License;
         /// <summary>
         /// The json data
         /// </summary>

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -66,12 +66,12 @@ namespace Duplicati.Server
         /// <summary>
         /// List of completed task results
         /// </summary>
-        public static List<KeyValuePair<long, Exception>> TaskResultCache = new List<KeyValuePair<long, Exception>>();
+        public static readonly List<KeyValuePair<long, Exception>> TaskResultCache = new List<KeyValuePair<long, Exception>>();
 
         /// <summary>
         /// The maximum number of completed task results to keep in memory
         /// </summary>
-        private static int MAX_TASK_RESULT_CACHE_SIZE = 100;
+        private static readonly int MAX_TASK_RESULT_CACHE_SIZE = 100;
 
         /// <summary>
         /// The thread running the ping-pong handler
@@ -106,12 +106,12 @@ namespace Duplicati.Server
         /// <summary>
         /// An event that is set once the server is ready to respond to requests
         /// </summary>
-        public static System.Threading.ManualResetEvent ServerStartedEvent = new System.Threading.ManualResetEvent(false);
+        public static readonly System.Threading.ManualResetEvent ServerStartedEvent = new System.Threading.ManualResetEvent(false);
 
         /// <summary>
         /// The status event signaler, used to controll long polling of status updates
         /// </summary>
-        public static EventPollNotify StatusEventNotifyer = new EventPollNotify();
+        public static readonly EventPollNotify StatusEventNotifyer = new EventPollNotify();
 
         /// <summary>
         /// A delegate method for creating a copy of the current progress state
@@ -131,7 +131,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The log redirect handler
         /// </summary>
-        public static LogWriteHandler LogHandler = new LogWriteHandler();
+        public static readonly LogWriteHandler LogHandler = new LogWriteHandler();
 
         /// <summary>
         /// Used to check the origin of the web server (e.g. Tray icon or a stand alone Server)
@@ -762,7 +762,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The default log retention
         /// </summary>
-        private static string DEFAULT_LOG_RETENTION = "30D";
+        private static readonly string DEFAULT_LOG_RETENTION = "30D";
 
         /// <summary>
         /// Gets a list of all supported commandline options

--- a/Duplicati/Server/WebServer/BodyWriter.cs
+++ b/Duplicati/Server/WebServer/BodyWriter.cs
@@ -24,7 +24,7 @@ namespace Duplicati.Server.WebServer
     {
         private readonly HttpServer.IHttpResponse m_resp;
         private readonly string m_jsonp;
-        private static object SUCCESS_RESPONSE = new { Status = "OK" };
+        private static readonly object SUCCESS_RESPONSE = new { Status = "OK" };
 
         // We override the format provider so all JSON output uses US format
         public override IFormatProvider FormatProvider

--- a/Duplicati/Server/WebServer/RESTHandler.cs
+++ b/Duplicati/Server/WebServer/RESTHandler.cs
@@ -66,7 +66,7 @@ namespace Duplicati.Server.WebServer
             DoProcess(request, response, session, method, module.Name.ToLowerInvariant(), (String.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase) ? request.Form : request.QueryString)["id"].Value);
         }
 
-        private static ConcurrentDictionary<string, System.Globalization.CultureInfo> _cultureCache = new ConcurrentDictionary<string, System.Globalization.CultureInfo>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, System.Globalization.CultureInfo> _cultureCache = new ConcurrentDictionary<string, System.Globalization.CultureInfo>(StringComparer.OrdinalIgnoreCase);
 
         private static System.Globalization.CultureInfo ParseRequestCulture(RequestInfo info)
         {

--- a/Duplicati/Server/WebServer/RESTMethods/CommandLine.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/CommandLine.cs
@@ -95,7 +95,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         {
             public readonly string ID = Guid.NewGuid().ToString();
             public DateTime LastAccess = DateTime.Now;
-            public Library.Utility.FileBackedStringList Log = new Library.Utility.FileBackedStringList();
+            public readonly Library.Utility.FileBackedStringList Log = new Library.Utility.FileBackedStringList();
             public Runner.IRunnerData Task;
             public LogWriter Writer;
             public readonly object Lock = new object();

--- a/Duplicati/Server/WebServer/Server.cs
+++ b/Duplicati/Server/WebServer/Server.cs
@@ -352,7 +352,7 @@ namespace Duplicati.Server.WebServer
             /// <summary>
             /// The hostnames that are always allowed
             /// </summary>
-            private static string[] DEFAULT_ALLOWED = new string[] { "localhost", "127.0.0.1", "::1", "localhost.localdomain" };
+            private static readonly string[] DEFAULT_ALLOWED = new string[] { "localhost", "127.0.0.1", "::1", "localhost.localdomain" };
 
             /// <summary>
             /// Process the received request

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -25,7 +25,7 @@ namespace Duplicati.UnitTest
 {
     public class CommandLineOperationsTests : BasicSetupHelper
     {
-        private static string S3_URL = $"https://s3.amazonaws.com/duplicati-test-file-hosting/";
+        private static readonly string S3_URL = $"https://s3.amazonaws.com/duplicati-test-file-hosting/";
 
         /// <summary>
         /// The log tag

--- a/Duplicati/UnitTest/RandomErrorBackend.cs
+++ b/Duplicati/UnitTest/RandomErrorBackend.cs
@@ -27,7 +27,7 @@ namespace Duplicati.UnitTest
     {
         static RandomErrorBackend() { WrappedBackend = "file"; }
 
-        private static Random random = new Random(42);
+        private static readonly Random random = new Random(42);
 
         public static string WrappedBackend { get; set; }
 

--- a/Duplicati/WindowsService/ServiceControl.cs
+++ b/Duplicati/WindowsService/ServiceControl.cs
@@ -145,12 +145,12 @@ namespace Duplicati.WindowsService
         [StructLayout(LayoutKind.Sequential)]
         private struct ServiceStatus
         {
-            public uint dwServiceType;
+            public readonly uint dwServiceType;
             public ServiceState dwCurrentState;
-            public uint dwControlsAccepted;
-            public uint dwWin32ExitCode;
-            public uint dwServiceSpecificExitCode;
-            public uint dwCheckPoint;
+            public readonly uint dwControlsAccepted;
+            public readonly uint dwWin32ExitCode;
+            public readonly uint dwServiceSpecificExitCode;
+            public readonly uint dwCheckPoint;
             public uint dwWaitHint;
         };
 

--- a/thirdparty/DnsLite/DnsLite.cs
+++ b/thirdparty/DnsLite/DnsLite.cs
@@ -26,7 +26,7 @@ namespace DnsLib
         private int position, id, length;
         private string name;
         private ArrayList dnsServers;
-        private static int DNS_PORT = 53;
+        private static readonly int DNS_PORT = 53;
         readonly Encoding ASCII = Encoding.ASCII;
         public DnsLite()
         {


### PR DESCRIPTION
This makes it explicit at compile-time that these fields should not be reassigned outside the constructor.