### PR TITLE
Issue warning when backup is cancelled by user

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -30,6 +30,7 @@ using Duplicati.Library.Snapshots;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Common;
+using Duplicati.Library.Logging;
 using Duplicati.Library.Main.Operation.Backup;
 using Duplicati.Library.Main.Operation.Common;
 
@@ -244,6 +245,7 @@ namespace Duplicati.Library.Main.Operation
                 if (token.IsCancellationRequested)
                 {
                     result.PartialBackup = true;
+                    Log.WriteWarningMessage(LOGTAG, "CancellationRequested", null, "Cancellation was requested by user.");
                 }
                 else
                 {


### PR DESCRIPTION
This issues a warning when a backup is cancelled by the user (e.g., by clicking "Stop after current file"). 
 Previously, a yellow warning icon would be displayed but the logs did not contain any details regarding the cause of the warning.

This concerns issue #3982.