### PR TITLE
Fix issue 4071 - with USN enabled, source deselection incorrectly brought forward

### DIFF
--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -429,6 +429,9 @@ namespace Duplicati.Library.Snapshots
             if (!m_volumeDataDict.TryGetValue(volumeRoot, out var volumeData))
                 return false;
 
+            if (volumeData.IsFullScan)
+                return true; // do not append from previous set, already scanned
+
             if (volumeData.Files.Contains(path))
                 return true; // do not append from previous set, already scanned
 


### PR DESCRIPTION
See issue https://github.com/duplicati/duplicati/issues/4071 for more detail.

With USN enabled, Duplicati only looks at files that have changed according to USN journal.  So it is desirable for Duplicati to bring forward unscanned (unchanged) files from the previous fileset to the new fileset so the user sees a full file listing.

A problem occurs when a folder is removed from the source selection list.  Duplicati doesn't see or process those files any more during backup.  It mistakenly interprets this as unscanned (unchanged) files and brings them forward in the fileset, per the previous paragraph.

Duplicati already has a mechanism in place to detect any change to source selection or filtering settings, and forces a Full Scan.  This proposed change causes Duplicati to check that Full Scan flag, and if it's set, don't bring forward any files from the previous fileset (for that volume).