### PR TITLE
Avoid possible invalid DateTimeOffset values

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -957,7 +957,12 @@ namespace Duplicati.Library.Utility
 	/// <param name="input">The input time</param>
         public static long NormalizeDateTimeToEpochSeconds(DateTime input)
         {
-            return (new DateTimeOffset(input)).ToUnixTimeSeconds(); 
+            // Note that we cannot return (new DateTimeOffset(input)).ToUnixTimeSeconds() here.
+            // The DateTimeOffset constructor will convert the provided DateTime to the UTC
+            // equivalent.  However, if DateTime.MinValue is provided (for example, when creating
+            // a new backup), this can result in values that fall outside the DateTimeOffset.MinValue
+            // and DateTimeOffset.MaxValue bounds.
+            return (long) Math.Floor((NormalizeDateTime(input) - EPOCH).TotalSeconds);
         }
         
         /// <summary>


### PR DESCRIPTION
When creating a new backup, a value of `DateTime.MinValue` can be provided to the `NormalizeDateTimeToEpochSeconds` method.  If `DateTimeOffset` is used, it will convert the provided `DateTime` to the UTC equivalent, which may result in a value outside of the allowable bounds.

See [this post](https://stackoverflow.com/questions/13799214/the-utc-time-represented-when-the-offset-is-applied-must-be-between-year-0-and-1/13799438#13799438) for more details.

This reverts the changes from pull request #3919.
This fixes issue #3955.