### PR TITLE
Mark fields as readonly but allow for deserializer to set them

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Duplicati.Library.Common.IO;
 using Duplicati.Server.Serialization;
 using Duplicati.Server.Serialization.Interface;
+using Newtonsoft.Json;
 
 namespace Duplicati.GUI.TrayIcon
 {
@@ -226,13 +227,13 @@ namespace Duplicati.GUI.TrayIcon
 
         private class SaltAndNonce
         {
-            // ReSharper disable once FieldCanBeMadeReadOnly.Local
-            // This cannot be made readonly as its value is set by a deserializer.
-            public string Salt = null;
-            
-            // ReSharper disable once FieldCanBeMadeReadOnly.Local
-            // This cannot be made readonly as its value is set by a deserializer.
-            public string Nonce = null;
+            // The JsonProperty attribute allows the Serializer.Deserialize method to
+            // set these readonly fields.
+            [JsonProperty]
+            public readonly string Salt = null;
+
+            [JsonProperty]
+            public readonly string Nonce = null;
         }
 
         private SaltAndNonce GetSaltAndNonce()


### PR DESCRIPTION
Marking these fields as `readonly` will notify us at compile-time that these fields should not be reassigned.  Adding the `JsonProperty` attribute still allows them to be set by the `Serializer.Deserialize` method.

See pull request #3978 and the related [forum discussion](https://forum.duplicati.com/t/after-last-update-duplicati-doesnt-work-anymore/8369).