### PR TITLE
Store fileset in a temp file instead of a memory stream

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -292,6 +292,8 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("asynchronous-concurrent-upload-limit", CommandLineArgument.ArgumentType.Integer, Strings.Options.AsynchronousconcurrentuploadlimitShort, Strings.Options.AsynchronousconcurrentuploadlimitLong, "4"),
                     new CommandLineArgument("asynchronous-upload-folder", CommandLineArgument.ArgumentType.Path, Strings.Options.AsynchronousuploadfolderShort, Strings.Options.AsynchronousuploadfolderLong, System.IO.Path.GetTempPath()),
 
+                    new CommandLineArgument("cache-fileset-on-disk", CommandLineArgument.ArgumentType.Boolean, Strings.Options.CachefilesetondiskShort,Strings.Options.CachefilesetondiskLong, "false"),
+
                     new CommandLineArgument("disable-streaming-transfers", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisableStreamingShort, Strings.Options.DisableStreamingLong, "false"),
 
                     new CommandLineArgument("throttle-upload", CommandLineArgument.ArgumentType.Size, Strings.Options.ThrottleuploadShort, Strings.Options.ThrottleuploadLong, "0kb"),
@@ -1097,6 +1099,11 @@ namespace Duplicati.Library.Main
                     return value;
             }
         }
+
+        /// <summary>
+        /// A value indicating if filesets should be cached on disk instead of in memory.
+        /// </summary>
+        public bool CacheFilesetOnDisk { get { return GetBool("cache-fileset-on-disk"); } }
 
         /// <summary>
         /// Gets the logfile filename

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -291,9 +291,7 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("asynchronous-upload-limit", CommandLineArgument.ArgumentType.Integer, Strings.Options.AsynchronousuploadlimitShort, Strings.Options.AsynchronousuploadlimitLong, "4"),
                     new CommandLineArgument("asynchronous-concurrent-upload-limit", CommandLineArgument.ArgumentType.Integer, Strings.Options.AsynchronousconcurrentuploadlimitShort, Strings.Options.AsynchronousconcurrentuploadlimitLong, "4"),
                     new CommandLineArgument("asynchronous-upload-folder", CommandLineArgument.ArgumentType.Path, Strings.Options.AsynchronousuploadfolderShort, Strings.Options.AsynchronousuploadfolderLong, System.IO.Path.GetTempPath()),
-
-                    new CommandLineArgument("cache-fileset-on-disk", CommandLineArgument.ArgumentType.Boolean, Strings.Options.CachefilesetondiskShort,Strings.Options.CachefilesetondiskLong, "false"),
-
+                    
                     new CommandLineArgument("disable-streaming-transfers", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisableStreamingShort, Strings.Options.DisableStreamingLong, "false"),
 
                     new CommandLineArgument("throttle-upload", CommandLineArgument.ArgumentType.Size, Strings.Options.ThrottleuploadShort, Strings.Options.ThrottleuploadLong, "0kb"),
@@ -1099,12 +1097,7 @@ namespace Duplicati.Library.Main
                     return value;
             }
         }
-
-        /// <summary>
-        /// A value indicating if filesets should be cached on disk instead of in memory.
-        /// </summary>
-        public bool CacheFilesetOnDisk { get { return GetBool("cache-fileset-on-disk"); } }
-
+        
         /// <summary>
         /// Gets the logfile filename
         /// </summary>

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -86,7 +86,7 @@ namespace Duplicati.Library.Main.Strings
         public static string EncryptionmoduleLong { get { return LC.L(@"Duplicati supports pluggable encryption modules. Use this option to select a module to use for encryption. This is only applied when creating new volumes, when reading an existing file, the filename is used to select the encryption module."); } }
         public static string EncryptionmoduleShort { get { return LC.L(@"Select what module to use for encryption"); } }
         public static string DisablemoduleLong { get { return LC.L(@"Supply one or more module names, separated by commas to unload them"); } }
-        public static string DisablemoduleShort { get { return LC.L(@"Disabled one or more modules"); } }
+        public static string DisablemoduleShort { get { return LC.L(@"Disables one or more modules"); } }
         public static string EnablemoduleLong { get { return LC.L(@"Supply one or more module names, separated by commas to load them"); } }
         public static string EnablemoduleShort { get { return LC.L(@"Enables one or more modules"); } }
         public static string SnapshotpolicyLong { get { return LC.L(@"This setting controls the usage of snapshots, which allows Duplicati to backup files that are locked by other programs. If this is set to ""off"", Duplicati will not attempt to create a disk snapshot. Setting this to ""auto"" makes Duplicati attempt to create a snapshot, and fail silently if that was not allowed or supported (note that the OS may still log system warnings). A setting of ""on"" will also make Duplicati attempt to create a snapshot, but will produce a warning message in the log if it fails. Setting it to ""required"" will make Duplicati abort the backup if the snapshot creation fails. On windows this uses the Volume Shadow Copy Services (VSS) and requires administrative privileges. On Linux this uses Logical Volume Management (LVM) and requires root privileges."); } }
@@ -97,6 +97,8 @@ namespace Duplicati.Library.Main.Strings
         public static string AsynchronousuploadlimitShort { get { return LC.L(@"The number of volumes to create ahead of time"); } }
         public static string AsynchronousconcurrentuploadlimitLong { get { return LC.L(@"When performing asynchronous uploads, the maximum number of concurrent uploads allowed. Set to zero to disable the limit."); } }
         public static string AsynchronousconcurrentuploadlimitShort { get { return LC.L(@"The number of concurrent uploads allowed"); } }
+        public static string CachefilesetondiskLong { get { return LC.L(@"Causes fileset writer to hold data on the disk instead of holding it in memory. May be useful on devices with limited memory."); } }
+        public static string CachefilesetondiskShort { get { return LC.L(@"Hold fileset data on disk instead of in memory"); } }
         public static string DebugoutputLong { get { return LC.L(@"Activating this option will make some error messages more verbose, which may help you track down a particular issue"); } }
         public static string DebugoutputShort { get { return LC.L(@"Enables debugging output"); } }
         public static string LogfileShort { get { return LC.L(@"Log internal information to a file"); } }

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -97,8 +97,6 @@ namespace Duplicati.Library.Main.Strings
         public static string AsynchronousuploadlimitShort { get { return LC.L(@"The number of volumes to create ahead of time"); } }
         public static string AsynchronousconcurrentuploadlimitLong { get { return LC.L(@"When performing asynchronous uploads, the maximum number of concurrent uploads allowed. Set to zero to disable the limit."); } }
         public static string AsynchronousconcurrentuploadlimitShort { get { return LC.L(@"The number of concurrent uploads allowed"); } }
-        public static string CachefilesetondiskLong { get { return LC.L(@"Causes fileset writer to hold data on the disk instead of holding it in memory. May be useful on devices with limited memory."); } }
-        public static string CachefilesetondiskShort { get { return LC.L(@"Hold fileset data on disk instead of in memory"); } }
         public static string DebugoutputLong { get { return LC.L(@"Activating this option will make some error messages more verbose, which may help you track down a particular issue"); } }
         public static string DebugoutputShort { get { return LC.L(@"Enables debugging output"); } }
         public static string LogfileShort { get { return LC.L(@"Log internal information to a file"); } }

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -8,7 +8,8 @@ namespace Duplicati.Library.Main.Volumes
 {
     public class FilesetVolumeWriter : VolumeWriterBase
     {
-        private readonly MemoryStream m_memorystream;
+        private readonly Library.Utility.TempFile m_tempFile;
+        private readonly Stream m_tempStream;
         private StreamWriter m_streamwriter;
         private readonly JsonWriter m_writer;
         private long m_filecount;
@@ -19,8 +20,17 @@ namespace Duplicati.Library.Main.Volumes
         public FilesetVolumeWriter(Options options, DateTime timestamp)
             : base(options, timestamp)
         {
-            m_memorystream = new MemoryStream();
-            m_streamwriter = new StreamWriter(m_memorystream, ENCODING);
+            if (options.CacheFilesetOnDisk)
+            {
+                m_tempFile = new Library.Utility.TempFile();
+                m_tempStream = File.Open(m_tempFile, FileMode.Create, FileAccess.ReadWrite);
+            }
+            else
+            {
+                m_tempStream = new MemoryStream();
+            }
+
+            m_streamwriter = new StreamWriter(m_tempStream, ENCODING);
             m_writer = new JsonTextWriter(m_streamwriter);
             m_writer.WriteStartArray();
         }
@@ -138,6 +148,12 @@ namespace Duplicati.Library.Main.Volumes
                 m_streamwriter = null;
             }
 
+            if (m_tempFile != null)
+            {
+                m_tempStream.Dispose();
+                m_tempFile.Dispose();
+            }
+
             base.Close();
         }
 
@@ -149,8 +165,8 @@ namespace Duplicati.Library.Main.Volumes
 
             using (Stream sr = m_compression.CreateFile(FILELIST, CompressionHint.Compressible, DateTime.UtcNow))
             {
-                m_memorystream.Seek(0, SeekOrigin.Begin);
-                m_memorystream.CopyTo(sr);
+                m_tempStream.Seek(0, SeekOrigin.Begin);
+                m_tempStream.CopyTo(sr);
                 sr.Flush();
             }
         }

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -20,16 +20,8 @@ namespace Duplicati.Library.Main.Volumes
         public FilesetVolumeWriter(Options options, DateTime timestamp)
             : base(options, timestamp)
         {
-            if (options.CacheFilesetOnDisk)
-            {
-                m_tempFile = new Library.Utility.TempFile();
-                m_tempStream = File.Open(m_tempFile, FileMode.Create, FileAccess.ReadWrite);
-            }
-            else
-            {
-                m_tempStream = new MemoryStream();
-            }
-
+            m_tempFile = new Library.Utility.TempFile();
+            m_tempStream = File.Open(m_tempFile, FileMode.Create, FileAccess.ReadWrite);
             m_streamwriter = new StreamWriter(m_tempStream, ENCODING);
             m_writer = new JsonTextWriter(m_streamwriter);
             m_writer.WriteStartArray();
@@ -148,9 +140,13 @@ namespace Duplicati.Library.Main.Volumes
                 m_streamwriter = null;
             }
 
-            if (m_tempFile != null)
+            if (m_tempStream != null)
             {
                 m_tempStream.Dispose();
+            }
+
+            if (m_tempFile != null)
+            {
                 m_tempFile.Dispose();
             }
 


### PR DESCRIPTION
I've been running Duplicati on a Raspberry Pi 4 4GB for a few weeks now, and have seen a number of OutOfMemoryExceptions which I'm trying to figure out how best to prevent.

Several of these exceptions have been in FilesetVolumeWriter.AddFilelistFile(), which is called when the fileset volume is disposed / closed. In looking at that method, I noticed that the temporary stream containing the JSON encoded fileset is stored in a memory stream. This change adds a flag `--cache-fileset-on-disk` which instead uses a temp file to store this temporary data before it is copied to the compressed file. The default is still to use the memory stream.

Callstacks for the exceptions I've seen:

```
System.OutOfMemoryException: Insufficient memory to continue the execution of the program.
  at (wrapper alloc) System.Object.AllocVector(intptr,intptr)
  at System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1[T].Rent (System.Int32 minimumLength) [0x0009d] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at System.IO.Stream.InternalCopyTo (System.IO.Stream destination, System.Int32 bufferSize) [0x00005] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at System.IO.Stream.CopyTo (System.IO.Stream destination) [0x00084] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at (wrapper remoting-invoke-with-check) System.IO.Stream.CopyTo(System.IO.Stream)
  at Duplicati.Library.Main.Volumes.FilesetVolumeWriter.AddFilelistFile () [0x00047] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Volumes.FilesetVolumeWriter.Close () [0x00008] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Volumes.FilesetVolumeWriter.Dispose () [0x00000] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Operation.BackupHandler.RunAsync (System.String[] sources, Duplicati.Library.Utility.IFilter filter, System.Threading.CancellationToken token) [0x01033] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at CoCoL.ChannelExtensions.WaitForTaskOrThrow (System.Threading.Tasks.Task task) [0x00050] in <9a758ff4db6c48d6b3d4d0e5c2adf6d1>:0 
  at Duplicati.Library.Main.Operation.BackupHandler.Run (System.String[] sources, Duplicati.Library.Utility.IFilter filter, System.Threading.CancellationToken token) [0x00009] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Controller+<>c__DisplayClass14_0.<Backup>b__0 (Duplicati.Library.Main.BackupResults result) [0x0004b] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Controller.RunAction[T] (T result, System.String[]& paths, Duplicati.Library.Utility.IFilter& filter, System.Action`1[T] method) [0x0026f] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Controller.Backup (System.String[] inputsources, Duplicati.Library.Utility.IFilter filter) [0x00074] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Server.Runner.Run (Duplicati.Server.Runner+IRunnerData data, System.Boolean fromQueue) [0x00353] in <d12ca99c5557481d973bd260fb77853b>:0 
```

```
System.OutOfMemoryException: Insufficient memory to continue the execution of the program.
  at (wrapper alloc) System.Object.AllocVector(intptr,intptr)
  at SharpCompress.Compressors.Deflate.DeflateManager.Initialize (SharpCompress.Compressors.Deflate.ZlibCodec codec, SharpCompress.Compressors.Deflate.CompressionLevel level, System.Int32 windowBits, System.Int32 memLevel, SharpCompress.Compressors.Deflate.CompressionStrategy strategy) [0x000b7] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at SharpCompress.Compressors.Deflate.DeflateManager.Initialize (SharpCompress.Compressors.Deflate.ZlibCodec codec, SharpCompress.Compressors.Deflate.CompressionLevel level, System.Int32 bits, SharpCompress.Compressors.Deflate.CompressionStrategy compressionStrategy) [0x00000] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at SharpCompress.Compressors.Deflate.ZlibCodec._InternalInitializeDeflate (System.Boolean wantRfc1950Header) [0x0002a] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at SharpCompress.Compressors.Deflate.ZlibCodec.InitializeDeflate (SharpCompress.Compressors.Deflate.CompressionLevel level, System.Boolean wantRfc1950Header) [0x00007] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at SharpCompress.Compressors.Deflate.ZlibBaseStream.get_z () [0x0004a] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at SharpCompress.Compressors.Deflate.ZlibBaseStream.end () [0x00000] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at SharpCompress.Compressors.Deflate.ZlibBaseStream.Dispose (System.Boolean disposing) [0x0002c] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at System.IO.Stream.Close () [0x00000] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at System.IO.Stream.Dispose () [0x00000] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at (wrapper remoting-invoke-with-check) System.IO.Stream.Dispose()
  at SharpCompress.Compressors.Deflate.DeflateStream.Dispose (System.Boolean disposing) [0x00015] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at System.IO.Stream.Close () [0x00000] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at System.IO.Stream.Dispose () [0x00000] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at (wrapper remoting-invoke-with-check) System.IO.Stream.Dispose()
  at SharpCompress.Writers.Zip.ZipWriter+ZipWritingStream.Dispose (System.Boolean disposing) [0x0001d] in <5717dfb1db2745ffb30a27e1fee78b19>:0 
  at System.IO.Stream.Close () [0x00000] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at System.IO.Stream.Dispose () [0x00000] in <254335e8c4aa42e3923a8ba0d5ce8650>:0 
  at Duplicati.Library.Main.Volumes.FilesetVolumeWriter.AddFilelistFile () [0x0005e] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Volumes.FilesetVolumeWriter.Close () [0x00008] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Volumes.FilesetVolumeWriter.Dispose () [0x00000] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Operation.BackupHandler.RunAsync (System.String[] sources, Duplicati.Library.Utility.IFilter filter, System.Threading.CancellationToken token) [0x01033] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at CoCoL.ChannelExtensions.WaitForTaskOrThrow (System.Threading.Tasks.Task task) [0x00050] in <9a758ff4db6c48d6b3d4d0e5c2adf6d1>:0 
  at Duplicati.Library.Main.Operation.BackupHandler.Run (System.String[] sources, Duplicati.Library.Utility.IFilter filter, System.Threading.CancellationToken token) [0x00009] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Controller+<>c__DisplayClass14_0.<Backup>b__0 (Duplicati.Library.Main.BackupResults result) [0x0004b] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Controller.RunAction[T] (T result, System.String[]& paths, Duplicati.Library.Utility.IFilter& filter, System.Action`1[T] method) [0x0026f] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Library.Main.Controller.Backup (System.String[] inputsources, Duplicati.Library.Utility.IFilter filter) [0x00074] in <24ac72dcd8164f1d99ab1cdfaa4d4619>:0 
  at Duplicati.Server.Runner.Run (Duplicati.Server.Runner+IRunnerData data, System.Boolean fromQueue) [0x00353] in <d12ca99c5557481d973bd260fb77853b>:0 
```