### PR TITLE
Advance the progress bar when files are skipped. Fixes #3407.

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/FilePreFilterProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FilePreFilterProcess.cs
@@ -41,6 +41,7 @@ namespace Duplicati.Library.Main.Operation.Backup
             new
             {
                 Input = Channels.ProcessedFiles.ForRead,
+                ProgressChannel = Channels.ProgressEvents.ForWrite,
                 Output = Channels.AcceptedChangedFile.ForWrite
             },
 
@@ -81,6 +82,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                     if (tooLargeFile)
                     {
                         Logging.Log.WriteVerboseMessage(FILELOGTAG, "SkipCheckTooLarge", "Skipped checking file, because the size exceeds limit {0}", e.Path);
+                        await self.ProgressChannel.WriteAsync(new ProgressEvent() { Filepath = e.Path, Length = filestatsize, Type = EventType.FileSkipped });
                         continue;
                     }
 
@@ -106,6 +108,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 throw;
                             Logging.Log.WriteWarningMessage(FILELOGTAG, "FailedToAddFile", ex, "Failed while attempting to add unmodified file to database: {0}", e.Path);
                         }
+                        await self.ProgressChannel.WriteAsync(new ProgressEvent() { Filepath = e.Path, Length = filestatsize, Type = EventType.FileSkipped });
                         continue;
                     }
 
@@ -143,6 +146,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                         {
                             Logging.Log.WriteWarningMessage(FILELOGTAG, "FailedToAddFile", ex, "Failed while attempting to add unmodified file to database: {0}", e.Path);
                         }
+                        await self.ProgressChannel.WriteAsync(new ProgressEvent() { Filepath = e.Path, Length = filestatsize, Type = EventType.FileSkipped });
                     }
                 }
             });

--- a/Duplicati/Library/Main/Operation/Backup/ProgressHandler.cs
+++ b/Duplicati/Library/Main/Operation/Backup/ProgressHandler.cs
@@ -73,6 +73,13 @@ namespace Duplicati.Library.Main.Operation.Backup
                             filesStarted.Remove(t.Filepath);
                             fileProgress.Remove(t.Filepath);
                             break;
+                        case EventType.FileSkipped:
+
+                            processedFileCount += 1;
+                            processedFileSize += t.Length;
+
+                            stat.OperationProgressUpdater.UpdatefilesProcessed(processedFileCount, processedFileSize);
+                            break;
                     }
 
                     if (current == null)

--- a/Duplicati/Library/Main/Operation/Common/ProgressEvent.cs
+++ b/Duplicati/Library/Main/Operation/Common/ProgressEvent.cs
@@ -25,7 +25,8 @@ namespace Duplicati.Library.Main.Operation.Common
     {
         FileStarted,
         FileProgressUpdate,
-        FileClosed
+        FileClosed,
+        FileSkipped
     }
 
     /// <summary>


### PR DESCRIPTION
According to the current implementation, the progress bar does not advance
when files are skipped by FilePreFilterProcess. This causes users'
confusion since the web frontend will get stuck at a certain stage for a
long time. This commit addresses this issue.