### PR TITLE
Add tests to verify fileset files after purge and repair operations

### DIFF
--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -115,6 +115,29 @@ namespace Duplicati.UnitTest
             Assert.AreEqual(2, backupTypes.Length);
             Assert.AreEqual(BackupType.FULL_BACKUP, backupTypes[1]);
             Assert.AreEqual(BackupType.PARTIAL_BACKUP, backupTypes[0]);
+
+            // Remove the dlist files.
+            foreach (string dlistFile in dlistFiles)
+            {
+                File.Delete(dlistFile);
+            }
+
+            // Run a repair and verify that the fileset file exists in the new dlist files.
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                c.Repair();
+                List<IListResultFileset> filesets = c.List().Filesets.ToList();
+                Assert.AreEqual(2, filesets.Count);
+                Assert.AreEqual(BackupType.FULL_BACKUP, filesets.Single(x => x.Version == 1).IsFullBackup);
+                Assert.AreEqual(BackupType.PARTIAL_BACKUP, filesets.Single(x => x.Version == 0).IsFullBackup);
+
+                backupTypeMap = GetBackupTypesFromRemoteFiles(c, out _);
+            }
+
+            backupTypes = backupTypeMap.OrderByDescending(x => x.Key).Select(x => x.Value).ToArray();
+            Assert.AreEqual(2, backupTypes.Length);
+            Assert.AreEqual(BackupType.FULL_BACKUP, backupTypes[1]);
+            Assert.AreEqual(BackupType.PARTIAL_BACKUP, backupTypes[0]);
         }
 
         [Test]


### PR DESCRIPTION
This add tests to verify the validity of the `fileset` file inside the `dlist` file in the two situations:
* Prior to revision 51b4ecfb28deb549e666ad1cdf51927a72f0abc0, the `fileset` file was missing after a purge operation.
* Prior to revision 0cfce6be39df91e09cd6f352c6f000cc2ee14c6c, the `fileset` file was missing after  a repair operation.

This concerns issues that were raised in #3982.