### PR TITLE
Add option to disable Update notification

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -86,7 +86,7 @@ namespace Duplicati.Library.AutoUpdater
         /// <summary>
         /// Show UI notification when update is found - default is True
         /// </summary>
-        public static bool ShowUpdateNotification { get { return Duplicati.Library.Utility.Utility.ParseBool(System.Environment.GetEnvironmentVariable(string.Format(UPDATE_NOTIFY_ENVNAME_TEMPLATE, APPNAME)), true); } }
+        public static bool ShowUpdateNotification { get { return Utility.Utility.ParseBool(Environment.GetEnvironmentVariable(string.Format(UPDATE_NOTIFY_ENVNAME_TEMPLATE, APPNAME)), true); } }
 
         /// <summary>
         /// Gets the original directory that this application was installed into

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -77,10 +77,16 @@ namespace Duplicati.Library.AutoUpdater
         private const string RUN_UPDATED_FOLDER_PATH = "AUTOUPDATER_LOAD_UPDATE";
         private const string SLEEP_ENVNAME_TEMPLATE = "AUTOUPDATER_{0}_SLEEP";
         internal const string UPDATE_STRATEGY_ENVNAME_TEMPLATE = "AUTOUPDATER_{0}_POLICY";
+        internal const string UPDATE_NOTIFY_ENVNAME_TEMPLATE = "AUTOUPDATER_{0}_NOTIFY";
         private const string UPDATE_MANIFEST_FILENAME = "autoupdate.manifest";
         private const string README_FILE = "README.txt";
         private const string INSTALL_FILE = "installation.txt";
         private const string CURRENT_FILE = "current";
+
+        /// <summary>
+        /// Show UI notification when update is found - default is True
+        /// </summary>
+        public static bool ShowUpdateNotification { get { return Duplicati.Library.Utility.Utility.ParseBool(System.Environment.GetEnvironmentVariable(string.Format(UPDATE_NOTIFY_ENVNAME_TEMPLATE, APPNAME)), true); } }
 
         /// <summary>
         /// Gets the original directory that this application was installed into

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -850,7 +850,7 @@ namespace Duplicati.Library.AutoUpdater
         {
             string optstr = Environment.GetEnvironmentVariable(string.Format(UPDATE_STRATEGY_ENVNAME_TEMPLATE, APPNAME));
             AutoUpdateStrategy strategy;
-            if (string.IsNullOrWhiteSpace(optstr) || !Enum.TryParse(optstr, out strategy))
+            if (string.IsNullOrWhiteSpace(optstr) || !Enum.TryParse(optstr, true, out strategy))
                 strategy = defaultstrategy;
 
             System.Threading.Thread backgroundChecker = null;

--- a/Duplicati/Server/UpdatePollThread.cs
+++ b/Duplicati/Server/UpdatePollThread.cs
@@ -174,7 +174,7 @@ namespace Duplicati.Server
                             Program.DataConnection.ApplicationSettings.UpdatedVersion = null;
                     }
 
-                    if (Program.DataConnection.ApplicationSettings.UpdatedVersion != null && Duplicati.Library.AutoUpdater.UpdaterManager.TryParseVersion(Program.DataConnection.ApplicationSettings.UpdatedVersion.Version) > System.Reflection.Assembly.GetExecutingAssembly().GetName().Version)
+                    if (Duplicati.Library.AutoUpdater.UpdaterManager.ShowUpdateNotification && Program.DataConnection.ApplicationSettings.UpdatedVersion != null && Duplicati.Library.AutoUpdater.UpdaterManager.TryParseVersion(Program.DataConnection.ApplicationSettings.UpdatedVersion.Version) > System.Reflection.Assembly.GetExecutingAssembly().GetName().Version)
                     {
                         Program.DataConnection.RegisterNotification(
                                     NotificationType.Information,


### PR DESCRIPTION
This adds a new environment variable that can disable the update notification prompt.  Other mechanisms of the update engine are unaffected:  manual check, automatic periodic check, triggering install, etc.

`AUTOUPDATER_Duplicati_NOTIFY`

Defaults to `True` if undefined, so standard Duplicati behavior remains unchanged.
If this environment variable is set to `False`, `No`, `Off`, or `0` then the popup UI notification will be suppressed.

User will still be able to see the version identified in the upgrade check by looking at the web UI About page.

This PR also makes the `AUTOUPDATER_Duplicati_POLICY` check case insensitive.  I noticed it wasn't when I was doing testing.

Can close issue https://github.com/duplicati/duplicati/issues/3983 once merged.