### PR TITLE
Fix unexpected difference in fileset when using Stop Now

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -1076,12 +1076,11 @@ namespace Duplicati.Library.Main
         public void Stop(bool allowCurrentFileToFinish)
         {
             var ct = m_currentTask;
-            if (ct == null) return;
-            if (allowCurrentFileToFinish)
-            {
-                Logging.Log.WriteVerboseMessage(LOGTAG, "CancellationRequested", "Cancellation Requested");
-                m_cancellationTokenSource.Cancel();
-            }
+            if (ct == null)
+                return;
+
+            Logging.Log.WriteVerboseMessage(LOGTAG, "CancellationRequested", "Cancellation Requested");
+            m_cancellationTokenSource.Cancel();
             ct.Stop(allowCurrentFileToFinish);
         }
 

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -412,36 +412,67 @@ namespace Duplicati.Library.Main.Database
                 var volIdsSubQuery = string.Format(@"SELECT ""ID"" FROM ""{0}"" ", volidstable);
                 deletecmd.Parameters.Clear();
 
-                // If the volume is a block or index volume, this will update the crosslink table, otherwise nothing will happen
-                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""IndexBlockLink"" WHERE ""BlockVolumeID"" IN ({0}) OR ""IndexVolumeID"" IN ({0})", volIdsSubQuery));
-
-                // If the volume is a fileset, this will remove the fileset, otherwise nothing will happen
-                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""FilesetEntry"" WHERE ""FilesetID"" IN (SELECT ""ID"" FROM ""Fileset"" WHERE ""VolumeID"" IN ({0}))", volIdsSubQuery));
-                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""ChangeJournalData"" WHERE ""FilesetID"" IN (SELECT ""ID"" FROM ""Fileset"" WHERE ""VolumeID"" IN ({0}))", volIdsSubQuery));
-                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Fileset"" WHERE ""VolumeID""  IN ({0})", volIdsSubQuery));
 
                 var bsIdsSubQuery = string.Format(
-                      @"SELECT ""BlocksetEntry"".""BlocksetID"" FROM ""BlocksetEntry"", ""Block"" "
+                      @"SELECT DISTINCT ""BlocksetEntry"".""BlocksetID"" FROM ""BlocksetEntry"", ""Block"""
                     + @" WHERE ""BlocksetEntry"".""BlockID"" = ""Block"".""ID"" AND ""Block"".""VolumeID"" IN ({0}) "
                     + @"UNION ALL "
-                    + @"SELECT ""BlocksetID"" FROM ""BlocklistHash"" "
-                    + @"WHERE ""Hash"" IN (SELECT ""Hash"" FROM ""Block"" WHERE ""VolumeID"" IN ({0}))"
+                    + @"SELECT DISTINCT ""BlocksetID"" FROM ""BlocklistHash"""
+                    + @" WHERE ""Hash"" IN (SELECT ""Hash"" FROM ""Block"" WHERE ""VolumeID"" IN ({0}))"
                     , volIdsSubQuery);
 
                 // Create a temporary table to cache subquery result, as it might take long (SQLite does not cache at all). 
                 deletecmd.ExecuteNonQuery(string.Format(@"CREATE TEMP TABLE ""{0}"" (""ID"" INTEGER PRIMARY KEY)", blocksetidstable));
                 deletecmd.ExecuteNonQuery(string.Format(@"INSERT OR IGNORE INTO ""{0}"" (""ID"") {1}", blocksetidstable, bsIdsSubQuery));
-                bsIdsSubQuery = string.Format(@"SELECT ""ID"" FROM ""{0}"" ", blocksetidstable);
+                bsIdsSubQuery = string.Format(@"SELECT DISTINCT ""ID"" FROM ""{0}"" ", blocksetidstable);
                 deletecmd.Parameters.Clear();
 
-                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""FileLookup"" WHERE ""BlocksetID"" IN ({0}) OR ""MetadataID"" IN ({0})", bsIdsSubQuery));
+                // Create a temp table to associate metadata that is being deleted to a fileset
+                var metadataFilesetQuery = $@"SELECT Metadataset.ID, FilesetEntry.FilesetID
+FROM Metadataset
+INNER JOIN FileLookup ON FileLookup.MetadataID = Metadataset.ID
+INNER JOIN FilesetEntry ON FilesetEntry.FileID = FileLookup.ID
+WHERE Metadataset.BlocksetID IN ({bsIdsSubQuery})
+OR Metadataset.ID IN (SELECT MetadataID FROM FileLookup WHERE BlocksetID IN ({bsIdsSubQuery}))";
+
+                var metadataFilesetTable = @"DelMetadataFilesetIds-" + temptransguid;
+                deletecmd.ExecuteNonQuery($@"CREATE TEMP TABLE ""{metadataFilesetTable}"" (MetadataID INTEGER PRIMARY KEY, FilesetID INTEGER)");
+                deletecmd.ExecuteNonQuery($@"INSERT OR IGNORE INTO ""{metadataFilesetTable}"" (MetadataID, FilesetID) {metadataFilesetQuery}");
+
+                // Delete FilesetEntry rows that had their metadata deleted
+                deletecmd.ExecuteNonQuery($@"DELETE FROM FilesetEntry
+WHERE FilesetEntry.FilesetID IN (SELECT DISTINCT FilesetID FROM ""{metadataFilesetTable}"")
+AND FilesetEntry.FileID IN (
+	SELECT FilesetEntry.FileID
+	FROM FilesetEntry
+	INNER JOIN FileLookup ON FileLookup.ID = FilesetEntry.FileID
+	WHERE FileLookup.MetadataID IN (SELECT MetadataID FROM ""{metadataFilesetTable}""))");
+
+                // Delete FilesetEntry rows that had their blocks deleted
+                deletecmd.ExecuteNonQuery($@"DELETE FROM FilesetEntry WHERE FilesetEntry.FileID IN (
+SELECT ID FROM FileLookup
+WHERE FileLookup.BlocksetID IN ({bsIdsSubQuery}))");
+                deletecmd.ExecuteNonQuery($@"DELETE FROM FileLookup WHERE FileLookup.MetadataID IN (SELECT MetadataID FROM ""{metadataFilesetTable}"")");
+
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Metadataset"" WHERE ""BlocksetID"" IN ({0})", bsIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""FileLookup"" WHERE ""BlocksetID"" IN ({0})", bsIdsSubQuery));
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Blockset"" WHERE ""ID"" IN ({0})", bsIdsSubQuery));
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""BlocksetEntry"" WHERE ""BlocksetID"" IN ({0})", bsIdsSubQuery));
-
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""BlocklistHash"" WHERE ""BlocklistHash"".""BlocksetID"" IN ({0})", bsIdsSubQuery));
+
+                // If the volume is a block or index volume, this will update the crosslink table, otherwise nothing will happen
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""IndexBlockLink"" WHERE ""BlockVolumeID"" IN ({0}) OR ""IndexVolumeID"" IN ({0})", volIdsSubQuery));
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""Block"" WHERE ""VolumeID"" IN ({0})", volIdsSubQuery));
                 deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""DeletedBlock"" WHERE ""VolumeID"" IN ({0})", volIdsSubQuery));
+                deletecmd.ExecuteNonQuery(string.Format(@"DELETE FROM ""ChangeJournalData"" WHERE ""FilesetID"" IN (SELECT ""ID"" FROM ""Fileset"" WHERE ""VolumeID"" IN ({0}))", volIdsSubQuery));
+                deletecmd.ExecuteNonQuery($@"DELETE FROM FilesetEntry WHERE FilesetID IN (SELECT ID FROM Fileset WHERE VolumeID IN ({volIdsSubQuery}))");
+                deletecmd.ExecuteNonQuery($@"DELETE FROM Fileset WHERE VolumeID IN ({volIdsSubQuery})");
+
+                // Delete from Fileset if FilesetEntry rows were deleted by related metadata and there are no references in FilesetEntry anymore
+                deletecmd.ExecuteNonQuery($@"DELETE FROM Fileset WHERE Fileset.ID IN
+(SELECT DISTINCT FilesetID FROM ""{metadataFilesetTable}"")
+AND Fileset.ID NOT IN
+    (SELECT DISTINCT FilesetID FROM FilesetEntry)");
 
                 // Clean up temp tables for subqueries. We truncate content and then try to delete.
                 // Drop in try-block, as it fails in nested transactions (SQLite problem)
@@ -453,6 +484,7 @@ namespace Duplicati.Library.Main.Database
                     deletecmd.CommandTimeout = 2;
                     deletecmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}"" ", blocksetidstable));
                     deletecmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}"" ", volidstable));
+                    deletecmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}"" ", metadataFilesetTable));
                 }
                 catch { /* Ignore, will be deleted on close anyway. */ }
 

--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -95,11 +95,11 @@ namespace Duplicati.Library.Main.Database
                 
                 //We save the block info for the remote files, before we delete it
                 cmd.ExecuteNonQuery(@"INSERT INTO ""DeletedBlock"" (""Hash"", ""Size"", ""VolumeID"") SELECT ""Hash"", ""Size"", ""VolumeID"" FROM ""Block"" WHERE ""ID"" NOT IN (SELECT DISTINCT ""BlockID"" AS ""BlockID"" FROM ""BlocksetEntry"" UNION SELECT DISTINCT ""ID"" FROM ""Block"", ""BlocklistHash"" WHERE ""Block"".""Hash"" = ""BlocklistHash"".""Hash"") ");
-                cmd.ExecuteNonQuery(@"DELETE FROM ""Block"" WHERE ""ID"" NOT IN (SELECT DISTINCT ""BlockID"" FROM ""BlocksetEntry"" UNION SELECT DISTINCT ""ID"" FROM ""Block"", ""BlocklistHash"" WHERE ""Block"".""Hash"" = ""BlocklistHash"".""Hash"") ");        
-    
+                cmd.ExecuteNonQuery(@"DELETE FROM ""Block"" WHERE ""ID"" NOT IN (SELECT DISTINCT ""BlockID"" FROM ""BlocksetEntry"" UNION SELECT DISTINCT ""ID"" FROM ""Block"", ""BlocklistHash"" WHERE ""Block"".""Hash"" = ""BlocklistHash"".""Hash"") ");
+
                 //Find all remote filesets that are no longer required, and mark them as delete
-                var updated = cmd.ExecuteNonQuery(@"UPDATE ""RemoteVolume"" SET ""State"" = ? WHERE ""Type"" = ? AND ""State"" IN (?, ?) AND ""ID"" NOT IN (SELECT ""VolumeID"" FROM ""Fileset"") ", RemoteVolumeState.Deleting.ToString(), RemoteVolumeType.Files.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString());
-    
+                var updated = cmd.ExecuteNonQuery(@"UPDATE ""RemoteVolume"" SET ""State"" = ? WHERE ""Type"" = ? AND ""State"" IN (?, ?, ?) AND ""ID"" NOT IN (SELECT ""VolumeID"" FROM ""Fileset"") ", RemoteVolumeState.Deleting.ToString(), RemoteVolumeType.Files.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString(), RemoteVolumeState.Temporary.ToString());
+
                 if (deleted != updated)
                     throw new Exception(string.Format("Unexpected number of remote volumes marked as deleted. Found {0} filesets, but {1} volumes", deleted, updated));
     

--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -99,7 +99,11 @@ namespace Duplicati.Library.Main.Operation
                 {
                     var backend = bk ?? sharedBackend;
                     if (!hasVerifiedBackend && !m_options.NoBackendverification)
-                        FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter);
+                    {
+                        var backupDatabase = new LocalBackupDatabase(db, m_options);
+                        var latestFilelist = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: true, transaction: transaction);
+                        FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter, latestFilelist);
+                    }
 
                     BlockVolumeWriter newvol = new BlockVolumeWriter(m_options);
                     newvol.VolumeID = db.RegisterRemoteVolume(newvol.RemoteFilename, RemoteVolumeType.Blocks, RemoteVolumeState.Temporary, transaction);

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -88,7 +88,11 @@ namespace Duplicati.Library.Main.Operation
                 var backend = bk ?? sharedManager;
 
                 if (!hasVerifiedBacked && !m_options.NoBackendverification)
-                    FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter);
+                {
+                    var backupDatabase = new LocalBackupDatabase(db, m_options);
+                    var latestFilelist = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: true, transaction: transaction);
+                    FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter, latestFilelist);
+                }
 
                 IListResultFileset[] filesets = db.FilesetsWithBackupVersion.ToArray();
                 List<IListResultFileset> versionsToDelete = new List<IListResultFileset>();

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -332,8 +332,11 @@ namespace Duplicati.Library.Main.Operation
 
                 if (!m_options.NoBackendverification)
                 {
-                    m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Restore_PreRestoreVerify);                
-                    FilelistProcessor.VerifyRemoteList(backend, m_options, database, result.BackendWriter);
+                    m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Restore_PreRestoreVerify);
+
+                    var backupDatabase = new LocalBackupDatabase(database, m_options);
+                    var tempFilelistVolumes = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: false);
+                    FilelistProcessor.VerifyRemoteList(backend, m_options, database, result.BackendWriter, tempFilelistVolumes);
                 }
 
                 //Figure out what files are to be patched, and what blocks are needed

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -53,9 +53,13 @@ namespace Duplicati.Library.Main.Operation
                 Utility.UpdateOptionsFromDb(db, m_options);
                 Utility.VerifyParameters(db, m_options);
                 db.VerifyConsistency(m_options.Blocksize, m_options.BlockhashSize, true, null);
-                
+
                 if (!m_options.NoBackendverification)
-                    FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_results.BackendWriter);
+                {
+                    var backupDatabase = new LocalBackupDatabase(db, m_options);
+                    var latestFilelist = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: true);
+                    FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_results.BackendWriter, latestFilelist);
+                }
                     
                 DoRun(samples, db, backend);
                 db.WriteResults();

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -515,7 +515,7 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Disruption")]
-        public void StopNow()
+        public async Task StopNow()
         {
             // Choose a dblock size that is small enough so that more than one volume is needed.
             Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions) {["dblock-size"] = "10mb", ["disable-synthetic-filelist"] = "true"};
@@ -541,7 +541,7 @@ namespace Duplicati.UnitTest
                 Thread.Sleep(1000);
 
                 c.Stop(false);
-                Assert.That(async () => await backupTask.ConfigureAwait(false), Throws.Exception);
+                await backupTask.ConfigureAwait(false);
             }
 
             // The next backup should proceed without issues.


### PR DESCRIPTION
The exception could occur due to the existing delete for FilesetEntry
deleting based on volume ids, which would only match a filelist.
The bsIdsSubQuery would return BlocksetIds that should
be deleted and would delete from the FileLookup table.

FilesetEntry would then have a higher count of rows
than what would be returned by the LEFT OUTER JOINS on all of the
other tables in VerifyConsistency() since more rows had been deleted
from FileLookup.

To fix this when rows are deleted in FileLookup, use the associated metadata id
to delete from FilesetEntry and other tables based on the blockset id for the
metadata id.

Some existing delete statements were moved, none were deleted.
The existing FileLookup delete had the match on metadata id removed as
a blockset id does not equal a metadata id.