### PR TITLE
Fix issue 3971 - Don't store USN journal data for partial backups

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -230,15 +230,18 @@ namespace Duplicati.Library.Main.Operation
                         return false;
                     });
 
-                    // store journal data in database
-                    var data = journalService.VolumeDataList.Where(p => p.JournalData != null).Select(p => p.JournalData).ToList();
-                    if (data.Any())
+                    // store journal data in database, unless job is being canceled
+                    if (!token.IsCancellationRequested)
                     {
-                        // always record change journal data for current fileset (entry may be dropped later if nothing is uploaded)
-                        await database.CreateChangeJournalDataAsync(data);
+                        var data = journalService.VolumeDataList.Where(p => p.JournalData != null).Select(p => p.JournalData).ToList();
+                        if (data.Any())
+                        {
+                            // always record change journal data for current fileset (entry may be dropped later if nothing is uploaded)
+                            await database.CreateChangeJournalDataAsync(data);
 
-                        // update the previous fileset's change journal entry to resume at this point in case nothing was backed up
-                        await database.UpdateChangeJournalDataAsync(data, lastfilesetid);
+                            // update the previous fileset's change journal entry to resume at this point in case nothing was backed up
+                            await database.UpdateChangeJournalDataAsync(data, lastfilesetid);
+                        }
                     }
                 }
 


### PR DESCRIPTION
See issue https://github.com/duplicati/duplicati/issues/3971

When --usn-policy is active, an interrupted backup job can cause the next job to miss files.  This is because the USN journal information is still recorded in the database.  The next time the backup is run, only files changed after that partial backup are processed.

The proposed change prevents journal data from being recorded for partial backups.  The effect is when the next backup starts, Duplicati doesn't find journal data for the previous backup and resorts to the safer filesystem scan.

In my testing this works and solves the issue.