### PR TITLE
Add RepairHandlerTests to UnitTest project

### DIFF
--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -46,6 +46,7 @@
     <Compile Include="DeleteHandlerTests.cs" />
     <Compile Include="DisruptionTests.cs" />
     <Compile Include="RecoveryToolTests.cs" />
+    <Compile Include="RepairHandlerTests.cs" />
     <Compile Include="RestoreHandlerTests.cs" />
     <Compile Include="SVNCheckoutsTest.cs" />
     <Compile Include="GeneralBlackBoxTesting.cs" />


### PR DESCRIPTION
This was accidentally removed via a bad merge in revision a64671a0c65673e49d413c07a03feda945eea94b.