### PR TITLE
Only warn if backend delete failure is confirmed

### DIFF
--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -1095,7 +1095,7 @@ namespace Duplicati.Library.Main
 
                 if (isFileMissingException || (wr != null && wr.StatusCode == System.Net.HttpStatusCode.NotFound))
                 {
-                    Logging.Log.WriteWarningMessage(LOGTAG, "DeleteRemoteFileFailed", ex, LC.L("Delete operation failed for {0} with FileNotFound, listing contents", item.RemoteFilename));
+                    Logging.Log.WriteInformationMessage(LOGTAG, "DeleteRemoteFileFailed", LC.L("Delete operation failed for {0} with FileNotFound, listing contents", item.RemoteFilename));
                     bool success = false;
 
                     try
@@ -1108,10 +1108,13 @@ namespace Duplicati.Library.Main
 
                     if (success)
                     {
-                        Logging.Log.WriteInformationMessage(LOGTAG, "DeleteRemoteFileSuccess", LC.L("Listing indicates file {0} is deleted correctly", item.RemoteFilename));
+                        Logging.Log.WriteInformationMessage(LOGTAG, "DeleteRemoteFileSuccess", LC.L("Listing indicates file {0} was deleted correctly", item.RemoteFilename));
                         return;
                     }
-
+                    else
+                    {
+                        Logging.Log.WriteWarningMessage(LOGTAG, "DeleteRemoteFileFailed", ex, LC.L("Listing confirms file {0} was not deleted", item.RemoteFilename));
+                    }
                 }
 
                 result = ex.ToString();


### PR DESCRIPTION
Current versions of Duplicati will flag the job with a warning when a back-end file deletion results in an exception (fails). When that happens, Duplicati smartly double checks if this failure is legitimate by doing a directory listing to test for the presence of the file. If the file is not there, the deletion either worked or is unnecessary. If the file IS present, then a failure did occur and the exception is thrown.

The problem with the current code is that the Warning flag is set prior to the double checking if the delete failure is valid. This change moves the Warning so that it only is triggered when the failure is confirmed (the file is still present on the back end).

In my testing this has solved some spurious warning messages I was getting occasionally with backups to the B2 back-end.

Discussion here: https://forum.duplicati.com/t/warning-at-end-of-job-after-upload-retry/8480

Thanks ts678 for assistance with troubleshooting.