### PR TITLE
Build RecoveryTool index in memory by default

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
+++ b/Duplicati/CommandLine/RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FileIndex.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Download.cs" />

--- a/Duplicati/CommandLine/RecoveryTool/FileIndex.cs
+++ b/Duplicati/CommandLine/RecoveryTool/FileIndex.cs
@@ -1,0 +1,246 @@
+﻿//  Copyright (C) 2015, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Duplicati.CommandLine.RecoveryTool
+{
+    public static class FileIndex
+    {
+        public static int Run(List<string> args, Dictionary<string, string> options, Library.Utility.IFilter filter)
+        {
+            if (args.Count != 2)
+            {
+                Console.WriteLine("Invalid argument count ({0} expected 2): {1}{2}", args.Count, Environment.NewLine, string.Join(Environment.NewLine, args));
+                return 100;
+            }
+
+            var folder = Path.GetFullPath(args[1]);
+
+            if (!Directory.Exists(folder))
+            {
+                Console.WriteLine("Folder not found: {0}", folder);
+                return 100;
+            }
+
+            Directory.SetCurrentDirectory(folder);
+
+            string ixfile;
+            options.TryGetValue("indexfile", out ixfile);
+            if (string.IsNullOrWhiteSpace(ixfile))
+                ixfile = "index.txt";
+
+            ixfile = Path.GetFullPath(ixfile);
+            if (!File.Exists(ixfile))
+            {
+                using (File.Create(ixfile))
+                {
+                }
+            }
+            else
+            {
+                Console.WriteLine("Sorting existing index file");
+                SortFile(ixfile, ixfile);
+            }
+
+            var filecount = Directory.EnumerateFiles(folder).Count();
+
+            Console.WriteLine("Processing {0} files", filecount);
+
+            var i = 0;
+            var errors = 0;
+            var totalblocks = 0L;
+            var files = 0;
+            foreach (var file in Directory.EnumerateFiles(folder))
+            {
+                Console.Write("{0}: {1}", i, file);
+
+                try
+                {
+                    var p = Duplicati.Library.Main.Volumes.VolumeBase.ParseFilename(file);
+                    if (p == null)
+                    {
+                        Console.WriteLine(" - Not a Duplicati file, ignoring");
+                        continue;
+                    }
+
+                    if (p.FileType != Duplicati.Library.Main.RemoteVolumeType.Blocks)
+                    {
+                        Console.WriteLine(" - Filetype {0}, skipping", p.FileType);
+                        continue;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(p.EncryptionModule))
+                    {
+                        Console.WriteLine(" - Encrypted, skipping");
+                        continue;
+                    }
+
+                    var filekey = Path.GetFileName(file);
+
+                    var blocks = 0;
+                    using (var stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    using (var cp = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, stream, Library.Interface.ArchiveMode.Read, options))
+                    using (var tf = new Library.Utility.TempFile())
+                    {
+                        using (var sw = new StreamWriter(tf))
+                            foreach (var f in cp.ListFiles(null))
+                            {
+                                sw.WriteLine("{0}, {1}", Library.Utility.Utility.Base64UrlToBase64Plain(f), filekey);
+                                blocks++;
+                            }
+
+                        files++;
+                        totalblocks += blocks;
+
+                        Console.Write(" {0} hashes found, sorting ...", blocks);
+
+                        SortFile(tf, tf);
+
+                        Console.WriteLine(" done!");
+
+                        Console.Write("Merging {0} hashes ...", totalblocks);
+
+                        MergeFiles(ixfile, tf, ixfile);
+
+                        Console.WriteLine(" done!");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(" error: {0}", ex);
+                    errors++;
+                }
+
+                i++;
+            }
+
+            Console.Write("Sorting index file ...");
+            SortFile(ixfile, ixfile);
+            Console.WriteLine(" done!");
+
+            Console.WriteLine("Processed {0} files and found {1} hashes", files, totalblocks);
+            if (errors > 0)
+                Console.WriteLine("Experienced {0} errors", errors);
+
+            return 0;
+        }
+
+        public static void SortFile(string filein, string fileout)
+        {
+            try
+            {
+                // If the file can fit into memory, this is MUCH faster
+                using (var tfout = new Library.Utility.TempFile())
+                {
+                    var data = File.ReadAllLines(filein);
+                    Array.Sort(data, StringComparer.Ordinal);
+                    File.WriteAllLines(tfout, data);
+
+                    File.Copy(tfout, fileout, true);
+                    return;
+                }
+            }
+            catch
+            {
+            }
+
+            using (var tfin = new Library.Utility.TempFile())
+            using (var tfout = new Library.Utility.TempFile())
+            {
+                long swaps;
+
+                File.Copy(filein, tfin, true);
+
+                do
+                {
+                    swaps = 0L;
+
+                    using (var sw = new System.IO.StreamWriter(tfout))
+                    using (var sr = new System.IO.StreamReader(tfin))
+                    {
+                        var c1 = sr.ReadLine();
+                        var c2 = sr.ReadLine();
+
+                        while (c1 != null || c2 != null)
+                        {
+                            if (c1 != null && c1.StartsWith("a", StringComparison.Ordinal))
+                                Console.Write("");
+                            var cmp = StringComparer.Ordinal.Compare(c1, c2);
+
+                            if (c2 == null || (c1 != null && cmp < 0))
+                            {
+                                sw.WriteLine(c1);
+
+                                c1 = c2;
+                                c2 = sr.ReadLine();
+                            }
+                            else
+                            {
+                                if (cmp != 0)
+                                    sw.WriteLine(c2);
+                                c2 = sr.ReadLine();
+                                swaps++;
+                            }
+                        }
+                    }
+
+                    File.Copy(tfout, tfin, true);
+                } while (swaps > 0);
+
+                File.Copy(tfout, fileout, true);
+            }
+        }
+
+        private static void MergeFiles(string file1, string file2, string fileout)
+        {
+            using (var tf = new Library.Utility.TempFile())
+            {
+                using (var sw = new System.IO.StreamWriter(tf))
+                using (var sr1 = new System.IO.StreamReader(file1))
+                using (var sr2 = new System.IO.StreamReader(file2))
+                {
+                    var c1 = sr1.ReadLine();
+                    var c2 = sr2.ReadLine();
+
+                    while (c1 != null || c2 != null)
+                    {
+                        var cmp = StringComparer.Ordinal.Compare(c1, c2);
+
+                        if (c2 == null || (c1 != null && cmp < 0))
+                        {
+                            sw.WriteLine(c1);
+                            c1 = sr1.ReadLine();
+                        }
+                        else
+                        {
+                            if (cmp != 0)
+                                sw.WriteLine(c2);
+
+                            c2 = sr2.ReadLine();
+                        }
+                    }
+                }
+
+                File.Copy(tf, fileout, true);
+            }
+        }
+    }
+}

--- a/Duplicati/CommandLine/RecoveryTool/Index.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Index.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
 using System;
 using System.IO;
 using System.Collections.Generic;
@@ -41,8 +42,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
             Directory.SetCurrentDirectory(folder);
 
-            SortedSet<string> ix_sorted =
-                new SortedSet<string>(StringComparer.Ordinal);
+            SortedSet<string> ix_sorted = new SortedSet<string>(StringComparer.Ordinal);
             string ixfile;
             options.TryGetValue("indexfile", out ixfile);
             if (string.IsNullOrWhiteSpace(ixfile))
@@ -64,14 +64,14 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 try
                 {
-                    var p = Duplicati.Library.Main.Volumes.VolumeBase.ParseFilename(file);
+                    var p = Library.Main.Volumes.VolumeBase.ParseFilename(file);
                     if (p == null)
                     {
                         Console.WriteLine(" - Not a Duplicati file, ignoring");
                         continue;
                     }
 
-                    if (p.FileType != Duplicati.Library.Main.RemoteVolumeType.Blocks)
+                    if (p.FileType != Library.Main.RemoteVolumeType.Blocks)
                     {
                         Console.WriteLine(" - Filetype {0}, skipping", p.FileType);
                         continue;
@@ -86,22 +86,20 @@ namespace Duplicati.CommandLine.RecoveryTool
                     var filekey = Path.GetFileName(file);
 
                     var blocks = 0;
-                    using (var stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    using (var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
                     using (var cp = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, stream, Library.Interface.ArchiveMode.Read, options))
-                    using (var tf = new Library.Utility.TempFile())
                     {
-                        using (var sw = new StreamWriter(tf))
-                            foreach (var f in cp.ListFiles(null))
-                            {                                
-                                ix_sorted.Add(String.Format("{0}, {1}", Library.Utility.Utility.Base64UrlToBase64Plain(f), filekey));
-                                blocks++;
-                            }
+                        foreach (var f in cp.ListFiles(null))
+                        {
+                            ix_sorted.Add($"{Library.Utility.Utility.Base64UrlToBase64Plain(f)}, {filekey}");
+                            blocks++;
+                        }
 
                         files++;
                         totalblocks += blocks;
 
                         Console.Write(" {0} hashes found, sorting ...", blocks);
-                        
+
                         Console.WriteLine(" done!");
 
                         Console.Write("Merging {0} hashes ...", totalblocks);
@@ -117,6 +115,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 i++;
             }
+
             WriteIndex(ref ix_sorted, ixfile);
             Console.WriteLine("Processed {0} files and found {1} hashes", files, totalblocks);
             if (errors > 0)
@@ -127,14 +126,13 @@ namespace Duplicati.CommandLine.RecoveryTool
 
         private static void WriteIndex(ref SortedSet<string> sorted_set, string file1)
         {
-            using (var sw = new System.IO.StreamWriter(file1))
+            using (var sw = new StreamWriter(file1))
             {
                 foreach (string line in sorted_set)
                 {
                     sw.WriteLine(line);
-                }                
+                }
             }
         }
     }
 }
-

--- a/Duplicati/CommandLine/RecoveryTool/Program.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Program.cs
@@ -79,10 +79,18 @@ namespace Duplicati.CommandLine.RecoveryTool
                 var actions = new Dictionary<string, CommandRunner>(StringComparer.OrdinalIgnoreCase);
                 actions["download"] = Download.Run;
                 actions["recompress"] = Recompress.Run;
-                actions["index"] = Index.Run;
                 actions["list"] = List.Run;
                 actions["restore"] = Restore.Run;
                 actions["help"] = Help.Run;
+
+                if (Library.Utility.Utility.ParseBoolOption(options, "build-index-with-files"))
+                {
+                    actions["index"] = FileIndex.Run;
+                }
+                else
+                {
+                    actions["index"] = Index.Run;
+                }
 
                 CommandRunner command;
 

--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -58,9 +58,6 @@ namespace Duplicati.CommandLine.RecoveryTool
                 return 100;
             }
 
-            Console.Write("Sorting index file ...");
-            Index.SortFile(ixfile, ixfile);
-            Console.WriteLine(" done!");
 
             string filelist;
             if (args.Count == 2)

--- a/Duplicati/UnitTest/RecoveryToolTests.cs
+++ b/Duplicati/UnitTest/RecoveryToolTests.cs
@@ -33,7 +33,9 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("RecoveryTool")]
-        public void Recover()
+        [TestCase("false")]
+        [TestCase("true")]
+        public void Recover(string buildIndexWithFiles)
         {
             // Files to create in MB.
             int[] fileSizes = {10, 20, 30};
@@ -71,7 +73,7 @@ namespace Duplicati.UnitTest
             Assert.AreEqual(0, status);
 
             // Create the index.
-            status = CommandLine.RecoveryTool.Program.RealMain(new[] {"index", $"{downloadFolder}"});
+            status = CommandLine.RecoveryTool.Program.RealMain(new[] {"index", $"{downloadFolder}", $"--build-index-with-files={buildIndexWithFiles}"});
             Assert.AreEqual(0, status);
 
             // Restore to a different folder.


### PR DESCRIPTION
This modifies the `RecoveryTool` so that the index is created in memory by default.  This should yield a dramatic increase in performance.  For low-resource situations, we allow one to use the original file-based index creation via the new `--build-index-with-files` option.  We also modified the `RecoveryTool` test to verify the behavior for both cases.

The work to build the index in memory was done by @tfriedel (see revision 8848ad4a74ab7dde300a8363d646a9af5362962b and pull request #4040).