### PR TITLE
Only warn if backend delete failure is confirmed

### DIFF
--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -1095,7 +1095,7 @@ namespace Duplicati.Library.Main
 
                 if (isFileMissingException || (wr != null && wr.StatusCode == System.Net.HttpStatusCode.NotFound))
                 {
-                    Logging.Log.WriteWarningMessage(LOGTAG, "DeleteRemoteFileFailed", ex, LC.L("Delete operation failed for {0} with FileNotFound, listing contents", item.RemoteFilename));
+                    Logging.Log.WriteInformationMessage(LOGTAG, "DeleteRemoteFileFailed", LC.L("Delete operation failed for {0} with FileNotFound, listing contents", item.RemoteFilename));
                     bool success = false;
 
                     try
@@ -1108,10 +1108,13 @@ namespace Duplicati.Library.Main
 
                     if (success)
                     {
-                        Logging.Log.WriteInformationMessage(LOGTAG, "DeleteRemoteFileSuccess", LC.L("Listing indicates file {0} is deleted correctly", item.RemoteFilename));
+                        Logging.Log.WriteInformationMessage(LOGTAG, "DeleteRemoteFileSuccess", LC.L("Listing indicates file {0} was deleted correctly", item.RemoteFilename));
                         return;
                     }
-
+                    else
+                    {
+                        Logging.Log.WriteWarningMessage(LOGTAG, "DeleteRemoteFileFailed", ex, LC.L("Listing confirms file {0} was not deleted", item.RemoteFilename));
+                    }
                 }
 
                 result = ex.ToString();

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -218,25 +218,9 @@ namespace Duplicati.Library.Main.Database
             get
             {
                 using (var cmd = m_connection.CreateCommand())
-                using (var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""IsFullBackup"", ""Timestamp"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC"))
-                {
-                    var isFullBackupEncountered = false;
+                using(var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""Timestamp"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC"))
                     while (rd.Read())
-                    {
-                        var id = rd.GetInt64(0);
-                        var isFullBackup = rd.GetInt32(1);
-                        var timeStamp = ParseFromEpochSeconds(rd.GetInt64(2)).ToLocalTime();
-
-                        if (isFullBackupEncountered && isFullBackup != BackupType.FULL_BACKUP) continue;
-
-                        yield return new KeyValuePair<long, DateTime>(id, timeStamp);
-
-                        if (!isFullBackupEncountered && isFullBackup == BackupType.FULL_BACKUP)
-                        {
-                            isFullBackupEncountered = true;
-                        }
-                    }
-                }
+                        yield return new KeyValuePair<long, DateTime>(rd.GetInt64(0), ParseFromEpochSeconds(rd.GetInt64(1)).ToLocalTime());
             }
         }
 

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -363,36 +363,14 @@ namespace Duplicati.Library.Main.Database
 
                     using (var cmd = m_connection.CreateCommand())
                     {
-                        using (var rd =
-                            cmd.ExecuteReader(
-                                @"SELECT DISTINCT ""ID"", ""IsFullBackup"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC ")
-                        )
+                        using (var rd = cmd.ExecuteReader(@"SELECT DISTINCT ""ID"", ""IsFullBackup"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC "))
                         {
-                            // partial backup sets are only included until the first full backup is encountered
-                            var isFullBackupEncountered = false;
                             while (rd.Read())
                             {
                                 var id = rd.GetInt64(0);
-
-                                if (!dict.ContainsKey(id))
-                                {
-                                    continue;
-                                }
-
                                 var backupType = rd.GetInt32(1);
                                 var e = dict[id];
-
-                                if (isFullBackupEncountered && backupType != BackupType.FULL_BACKUP)
-                                {
-                                    continue;
-                                }
-
                                 yield return new Fileset(e, backupType, m_filesets[e].Value, -1L, -1L);
-
-                                if (!isFullBackupEncountered && backupType == BackupType.FULL_BACKUP)
-                                {
-                                    isFullBackupEncountered = true;
-                                }
                             }
                         }
                     }
@@ -421,13 +399,8 @@ namespace Duplicati.Library.Main.Database
                             while (rd.Read())
                             {
                                 var id = rd.GetInt64(0);
-                                if (!dict.ContainsKey(id))
-                                {
-                                    continue;
-                                }
                                 var isFullBackup = rd.GetInt32(1);
                                 var e = dict[id];
-
                                 var filecount = rd.ConvertValueToInt64(2, -1L);
                                 var filesizes = rd.ConvertValueToInt64(3, -1L);
 

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -94,12 +94,13 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(BackupType.PARTIAL_BACKUP, c.List().Filesets.Single(x => x.Version == 0).IsFullBackup);
             }
 
-            // Run a complete backup.  Listing the Filesets should omit the previous partial backup.
+            // Run a complete backup.  Listing the Filesets should include both full and partial backups.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
                 c.Backup(new[] {this.DATAFOLDER});
-                Assert.AreEqual(2, c.List().Filesets.Count());
-                Assert.AreEqual(BackupType.FULL_BACKUP, c.List().Filesets.Single(x => x.Version == 1).IsFullBackup);
+                Assert.AreEqual(3, c.List().Filesets.Count());
+                Assert.AreEqual(BackupType.FULL_BACKUP, c.List().Filesets.Single(x => x.Version == 2).IsFullBackup);
+                Assert.AreEqual(BackupType.PARTIAL_BACKUP, c.List().Filesets.Single(x => x.Version == 1).IsFullBackup);
                 Assert.AreEqual(BackupType.FULL_BACKUP, c.List().Filesets.Single(x => x.Version == 0).IsFullBackup);
             }
 


### PR DESCRIPTION
Current versions of Duplicati will flag the job with a warning when a back-end file deletion results in an exception (fails).  When that happens, Duplicati smartly double checks if this failure is legitimate by doing a directory listing to test for the presence of the file.  If the file is not there, the deletion either worked or is unnecessary.  If the file IS present, then a failure did occur and the exception is thrown.

The problem with the current code is that the Warning flag is set prior to the double checking if the delete failure is valid.  This change moves the Warning so that it only is triggered when the failure is confirmed (the file is still present on the back end).

In my testing this has solved some spurious warning messages I was getting occasionally with backups to the B2 back-end.