### PR TITLE
Fix exceptions caused by Stop Now

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -439,7 +439,7 @@ namespace Duplicati.Library.Main.Database
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Blockset"" WHERE ""ID"" IN ({0})", bsIdsSubQuery));
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""BlocksetEntry"" WHERE ""BlocksetID"" IN ({0})", bsIdsSubQuery));
 
-                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""BlocklistHash"" WHERE ""Hash"" IN (SELECT ""Hash"" FROM ""Block"" WHERE ""VolumeID"" IN ({0}))", volIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""BlocklistHash"" WHERE ""BlocklistHash"".""BlocksetID"" IN ({0})", bsIdsSubQuery));
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Block"" WHERE ""VolumeID"" IN ({0})", volIdsSubQuery));
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""DeletedBlock"" WHERE ""VolumeID"" IN ({0})", volIdsSubQuery));
 

--- a/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
@@ -108,10 +108,12 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 }
 
                                 var uploadRequest = new VolumeUploadRequest(blockvolume, blockEntry, indexVolumeCopy, options, database);
-                                await self.Output.WriteAsync(uploadRequest);
 
                                 blockvolume = null;
                                 indexvolume = null;
+
+                                // Write to output at the end here to prevent sending a full volume to the SpillCollector
+                                await self.Output.WriteAsync(uploadRequest);
                             }
 
                         }

--- a/Duplicati/Library/Utility/RegistryUtility.cs
+++ b/Duplicati/Library/Utility/RegistryUtility.cs
@@ -36,7 +36,7 @@ namespace Duplicati.Library.Utility
                 }
 
                 var lmParentKey = Registry.LocalMachine.OpenSubKey(parentKeyName, RegistryKeyPermissionCheck.ReadSubTree);
-                return lmParentKey.GetValue(name).ToString();
+                return lmParentKey?.GetValue(name).ToString();
             }
             catch
             {


### PR DESCRIPTION
The LocalDatabase class was deleting from the BlocklistHash table based on the volume id of blocks. The deletes for the Blockset and BlocksetEntry tables were using a union query which included the same query the BlocklistHash delete was using. Changed the BlocklistHash delete query to use the union as well to ensure that all three tables would use the same query to delete the necessary rows. This fixes the "Detected non-empty blocksets with no associated blocks!" error.

Moved a write call in the DataBlockProcessor to send a volume for upload after setting blockvolume to null. This prevents a null reference exception because otherwise it would be sent to the SpillCollector and it tries to add a block, but the volume has already been closed.

Added the ? operator to the RegistryUtility class to prevent a null reference exception while debugging. It was annoying catching it in the debugger.

Fixes #4037