### PR TITLE
Build true multi-arch Docker images and add arm64

### DIFF
--- a/Installer/Docker/README.md
+++ b/Installer/Docker/README.md
@@ -17,6 +17,7 @@ Images for the following OS/architecture combinations are available using Docker
 
   * `linux/amd64`
   * `linux/arm/v7` - 32-bit ARMv7 devices like the Raspberry Pi 2
+  * `linux/arm64` - 64-bit ARMv8 devices like the Raspberry Pi 4 (when running a 64-bit OS)
 
 ## How to use this image
 

--- a/Installer/Docker/README.md
+++ b/Installer/Docker/README.md
@@ -13,12 +13,10 @@ Duplicati is licensed under LGPL and available for Windows, OSX and Linux (.NET 
   * `latest` - an alias for `beta`
   * specific versions like `2.0.2.1_beta_2017-08-01`
 
-Images for the following OS/architecture combinations are available:
+Images for the following OS/architecture combinations are available using Docker's multi-arch support:
 
-  * `linux-amd64`
-  * `linux-arm32v7` - 32-bit ARMv7 devices like the Raspberry Pi 2
-
-The default architecture is `linux-amd64`. To pull an image for another architecture, prepend the architecture string to the image tag, e.g. `linux-arm32v7-beta`.
+  * `linux/amd64`
+  * `linux/arm/v7` - 32-bit ARMv7 devices like the Raspberry Pi 2
 
 ## How to use this image
 

--- a/Installer/Docker/README.md
+++ b/Installer/Docker/README.md
@@ -7,16 +7,16 @@ Duplicati is licensed under LGPL and available for Windows, OSX and Linux (.NET 
 
 ## Available tags
 
-* `beta` - the most recent beta release
-* `experimental` - the most recent experimental release
-* `canary` - the most recent canary release
-* `latest` - an alias for `beta`
-* specific versions like `2.0.2.1_beta_2017-08-01`
+  * `beta` - the most recent beta release
+  * `experimental` - the most recent experimental release
+  * `canary` - the most recent canary release
+  * `latest` - an alias for `beta`
+  * specific versions like `2.0.2.1_beta_2017-08-01`
 
 Images for the following OS/architecture combinations are available:
 
-* `linux-amd64`
-* `linux-arm32v7` - 32-bit ARMv7 devices like the Raspberry Pi 2
+  * `linux-amd64`
+  * `linux-arm32v7` - 32-bit ARMv7 devices like the Raspberry Pi 2
 
 The default architecture is `linux-amd64`. To pull an image for another architecture, prepend the architecture string to the image tag, e.g. `linux-arm32v7-beta`.
 

--- a/Installer/Docker/build-images.sh
+++ b/Installer/Docker/build-images.sh
@@ -5,10 +5,10 @@ if [ ! -f "$1" ]; then
     exit
 fi
 
-ARCHITECTURES="amd64 arm32v7"
-DEFAULT_ARCHITECTURE=amd64
+PLATFORMS="linux/amd64,linux/arm/v7"
 DEFAULT_CHANNEL=beta
 REPOSITORY=duplicati/duplicati
+PUSH_TO_REGISTRY=${PUSH_TO_REGISTRY:-true}
 
 ARCHIVE_NAME=$(basename -s .zip $1)
 VERSION=$(echo "${ARCHIVE_NAME}" | cut -d "-" -f 2-)
@@ -40,34 +40,27 @@ do
     done
 done
 
-for arch in ${ARCHITECTURES}; do
-    tags="linux-${arch}-${VERSION} linux-${arch}-${CHANNEL}"
-    if [ ${CHANNEL} = ${DEFAULT_CHANNEL} ]; then
-        tags="linux-${arch}-latest ${tags}"
-    fi
-    if [ ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
-        tags="${VERSION} ${CHANNEL} ${tags}"
-    fi
-    if [ ${CHANNEL} = ${DEFAULT_CHANNEL} -a ${arch} = ${DEFAULT_ARCHITECTURE} ]; then
-        tags="latest ${tags}"
-    fi
+tags="${VERSION} ${CHANNEL}"
+if [ ${CHANNEL} = ${DEFAULT_CHANNEL} ]; then
+    tags="latest ${tags}"
+fi
 
-    args=""
-    for tag in ${tags}; do
-        args="-t ${REPOSITORY}:${tag} ${args}"
-    done
-
-    docker build \
-        ${args} \
-        --build-arg ARCH=${arch}/ \
-        --build-arg VERSION=${VERSION} \
-        --build-arg CHANNEL=${CHANNEL} \
-        --file context/Dockerfile \
-        .
-
-    for tag in ${tags}; do
-        docker push ${REPOSITORY}:${tag}
-    done
+args=""
+for tag in ${tags}; do
+    args="-t ${REPOSITORY}:${tag} ${args}"
 done
+
+docker buildx create --use --name duplicati-multiarch
+
+docker buildx build \
+    ${args} \
+    --platform ${PLATFORMS} \
+    --build-arg VERSION=${VERSION} \
+    --build-arg CHANNEL=${CHANNEL} \
+    --file context/Dockerfile \
+    --output type=image,push=${PUSH_TO_REGISTRY} \
+    .
+
+docker buildx rm duplicati-multiarch
 
 rm -rf "${DIRNAME}"

--- a/Installer/Docker/build-images.sh
+++ b/Installer/Docker/build-images.sh
@@ -5,7 +5,7 @@ if [ ! -f "$1" ]; then
     exit
 fi
 
-PLATFORMS="linux/amd64,linux/arm/v7"
+PLATFORMS="linux/amd64,linux/arm/v7,linux/arm64"
 DEFAULT_CHANNEL=beta
 REPOSITORY=duplicati/duplicati
 PUSH_TO_REGISTRY=${PUSH_TO_REGISTRY:-true}

--- a/Installer/Docker/context/Dockerfile
+++ b/Installer/Docker/context/Dockerfile
@@ -1,5 +1,4 @@
-ARG ARCH=
-FROM ${ARCH}mono:5-slim
+FROM --platform=$TARGETPLATFORM mono:5-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Docker has native support for multi-arch images and it should no longer be necessary for users to use architecture-specific tags to select images manually.

See https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images -- though please note that at this time experimental features must be enabled on the build host in order to use `buildx`.

This PR also adds builds for the `arm64v8` architecture now that 64-bit Linux distributions for the Raspberry Pi are becoming more common.

Supersedes #4057.