### PR TITLE
Change config hash calculation (USN improvement)

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -104,17 +104,9 @@ namespace Duplicati.Library.Main.Operation
         {
             if (m_options.UsnStrategy == Options.OptimizationStrategy.Off) return null;
 
-            // get hash identifying current source filter / sources configuration
-            // ReSharper disable once PossibleMultipleEnumeration
-            var configHash = Library.Utility.Utility.ByteArrayAsHexString(MD5HashHelper.GetHash(
-                (filter == null ? string.Empty : filter.ToString()) +
-                string.Join("; ", sources) +
-                m_options.FileAttributeFilter.ToString() +
-                m_options.SkipFilesLargerThan.ToString()
-            ));
-
             var journalData = m_database.GetChangeJournalData(lastfilesetid);
-            var service = new UsnJournalService(sources, snapshot, configHash, journalData, cancellationTokenSource.Token);
+            var service = new UsnJournalService(sources, snapshot, filter, m_options.FileAttributeFilter, m_options.SkipFilesLargerThan,
+                journalData, cancellationTokenSource.Token);
 
             foreach (var volumeData in service.VolumeDataList)
             {

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -103,8 +103,18 @@ namespace Duplicati.Library.Main.Operation
         private UsnJournalService GetJournalService(IEnumerable<string> sources, ISnapshotService snapshot, IFilter filter, long lastfilesetid)
         {
             if (m_options.UsnStrategy == Options.OptimizationStrategy.Off) return null;
+
+            // get hash identifying current source filter / sources configuration
+            // ReSharper disable once PossibleMultipleEnumeration
+            var configHash = Library.Utility.Utility.ByteArrayAsHexString(MD5HashHelper.GetHash(
+                (filter == null ? string.Empty : filter.ToString()) +
+                string.Join("; ", sources) +
+                m_options.FileAttributeFilter.ToString() +
+                m_options.SkipFilesLargerThan.ToString()
+            ));
+
             var journalData = m_database.GetChangeJournalData(lastfilesetid);
-            var service = new UsnJournalService(sources, snapshot, filter, journalData, cancellationTokenSource.Token);
+            var service = new UsnJournalService(sources, snapshot, filter, configHash, journalData, cancellationTokenSource.Token);
 
             foreach (var volumeData in service.VolumeDataList)
             {

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -114,7 +114,7 @@ namespace Duplicati.Library.Main.Operation
             ));
 
             var journalData = m_database.GetChangeJournalData(lastfilesetid);
-            var service = new UsnJournalService(sources, snapshot, filter, configHash, journalData, cancellationTokenSource.Token);
+            var service = new UsnJournalService(sources, snapshot, configHash, journalData, cancellationTokenSource.Token);
 
             foreach (var volumeData in service.VolumeDataList)
             {

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -45,12 +45,12 @@ namespace Duplicati.Library.Snapshots
         /// <param name="snapshot"></param>
         /// <param name="emitFilter">Emit filter</param>
         /// <param name="prevJournalData">Journal-data of previous fileset</param>
-        public UsnJournalService(IEnumerable<string> sources, ISnapshotService snapshot, IFilter emitFilter, 
+        public UsnJournalService(IEnumerable<string> sources, ISnapshotService snapshot, IFilter emitFilter, string configHash,
             IEnumerable<USNJournalDataEntry> prevJournalData, CancellationToken token)
         {
             m_sources = sources;
             m_snapshot = snapshot;
-            m_volumeDataDict = Initialize(emitFilter, prevJournalData);
+            m_volumeDataDict = Initialize(emitFilter, configHash, prevJournalData);
             m_token = token;
         }
 
@@ -62,16 +62,12 @@ namespace Duplicati.Library.Snapshots
         /// <param name="emitFilter"></param>
         /// <param name="prevJournalData"></param>
         /// <returns></returns>
-        private Dictionary<string, VolumeData> Initialize(IFilter emitFilter, IEnumerable<USNJournalDataEntry> prevJournalData)
+        private Dictionary<string, VolumeData> Initialize(IFilter emitFilter, string configHash, IEnumerable<USNJournalDataEntry> prevJournalData)
         {
             if (prevJournalData == null)
                 throw new UsnJournalSoftFailureException();
 
             var result = new Dictionary<string, VolumeData>();
-
-            // get filter identifying current source filter / sources configuration
-            // ReSharper disable once PossibleMultipleEnumeration
-            var configHash = (emitFilter == null ? string.Empty : emitFilter.GetFilterHash()) + Utility.Utility.ByteArrayAsHexString(MD5HashHelper.GetHash(m_sources));
 
             // create lookup for journal data
             var journalDataDict = prevJournalData.ToDictionary(data => data.Volume);

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -77,12 +77,12 @@ namespace Duplicati.Library.Snapshots
 
             // get hash identifying current source filter / sources configuration
             // ReSharper disable once PossibleMultipleEnumeration
-            var configHash = Library.Utility.Utility.ByteArrayAsHexString(MD5HashHelper.GetHash(
-                (emitFilter == null ? string.Empty : emitFilter.ToString()) +
-                string.Join("; ", m_sources) +
-                fileAttributeFilter.ToString() +
+            var configHash = Utility.Utility.ByteArrayAsHexString(MD5HashHelper.GetHash(new string[] {
+                emitFilter == null ? string.Empty : emitFilter.ToString(),
+                string.Join("; ", m_sources),
+                fileAttributeFilter.ToString(),
                 skipFilesLargerThan.ToString()
-            ));
+            }));
 
             // create lookup for journal data
             var journalDataDict = prevJournalData.ToDictionary(data => data.Volume);

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -45,12 +45,12 @@ namespace Duplicati.Library.Snapshots
         /// <param name="snapshot"></param>
         /// <param name="emitFilter">Emit filter</param>
         /// <param name="prevJournalData">Journal-data of previous fileset</param>
-        public UsnJournalService(IEnumerable<string> sources, ISnapshotService snapshot, IFilter emitFilter, string configHash,
+        public UsnJournalService(IEnumerable<string> sources, ISnapshotService snapshot, string configHash,
             IEnumerable<USNJournalDataEntry> prevJournalData, CancellationToken token)
         {
             m_sources = sources;
             m_snapshot = snapshot;
-            m_volumeDataDict = Initialize(emitFilter, configHash, prevJournalData);
+            m_volumeDataDict = Initialize(configHash, prevJournalData);
             m_token = token;
         }
 
@@ -62,7 +62,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="emitFilter"></param>
         /// <param name="prevJournalData"></param>
         /// <returns></returns>
-        private Dictionary<string, VolumeData> Initialize(IFilter emitFilter, string configHash, IEnumerable<USNJournalDataEntry> prevJournalData)
+        private Dictionary<string, VolumeData> Initialize(string configHash, IEnumerable<USNJournalDataEntry> prevJournalData)
         {
             if (prevJournalData == null)
                 throw new UsnJournalSoftFailureException();

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -44,13 +44,16 @@ namespace Duplicati.Library.Snapshots
         /// <param name="sources">Sources to filter</param>
         /// <param name="snapshot"></param>
         /// <param name="emitFilter">Emit filter</param>
+        /// <param name="fileAttributeFilter"></param>
+        /// <param name="skipFilesLargerThan"></param>
         /// <param name="prevJournalData">Journal-data of previous fileset</param>
-        public UsnJournalService(IEnumerable<string> sources, ISnapshotService snapshot, string configHash,
-            IEnumerable<USNJournalDataEntry> prevJournalData, CancellationToken token)
+        /// <param name="token"></param>
+        public UsnJournalService(IEnumerable<string> sources, ISnapshotService snapshot, IFilter emitFilter, FileAttributes fileAttributeFilter,
+            long skipFilesLargerThan, IEnumerable<USNJournalDataEntry> prevJournalData, CancellationToken token)
         {
             m_sources = sources;
             m_snapshot = snapshot;
-            m_volumeDataDict = Initialize(configHash, prevJournalData);
+            m_volumeDataDict = Initialize(emitFilter, fileAttributeFilter, skipFilesLargerThan, prevJournalData);
             m_token = token;
         }
 
@@ -60,14 +63,26 @@ namespace Duplicati.Library.Snapshots
         /// Initialize list of modified files / folder for each volume
         /// </summary>
         /// <param name="emitFilter"></param>
+        /// <param name="fileAttributeFilter"></param>
+        /// <param name="skipFilesLargerThan"></param>
         /// <param name="prevJournalData"></param>
         /// <returns></returns>
-        private Dictionary<string, VolumeData> Initialize(string configHash, IEnumerable<USNJournalDataEntry> prevJournalData)
+        private Dictionary<string, VolumeData> Initialize(IFilter emitFilter, FileAttributes fileAttributeFilter, long skipFilesLargerThan,
+            IEnumerable<USNJournalDataEntry> prevJournalData)
         {
             if (prevJournalData == null)
                 throw new UsnJournalSoftFailureException();
 
             var result = new Dictionary<string, VolumeData>();
+
+            // get hash identifying current source filter / sources configuration
+            // ReSharper disable once PossibleMultipleEnumeration
+            var configHash = Library.Utility.Utility.ByteArrayAsHexString(MD5HashHelper.GetHash(
+                (emitFilter == null ? string.Empty : emitFilter.ToString()) +
+                string.Join("; ", m_sources) +
+                fileAttributeFilter.ToString() +
+                skipFilesLargerThan.ToString()
+            ));
 
             // create lookup for journal data
             var journalDataDict = prevJournalData.ToDictionary(data => data.Volume);


### PR DESCRIPTION
Duplicati calculates a configuration hash based on source folder list and exclude/include filters, the purpose of which is to detect changes that could cause problems with USN journal usage.  If a config change is detected, it forces a full volume scan.

The proposed change adds File Attribute and Max File Size filtering into this config hash calculation.

Since I needed access to m_options, the most straight forward approach I could think of was to move the hash calculation to BackupHandler.cs.