### PR TITLE
Fix long path issue when 259 or 260 characters

### DIFF
--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -35,6 +35,7 @@ namespace Duplicati.Library.Common.IO
 
         private static bool IsPathTooLong(string path)
         {
+            // Use 258 for length check instead of 260 (MAX_PATH) - we need to leave room for the 16-bit (wide) null terminator
             return path.StartsWith(UNCPREFIX, StringComparison.Ordinal) || path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal) || path.Length > 258;
         }
 

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -35,7 +35,7 @@ namespace Duplicati.Library.Common.IO
 
         private static bool IsPathTooLong(string path)
         {
-            return path.StartsWith(UNCPREFIX, StringComparison.Ordinal) || path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal) || path.Length > 260;
+            return path.StartsWith(UNCPREFIX, StringComparison.Ordinal) || path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal) || path.Length > 258;
         }
 
         public static string PrefixWithUNC(string path)


### PR DESCRIPTION
Duplicati currently fails when backing up files or folders that are exactly 259 or 260 characters in length.  The cause appears to be a faulty test used to decide when to use the alternate API.

Right now it tests for `Length > 260` (MAX_PATH), but this doesn't leave room for the null terminator, which is [documented](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation) as counting towards the 260 limit.

Changing the test to `Length > 259` solves some but not all issues.  Because the string type is UTF-16 I believe we need to leave 2 bytes for the null terminator.  Using `Length > 258` as the test resolves all issues in my testing.

Discussion in the forum here:  https://forum.duplicati.com/t/filepath-longer-than-256-bytes-cause-fileaccesserror-under-windows-7

Thanks @ts678 for spotting the root cause and providing a testing formula.