### PR TITLE
Remove readonly keyword from fields that are set by deserializer

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -226,8 +226,13 @@ namespace Duplicati.GUI.TrayIcon
 
         private class SaltAndNonce
         {
-            public readonly string Salt = null;
-            public readonly string Nonce = null;
+            // ReSharper disable once FieldCanBeMadeReadOnly.Local
+            // This cannot be made readonly as its value is set by a deserializer.
+            public string Salt = null;
+            
+            // ReSharper disable once FieldCanBeMadeReadOnly.Local
+            // This cannot be made readonly as its value is set by a deserializer.
+            public string Nonce = null;
         }
 
         private SaltAndNonce GetSaltAndNonce()


### PR DESCRIPTION
Making these `readonly` resulted in startup issues when a password was set for the UI.

See forum discussion here:

https://forum.duplicati.com/t/after-last-update-duplicati-doesnt-work-anymore/8369