### PR TITLE
Add test for restoring permissions with inheritance breaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         directories:
           - $BUILD_DIR
       script:
-        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption
+        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler
 
     - stage: tests
       cache:

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DisruptionTests.cs" />
+    <Compile Include="RestoreHandlerTests.cs" />
     <Compile Include="SVNCheckoutsTest.cs" />
     <Compile Include="GeneralBlackBoxTesting.cs" />
     <Compile Include="CommandLineOperationsTests.cs" />

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -1,0 +1,63 @@
+using Duplicati.Library.Common;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.AccessControl;
+
+namespace Duplicati.UnitTest
+{
+    public class RestoreHandlerTests : BasicSetupHelper
+    {
+        [Test]
+        [Category("RestoreHandler")]
+        public void RestoreInheritanceBreaks()
+        {
+            if (!Platform.IsClientWindows)
+            {
+                return;
+            }
+
+            string folderPath = Path.Combine(this.DATAFOLDER, "folder");
+            Directory.CreateDirectory(folderPath);
+            string filePath = Path.Combine(folderPath, "file");
+            File.WriteAllBytes(filePath, new byte[] {0});
+
+            // Protect access rules on the file.
+            FileSecurity fileSecurity = File.GetAccessControl(filePath);
+            fileSecurity.SetAccessRuleProtection(true, true);
+            File.SetAccessControl(filePath, fileSecurity);
+
+            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions);
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                c.Backup(new[] {this.DATAFOLDER});
+            }
+
+            // First, restore without restoring permissions.
+            Dictionary<string, string> restoreOptions = new Dictionary<string, string>(this.TestOptions) {["restore-path"] = this.RESTOREFOLDER};
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+            {
+                c.Restore(new[] {filePath});
+                string restoredFilePath = Path.Combine(this.RESTOREFOLDER, "file");
+                Assert.IsTrue(File.Exists(restoredFilePath));
+
+                FileSecurity restoredFileSecurity = File.GetAccessControl(restoredFilePath);
+                Assert.IsFalse(restoredFileSecurity.AreAccessRulesProtected);
+            }
+
+            // Restore with restoring permissions.
+            restoreOptions["overwrite"] = "true";
+            restoreOptions["restore-permissions"] = "true";
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+            {
+                c.Restore(new[] {filePath});
+                string restoredFilePath = Path.Combine(this.RESTOREFOLDER, "file");
+                Assert.IsTrue(File.Exists(restoredFilePath));
+
+                FileSecurity restoredFileSecurity = File.GetAccessControl(restoredFilePath);
+                Assert.IsTrue(restoredFileSecurity.AreAccessRulesProtected);
+            }
+        }
+    }
+}

--- a/pipeline/start.sh
+++ b/pipeline/start.sh
@@ -8,5 +8,5 @@ ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNormal
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNoSize
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Border
-${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption
+${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler
 


### PR DESCRIPTION
This adds a simple test for restoring permissions with inheritance breaks on Windows.

This concerns pull request #4031.  Some related discussion occurs in issue #4028.