### PR TITLE
Fix regression with SharePoint backend

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -357,8 +357,6 @@ namespace Duplicati.Library.Backend
                 // but also states that the nextExpectedRanges value returned may indicate multiple ranges...
                 // For now, this plays it safe and does a sequential upload.
                 using (HttpRequestMessage createSessionRequest = new HttpRequestMessage(HttpMethod.Post, string.Format("{0}/root:{1}{2}:/createUploadSession", this.DrivePrefix, this.RootPath, NormalizeSlashes(remotename))))
-                /* Indicate that we want to replace any existing content with this new data we're uploading */
-                using (createSessionRequest.Content = this.PrepareContent(new UploadSession() { Item = new DriveItem() { ConflictBehavior = ConflictBehavior.Replace } }))
                 {
                     using (HttpResponseMessage createSessionResponse = await m_client.SendAsync(createSessionRequest, cancelToken).ConfigureAwait(false))
                     {


### PR DESCRIPTION
In pull request #3989, we set the conflict resolution behavior for creating new items to be `"Replace"`. 
While this worked for OneDrive, SharePoint apparently is case-sensitive and expects `"replace"`. 
Since the default behavior is to replace, we will simply remove the specification to avoid possible conflicts.

See the forum discussion below:

https://forum.duplicati.com/t/bad-request-error-from-request-nameconflictbehavior-must-be-fail-replace-or-rename/8578