### PR TITLE
Add test for listing filesets without local database

### DIFF
--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -195,6 +195,35 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Disruption")]
+        public async Task ListWithoutLocalDb()
+        {
+            // Choose a dblock size that is small enough so that more than one volume is needed.
+            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "10mb",
+                ["no-local-db"] = "true"
+            };
+
+            // Run a full backup.
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                c.Backup(new[] {this.DATAFOLDER});
+            }
+
+            // Run a partial backup.
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                await this.RunPartialBackup(c).ConfigureAwait(false);
+
+                List<IListResultFileset> filesets = c.List().Filesets.ToList();
+                Assert.AreEqual(2, filesets.Count);
+                Assert.AreEqual(BackupType.FULL_BACKUP, filesets[1].IsFullBackup);
+                Assert.AreEqual(BackupType.PARTIAL_BACKUP, filesets[0].IsFullBackup);
+            }
+        }
+
+        [Test]
+        [Category("Disruption")]
         public async Task RetentionPolicyRetention()
         {
             Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions)


### PR DESCRIPTION
This adds a test to verify the backup type associated with the filesets obtained when performing a list operation without the local database.

Prior to revision 8ab64071f006033c64e2f8acc3682230e915e2fe, all filesets would have been marked as partial when performing a direct restore without the local database.

This concerns issues that were raised in #3982.