### PR TITLE
Ensure files are selected for restore

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -298,6 +298,12 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
     };
 
     $scope.onStartRestore = function() {
+        if ($scope.Selected.length == 0) {
+            DialogService.dialog(gettextCatalog.getString('No items selected'), gettextCatalog.getString('No items to restore, please select one or more items'));
+            $scope.restore_step = 0;
+			return;
+        }
+
         if ($scope.RestoreLocation == 'custom' && ($scope.RestorePath || '').trim().length == 0)
         {
             DialogService.alert(gettextCatalog.getString('You have chosen to restore to a new location, but not entered one'));

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -298,12 +298,6 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
     };
 
     $scope.onStartRestore = function() {
-        if ($scope.Selected.length == 0) {
-            DialogService.dialog(gettextCatalog.getString('No items selected'), gettextCatalog.getString('No items to restore, please select one or more items'));
-            $scope.restore_step = 0;
-            return;
-        }
-
         if ($scope.RestoreLocation == 'custom' && ($scope.RestorePath || '').trim().length == 0)
         {
             DialogService.alert(gettextCatalog.getString('You have chosen to restore to a new location, but not entered one'));

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -301,7 +301,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
         if ($scope.Selected.length == 0) {
             DialogService.dialog(gettextCatalog.getString('No items selected'), gettextCatalog.getString('No items to restore, please select one or more items'));
             $scope.restore_step = 0;
-			return;
+            return;
         }
 
         if ($scope.RestoreLocation == 'custom' && ($scope.RestorePath || '').trim().length == 0)

--- a/Duplicati/Server/webroot/ngax/templates/restore.html
+++ b/Duplicati/Server/webroot/ngax/templates/restore.html
@@ -12,7 +12,7 @@
         <div class="step step3" ng-class="{active: restore_step == 0}" ng-click="trySetStep(0)">
             <span>3</span>
         </div>
-        <div class="step step4" ng-class="{active: restore_step == 1}" ng-click="trySetStep(1)">
+        <div class="step step4" ng-class="{active: restore_step == 1}" ng-click="onClickNext()">
             <span>4</span>
         </div>
     </div>
@@ -21,7 +21,7 @@
         <li class="step1 not-clickable" translate>Backup location</li>
         <li class="step2 not-clickable" translate>Encryption</li>
         <li ng-class="{active: restore_step == 0}" class="step3" ng-click="trySetStep(0)" translate>Select files</li>
-        <li ng-class="{active: restore_step == 1}" class="step4" ng-click="trySetStep(1)" translate>Restore options</li>
+        <li ng-class="{active: restore_step == 1}" class="step4" ng-click="onClickNext()" translate>Restore options</li>
     </ol>
 
 
@@ -29,14 +29,14 @@
         <div class="step step1" ng-class="{active: restore_step == 0}" ng-click="trySetStep(0)">
             <span>1</span>
         </div>
-        <div class="step step2" ng-class="{active: restore_step == 1}" ng-click="trySetStep(1)">
+        <div class="step step2" ng-class="{active: restore_step == 1}" ng-click="onClickNext()">
             <span>2</span>
         </div>
     </div>
 
     <ol class="steps-legend" ng-hide="IsBackupTemporary || restore_step &gt; 1">
         <li ng-class="{active: restore_step == 0}" class="step1" ng-click="trySetStep(0)" translate>Select files</li>
-        <li ng-class="{active: restore_step == 1}" class="step2" ng-click="trySetStep(1)" translate>Restore options</li>
+        <li ng-class="{active: restore_step == 1}" class="step2" ng-click="onClickNext()" translate>Restore options</li>
     </ol>
 
     <form id="restore" class="styled">


### PR DESCRIPTION
Currently it is possible to submit a restore job without selecting anything to restore.  This causes ALL files to be restored.

To reproduce:

1. In the Web UI, start the restore process either from existing backup set or direct restore.
2. When you get to the Select Files step, do not select anything.
3. Click the Continue button and observe the check that ensures something is selected.
4. Instead click the circled step number for the Restore Options step (2 - in the case of restore from backup set, 4 - in the case of direct restore).
5. Observe that the same check from step 3 was not performed in this case.
6. The job can be submitted and all files will be restored.

The proposed change performs the check when the ~~Restore button is clicked~~ Restore Options step is clicked, but I'm not convinced this is the preferred way to handle it.

Another way to fix this is to disallow clicking the Restore Options step number to force the user to click Continue, similar to how you cannot click Step 3 or 4 when you first start a Direct Restore from files.  I am thinking the latter more consistent with the rest of the UI, but want feedback first.

From my observations in the UI, if `< Previous` button is present you can also click the previous step number directly.  Likewise if `Next >` button is shown, you can directly click the next step number.

Instead if `Continue` or `Connect` is shown, you cannot click future step numbers. If `Back` is shown, you cannot click previous step numbers.

Thoughts?