### PR TITLE
Disable file attribute masking on Windows 10

### DIFF
--- a/Duplicati/Library/Main/ProcessController.cs
+++ b/Duplicati/Library/Main/ProcessController.cs
@@ -237,7 +237,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// Expose all filesystem attributes
         /// </summary>
-        private void ExposeAllFilesystemAttributes()
+        private static void ExposeAllFilesystemAttributes()
         {
             // Starting with Windows 10 1803, the operating system may mask the process's view of some
             // file attributes such as reparse, offline, and sparse.

--- a/Duplicati/Library/Main/ProcessController.cs
+++ b/Duplicati/Library/Main/ProcessController.cs
@@ -250,15 +250,11 @@ namespace Duplicati.Library.Main
             {
                 try
                 {
-                    var currentPcm = Win32.RtlQueryProcessPlaceholderCompatibilityMode();
-                    if (currentPcm == Win32.PHCM_VALUES.PHCM_DISGUISE_PLACEHOLDER)
-                    {
-                        Win32.RtlSetProcessPlaceholderCompatibilityMode(Win32.PHCM_VALUES.PHCM_EXPOSE_PLACEHOLDERS);
-                    }
+                    Win32.RtlSetProcessPlaceholderCompatibilityMode(Win32.PHCM_VALUES.PHCM_EXPOSE_PLACEHOLDERS);
                 }
                 catch
                 {
-                    // Ignore exceptions - not supported on this version of Windows
+                    // Ignore exceptions - not applicable on this version of Windows
                 }
             }
         }

--- a/Duplicati/Library/Utility/Win32.cs
+++ b/Duplicati/Library/Utility/Win32.cs
@@ -242,13 +242,6 @@ namespace Duplicati.Library.Utility
         public static extern PROCESS_PRIORITY_CLASS GetPriorityClass(IntPtr handle);
 
         /// <summary>
-        /// Gets the current placeholder compatibility mode for the process.
-        /// </summary>
-        /// <returns>The <see cref="PHCM_VALUES"/> value.</returns>
-        [DllImport("ntdll.dll")]
-        public static extern PHCM_VALUES RtlQueryProcessPlaceholderCompatibilityMode();
-
-        /// <summary>
         /// Sets the current placeholder compatibility mode for the process.
         /// </summary>
         /// <returns>The previous <see cref="PHCM_VALUES"/> value.</returns>

--- a/Duplicati/Library/Utility/Win32.cs
+++ b/Duplicati/Library/Utility/Win32.cs
@@ -170,6 +170,19 @@ namespace Duplicati.Library.Utility
             MaxProcessInfoClass
         }
 
+        /// <summary>
+        /// Placeholder Compatibility Mode values
+        /// </summary>
+        public enum PHCM_VALUES : sbyte
+        {
+            PHCM_APPLICATION_DEFAULT = 0,
+            PHCM_DISGUISE_PLACEHOLDER = 1,
+            PHCM_EXPOSE_PLACEHOLDERS = 2,
+            PHCM_MAX = 2,
+            PHCM_ERROR_INVALID_PARAMETER = -1,
+            PHCM_ERROR_NO_TEB = -2,
+        }
+
         #endregion
 
         #region Function calls
@@ -227,6 +240,22 @@ namespace Duplicati.Library.Utility
         /// <param name="handle">A handle to the process. The handle must have the PROCESS_SET_INFORMATION access right.</param>
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern PROCESS_PRIORITY_CLASS GetPriorityClass(IntPtr handle);
+
+        /// <summary>
+        /// Gets the current placeholder compatibility mode for the process.
+        /// </summary>
+        /// <returns>The <see cref="PHCM_VALUES"/> value.</returns>
+        [DllImport("ntdll.dll")]
+        public static extern PHCM_VALUES RtlQueryProcessPlaceholderCompatibilityMode();
+
+        /// <summary>
+        /// Sets the current placeholder compatibility mode for the process.
+        /// </summary>
+        /// <returns>The previous <see cref="PHCM_VALUES"/> value.</returns>
+        /// <param name="pcm">New value to set.</param>
+        [DllImport("ntdll.dll")]
+        public static extern PHCM_VALUES RtlSetProcessPlaceholderCompatibilityMode(PHCM_VALUES pcm);
+
         #endregion
     }
 }


### PR DESCRIPTION
Fix (partial?) for Issue https://github.com/duplicati/duplicati/issues/3411

Discussion here:  https://forum.duplicati.com/t/exclude-offline-files-broken-with-onedrive/5196/13

Root cause:
Starting with Windows 10 1803, the operating system may mask the process's view of some file attributes such as reparse, offline, and sparse.

See:
https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-rtlqueryprocessplaceholdercompatibilitymode

Proposed change below disables this masking.

Demonstration:

Screen shot showing that the "Offline.txt" file has been flagged in OneDrive as available online only. You can see the cloud icon for its status:
![Capture](https://user-images.githubusercontent.com/39164691/69441564-d6e8db80-0cff-11ea-9fde-a962e2e642d7.PNG)

Now when I run test-filter the file is properly excluded.  Before it was included due to the file attribute masking:
```
Duplicati.CommandLine.exe test-filter "C:\Users\xxx\OneDrive\Test" --exclude-files-attributes=Offline

Including source path: C:\Users\xxx\OneDrive\Test\
Excluding path due to attribute filter: C:\Users\xxx\OneDrive\Test\Offline.txt
Including path as no filters matched: C:\Users\xxx\OneDrive\Test\Online.txt
Matched 1 files (6 bytes)
```

For a full fix of issue 3411 maybe Duplicati defaults need to change to skip Offline files by default? If decision to go that route, I think it should be in a separate PR.