### PR TITLE
Windows Filters cleanup

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -324,7 +324,7 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"*/Microsoft*/Windows/Cookies*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/MSOCache*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/NTUSER*");
-                yield return FilterGroups.CreateWildcardFilter(@"*UsrClass.dat*");
+                yield return FilterGroups.CreateWildcardFilter(@"*/UsrClass.dat");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/hiberfil.sys");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/pagefile.sys");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/swapfile.sys");

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -324,12 +324,13 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"*/Microsoft*/Windows/Cookies*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/MSOCache*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/NTUSER*");
-                yield return FilterGroups.CreateWildcardFilter(@"*/$RECYCLE.BIN/");
-                yield return FilterGroups.CreateWildcardFilter(@"*/RECYCLER/");
                 yield return FilterGroups.CreateWildcardFilter(@"*UsrClass.dat*");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/hiberfil.sys");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/pagefile.sys");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/swapfile.sys");
+                yield return FilterGroups.CreateWildcardFilter(@"?:/$RECYCLE.BIN/");
+                yield return FilterGroups.CreateWildcardFilter(@"?:/RECYCLED/");
+                yield return FilterGroups.CreateWildcardFilter(@"?:/RECYCLER/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/System Volume Information/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Installer*");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Temp*");

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -582,7 +582,7 @@ namespace Duplicati.Library.Utility
 
                 // Duplicati matches filters against folder paths exactly.
                 // Meaning a filter for 'C:\Windows' won't match 'C:\Windows\'.
-                // So this makes sure special folder's filters have a trailing directory separator.
+                // So this makes sure special folder filters have a trailing directory separator.
                 // (Alternatively, this could append '*' to all folder filters.)
                 return Common.IO.Util.AppendDirSeparator(filter);
             }

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -332,7 +332,7 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"?:/RECYCLED/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/RECYCLER/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/System Volume Information/");
-                yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Installer*");
+                yield return FilterGroups.CreateWildcardFilter(FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.Windows) + "Installer/");
 
                 foreach (var s in GetWindowsRegistryFilters() ?? new string[0])
                 {

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -333,7 +333,6 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"?:/RECYCLER/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/System Volume Information/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Installer*");
-                yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Temp*");
 
                 foreach (var s in GetWindowsRegistryFilters() ?? new string[0])
                 {

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -324,6 +324,7 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"*/Microsoft*/Windows/Cookies*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/MSOCache*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/NTUSER*");
+                yield return FilterGroups.CreateWildcardFilter(@"*/$RECYCLE.BIN/");
                 yield return FilterGroups.CreateWildcardFilter(@"*/RECYCLER/");
                 yield return FilterGroups.CreateWildcardFilter(@"*UsrClass.dat*");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/hiberfil.sys");
@@ -396,7 +397,6 @@ namespace Duplicati.Library.Utility
 
             if (group.HasFlag(FilterGroup.TemporaryFiles))
             {
-                yield return FilterGroups.CreateWildcardFilter(@"*/$RECYCLE.BIN/");
                 yield return FilterGroups.CreateWildcardFilter(@"*.tmp");
                 yield return FilterGroups.CreateWildcardFilter(@"*.tmp/");
                 yield return FilterGroups.CreateWildcardFilter(@"*/AppData/Local/Temp*");

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -582,7 +582,7 @@ namespace Duplicati.Library.Utility
 
                 // Duplicati matches filters against folder paths exactly.
                 // Meaning a filter for 'C:\Windows' won't match 'C:\Windows\'.
-                // So this makes sure special folder's filter's have a trailing directory separator.
+                // So this makes sure special folder's filters have a trailing directory separator.
                 // (Alternatively, this could append '*' to all folder filters.)
                 return Common.IO.Util.AppendDirSeparator(filter);
             }

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -328,9 +328,9 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"?:/hiberfil.sys");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/pagefile.sys");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/swapfile.sys");
-                yield return FilterGroups.CreateWildcardFilter(@"?:/$RECYCLE.BIN/");
-                yield return FilterGroups.CreateWildcardFilter(@"?:/RECYCLED/");
-                yield return FilterGroups.CreateWildcardFilter(@"?:/RECYCLER/");
+                yield return FilterGroups.CreateWildcardFilter(@"?:/$Recycle.Bin/");
+                yield return FilterGroups.CreateWildcardFilter(@"?:/Recycled/");
+                yield return FilterGroups.CreateWildcardFilter(@"?:/Recycler/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/System Volume Information/");
                 yield return FilterGroups.CreateWildcardFilter(FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.Windows) + "Installer/");
 

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -334,7 +334,6 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"?:/System Volume Information/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Installer*");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Temp*");
-                yield return FilterGroups.CreateWildcardFilter(@"*/ntuser.dat*");
 
                 foreach (var s in GetWindowsRegistryFilters() ?? new string[0])
                 {

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -401,7 +401,7 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"*/AppData/Local/Temp*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/AppData/Temp*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/Local Settings/Temp*");
-                yield return FilterGroups.CreateWildcardFilter(@"?:/Windows/Temp*");
+                yield return FilterGroups.CreateWildcardFilter(FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.Windows) + "Temp/");
             }
 
             if (group.HasFlag(FilterGroup.Applications))

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -351,7 +351,6 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"?:/autoexec.bat");
                 yield return FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.System);
                 yield return FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.SystemX86);
-                yield return FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.Windows);
                 yield return FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.Recent);
 
                 var windir = FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.Windows);


### PR DESCRIPTION
Changed hard-coded `/Windows` paths to use Environment.SpecialFolder instead.
Moved `Recycle.Bin` filter to SystemFiles for consistency (that's where `Recycler` was).
Added `Recycled` - used for FAT volumes on some OS versions.
Removed some filter duplication.

I was also going to change AppData to use SpecialFolder, but then realized this may not be ideal as it would only return the current user's AppData folder.  Leaving the paths hard coded (with wildcards) will match all users AppData folders.