### PR TITLE
Fix bug when performing repair with missing dindex files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         directories:
           - $BUILD_DIR
       script:
-        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler
+        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler,RepairHandler
 
     - stage: tests
       cache:

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -309,138 +309,134 @@ namespace Duplicati.Library.Main.Operation
                             }
                             else if (n.Type == RemoteVolumeType.Index)
                             {
-                                using (IndexVolumeWriter w = new IndexVolumeWriter(m_options))
+                                IndexVolumeWriter w = new IndexVolumeWriter(m_options);
+                                newEntry = w;
+                                w.SetRemoteFilename(n.Name);
+
+                                var h = Library.Utility.HashAlgorithmHelper.Create(m_options.BlockHashAlgorithm);
+
+                                foreach (var blockvolume in db.GetBlockVolumesFromIndexName(n.Name))
                                 {
-                                    newEntry = w;
-                                    w.SetRemoteFilename(n.Name);
+                                    w.StartVolume(blockvolume.Name);
+                                    var volumeid = db.GetRemoteVolumeID(blockvolume.Name);
 
-                                    var h = Library.Utility.HashAlgorithmHelper.Create(m_options.BlockHashAlgorithm);
+                                    foreach (var b in db.GetBlocks(volumeid))
+                                        w.AddBlock(b.Hash, b.Size);
 
-                                    foreach (var blockvolume in db.GetBlockVolumesFromIndexName(n.Name))
-                                    {
-                                        w.StartVolume(blockvolume.Name);
-                                        var volumeid = db.GetRemoteVolumeID(blockvolume.Name);
+                                    w.FinishVolume(blockvolume.Hash, blockvolume.Size);
 
-                                        foreach (var b in db.GetBlocks(volumeid))
-                                            w.AddBlock(b.Hash, b.Size);
+                                    if (m_options.IndexfilePolicy == Options.IndexFileStrategy.Full)
+                                        foreach (var b in db.GetBlocklists(volumeid, m_options.Blocksize, hashsize))
+                                        {
+                                            var bh = Convert.ToBase64String(h.ComputeHash(b.Item2, 0, b.Item3));
+                                            if (bh != b.Item1)
+                                                throw new Exception(string.Format("Internal consistency check failed, generated index block has wrong hash, {0} vs {1}", bh, b.Item1));
 
-                                        w.FinishVolume(blockvolume.Hash, blockvolume.Size);
+                                            w.WriteBlocklist(b.Item1, b.Item2, 0, b.Item3);
+                                        }
+                                }
 
-                                        if (m_options.IndexfilePolicy == Options.IndexFileStrategy.Full)
-                                            foreach (var b in db.GetBlocklists(volumeid, m_options.Blocksize, hashsize))
-                                            {
-                                                var bh = Convert.ToBase64String(h.ComputeHash(b.Item2, 0, b.Item3));
-                                                if (bh != b.Item1)
-                                                    throw new Exception(string.Format("Internal consistency check failed, generated index block has wrong hash, {0} vs {1}", bh, b.Item1));
+                                w.Close();
 
-                                                w.WriteBlocklist(b.Item1, b.Item2, 0, b.Item3);
-                                            }
-                                    }
-
-                                    w.Close();
-
-                                    if (m_options.Dryrun)
-                                        Logging.Log.WriteDryrunMessage(LOGTAG, "WouldReUploadIndexFile", "would re-upload index file {0}, with size {1}, previous size {2}", n.Name, Library.Utility.Utility.FormatSizeString(new System.IO.FileInfo(w.LocalFilename).Length), Library.Utility.Utility.FormatSizeString(n.Size));
-                                    else
-                                    {
-                                        db.UpdateRemoteVolume(w.RemoteFilename, RemoteVolumeState.Uploading, -1, null, null);
-                                        backend.Put(w);
-                                    }
+                                if (m_options.Dryrun)
+                                    Logging.Log.WriteDryrunMessage(LOGTAG, "WouldReUploadIndexFile", "would re-upload index file {0}, with size {1}, previous size {2}", n.Name, Library.Utility.Utility.FormatSizeString(new System.IO.FileInfo(w.LocalFilename).Length), Library.Utility.Utility.FormatSizeString(n.Size));
+                                else
+                                {
+                                    db.UpdateRemoteVolume(w.RemoteFilename, RemoteVolumeState.Uploading, -1, null, null);
+                                    backend.Put(w);
                                 }
                             }
                             else if (n.Type == RemoteVolumeType.Blocks)
                             {
-                                using (BlockVolumeWriter w = new BlockVolumeWriter(m_options))
+                                BlockVolumeWriter w = new BlockVolumeWriter(m_options);
+                                newEntry = w;
+                                w.SetRemoteFilename(n.Name);
+
+                                using (var mbl = db.CreateBlockList(n.Name))
                                 {
-                                    newEntry = w;
-                                    w.SetRemoteFilename(n.Name);
-
-                                    using (var mbl = db.CreateBlockList(n.Name))
+                                    //First we grab all known blocks from local files
+                                    foreach (var block in mbl.GetSourceFilesWithBlocks(m_options.Blocksize))
                                     {
-                                        //First we grab all known blocks from local files
-                                        foreach (var block in mbl.GetSourceFilesWithBlocks(m_options.Blocksize))
+                                        var hash = block.Hash;
+                                        var size = (int) block.Size;
+
+                                        foreach (var source in block.Sources)
                                         {
-                                            var hash = block.Hash;
-                                            var size = (int) block.Size;
+                                            var file = source.File;
+                                            var offset = source.Offset;
 
-                                            foreach (var source in block.Sources)
-                                            {
-                                                var file = source.File;
-                                                var offset = source.Offset;
-
-                                                try
-                                                {
-                                                    if (System.IO.File.Exists(file))
-                                                        using (var f = System.IO.File.OpenRead(file))
-                                                        {
-                                                            f.Position = offset;
-                                                            if (size == Library.Utility.Utility.ForceStreamRead(f, buffer, size))
-                                                            {
-                                                                var newhash = Convert.ToBase64String(blockhasher.ComputeHash(buffer, 0, size));
-                                                                if (newhash == hash)
-                                                                {
-                                                                    if (mbl.SetBlockRestored(hash, size))
-                                                                        w.AddBlock(hash, buffer, 0, size, Duplicati.Library.Interface.CompressionHint.Default);
-                                                                    break;
-                                                                }
-                                                            }
-                                                        }
-                                                }
-                                                catch (Exception ex)
-                                                {
-                                                    Logging.Log.WriteErrorMessage(LOGTAG, "FileAccessError", ex, "Failed to access file: {0}", file);
-                                                }
-                                            }
-                                        }
-
-                                        //Then we grab all remote volumes that have the missing blocks
-                                        foreach (var vol in new AsyncDownloader(mbl.GetMissingBlockSources().ToList(), backend))
-                                        {
                                             try
                                             {
-                                                using (var tmpfile = vol.TempFile)
-                                                using (var f = new BlockVolumeReader(RestoreHandler.GetCompressionModule(vol.Name), tmpfile, m_options))
-                                                    foreach (var b in f.Blocks)
-                                                        if (mbl.SetBlockRestored(b.Key, b.Value))
-                                                            if (f.ReadBlock(b.Key, buffer) == b.Value)
-                                                                w.AddBlock(b.Key, buffer, 0, (int) b.Value, Duplicati.Library.Interface.CompressionHint.Default);
+                                                if (System.IO.File.Exists(file))
+                                                    using (var f = System.IO.File.OpenRead(file))
+                                                    {
+                                                        f.Position = offset;
+                                                        if (size == Library.Utility.Utility.ForceStreamRead(f, buffer, size))
+                                                        {
+                                                            var newhash = Convert.ToBase64String(blockhasher.ComputeHash(buffer, 0, size));
+                                                            if (newhash == hash)
+                                                            {
+                                                                if (mbl.SetBlockRestored(hash, size))
+                                                                    w.AddBlock(hash, buffer, 0, size, Duplicati.Library.Interface.CompressionHint.Default);
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
                                             }
                                             catch (Exception ex)
                                             {
-                                                Logging.Log.WriteErrorMessage(LOGTAG, "RemoteFileAccessError", ex, "Failed to access remote file: {0}", vol.Name);
+                                                Logging.Log.WriteErrorMessage(LOGTAG, "FileAccessError", ex, "Failed to access file: {0}", file);
                                             }
                                         }
+                                    }
 
-                                        // If we managed to recover all blocks, NICE!
-                                        var missingBlocks = mbl.GetMissingBlocks().Count();
-                                        if (missingBlocks > 0)
+                                    //Then we grab all remote volumes that have the missing blocks
+                                    foreach (var vol in new AsyncDownloader(mbl.GetMissingBlockSources().ToList(), backend))
+                                    {
+                                        try
                                         {
-                                            Logging.Log.WriteInformationMessage(LOGTAG, "RepairMissingBlocks", "Repair cannot acquire {0} required blocks for volume {1}, which are required by the following filesets: ", missingBlocks, n.Name);
-                                            foreach (var f in mbl.GetFilesetsUsingMissingBlocks())
-                                                Logging.Log.WriteInformationMessage(LOGTAG, "AffectedFilesetName", f.Name);
+                                            using (var tmpfile = vol.TempFile)
+                                            using (var f = new BlockVolumeReader(RestoreHandler.GetCompressionModule(vol.Name), tmpfile, m_options))
+                                                foreach (var b in f.Blocks)
+                                                    if (mbl.SetBlockRestored(b.Key, b.Value))
+                                                        if (f.ReadBlock(b.Key, buffer) == b.Value)
+                                                            w.AddBlock(b.Key, buffer, 0, (int) b.Value, Duplicati.Library.Interface.CompressionHint.Default);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            Logging.Log.WriteErrorMessage(LOGTAG, "RemoteFileAccessError", ex, "Failed to access remote file: {0}", vol.Name);
+                                        }
+                                    }
 
-                                            var recoverymsg = string.Format("If you want to continue working with the database, you can use the \"{0}\" and \"{1}\" commands to purge the missing data from the database and the remote storage.", "list-broken-files", "purge-broken-files");
+                                    // If we managed to recover all blocks, NICE!
+                                    var missingBlocks = mbl.GetMissingBlocks().Count();
+                                    if (missingBlocks > 0)
+                                    {
+                                        Logging.Log.WriteInformationMessage(LOGTAG, "RepairMissingBlocks", "Repair cannot acquire {0} required blocks for volume {1}, which are required by the following filesets: ", missingBlocks, n.Name);
+                                        foreach (var f in mbl.GetFilesetsUsingMissingBlocks())
+                                            Logging.Log.WriteInformationMessage(LOGTAG, "AffectedFilesetName", f.Name);
 
-                                            if (!m_options.Dryrun)
-                                            {
-                                                Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", "This may be fixed by deleting the filesets and running repair again");
+                                        var recoverymsg = string.Format("If you want to continue working with the database, you can use the \"{0}\" and \"{1}\" commands to purge the missing data from the database and the remote storage.", "list-broken-files", "purge-broken-files");
 
-                                                throw new UserInformationException(string.Format("Repair not possible, missing {0} blocks.\n" + recoverymsg, missingBlocks), "RepairIsNotPossible");
-                                            }
-                                            else
-                                            {
-                                                Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", recoverymsg);
-                                            }
+                                        if (!m_options.Dryrun)
+                                        {
+                                            Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", "This may be fixed by deleting the filesets and running repair again");
+
+                                            throw new UserInformationException(string.Format("Repair not possible, missing {0} blocks.\n" + recoverymsg, missingBlocks), "RepairIsNotPossible");
                                         }
                                         else
                                         {
-                                            if (m_options.Dryrun)
-                                                Logging.Log.WriteDryrunMessage(LOGTAG, "WouldReUploadBlockFile", "would re-upload block file {0}, with size {1}, previous size {2}", n.Name, Library.Utility.Utility.FormatSizeString(new System.IO.FileInfo(w.LocalFilename).Length), Library.Utility.Utility.FormatSizeString(n.Size));
-                                            else
-                                            {
-                                                db.UpdateRemoteVolume(w.RemoteFilename, RemoteVolumeState.Uploading, -1, null, null);
-                                                backend.Put(w);
-                                            }
+                                            Logging.Log.WriteInformationMessage(LOGTAG, "RecoverySuggestion", recoverymsg);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (m_options.Dryrun)
+                                            Logging.Log.WriteDryrunMessage(LOGTAG, "WouldReUploadBlockFile", "would re-upload block file {0}, with size {1}, previous size {2}", n.Name, Library.Utility.Utility.FormatSizeString(new System.IO.FileInfo(w.LocalFilename).Length), Library.Utility.Utility.FormatSizeString(n.Size));
+                                        else
+                                        {
+                                            db.UpdateRemoteVolume(w.RemoteFilename, RemoteVolumeState.Uploading, -1, null, null);
+                                            backend.Put(w);
                                         }
                                     }
                                 }

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DisruptionTests.cs" />
+    <Compile Include="RepairHandlerTests.cs" />
     <Compile Include="RestoreHandlerTests.cs" />
     <Compile Include="SVNCheckoutsTest.cs" />
     <Compile Include="GeneralBlackBoxTesting.cs" />

--- a/Duplicati/UnitTest/RepairHandlerTests.cs
+++ b/Duplicati/UnitTest/RepairHandlerTests.cs
@@ -12,7 +12,7 @@ namespace Duplicati.UnitTest
         public override void SetUp()
         {
             base.SetUp();
-            File.WriteAllBytes(Path.Combine(this.DATAFOLDER, "emptyFile"), new byte[] {0});
+            File.WriteAllBytes(Path.Combine(this.DATAFOLDER, "file"), new byte[] {0});
         }
 
         [Test]

--- a/Duplicati/UnitTest/RepairHandlerTests.cs
+++ b/Duplicati/UnitTest/RepairHandlerTests.cs
@@ -28,6 +28,7 @@ namespace Duplicati.UnitTest
             }
 
             string[] dindexFiles = Directory.EnumerateFiles(this.TARGETFOLDER, "*dindex*").ToArray();
+            Assert.Greater(dindexFiles.Length, 0);
             foreach (string f in dindexFiles)
             {
                 File.Delete(f);

--- a/Duplicati/UnitTest/RepairHandlerTests.cs
+++ b/Duplicati/UnitTest/RepairHandlerTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    [TestFixture]
+    public class RepairHandlerTests : BasicSetupHelper
+    {
+        public override void SetUp()
+        {
+            base.SetUp();
+            File.WriteAllBytes(Path.Combine(this.DATAFOLDER, "emptyFile"), new byte[] {0});
+        }
+
+        [Test]
+        [Category("RepairHandler")]
+        [TestCase("true")]
+        [TestCase("false")]
+        public void RepairMissingIndexFiles(string noEncryption)
+        {
+            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions) {["no-encryption"] = noEncryption};
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                c.Backup(new[] {this.DATAFOLDER});
+            }
+
+            string[] dindexFiles = Directory.EnumerateFiles(this.TARGETFOLDER, "*dindex*").ToArray();
+            foreach (string f in dindexFiles)
+            {
+                File.Delete(f);
+            }
+
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                c.Repair();
+            }
+
+            foreach (string file in dindexFiles)
+            {
+                Assert.IsTrue(File.Exists(Path.Combine(this.TARGETFOLDER, file)));
+            }
+        }
+    }
+}

--- a/pipeline/start.sh
+++ b/pipeline/start.sh
@@ -8,5 +8,5 @@ ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNormal
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNoSize
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Border
-${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler
+${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler,RepairHandler
 


### PR DESCRIPTION
This fixes a bug introduced in pull request #3930 that broke the repair operation when `dindex` files were missing and no encryption was used.  Since we are keeping around a reference to the `IndexVolumeWriter` and `BlockVolumeWriter` instances, we cannot wrap their usages in `using` statements.


This also adds a test to verify the behavior.

This fixes issue #4046.