### PR TITLE
Remove unnecessary variable assignment

### DIFF
--- a/Duplicati/Library/Utility/Power/LinuxPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/LinuxPowerSupplyState.cs
@@ -69,7 +69,7 @@ namespace Duplicati.Library.Utility.Power
                 return false;
             }
 
-            return reply |= !haveMains;
+            return reply || !haveMains;
         }
 
         private bool IsBattery()


### PR DESCRIPTION
This variable has no further usages so the assignment is unnecessary.