### PR TITLE
Fix issue 4028 - Unable to restore file permissions on Windows

### DIFF
--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -23,6 +23,7 @@ using System.Linq;
 
 using AlphaFS = Alphaleonis.Win32.Filesystem;
 using Duplicati.Library.Interface;
+using Newtonsoft.Json;
 
 namespace Duplicati.Library.Common.IO
 {
@@ -59,11 +60,19 @@ namespace Duplicati.Library.Common.IO
 
         private class FileSystemAccess
         {
+            // Use JsonProperty Attribute to allow readonly fields to be set by deserializer
+            // https://github.com/duplicati/duplicati/issues/4028
+            [JsonProperty]
             public readonly FileSystemRights Rights;
+            [JsonProperty]
             public readonly AccessControlType ControlType;
+            [JsonProperty]
             public readonly string SID;
+            [JsonProperty]
             public readonly bool Inherited;
+            [JsonProperty]
             public readonly InheritanceFlags Inheritance;
+            [JsonProperty]
             public readonly PropagationFlags Propagation;
 
             public FileSystemAccess()


### PR DESCRIPTION
Fix issue https://github.com/duplicati/duplicati/issues/4028

File permissions are not restored on Windows. Instead the following error is produced for each file:

```
- [Warning-Duplicati.Library.Main.Operation.RestoreHandler-MetadataWriteFailed]: 
Failed to apply metadata to file: \"D:\\PATH\\FILE", 
message: Value cannot be null.\r\nParameter name: sddlForm"
```

Bug introduced in 2.0.4.32 by PR https://github.com/duplicati/duplicati/pull/3953/
Read only fields not settable by deserializer.

Adding `[JsonProperty]` overcomes this as an alternative to removing `readonly`.