### PR TITLE
Write blocklists when compacting files

### DIFF
--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -1180,7 +1180,7 @@ namespace Duplicati.Library.Main
                 throw m_lastException;
         }
 
-        public void Put(VolumeWriterBase item, IndexVolumeWriter indexfile = null, bool synchronous = false)
+        public void Put(VolumeWriterBase item, IndexVolumeWriter indexfile = null, Action indexVolumeFinishedCallback = null, bool synchronous = false)
         {
             if (m_lastException != null)
                 throw m_lastException;
@@ -1212,6 +1212,11 @@ namespace Duplicati.Library.Main
                 req2 = new FileEntryItem(OperationType.Put, indexfile.RemoteFilename);
                 req2.LocalTempfile = indexfile.TempFile;
                 req.Indexfile = new Tuple<IndexVolumeWriter, FileEntryItem>(indexfile, req2);
+
+                indexfile.FinishVolume(req.Hash, req.Size);
+                indexVolumeFinishedCallback?.Invoke();
+                indexfile.Close();
+                req.IndexfileUpdated = true;
             }
 
             try


### PR DESCRIPTION
The list folder was not being written to dindex files when performing a
compact operation. After the data blocks have been moved to a new
volume the blocklists are now read from the database and written to
the new dindex file.

Fixes #4048 