### PR TITLE
Move CreateFilesetFile method to FilesetVolumeWriter class

### DIFF
--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -188,5 +188,13 @@ namespace Duplicati.Library.Main.Volumes
         {
             AddMetaEntry(FilelistEntryType.Symlink, name, metahash, metasize, metablockhash, metablocklisthashes);
         }
+
+        public void CreateFilesetFile(bool isFullBackup)
+        {
+            using (var sr = new StreamWriter(this.m_compression.CreateFile(FILESET_FILENAME, CompressionHint.Compressible, DateTime.UtcNow), ENCODING))
+            {
+                sr.Write(FilesetData.GetFilesetInstance(isFullBackup));
+            }
+        }
     }
 }

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -81,14 +81,6 @@ namespace Duplicati.Library.Main.Volumes
             return fileEntry;
         }
 
-        public void CreateFilesetFile(bool isFullBackup)
-        {
-            using (var sr = new StreamWriter(m_compression.CreateFile(FILESET_FILENAME, CompressionHint.Compressible, DateTime.UtcNow), ENCODING))
-            {
-                sr.Write(FilesetData.GetFilesetInstance(isFullBackup));
-            }
-        }
-
         public virtual void Dispose()
         {
             if (m_compression != null)


### PR DESCRIPTION
This method concerns filesets, so it should not reside in the `VolumeWriterBase` class.