### PR TITLE
improve speed of indexing in RecoveryTool

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -58,9 +58,6 @@ namespace Duplicati.CommandLine.RecoveryTool
                 return 100;
             }
 
-            Console.Write("Sorting index file ...");
-            Index.SortFile(ixfile, ixfile);
-            Console.WriteLine(" done!");
 
             string filelist;
             if (args.Count == 2)


### PR DESCRIPTION
I noticed Duplicati is not a good tool for huge backups over 1TB. Restoring is very slow (weeks). 
The RecoveryTool especially is not optimized. No multi threading and the algorithms don't use efficient data structures. 
One thing that was unbearably slow was the index command. It would accumulate lines in the index.txt and for each file it would merge the sorted index (which at some point was 700mb of lines) with it.
I changed this behaviour so it's using a SortedSet which always keeps the lines sorted. Indexing was done in a couple of minutes instead of weeks. The disadvantage is, the datastructure has to fit in memory. But I guess for most people it would be an improvement. 