### PR TITLE
Fix issues related to partial backups

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -218,25 +218,9 @@ namespace Duplicati.Library.Main.Database
             get
             {
                 using (var cmd = m_connection.CreateCommand())
-                using (var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""IsFullBackup"", ""Timestamp"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC"))
-                {
-                    var isFullBackupEncountered = false;
+                using(var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""Timestamp"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC"))
                     while (rd.Read())
-                    {
-                        var id = rd.GetInt64(0);
-                        var isFullBackup = rd.GetInt32(1);
-                        var timeStamp = ParseFromEpochSeconds(rd.GetInt64(2)).ToLocalTime();
-
-                        if (isFullBackupEncountered && isFullBackup != BackupType.FULL_BACKUP) continue;
-
-                        yield return new KeyValuePair<long, DateTime>(id, timeStamp);
-
-                        if (!isFullBackupEncountered && isFullBackup == BackupType.FULL_BACKUP)
-                        {
-                            isFullBackupEncountered = true;
-                        }
-                    }
-                }
+                        yield return new KeyValuePair<long, DateTime>(rd.GetInt64(0), ParseFromEpochSeconds(rd.GetInt64(1)).ToLocalTime());
             }
         }
 

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -363,36 +363,14 @@ namespace Duplicati.Library.Main.Database
 
                     using (var cmd = m_connection.CreateCommand())
                     {
-                        using (var rd =
-                            cmd.ExecuteReader(
-                                @"SELECT DISTINCT ""ID"", ""IsFullBackup"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC ")
-                        )
+                        using (var rd = cmd.ExecuteReader(@"SELECT DISTINCT ""ID"", ""IsFullBackup"" FROM ""Fileset"" ORDER BY ""Timestamp"" DESC "))
                         {
-                            // partial backup sets are only included until the first full backup is encountered
-                            var isFullBackupEncountered = false;
                             while (rd.Read())
                             {
                                 var id = rd.GetInt64(0);
-
-                                if (!dict.ContainsKey(id))
-                                {
-                                    continue;
-                                }
-
                                 var backupType = rd.GetInt32(1);
                                 var e = dict[id];
-
-                                if (isFullBackupEncountered && backupType != BackupType.FULL_BACKUP)
-                                {
-                                    continue;
-                                }
-
                                 yield return new Fileset(e, backupType, m_filesets[e].Value, -1L, -1L);
-
-                                if (!isFullBackupEncountered && backupType == BackupType.FULL_BACKUP)
-                                {
-                                    isFullBackupEncountered = true;
-                                }
                             }
                         }
                     }

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -399,13 +399,8 @@ namespace Duplicati.Library.Main.Database
                             while (rd.Read())
                             {
                                 var id = rd.GetInt64(0);
-                                if (!dict.ContainsKey(id))
-                                {
-                                    continue;
-                                }
                                 var isFullBackup = rd.GetInt32(1);
                                 var e = dict[id];
-
                                 var filecount = rd.ConvertValueToInt64(2, -1L);
                                 var filesizes = rd.ConvertValueToInt64(3, -1L);
 

--- a/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
@@ -111,6 +111,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 foreach (var p in options.ControlFiles.Split(new char[] {System.IO.Path.PathSeparator}, StringSplitOptions.RemoveEmptyEntries))
                                     fsw.AddControlFile(p, options.GetCompressionHintFromFilename(p));
 
+                            fsw.CreateFilesetFile(false);
                             var newFilesetID = await database.CreateFilesetAsync(fsw.VolumeID, fileTime);
                             await database.LinkFilesetToVolumeAsync(newFilesetID, fsw.VolumeID);
                             await database.AppendFilesFromPreviousSetAsync(null, newFilesetID, prevId, fileTime);

--- a/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
@@ -111,6 +111,8 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 foreach (var p in options.ControlFiles.Split(new char[] {System.IO.Path.PathSeparator}, StringSplitOptions.RemoveEmptyEntries))
                                     fsw.AddControlFile(p, options.GetCompressionHintFromFilename(p));
 
+                            // We declare this to be a partial backup since the synthetic filelist is only created
+                            // when a backup is interrupted.
                             fsw.CreateFilesetFile(false);
                             var newFilesetID = await database.CreateFilesetAsync(fsw.VolumeID, fileTime);
                             await database.LinkFilesetToVolumeAsync(newFilesetID, fsw.VolumeID);

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -254,8 +254,7 @@ namespace Duplicati.Library.Main.Operation
 
                     if (fullVersionsKeptCount < fullVersionsToKeep)
                     {
-                        // count only a full backup
-                        if (fullVersionsKeptCount < fullVersionsToKeep && isFullBackup)
+                        if (isFullBackup)
                         {
                             fullVersionsKeptCount++;
                         }

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -239,16 +239,17 @@ namespace Duplicati.Library.Main.Operation
                     bool isFullBackup = db.IsFilesetFullBackup(backup);
                     if (isFullBackup)
                     {
-                        if (haveFullBackup)
-                        {
-                            toDelete.AddRange(intermediatePartials);
-                            intermediatePartials.Clear();
-                        }
+                        toDelete.AddRange(intermediatePartials);
+                        intermediatePartials.Clear();
                         haveFullBackup = true;
                     }
                     else
                     {
-                        intermediatePartials.Add(backup);
+                        // Only consider a partial backup for deletion if we have already encountered a full backup.
+                        if (haveFullBackup)
+                        {
+                            intermediatePartials.Add(backup);
+                        }
                     }
 
                     if (fullVersionsKeptCount < fullVersionsToKeep)

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -232,7 +232,7 @@ namespace Duplicati.Library.Main.Operation
                 bool haveFullBackup = false;
 
                 // Keep the number of full backups specified in fullVersionsToKeep.
-                // Remove partial backups that are surrounded by full backups.
+                // Remove partial backups that are followed by full backups.
                 // Once enough versions are kept, delete all older backups.
                 foreach (var backup in backupsRemaining)
                 {

--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -212,6 +212,12 @@ namespace Duplicati.Library.Main.Operation
                 AsyncDownloader downloader = new AsyncDownloader(new IRemoteVolume[] {new RemoteVolume(entry.Value.File)}, backendManager);
                 foreach (IAsyncDownloadedFile file in downloader)
                 {
+                    // We must obtain the partial/full status from the fileset file in the dlist files.
+                    // Without this, the restore dialog will show all versions as full, or all versions
+                    // as partial.  While the dlist files are already downloaded elsewhere, doing so again
+                    // here is the most direct way to obtain the partial/full status without a major
+                    // refactoring.  Since restoring directly from the backend files should be a relatively
+                    // rare event, we can work on improving the performance later.
                     VolumeBase.FilesetData filesetData = VolumeReaderBase.GetFilesetData(entry.Value.CompressionModule, file.TempFile, options);
                     list.Add(new ListResultFileset(entry.Key, filesetData.IsFullBackup ? BackupType.FULL_BACKUP : BackupType.PARTIAL_BACKUP, entry.Value.Time.ToLocalTime(), -1, -1));
                 }

--- a/Duplicati/Library/Main/Operation/PurgeFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeFilesHandler.cs
@@ -162,6 +162,7 @@ namespace Duplicati.Library.Main.Operation
                                     var isOriginalFilesetFullBackup = db.IsFilesetFullBackup(tsOriginal);
                                     var newids = tempset.ConvertToPermanentFileset(vol.RemoteFilename, ts, isOriginalFilesetFullBackup);
                                     vol.VolumeID = newids.Item1;
+                                    vol.CreateFilesetFile(isOriginalFilesetFullBackup);
 
                                     Logging.Log.WriteInformationMessage(LOGTAG, "ReplacingFileset", "Replacing fileset {0} with {1} which has with {2} fewer file(s) ({3} reduction)", prevfilename, vol.RemoteFilename, tempset.RemovedFileCount, Library.Utility.Utility.FormatSizeString(tempset.RemovedFileSize));
 

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -147,7 +147,6 @@ namespace Duplicati.UnitTest
                 opts["dbpath"] = DBFILE;
                 opts["blocksize"] = "10kb";
                 opts["backup-test-samples"] = "0";
-                opts["keep-versions"] = "100";
                 opts["unittest-mode"] = "true";
 
                 return opts;

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -175,6 +175,22 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(fifthBackupTime, filesets[0].Time);
                 Assert.AreEqual(BackupType.PARTIAL_BACKUP, filesets[0].IsFullBackup);
             }
+
+            // Run a full backup.
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                this.ModifySourceFiles();
+                c.Backup(new[] {this.DATAFOLDER});
+                DateTime sixthBackupTime = c.List().Filesets.First().Time;
+
+                // Since the last backup was full, we can now expect to have just the 2 most recent full backups.
+                List<IListResultFileset> filesets = c.List().Filesets.ToList();
+                Assert.AreEqual(2, filesets.Count);
+                Assert.AreEqual(fourthBackupTime, filesets[1].Time);
+                Assert.AreEqual(BackupType.FULL_BACKUP, filesets[1].IsFullBackup);
+                Assert.AreEqual(sixthBackupTime, filesets[0].Time);
+                Assert.AreEqual(BackupType.FULL_BACKUP, filesets[0].IsFullBackup);
+            }
         }
 
         [Test]

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -75,7 +75,7 @@ namespace Duplicati.UnitTest
             // Run a partial backup.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                await this.RunPartialBackup(c);
+                await this.RunPartialBackup(c).ConfigureAwait(false);
             }
 
             // Set the keep-time option so that the threshold lies between the first and second backups
@@ -98,7 +98,7 @@ namespace Duplicati.UnitTest
             // even when all the "recent" backups are partial.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                await this.RunPartialBackup(c);
+                await this.RunPartialBackup(c).ConfigureAwait(false);
 
                 // Set the keep-time option so that the threshold lies after the most recent full backup
                 // and run the delete operation.
@@ -129,13 +129,13 @@ namespace Duplicati.UnitTest
             // Run a partial backup.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                await this.RunPartialBackup(c);
+                await this.RunPartialBackup(c).ConfigureAwait(false);
             }
 
             // Run a partial backup.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                await this.RunPartialBackup(c);
+                await this.RunPartialBackup(c).ConfigureAwait(false);
             }
 
             // Run a full backup.
@@ -149,7 +149,7 @@ namespace Duplicati.UnitTest
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
                 options["keep-versions"] = "2";
-                await this.RunPartialBackup(c);
+                await this.RunPartialBackup(c).ConfigureAwait(false);
 
                 // Partial backups that are followed by a full backup can be deleted.
                 List<IListResultFileset> filesets = c.List().Filesets.ToList();
@@ -178,7 +178,7 @@ namespace Duplicati.UnitTest
             // Run a partial backup.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                await this.RunPartialBackup(c);
+                await this.RunPartialBackup(c).ConfigureAwait(false);
 
                 // If we interrupt the backup, the most recent Fileset should be marked as partial.
                 Assert.AreEqual(2, c.List().Filesets.Count());

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -94,12 +94,13 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(BackupType.PARTIAL_BACKUP, c.List().Filesets.Single(x => x.Version == 0).IsFullBackup);
             }
 
-            // Run a complete backup.  Listing the Filesets should omit the previous partial backup.
+            // Run a complete backup.  Listing the Filesets should include both full and partial backups.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
                 c.Backup(new[] {this.DATAFOLDER});
-                Assert.AreEqual(2, c.List().Filesets.Count());
-                Assert.AreEqual(BackupType.FULL_BACKUP, c.List().Filesets.Single(x => x.Version == 1).IsFullBackup);
+                Assert.AreEqual(3, c.List().Filesets.Count());
+                Assert.AreEqual(BackupType.FULL_BACKUP, c.List().Filesets.Single(x => x.Version == 2).IsFullBackup);
+                Assert.AreEqual(BackupType.PARTIAL_BACKUP, c.List().Filesets.Single(x => x.Version == 1).IsFullBackup);
                 Assert.AreEqual(BackupType.FULL_BACKUP, c.List().Filesets.Single(x => x.Version == 0).IsFullBackup);
             }
 

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -88,7 +88,7 @@ namespace Duplicati.UnitTest
             // and run the delete operation.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                options["keep-time"] = $"{(DateTime.Now - firstBackupTime).Seconds - (secondBackupTime - firstBackupTime).Seconds / 2}s";
+                options["keep-time"] = $"{(int) ((DateTime.Now - firstBackupTime).TotalSeconds - (secondBackupTime - firstBackupTime).TotalSeconds / 2)}s";
                 c.Delete();
 
                 List<IListResultFileset> filesets = c.List().Filesets.ToList();


### PR DESCRIPTION
This fixes some issues regarding how we treated partial backups.  Several inconsistencies arose by hiding partial backups from restore lists, etc., which resulted in some backup versions begin inaccessible to certain operations.  The approach here is to treat partial backups almost like full backups, except for some special cases (e.g., in the retention policy so that we do not discard a full backup in favor of a partial one).

Some notable changes:
* For "keep a specific number of backups", a partial backup can be deleted if it is followed by a full backup.
* For a "retention rule" (e.g., `1W:1D,4W:1W,12M:1M`), partials are not removed, and a full backup will not be discarded in favor of a partial one.
* For "delete backups that are older than", backups are kept if they are recent enough.  If all of the recent backups are partial, we continue to keep backup versions until we encounter a full backup.
* When restoring without a local database ("direct restore"), the partial/full state is correctly displayed in the restore list.
* When repairing the database due to missing `dlist` files, the newly created `dlist` files are no longer missing the `fileset` file.
* When recreating `dlist` files after a purge operation, the new `dlist` files are no longer missing the `fileset` file.
* Some simple unit tests were added to verify the behaviors of the various retention strategies.

This addresses issue #3982.
