### PR TITLE
Build docker images for arm64v8

### DIFF
--- a/Installer/Docker/README.md
+++ b/Installer/Docker/README.md
@@ -17,6 +17,7 @@ Images for the following OS/architecture combinations are available:
 
 * `linux-amd64`
 * `linux-arm32v7` - 32-bit ARMv7 devices like the Raspberry Pi 2
+* `linux-arm64v8` - 64-bit ARMv8 devices like the Raspberry Pi 4 (when running a 64-bit OS)
 
 The default architecture is `linux-amd64`. To pull an image for another architecture, prepend the architecture string to the image tag, e.g. `linux-arm32v7-beta`.
 

--- a/Installer/Docker/build-images.sh
+++ b/Installer/Docker/build-images.sh
@@ -5,7 +5,7 @@ if [ ! -f "$1" ]; then
     exit
 fi
 
-ARCHITECTURES="amd64 arm32v7"
+ARCHITECTURES="amd64 arm32v7 arm64v8"
 DEFAULT_ARCHITECTURE=amd64
 DEFAULT_CHANNEL=beta
 REPOSITORY=duplicati/duplicati


### PR DESCRIPTION
64-bit Linux distributions for the Raspberry Pi are becoming more common. This PR adds Docker builds for the `arm64v8` architecture.