### PR TITLE
Remove redundant calls to String.Format

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -489,7 +489,7 @@ namespace Duplicati.CommandLine.BackendTester
                 while (e.InnerException != null)
                 {
                     e = e.InnerException;
-                    Console.WriteLine(string.Format("  Inner exception: {0}", e));
+                    Console.WriteLine("  Inner exception: {0}", e);
                 }
             }
             else

--- a/Duplicati/CommandLine/BackendTool/Program.cs
+++ b/Duplicati/CommandLine/BackendTool/Program.cs
@@ -100,10 +100,10 @@ namespace Duplicati.CommandLine.BackendTool
                     {
                         if (args.Count != 2)
                             throw new UserInformationException(string.Format("too many arguments: {0}", string.Join(",", args)), "BackendToolTooManyArguments");
-                        Console.WriteLine(string.Format("{0}\t{1}\t{2}\t{3}", "Name", "Dir/File", "LastChange", "Size"));
+                        Console.WriteLine("{0}\t{1}\t{2}\t{3}", "Name", "Dir/File", "LastChange", "Size");
                     
                         foreach(var e in backend.List())
-                            Console.WriteLine(string.Format("{0}\t{1}\t{2}\t{3}", e.Name, e.IsFolder ? "Dir" : "File", e.LastModification, e.Size < 0 ? "" : Library.Utility.Utility.FormatSizeString(e.Size)));
+                            Console.WriteLine("{0}\t{1}\t{2}\t{3}", e.Name, e.IsFolder ? "Dir" : "File", e.LastModification, e.Size < 0 ? "" : Library.Utility.Utility.FormatSizeString(e.Size));
 
                         return 0;
                     }

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -414,7 +414,7 @@ namespace Duplicati.CommandLine
                         outwriter.WriteLine(Strings.Program.DeletedBackups);
 
                     foreach(var f in res.DeletedSets)
-                        outwriter.WriteLine(string.Format("{0}: {1}", f.Item1, f.Item2));
+                        outwriter.WriteLine("{0}: {1}", f.Item1, f.Item2);
                 }
             }
 

--- a/Duplicati/CommandLine/Program.cs
+++ b/Duplicati/CommandLine/Program.cs
@@ -187,7 +187,7 @@ namespace Duplicati.CommandLine
             Duplicati.Library.Utility.TempFile.RemoveOldApplicationTempFiles((path, ex) =>
             {
                 if (showDeletionErrors)
-                    outwriter.WriteLine(string.Format("Failed to delete temp file: {0}", path));
+                    outwriter.WriteLine("Failed to delete temp file: {0}", path);
             });
 
             string command = cargs[0];

--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -79,7 +79,7 @@ namespace Duplicati.Library.Backend
             if (options.ContainsKey(OPTION_RCLONE_EXECUTABLE))
                 rclone_executable = options[OPTION_RCLONE_EXECUTABLE];
 #if DEBUG
-            Console.WriteLine(string.Format("Constructor {0}: {1}:{2} {3}", local_repo, remote_repo, remote_path, opt_rclone));
+            Console.WriteLine("Constructor {0}: {1}:{2} {3}", local_repo, remote_repo, remote_path, opt_rclone);
 #endif
         }
 
@@ -114,7 +114,7 @@ namespace Duplicati.Library.Backend
             };
 
 #if DEBUG
-            Console.Error.WriteLine(String.Format("command executing: {0} {1}", psi.FileName, psi.Arguments));
+            Console.Error.WriteLine("command executing: {0} {1}", psi.FileName, psi.Arguments);
 #endif
             process = new Process
             {
@@ -146,7 +146,7 @@ namespace Duplicati.Library.Backend
                     if (!String.IsNullOrEmpty(e.Data))
                     {
 #if DEBUG
-                        Console.Error.WriteLine(String.Format("error {0}", e.Data));
+                        Console.Error.WriteLine("error {0}", e.Data);
 #endif
                         errorBuilder.Append(e.Data);
                     }

--- a/Duplicati/Library/Encryption/GPGEncryption.cs
+++ b/Duplicati/Library/Encryption/GPGEncryption.cs
@@ -226,7 +226,7 @@ namespace Duplicati.Library.Encryption
 #if DEBUG
             psi.CreateNoWindow = false;
             psi.WindowStyle = System.Diagnostics.ProcessWindowStyle.Normal;
-            Console.Error.WriteLine(string.Format("Running command: {0} {1}", m_programpath, args));
+            Console.Error.WriteLine("Running command: {0} {1}", m_programpath, args);
 #endif
 
             System.Diagnostics.Process p;

--- a/Duplicati/Library/Main/Database/ExtensionMethods.cs
+++ b/Duplicati/Library/Main/Database/ExtensionMethods.cs
@@ -257,7 +257,7 @@ namespace Duplicati.Library.Main.Database
                     while (rd.Read())
                     {
                         for (int i = 0; i < rd.FieldCount; i++)
-                            Console.Write(string.Format((i == 0 ? "{0}" : "\t{0}"), rd.GetValue(i)));
+                            Console.Write((i == 0 ? "{0}" : "\t{0}"), rd.GetValue(i));
                         Console.WriteLine();
                         n++;
                     }

--- a/Duplicati/Library/Snapshots/Program.cs
+++ b/Duplicati/Library/Snapshots/Program.cs
@@ -84,24 +84,24 @@ Where <test-folder> is the folder where files will be locked/created etc");
 
                 string filename = System.IO.Path.Combine(args[0], "testfile.bin");
 
-                Console.WriteLine(string.Format("Creating file {0}", filename));
+                Console.WriteLine("Creating file {0}", filename);
 
                 using (System.IO.FileStream fs = new System.IO.FileStream(filename, System.IO.FileMode.Create, System.IO.FileAccess.ReadWrite, System.IO.FileShare.None))
                 {
-                    Console.WriteLine(string.Format("Attempting to read locked file {0}", filename));
+                    Console.WriteLine("Attempting to read locked file {0}", filename);
 
                     try
                     {
                         using (System.IO.FileStream fs2 = new System.IO.FileStream(filename, System.IO.FileMode.Create, System.IO.FileAccess.ReadWrite, System.IO.FileShare.None))
                         { }
 
-                        Console.WriteLine(string.Format("Could open locked file {0}, cannot test", filename));
+                        Console.WriteLine("Could open locked file {0}, cannot test", filename);
                         Console.WriteLine("* Test failed");
                         return;
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(string.Format("The file {0} was correctly locked, message: {1}", filename, ex.Message));
+                        Console.WriteLine("The file {0} was correctly locked, message: {1}", filename, ex.Message);
                     }
 
                     Console.WriteLine("Creating snapshot for folder: {0}", args[0]);
@@ -114,11 +114,11 @@ Where <test-folder> is the folder where files will be locked/created etc");
                             using (System.IO.Stream s = snapshot.OpenRead(filename))
                             { }
 
-                            Console.WriteLine(string.Format("Could open locked file {0}, through snapshot", filename));
+                            Console.WriteLine("Could open locked file {0}, through snapshot", filename);
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine(string.Format("The file {0} was locked even through snapshot, message: {1}", filename, ex));
+                            Console.WriteLine("The file {0} was locked even through snapshot, message: {1}", filename, ex);
                             Console.WriteLine("* Test failed");
                             return;
                         }
@@ -129,7 +129,7 @@ Where <test-folder> is the folder where files will be locked/created etc");
             }
             catch (Exception ex)
             {
-                Console.WriteLine(string.Format("The snapshot tester failed: {0}", ex));
+                Console.WriteLine("The snapshot tester failed: {0}", ex);
                 Console.WriteLine("* Test failed");
             }
 

--- a/Duplicati/Server/WebServer/RESTMethods/CommandLine.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/CommandLine.cs
@@ -133,7 +133,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                             k.Task.SetController(c);
                             c.AppendSink(sink);
                         }, args);
-                        k.Writer.WriteLine(string.Format("Return code: {0}", code));
+                        k.Writer.WriteLine("Return code: {0}", code);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
It is redundant to use `String.Format` with `Console.WriteLine`.