### PR TITLE
Fix spelling errors in comments

### DIFF
--- a/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
+++ b/Duplicati/Library/Backend/CloudFiles/CloudFiles.cs
@@ -152,7 +152,7 @@ namespace Duplicati.Library.Backend
                 }
                 catch (WebException wex)
                 {
-                    if (markerUrl == "") //Only check on first itteration
+                    if (markerUrl == "") //Only check on first iteration
                         if (wex.Response is HttpWebResponse response && response.StatusCode == HttpStatusCode.NotFound)
                             throw new FolderMissingException(wex);
                     
@@ -164,7 +164,7 @@ namespace Duplicati.Library.Backend
 
                 //Perhaps the folder does not exist?
                 //The response should be 404 from the server, but it is not :(
-                if (lst.Count == 0 && markerUrl == "") //Only on first itteration
+                if (lst.Count == 0 && markerUrl == "") //Only on first iteration
                 {
                     try { CreateFolder(); }
                     catch { } //Ignore

--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -218,7 +218,7 @@ namespace Duplicati.Library.Backend
             // Handle XML response. Since we in the constructor demand a folder below the mount point we know the root
             // element must be a "folder", else it could also have been a "mountPoint" (which has a very similar structure).
             // We must check for "deleted" attribute, because files/folders which has it is deleted (attribute contains the timestamp of deletion)
-            // so we treat them as non-existant here.
+            // so we treat them as non-existent here.
             var xRoot = doc.DocumentElement;
             if (xRoot.Attributes["deleted"] != null)
             {
@@ -294,7 +294,7 @@ namespace Duplicati.Library.Backend
             // Handle XML response. Since we in the constructor demand a folder below the mount point we know the root
             // element must be a "folder", else it could also have been a "mountPoint" (which has a very similar structure).
             // We must check for "deleted" attribute, because files/folders which has it is deleted (attribute contains the timestamp of deletion)
-            // so we treat them as non-existant here.
+            // so we treat them as non-existent here.
             var xFile = doc.DocumentElement;
             if (xFile.Attributes["deleted"] != null)
             {

--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHelper.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHelper.cs
@@ -76,7 +76,7 @@ namespace Duplicati.Library
         }
 
         /// <summary>
-        /// Set to true to automatically add the Authorization header to requets
+        /// Set to true to automatically add the Authorization header to requests
         /// </summary>
         public bool AutoAuthHeader { get; set; }
         /// <summary>

--- a/Duplicati/Library/Backend/SharePoint/OneDriveForBusinessBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/OneDriveForBusinessBackend.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Library.Backend
     /// <summary>
     /// Shadow class above SharePointBackend to provide an extra protocol key for OneDrive for Business.
     /// Right now, OneDrive for Business *IS* SharePoint. But if MS turns funny sometimes in the future and 
-    /// moves away from SharePoint as OD4B base, this allows to reimplement it without breaking existing
+    /// moves away from SharePoint as OD4B base, this allows to re-implement it without breaking existing
     /// configurations...
     /// </summary>
     // ReSharper disable once UnusedMember.Global

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -282,7 +282,7 @@ namespace Duplicati.Library.Backend
         /// slash to separate web.
         /// Otherwise it's a good guess to look for "/documents", as we expect
         /// that the default document library is used in the path.
-        /// If that won't help, we will try all possible pathes from longest
+        /// If that won't help, we will try all possible paths from longest
         /// to shortest...
         /// </summary>
         private static string findCorrectWebPath(Utility.Uri orgUrl, System.Net.ICredentials userInfo, out SP.ClientContext retCtx)

--- a/Duplicati/Library/Common/IO/FileEntry.cs
+++ b/Duplicati/Library/Common/IO/FileEntry.cs
@@ -114,7 +114,7 @@ namespace Duplicati.Library.Common.IO
         }
 
         /// <summary>
-        /// Construcs an entry supplying all information
+        /// Constructs an entry supplying all information
         /// </summary>
         /// <param name="filename">The name of the file or folder</param>
         /// <param name="size">The size of the file or folder</param>

--- a/Duplicati/Library/Common/IO/SystemIOLinux.cs
+++ b/Duplicati/Library/Common/IO/SystemIOLinux.cs
@@ -297,7 +297,7 @@ namespace Duplicati.Library.Common.IO
         {
             var p = Path.GetFullPath(path);
 
-            // This should not be required, but some versions of Mono apperently do not strip the trailing slash
+            // This should not be required, but some versions of Mono apparently do not strip the trailing slash
             return p.Length > 1 && p[p.Length - 1] == Path.DirectorySeparatorChar ? p.Substring(0, p.Length - 1) : p;
         }
 

--- a/Duplicati/Library/Compression/SevenZipCompression.cs
+++ b/Duplicati/Library/Compression/SevenZipCompression.cs
@@ -55,7 +55,7 @@ namespace Duplicati.Library.Compression
         /// you may reuse it and have to dispose it yourself.
         /// </summary>
         /// <param name="stream">The stream to read or write depending access mode</param>
-        /// <param name="mode">The archive acces mode</param>
+        /// <param name="mode">The archive access mode</param>
         /// <param name="options">The options passed on the commandline</param>
         public SevenZipCompression(Stream stream, ArchiveMode mode, IDictionary<string, string> options)
         {

--- a/Duplicati/Library/DynamicLoader/DynamicLoader.cs
+++ b/Duplicati/Library/DynamicLoader/DynamicLoader.cs
@@ -57,7 +57,7 @@ namespace Duplicati.Library.DynamicLoader
         protected abstract string[] Subfolders { get; }
 
         /// <summary>
-        /// Construcst a new instance of the dynamic loader,
+        /// Construct a new instance of the dynamic loader,
         ///  does not load anything
         /// </summary>
         protected DynamicLoader()

--- a/Duplicati/Library/Encryption/CryptoStreamWrapper.cs
+++ b/Duplicati/Library/Encryption/CryptoStreamWrapper.cs
@@ -27,7 +27,7 @@ namespace Duplicati.Library.Encryption
         /// <summary>
         /// Wraps a crypto stream, ensuring that it is correctly disposed
         /// </summary>
-        /// <param name="basestream">The stream to wrape</param>
+        /// <param name="basestream">The stream to wrap</param>
         public CryptoStreamWrapper(System.Security.Cryptography.CryptoStream basestream)
             : base(basestream)
         {

--- a/Duplicati/Library/Encryption/EncryptionBase.cs
+++ b/Duplicati/Library/Encryption/EncryptionBase.cs
@@ -24,7 +24,7 @@ using Duplicati.Library.Interface;
 namespace Duplicati.Library.Encryption
 {
     /// <summary>
-    /// Simple helper class that implements the filebased functions, and wraps them onto the stream based ones
+    /// Simple helper class that implements the file-based functions, and wraps them onto the stream based ones
     /// </summary>
     public abstract class EncryptionBase : IEncryption
     {

--- a/Duplicati/Library/Encryption/GPGStreamWrapper.cs
+++ b/Duplicati/Library/Encryption/GPGStreamWrapper.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Library.Encryption
         /// <summary>
         /// Wraps a crypto stream, ensuring that it is correctly disposed
         /// </summary>
-        /// <param name="basestream">The stream to wrape</param>
+        /// <param name="basestream">The stream to wrap</param>
         public GPGStreamWrapper(System.Diagnostics.Process p, System.Threading.Thread t, Stream basestream)
             : base(basestream)
         {

--- a/Duplicati/Library/Interface/CommandLineArgument.cs
+++ b/Duplicati/Library/Interface/CommandLineArgument.cs
@@ -205,7 +205,7 @@ namespace Duplicati.Library.Interface
         /// <param name="type">The argument type</param>
         /// <param name="shortDescription">The arguments short description</param>
         /// <param name="longDescription">The arguments long description</param>
-        /// <param name="defaultValue">The default value of the argumen</param>
+        /// <param name="defaultValue">The default value of the argument</param>
         public CommandLineArgument(string name, ArgumentType type, string shortDescription, string longDescription, string defaultValue)
             : this(name, type, shortDescription, longDescription)
         {
@@ -219,7 +219,7 @@ namespace Duplicati.Library.Interface
         /// <param name="type">The argument type</param>
         /// <param name="shortDescription">The arguments short description</param>
         /// <param name="longDescription">The arguments long description</param>
-        /// <param name="defaultValue">The default value of the argumen</param>
+        /// <param name="defaultValue">The default value of the argument</param>
         /// <param name="aliases">A list of aliases for the command</param>
         public CommandLineArgument(string name, ArgumentType type, string shortDescription, string longDescription, string defaultValue, string[] aliases)
             : this(name, type, shortDescription, longDescription, defaultValue)
@@ -234,7 +234,7 @@ namespace Duplicati.Library.Interface
         /// <param name="type">The argument type</param>
         /// <param name="shortDescription">The arguments short description</param>
         /// <param name="longDescription">The arguments long description</param>
-        /// <param name="defaultValue">The default value of the argumen</param>
+        /// <param name="defaultValue">The default value of the argument</param>
         /// <param name="aliases">A list of aliases for the command</param>
         /// <param name="values">A list of valid values for the command</param>
         public CommandLineArgument(string name, ArgumentType type, string shortDescription, string longDescription, string defaultValue, string[] aliases, string[] values)
@@ -251,7 +251,7 @@ namespace Duplicati.Library.Interface
         /// <param name="type">The argument type</param>
         /// <param name="shortDescription">The arguments short description</param>
         /// <param name="longDescription">The arguments long description</param>
-        /// <param name="defaultValue">The default value of the argumen</param>
+        /// <param name="defaultValue">The default value of the argument</param>
         /// <param name="aliases">A list of aliases for the command</param>
         /// <param name="values">A list of valid values for the command</param>
         /// <param name="deprecationMessage">A message indicating the reason for deprecation and any change suggestions</param>

--- a/Duplicati/Library/Interface/IBackend.cs
+++ b/Duplicati/Library/Interface/IBackend.cs
@@ -27,7 +27,7 @@ namespace Duplicati.Library.Interface
     /// <summary>
     /// The interface all backends must implement.
     /// The classes that implements this interface MUST also 
-    /// implement a default constructor and a construtor that
+    /// implement a default constructor and a constructor that
     /// has the signature new(string url, Dictionary&lt;string, string&gt; options).
     /// The default constructor is used to construct an instance
     /// so the DisplayName and other values can be read.

--- a/Duplicati/Library/Interface/ICompression.cs
+++ b/Duplicati/Library/Interface/ICompression.cs
@@ -134,7 +134,7 @@ namespace Duplicati.Library.Interface
     /// An interface for accessing files in an archive, such as a folder or compressed file.
     /// All modules that implements compression must implement this interface.
     /// The classes that implements this interface MUST also 
-    /// implement a default constructor and a construtor that
+    /// implement a default constructor and a constructor that
     /// has the signature new(string file, Dictionary&lt;string, string&gt; options).
     /// The default constructor is used to construct an instance
     /// so the DisplayName and other values can be read.

--- a/Duplicati/Library/Interface/IConnectionModule.cs
+++ b/Duplicati/Library/Interface/IConnectionModule.cs
@@ -20,7 +20,7 @@ using System;
 namespace Duplicati.Library.Interface
 {
     /// <summary>
-    /// A marker interface that can be addedd to a IGenericModule
+    /// A marker interface that can be added to a IGenericModule
     /// class to indicate that this module is required for the
     /// connections to succeed
     /// </summary>

--- a/Duplicati/Library/Interface/IEncryption.cs
+++ b/Duplicati/Library/Interface/IEncryption.cs
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Interface
     /// Public interface for an encryption method.
     /// All modules that implements encryption must implement this interface.
     /// The classes that implements this interface MUST also 
-    /// implement a default constructor and a construtor that
+    /// implement a default constructor and a constructor that
     /// has the signature new(string passphrase, Dictionary&lt;string, string&gt; options).
     /// The default constructor is used to construct an instance
     /// so the DisplayName and other values can be read.
@@ -59,7 +59,7 @@ namespace Duplicati.Library.Interface
         void Decrypt(string inputfile, string outputfile);
 
         /// <summary>
-        /// Dencrypts the contents of the input stream, and writes the result to the output stream.
+        /// Decrypts the contents of the input stream, and writes the result to the output stream.
         /// </summary>
         /// <param name="input">The stream to decrypt</param>
         /// <param name="output">The decrypted stream</param>

--- a/Duplicati/Library/Interface/IStreamingBackend.cs
+++ b/Duplicati/Library/Interface/IStreamingBackend.cs
@@ -25,7 +25,7 @@ namespace Duplicati.Library.Interface
     /// <summary>
     /// An interface a backend may implement if it supports streaming operations.
     /// Backends that implement this interface can be throttled and correctly shows 
-    /// the progressbar when transfering data.
+    /// the progressbar when transferring data.
     /// </summary>
     public interface IStreamingBackend : IBackend
     {

--- a/Duplicati/Library/Logging/ILogDestination.cs
+++ b/Duplicati/Library/Logging/ILogDestination.cs
@@ -24,7 +24,7 @@ using System.Text;
 namespace Duplicati.Library.Logging
 {
     /// <summary>
-    /// Interface for a loggin destination
+    /// Interface for a log destination
     /// </summary>
     public interface ILogDestination
     {

--- a/Duplicati/Library/Logging/Log.cs
+++ b/Duplicati/Library/Logging/Log.cs
@@ -37,7 +37,7 @@ namespace Duplicati.Library.Logging
         /// </summary>
         Profiling,
         /// <summary>
-        /// Messags that are normally not wanted for display
+        /// Messages that are normally not wanted for display
         /// </summary>
         Verbose,
         /// <summary>
@@ -53,7 +53,7 @@ namespace Duplicati.Library.Logging
         /// </summary>
         DryRun,
         /// <summary>
-        /// The message is a warning, meaning that later errors may be releated to this message
+        /// The message is a warning, meaning that later errors may be related to this message
         /// </summary>
         Warning,
         /// <summary>
@@ -123,7 +123,7 @@ namespace Duplicati.Library.Logging
             var items = new List<string>();
             items.Add("version=" + System.Uri.EscapeDataString(typeof(Log).Assembly.GetName().Version.ToString()));
             items.Add("cli=" + (fromCommandLine ? "t" : "f"));
-            // TOOD: Add OS type? mono version? install id? app-name?
+            // TODO: Add OS type? mono version? install id? app-name?
 
             return items;
         }

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -876,7 +876,7 @@ namespace Duplicati.Library.Main
             }
             finally
             {
-                // Be tidy: manually do some cleanup to temp files, as we could not use using's.
+                // Be tidy: manually do some cleanup to temp files, as we could not use usings.
                 // Unclosed streams should only occur if we failed even before tasks were started.
                 if (dlToStream != null) dlToStream.Dispose();
                 if (dlTarget != null) dlTarget.Dispose();

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -437,7 +437,7 @@ namespace Duplicati.Library.Main
                         // Perform the module shutdown
                         OnOperationComplete(ex);
 
-                        // Log this as a normal operation, as the script rasing the exception,
+                        // Log this as a normal operation, as the script raising the exception,
                         // has already populated either warning or log messages as required
                         Logging.Log.WriteInformationMessage(LOGTAG, "AbortOperation", "Aborting operation by request, requested result: {0}", oae.AbortReason);
 

--- a/Duplicati/Library/Main/Database/HashLookupHelper.cs
+++ b/Duplicati/Library/Main/Database/HashLookupHelper.cs
@@ -49,7 +49,7 @@ namespace Duplicati.Library.Main
         /// if not already found.
         /// </summary>
         /// <param name="hash">The hash to add</param>
-        /// <param name="value">The value assocated with the hash</param>
+        /// <param name="value">The value associated with the hash</param>
         /// <returns>>True if the value was added, false otherwise</returns>
         public bool TryAdd(string hash, long size, T value)
         {
@@ -72,7 +72,7 @@ namespace Duplicati.Library.Main
         /// Adds the specified hash and value to the lookup
         /// </summary>
         /// <param name="hash">The hash to add</param>
-        /// <param name="value">The value assocated with the hash</param>
+        /// <param name="value">The value associated with the hash</param>
         public void Add(string hash, long size, T value)
         {
             var key = DecodeBase64Hash(hash) % m_entries;

--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -51,7 +51,7 @@ namespace Duplicati.Library.Main.Database
         /// It is intended to be used for fast identification of fully restored files to trigger their verification.
         /// It should be read after a commit and truncated after putting the files to a verification queue.
         /// Note: If a file is done once and then set back to a none restored state, the file is not automatically removed.
-        ///       But if it reaches a restored state later, it will be readded (trigger will fire)
+        ///       But if it reaches a restored state later, it will be re-added (trigger will fire)
         /// </remarks>
         public void CreateProgressTracker(bool createFilesNewlyDoneTracker)
         {
@@ -96,7 +96,7 @@ namespace Duplicati.Library.Main.Database
                         + @" SELECT   ""F"".""ID"", IFNULL(COUNT(""B"".""ID""), 0), IFNULL(SUM(""B"".""Size""), 0)"
                         + @"        , IFNULL(COUNT(CASE ""B"".""Restored"" WHEN 1 THEN ""B"".""ID"" ELSE NULL END), 0) "
                         + @"        , IFNULL(SUM(CASE ""B"".""Restored"" WHEN 1 THEN ""B"".""Size"" ELSE 0 END), 0) "
-                        + @"   FROM ""{1}"" ""F"" LEFT JOIN ""{2}"" ""B""" // allow for emtpy files (no data Blocks)
+                        + @"   FROM ""{1}"" ""F"" LEFT JOIN ""{2}"" ""B""" // allow for empty files (no data Blocks)
                         + @"        ON  ""B"".""FileID"" = ""F"".""ID"" "
                         + @"  WHERE ""B"".""Metadata"" IS NOT 1 " // Use "IS" because of Left Join
                         + @"  GROUP BY ""F"".""ID"" "
@@ -717,9 +717,9 @@ namespace Duplicati.Library.Main.Database
                 // Return order from SQLite-DISTINCT is likely to be sorted by Name, which is bad for restore.
                 // If the end of very large files (e.g. iso's) is restored before the beginning, most OS write out zeros to fill the file.
                 // If we manage to get the volumes in an order restoring front blocks first, this can save time.
-                // An optimal algorithm would build a depency net with cycle resolution to find the best near topological
+                // An optimal algorithm would build a dependency net with cycle resolution to find the best near topological
                 // order of volumes, but this is a bit too fancy here.
-                // We will just put a very simlpe heuristic to work, that will try to prefer volumes containing lower block indexes:
+                // We will just put a very simple heuristic to work, that will try to prefer volumes containing lower block indexes:
                 // We just order all volumes by the maximum block index they contain. This query is slow, but should be worth the effort.
                 // Now it is likely to restore all files from front to back. Large files will always be done last.
                 // One could also use like the average block number in a volume, that needs to be measured.

--- a/Duplicati/Library/Main/Enums.cs
+++ b/Duplicati/Library/Main/Enums.cs
@@ -78,7 +78,7 @@ namespace Duplicati.Library.Main
         Verified,
 
         /// <summary>
-        /// Indicattes that the remote volume should be deleted
+        /// Indicates that the remote volume should be deleted
         /// </summary>
         Deleting,
 

--- a/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Main.Operation.Backup
     {
         public static async Task Run(IEnumerable<string> sources, Snapshots.ISnapshotService snapshot, BackupResults result, Options options, IFilter sourcefilter, IFilter filter, Common.ITaskReader taskreader, System.Threading.CancellationToken token)
         {
-            // Make sure we create the enumeration process in a seperate scope,
+            // Make sure we create the enumeration process in a separate scope,
             // but keep the log channel from the parent scope
             using(Logging.Log.StartIsolatingScope(true))
             using (new IsolatedChannelScope())

--- a/Duplicati/Library/Main/Operation/Backup/FilePreFilterProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FilePreFilterProcess.cs
@@ -93,7 +93,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                     // Otherwise we check that the timestamps are different or if any of them are empty
                     var timestampChanged = DISABLEFILETIMECHECK || e.LastWrite != e.OldModified || e.LastWrite.Ticks == 0 || e.OldModified.Ticks == 0;
 
-                    // Avoid generating a new matadata blob if timestamp has not changed
+                    // Avoid generating a new metadata blob if timestamp has not changed
                     // and we only check for timestamp changes
                     if (CHECKFILETIMEONLY && !timestampChanged && !isNewFile)
                     {

--- a/Duplicati/Library/Main/Operation/Backup/MetadataGenerator.cs
+++ b/Duplicati/Library/Main/Operation/Backup/MetadataGenerator.cs
@@ -24,7 +24,7 @@ using Duplicati.Library.Snapshots;
 namespace Duplicati.Library.Main.Operation.Backup
 {
     /// <summary>
-    /// This class encasuplates the generation of metadata for a filesystem entry
+    /// This class encapsulates the generation of metadata for a filesystem entry
     /// </summary>
     internal static class MetadataGenerator
     {

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -79,7 +79,7 @@ namespace Duplicati.Library.Main.Operation
         /// <param name="options">The options used</param>
         /// <param name="database">The database to compare with</param>
         /// <param name="log">The log instance to use</param>
-        /// <param name="protectedfile">A filename that should be excempted for deletion</param>
+        /// <param name="protectedfile">A filename that should be exempted for deletion</param>
         public static void VerifyRemoteList(BackendManager backend, Options options, LocalDatabase database, IBackendWriter log, string protectedfile = null)
         {
             var tp = RemoteListAnalysis(backend, options, database, log, protectedfile);
@@ -187,7 +187,7 @@ namespace Duplicati.Library.Main.Operation
         /// <param name="backend">The backend instance to use</param>
         /// <param name="options">The options used</param>
         /// <param name="database">The database to compare with</param>
-        /// <param name="protectedfile">A filename that should be excempted for deletion</param>
+        /// <param name="protectedfile">A filename that should be exempted for deletion</param>
         public static RemoteAnalysisResult RemoteListAnalysis(BackendManager backend, Options options, LocalDatabase database, IBackendWriter log, string protectedfile)
         {
             var rawlist = backend.List();

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1081,7 +1081,7 @@ namespace Duplicati.Library.Main
         }
 
         /// <summary>
-        /// Gets the temporary folder to use for asyncronous transfers
+        /// Gets the temporary folder to use for asynchronous transfers
         /// </summary>
         public string AsynchronousUploadFolder
         {
@@ -1975,7 +1975,7 @@ namespace Duplicati.Library.Main
         }
 
         /// <summary>
-        /// Class for handling a single RententionPolicy timeframe-interval-pair
+        /// Class for handling a single RetentionPolicy timeframe-interval-pair
         /// </summary>
         public class RetentionPolicyValue
         {
@@ -2003,7 +2003,7 @@ namespace Duplicati.Library.Main
             /// <returns></returns>
             public Boolean IsUnlimtedTimeframe()
             {
-                // Timeframes equal or bigger than the maximum TimeSpan effectivly represent an unlimited timeframe
+                // Timeframes equal or bigger than the maximum TimeSpan effectively represent an unlimited timeframe
                 return Timeframe >= TimeSpan.MaxValue;
             }
 
@@ -2024,7 +2024,7 @@ namespace Duplicati.Library.Main
             }
 
             /// <summary>
-            /// Parses a string representation of a timeframe-interval-pair and returns a RentionPolicyValue object
+            /// Parses a string representation of a timeframe-interval-pair and returns a RetentionPolicyValue object
             /// </summary>
             /// <returns></returns>
             public static RetentionPolicyValue CreateFromString(string rententionPolicyValueString)
@@ -2032,7 +2032,7 @@ namespace Duplicati.Library.Main
                 var periodInterval = rententionPolicyValueString.Split(':');
 
                 TimeSpan timeframe;
-                // Timeframe "U" (= Unlimited) means: For unlimted time keep one version every X interval.
+                // Timeframe "U" (= Unlimited) means: For unlimited time keep one version every X interval.
                 // So the timeframe has to span the maximum time possible.
                 if (String.Equals(periodInterval[0], "U", StringComparison.OrdinalIgnoreCase))
                 {

--- a/Duplicati/Library/Main/ProcessController.cs
+++ b/Duplicati/Library/Main/ProcessController.cs
@@ -139,7 +139,7 @@ namespace Duplicati.Library.Main
         }
 
         /// <summary>
-        /// Activates the process bacground IO priority
+        /// Activates the process background IO priority
         /// </summary>
         private void ActivateBackgroundIOPriority()
         {

--- a/Duplicati/Library/Main/ProgressClasses.cs
+++ b/Duplicati/Library/Main/ProgressClasses.cs
@@ -22,7 +22,7 @@ using Duplicati.Library.Logging;
 namespace Duplicati.Library.Main
 {
     /// <summary>
-    /// Interface for recieving messages from the Duplicati operations
+    /// Interface for receiving messages from the Duplicati operations
     /// </summary>
     public interface IMessageSink : Logging.ILogDestination
     {

--- a/Duplicati/Library/Modules/Builtin/HttpOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HttpOptions.cs
@@ -54,7 +54,7 @@ namespace Duplicati.Library.Modules.Builtin
 		private IDisposable m_httpsettings;
 
         /// <summary>
-        /// The handle to the call-contet oauth setttings
+        /// The handle to the call-context oauth settings
         /// </summary>
 		private IDisposable m_oauthsettings;
 
@@ -169,7 +169,7 @@ namespace Duplicati.Library.Modules.Builtin
             bool disableExpect100 = Utility.Utility.ParseBoolOption(commandlineOptions, OPTION_DISABLE_EXPECT100);
 
             // TODO: This is done to avoid conflicting settings,
-            // but ideally, we should run each operation in a seperate
+            // but ideally, we should run each operation in a separate
             // app-domain to ensure that multiple invocations of this module
             // does not interfere, as the options are shared in the app-domain
             m_resetNagle = commandlineOptions.ContainsKey(OPTION_DISABLE_NAGLING);

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -150,7 +150,7 @@ namespace Duplicati.Library.Modules.Builtin
         /// </summary>
         protected string m_parsedresultlevel = string.Empty;
         /// <summary>
-        /// The maxmimum number of log lines to include
+        /// The maximum number of log lines to include
         /// </summary>
         protected int m_maxmimumLogLines;
 

--- a/Duplicati/Library/Modules/Builtin/RunScript.cs
+++ b/Duplicati/Library/Modules/Builtin/RunScript.cs
@@ -314,7 +314,7 @@ namespace Duplicati.Library.Modules.Builtin
                     {
                         string line = rawline.Trim();
                         if (!line.StartsWith("--", StringComparison.Ordinal))
-                            continue; //Ingore anything that does not start with --
+                            continue; //Ignore anything that does not start with --
 
                         line = line.Substring(2);
                         int lix = line.IndexOf('=');

--- a/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
+++ b/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
@@ -32,7 +32,7 @@ namespace Duplicati.Library.SQLiteHelper
     /// This class will read embedded files from the given folder.
     /// Updates should have the form &quot;1.Sample upgrade.sql&quot;.
     /// When the database schema changes, simply put a new file into the folder
-    /// and set it to be emnbedded in the binary.
+    /// and set it to be embedded in the binary.
     /// 
     /// Additionally, it's possible to execute custom code before and after 
     /// the SQL is executed. To set up a custom upgrade stage, add your
@@ -236,7 +236,7 @@ namespace Duplicati.Library.SQLiteHelper
                 }
 
                 //On a new database, we just load the most current schema, and upgrade from there
-                //This avoids potentitally lenghty upgrades
+                //This avoids potentially lengthy upgrades
                 if (dbversion == -1)
                 {
                     cmd.CommandText = PreparseSQL(schema, preparserVars);

--- a/Duplicati/Library/Snapshots/ISnapshotService.cs
+++ b/Duplicati/Library/Snapshots/ISnapshotService.cs
@@ -61,7 +61,7 @@ namespace Duplicati.Library.Snapshots
         /// Returns the size of a file
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
-        /// <returns>The lenth of the file</returns>
+        /// <returns>The length of the file</returns>
         long GetFileSize(string localPath);
 
         /// <summary>

--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -438,7 +438,7 @@ namespace Duplicati.Library.Snapshots
         /// Returns the size of a file
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
-        /// <returns>The lenth of the file</returns>
+        /// <returns>The length of the file</returns>
         public override long GetFileSize(string localPath)
         {
             return new System.IO.FileInfo(ConvertToSnapshotPath(localPath)).Length;

--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -50,7 +50,7 @@ namespace Duplicati.Library.Snapshots
         /// Returns the size of a file
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
-        /// <returns>The lenth of the file</returns>
+        /// <returns>The length of the file</returns>
         public override long GetFileSize (string localPath)
         {
             return SystemIO.IO_WIN.FileLength(localPath);

--- a/Duplicati/Library/Snapshots/SnapshotBase.cs
+++ b/Duplicati/Library/Snapshots/SnapshotBase.cs
@@ -87,7 +87,7 @@ namespace Duplicati.Library.Snapshots
         /// Returns the size of a file
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
-        /// <returns>The lenth of the file</returns>
+        /// <returns>The length of the file</returns>
         public virtual long GetFileSize(string localPath)
         {
             return new FileInfo(localPath).Length;

--- a/Duplicati/Library/Snapshots/SnapshotUtility.cs
+++ b/Duplicati/Library/Snapshots/SnapshotUtility.cs
@@ -45,7 +45,7 @@ namespace Duplicati.Library.Snapshots
             
         }
 
-        // The two loader methods below guard agains the type system attempting to load types
+        // The two loader methods below guard against the type system attempting to load types
         // related to the OS specific implementations which may not be present for
         // the operation system we are not running on (i.e. prevent loading AlphaVSS on Linux)
 

--- a/Duplicati/Library/Snapshots/USNJournal.cs
+++ b/Duplicati/Library/Snapshots/USNJournal.cs
@@ -370,7 +370,7 @@ namespace Duplicati.Library.Snapshots
                 UsnJournalID = m_journal.UsnJournalID
             };
 
-            var bufferSize = 4096; // larger buffer returns more record, but pervents user from cancelling operation for a longer time
+            var bufferSize = 4096; // larger buffer returns more record, but prevents user from cancelling operation for a longer time
             while (readData.StartUsn < m_journal.NextUsn)
             {
                 if (!Win32USN.ControlWithInput(m_volumeHandle, Win32USN.FsCtl.ReadUSNJournal,

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -257,7 +257,7 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="files">Files to filter</param>
         /// <param name="filter">Exclusion filter</param>
-        /// <param name="cache">Cache of included and exculded files / folders</param>
+        /// <param name="cache">Cache of included and excluded files / folders</param>
         /// <param name="errorCallback"></param>
         /// <returns>Filtered files</returns>
         private IEnumerable<string> FilterExcludedFiles(IEnumerable<string> files,

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -211,7 +211,7 @@ namespace Duplicati.Library.Snapshots
         /// Returns the size of a file
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
-        /// <returns>The lenth of the file</returns>
+        /// <returns>The length of the file</returns>
         public override long GetFileSize(string localPath)
         {
             return SystemIO.IO_WIN.FileLength(ConvertToSnapshotPath(localPath));

--- a/Duplicati/Library/UsageReporter/OSInfoHelper.cs
+++ b/Duplicati/Library/UsageReporter/OSInfoHelper.cs
@@ -93,7 +93,7 @@ namespace Duplicati.Library.UsageReporter
                 }
                 else
                 {
-                    // Manual extraction, this grabs the distro identication files directly
+                    // Manual extraction, this grabs the distro identification files directly
                     try
                     {
                         var keys = new List<Tuple<string, string>>();

--- a/Duplicati/Library/UsageReporter/ReportSet.cs
+++ b/Duplicati/Library/UsageReporter/ReportSet.cs
@@ -86,7 +86,7 @@ namespace Duplicati.Library.UsageReporter
 
         static ReportSet()
         {
-            // Keep it here to avoid crasing
+            // Keep it here to avoid crashing
             // if the loader fails to grab an ID
             try { DoInitUID(); }
             catch { }

--- a/Duplicati/Library/UsageReporter/Reporter.cs
+++ b/Duplicati/Library/UsageReporter/Reporter.cs
@@ -162,7 +162,7 @@ namespace Duplicati.Library.UsageReporter
         }
 
         /// <summary>
-        /// The maxmimum allowed report level
+        /// The maximum allowed report level
         /// </summary>
         /// <value>The type of the max report.</value>
         private static ReportType MaxReportLevel

--- a/Duplicati/Library/Utility/AsyncHttpRequest.cs
+++ b/Duplicati/Library/Utility/AsyncHttpRequest.cs
@@ -182,7 +182,7 @@ namespace Duplicati.Library.Utility
         }
             
         /// <summary>
-        /// Wrapper class for getting request and respone objects in a async manner
+        /// Wrapper class for getting request and response objects in a async manner
         /// </summary>
         private class AsyncWrapper
         {

--- a/Duplicati/Library/Utility/BlockingQueue.cs
+++ b/Duplicati/Library/Utility/BlockingQueue.cs
@@ -201,7 +201,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// Dequeues an element from the queue
         /// </summary>
-        /// <returns>The dequed element or default(T) if there are no more elements</returns>
+        /// <returns>The dequeued element or default(T) if there are no more elements</returns>
         public T Dequeue()
         {
             while(true)

--- a/Duplicati/Library/Utility/DirectStreamLink.cs
+++ b/Duplicati/Library/Utility/DirectStreamLink.cs
@@ -331,7 +331,7 @@ namespace Duplicati.Library.Utility
         }
 
 
-        /// <summary> The class for readig from DirectStreamLink. </summary>
+        /// <summary> The class for reading from DirectStreamLink. </summary>
         private class LinkedReaderStream : LinkedSubStream
         {
             public LinkedReaderStream(DirectStreamLink linkStream)

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -177,7 +177,7 @@ namespace Duplicati.Library.Utility
             }
             
             /// <summary>
-            /// Tests whether specified string can be matched agains provided pattern string. Pattern may contain single- and multiple-replacing
+            /// Tests whether specified string can be matched against provided pattern string. Pattern may contain single- and multiple-replacing
             /// wildcard characters.
             /// </summary>
             /// <param name="input">String which is matched against the pattern.</param>

--- a/Duplicati/Library/Utility/ThrottledStream.cs
+++ b/Duplicati/Library/Utility/ThrottledStream.cs
@@ -29,7 +29,7 @@ namespace Duplicati.Library.Utility
 {
     /// <summary>
     /// This class throttles the rate data can be read or written to the underlying stream.
-    /// This creates a bandwith throttle option for any stream, including a network stream.
+    /// This creates a bandwidth throttle option for any stream, including a network stream.
     /// </summary>
     public class ThrottledStream : OverrideableStream
     {
@@ -245,7 +245,7 @@ namespace Duplicati.Library.Utility
 				if (target_delay.Ticks > 1000)
 				{
 					// With large changes, we avoid sleeping for several minutes
-					// This makes the throttling more resposive when increasing the
+					// This makes the throttling more responsive when increasing the
 					// throughput, even with large changes
 					var ms = (int)Math.Min(target_delay.TotalMilliseconds, 2 * 1000);
 					System.Threading.Thread.Sleep(ms);

--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -26,7 +26,7 @@ namespace Duplicati.Library.Utility
     /// <summary>
     /// Represents a relaxed parsing of a URL.
     /// The goal is to cover as many types of url's as possible,
-    /// without being ambiguos.
+    /// without being ambiguous.
     /// The major limitations is that an embedded username may not contain a :,
     /// and the password may not contain a @.
     /// </summary>
@@ -77,7 +77,7 @@ namespace Duplicati.Library.Utility
         private NameValueCollection m_queryParams;
 
         /// <summary>
-        /// Gets the paramters in the query string
+        /// Gets the parameters in the query string
         /// </summary>
         /// <value>The query parameters.</value>
         public NameValueCollection QueryParameters
@@ -489,7 +489,7 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>The generated querystring</returns>
         /// <param name="query">A collection of name value pairs to be translated into a query string that is
-        /// ampsersand delimited.</param>
+        /// ampersand delimited.</param>
         public static string BuildUriQuery(NameValueCollection query)
         {
             return BuildUriQuery(query, "&");

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -499,7 +499,7 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <param name="stream">The stream to read</param>
         /// <param name="buf">The buffer to read into</param>
-        /// <param name="count">The amout of bytes to read</param>
+        /// <param name="count">The amount of bytes to read</param>
         /// <returns>The actual number of bytes read</returns>
         public static int ForceStreamRead(Stream stream, byte[] buf, int count)
         {
@@ -522,7 +522,7 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <param name="stream">The stream to read.</param>
         /// <param name="buf">The buffer to read into.</param>
-        /// <param name="count">The amout of bytes to read.</param>
+        /// <param name="count">The amount of bytes to read.</param>
         /// <returns>The number of bytes read</returns>
         public static async Task<int> ForceStreamReadAsync(this System.IO.Stream stream, byte[] buf, int count)
         {
@@ -833,7 +833,7 @@ namespace Duplicati.Library.Utility
                     var str = Environment.GetEnvironmentVariable("FILESYSTEM_CASE_SENSITIVE");
 
                     // TODO: This should probably be determined by filesystem rather than OS,
-                    // OSX can actually have the disks formated as Case Sensitive, but insensitive is default
+                    // OSX can actually have the disks formatted as Case Sensitive, but insensitive is default
                     CachedIsFSCaseSensitive = ParseBool(str, () => Platform.IsClientPosix && !Platform.IsClientOSX);
                 }
 
@@ -1147,7 +1147,7 @@ namespace Duplicati.Library.Utility
         /// <param name="filter">A filter applied to properties to decide if they are omitted or not</param>
         /// <param name="recurseobjects">A value indicating if non-primitive values are recursed</param>
         /// <param name="indentation">The string indentation</param>
-        /// <param name="visited">A lookup table with visited objects, used to avoid inifinite recursion</param>
+        /// <param name="visited">A lookup table with visited objects, used to avoid infinite recursion</param>
         /// <param name="collectionlimit">The maximum number of items to report from an IEnumerable instance</param>
         public static void PrintSerializeObject(object item, TextWriter writer, Func<System.Reflection.PropertyInfo, object, bool> filter = null, bool recurseobjects = false, int indentation = 0, int collectionlimit = 0, Dictionary<object, object> visited = null)
         {

--- a/Duplicati/Library/Utility/WorkerThread.cs
+++ b/Duplicati/Library/Utility/WorkerThread.cs
@@ -83,7 +83,7 @@ namespace Duplicati.Library.Utility
         /// </summary>
         public event Action<WorkerThread<Tx>, Tx, Exception> OnError;
         /// <summary>
-        /// An evnet that occurs when a new task is added to the queue or an existing one is removed
+        /// An event that occurs when a new task is added to the queue or an existing one is removed
         /// </summary>
         public event Action<WorkerThread<Tx>> WorkQueueChanged;
 

--- a/Duplicati/Server/Database/Backup.cs
+++ b/Duplicati/Server/Database/Backup.cs
@@ -128,7 +128,7 @@ namespace Duplicati.Server.Database
         }
 
         /// <summary>
-        /// Sanitizes the settings from any fields in the PassworldFields list.
+        /// Sanitizes the settings from any fields in the PasswordFields list.
         /// </summary>
         public void SanitizeSettings()
         {

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -29,7 +29,7 @@ namespace Duplicati.Server
         private static readonly string DATAFOLDER_ENV_NAME = Duplicati.Library.AutoUpdater.AutoUpdateSettings.AppName.ToUpper(CultureInfo.InvariantCulture) + "_HOME";
 
         /// <summary>
-        /// The environment variable that holdes the database key used to encrypt the SQLite database
+        /// The environment variable that holds the database key used to encrypt the SQLite database
         /// </summary>
         private static readonly string DB_KEY_ENV_NAME = Duplicati.Library.AutoUpdater.AutoUpdateSettings.AppName.ToUpper(CultureInfo.InvariantCulture) + "_DB_KEY";
 
@@ -109,7 +109,7 @@ namespace Duplicati.Server
         public static readonly System.Threading.ManualResetEvent ServerStartedEvent = new System.Threading.ManualResetEvent(false);
 
         /// <summary>
-        /// The status event signaler, used to controll long polling of status updates
+        /// The status event signaler, used to control long polling of status updates
         /// </summary>
         public static readonly EventPollNotify StatusEventNotifyer = new EventPollNotify();
 

--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -53,7 +53,7 @@ namespace Duplicati.Server
         /// </summary>
         private readonly AutoResetEvent m_event;
         /// <summary>
-        /// The data syncronization lock
+        /// The data synchronization lock
         /// </summary>
         private readonly object m_lock = new object();
 
@@ -151,7 +151,7 @@ namespace Duplicati.Server
             while (res < firstdate && i-- > 0)
                 res = Timeparser.ParseTimeInterval(repetition, res);
 
-            // If we arived somewhere after the first allowed date
+            // If we arrived somewhere after the first allowed date
             if (res >= firstdate)
             {
                 var ts = Timeparser.ParseTimeSpan(repetition);
@@ -295,7 +295,7 @@ namespace Duplicati.Server
                                 }
                             }
 
-                            //Caluclate next time, by finding the first entry later than now
+                            // Calculate next time, by finding the first entry later than now
                             try
                             {
                                 start = GetNextValidTime(start, new DateTime(Math.Max(DateTime.UtcNow.AddSeconds(1).Ticks, start.AddSeconds(1).Ticks), DateTimeKind.Utc), sc.Repeat, sc.AllowedDays);

--- a/Duplicati/Server/SingleInstance.cs
+++ b/Duplicati/Server/SingleInstance.cs
@@ -87,7 +87,7 @@ namespace Duplicati.Server
         /// <summary>
         /// The delegate that is used to inform the first instance of the second invocation
         /// </summary>
-        /// <param name="commandlineargs">The commandlinearguments for the second invocation</param>
+        /// <param name="commandlineargs">The command-line arguments for the second invocation</param>
         public delegate void SecondInstanceDelegate(string[] commandlineargs);
 
         /// <summary>

--- a/Duplicati/Server/WebServer/RESTMethods/ServerState.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/ServerState.cs
@@ -29,7 +29,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             if (info.LongPollCheck(Program.StatusEventNotifyer, ref id, out isError))
             {
-                //Make sure we do not report a higher number than the eventnotifyer says
+                //Make sure we do not report a higher number than the eventnotifier says
                 var st = new Serializable.ServerStatus();
                 st.LastEventID = id;
                 info.OutputOK(st);

--- a/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
@@ -54,7 +54,7 @@ namespace Duplicati.Server.WebServer
         private readonly bool FULLY_DISABLED;
 
         /// <summary>
-        /// Re-evealuate the logins periodically to ensure it is still valid
+        /// Re-evaluate the logins periodically to ensure it is still valid
         /// </summary>
         private readonly TimeSpan CACHE_TIMEOUT = TimeSpan.FromMinutes(3);
 

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -46,7 +46,7 @@ namespace Duplicati.UnitTest
         /// </summary>
         protected readonly string RESTOREFOLDER = Path.Combine(BASEFOLDER, "restored");
         /// <summary>
-        /// The log file for manual examiniation
+        /// The log file for manual examination
         /// </summary>
         protected readonly string LOGFILE = Path.Combine(BASEFOLDER, "logfile.log");
         /// <summary>


### PR DESCRIPTION
This fixes several spelling errors in comments.  I tried to only fix obvious ones and did not address differences due to spelling preferences of different English speaking locales.

In doing so, this also normalized several line endings.