### PR TITLE
Make environment variable tests case-insensitive

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -850,7 +850,7 @@ namespace Duplicati.Library.AutoUpdater
         {
             string optstr = Environment.GetEnvironmentVariable(string.Format(UPDATE_STRATEGY_ENVNAME_TEMPLATE, APPNAME));
             AutoUpdateStrategy strategy;
-            if (string.IsNullOrWhiteSpace(optstr) || !Enum.TryParse(optstr, out strategy))
+            if (string.IsNullOrWhiteSpace(optstr) || !Enum.TryParse(optstr, true, out strategy))
                 strategy = defaultstrategy;
 
             System.Threading.Thread backgroundChecker = null;

--- a/Duplicati/Library/UsageReporter/Reporter.cs
+++ b/Duplicati/Library/UsageReporter/Reporter.cs
@@ -173,7 +173,7 @@ namespace Duplicati.Library.UsageReporter
                 {
                     var str = Environment.GetEnvironmentVariable(string.Format(DISABLED_ENVNAME_TEMPLATE, AutoUpdater.AutoUpdateSettings.AppName));
                     ReportType tmp;
-                    if (string.IsNullOrWhiteSpace(str) || !Enum.TryParse(str, out tmp))
+                    if (string.IsNullOrWhiteSpace(str) || !Enum.TryParse(str, true, out tmp))
                         Cached_MaxReportLevel = ReportType.Information;
                     else
                         Cached_MaxReportLevel = tmp;


### PR DESCRIPTION
There are two usages of `Enum.TryParse` that are currently case sensitive.  Both are instances of parsing environment variable settings.

This change makes them case insensitive, consistent with all other uses of `Enum.TryParse` within Duplicati source.