### PR TITLE
Back up and restore inheritance breaks

### DIFF
--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -101,17 +101,6 @@ namespace Duplicati.Library.Common.IO
             }
         }
 
-        private class FileSystemAccessProtected
-        {
-            [JsonProperty]
-            public readonly bool IsProtected;
-
-            public FileSystemAccessProtected(bool Protected)
-            {
-                IsProtected = Protected;
-            }
-        }
-
         private static Newtonsoft.Json.JsonSerializer _cachedSerializer;
 
         private Newtonsoft.Json.JsonSerializer Serializer
@@ -498,7 +487,7 @@ namespace Duplicati.Library.Common.IO
                 objs.Add(new FileSystemAccess((FileSystemAccessRule)f));
 
             dict["win-ext:accessrules"] = SerializeObject(objs);
-            dict["win-ext:accessrulesprotected"] = SerializeObject(new FileSystemAccessProtected(rules.AreAccessRulesProtected));
+            dict["win-ext:accessrulesprotected"] = rules.AreAccessRulesProtected.ToString();
 
             return dict;
         }
@@ -514,10 +503,10 @@ namespace Duplicati.Library.Common.IO
 
                 if (data.ContainsKey("win-ext:accessrulesprotected"))
                 {
-                    var content = DeserializeObject<FileSystemAccessProtected>(data["win-ext:accessrulesprotected"]);
-                    if (rules.AreAccessRulesProtected != content.IsProtected)
+                    bool IsProtected = bool.Parse(data["win-ext:accessrulesprotected"]);
+                    if (rules.AreAccessRulesProtected != IsProtected)
                     {
-                        rules.SetAccessRuleProtection(content.IsProtected, false);
+                        rules.SetAccessRuleProtection(IsProtected, false);
                     }
                 }
 

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -503,10 +503,10 @@ namespace Duplicati.Library.Common.IO
 
                 if (data.ContainsKey("win-ext:accessrulesprotected"))
                 {
-                    bool IsProtected = bool.Parse(data["win-ext:accessrulesprotected"]);
-                    if (rules.AreAccessRulesProtected != IsProtected)
+                    bool isProtected = bool.Parse(data["win-ext:accessrulesprotected"]);
+                    if (rules.AreAccessRulesProtected != isProtected)
                     {
-                        rules.SetAccessRuleProtection(IsProtected, false);
+                        rules.SetAccessRuleProtection(isProtected, false);
                     }
                 }
 

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -106,9 +106,9 @@ namespace Duplicati.Library.Common.IO
             [JsonProperty]
             public readonly bool IsProtected;
 
-            public FileSystemAccessProtected(bool isProtected)
+            public FileSystemAccessProtected(bool Protected)
             {
-                IsProtected = isProtected;
+                IsProtected = Protected;
             }
         }
 

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -508,9 +508,10 @@ namespace Duplicati.Library.Common.IO
             var isDirTarget = path.EndsWith(DIRSEP, StringComparison.Ordinal);
             var targetpath = isDirTarget ? path.Substring(0, path.Length - 1) : path;
 
-            FileSystemSecurity rules = isDirTarget ? GetAccessControlDir(targetpath) : GetAccessControlFile(targetpath);
             if (restorePermissions)
             {
+                FileSystemSecurity rules = isDirTarget ? GetAccessControlDir(targetpath) : GetAccessControlFile(targetpath);
+
                 if (data.ContainsKey("win-ext:accessrulesprotected"))
                 {
                     var content = DeserializeObject<FileSystemAccessProtected>(data["win-ext:accessrulesprotected"]);
@@ -544,12 +545,12 @@ namespace Duplicati.Library.Common.IO
 
                     if (ex != null)
                         throw ex;
-
-                    if (isDirTarget)
-                        SetAccessControlDir(targetpath, (DirectorySecurity)rules);
-                    else
-                        SetAccessControlFile(targetpath, (FileSecurity)rules);
                 }
+
+                if (isDirTarget)
+                    SetAccessControlDir(targetpath, (DirectorySecurity)rules);
+                else
+                    SetAccessControlFile(targetpath, (FileSecurity)rules);
             }
         }
 


### PR DESCRIPTION
When Duplicati backs up ACLs on Windows, it does not record information related to inheritance breaks.  When restoring files with ACLs this causes incorrect results for files or folders where inheritance was originally broken.

With the below change, inheritance break states are backed up with the file/folder metadata.  When restoring, the inheritance break state is restored just before the ACL.

I have done some testing and it works well for me, but would really like some others to test.