### PR TITLE
Fix SKIP_UPDATE check

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -56,7 +56,7 @@ namespace Duplicati.Library.AutoUpdater
             ? System.IO.Path.GetDirectoryName(Duplicati.Library.Utility.Utility.getEntryAssembly().Location)
             : Environment.ExpandEnvironmentVariables(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)));
 
-        private static readonly bool DISABLE_UPDATE_DOMAIN = !string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable(string.Format(SKIPUPDATE_ENVNAME_TEMPLATE, APPNAME)));
+        private static readonly bool DISABLE_UPDATE_DOMAIN = Utility.Utility.ParseBool(Environment.GetEnvironmentVariable(string.Format(SKIPUPDATE_ENVNAME_TEMPLATE, APPNAME)), false);
 
         public static bool RequiresRespawn { get; set; }
 


### PR DESCRIPTION
As discussed in separate PR https://github.com/duplicati/duplicati/pull/4017

Currently `DISABLE_UPDATE_DOMAIN` is set to `True` when `AUTOUPDATER_Duplicati_SKIP_UPDATE` is set to any value.

This changes it so that it is parsed like any other boolean option. The default is `False` unless `AUTOUPDATER_Duplicati_SKIP_UPDATE` is set to one of the following:  `True`, `On`, `Yes`, or `1`.