### PR TITLE
Improve USN and Snapshot error handling

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -126,7 +126,7 @@ namespace Duplicati.Library.Main.Operation
                         }
                         else if (m_options.UsnStrategy == Options.OptimizationStrategy.On)
                         {
-                            Logging.Log.WriteErrorMessage(LOGTAG, "FailedToUseChangeJournal", volumeData.Exception,
+                            Logging.Log.WriteWarningMessage(LOGTAG, "FailedToUseChangeJournal", volumeData.Exception,
                                 "Failed to use change journal for volume \"{0}\": {1}", volumeData.Volume, volumeData.Exception.Message);
                         }
                         else

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -83,7 +83,9 @@ namespace Duplicati.Library.Main.Operation
                 if (options.SnapShotStrategy == Options.OptimizationStrategy.Required)
                     throw new Exception("Failed to create a snapshot");
                 else if (options.SnapShotStrategy == Options.OptimizationStrategy.On)
-                    Logging.Log.WriteWarningMessage(LOGTAG, "SnapshotFailed", ex, Strings.Common.SnapshotFailedError(ex.ToString()));
+                    Logging.Log.WriteWarningMessage(LOGTAG, "SnapshotFailed", ex, Strings.Common.SnapshotFailedError(ex.Message));
+                else if (options.SnapShotStrategy == Options.OptimizationStrategy.Auto)
+                    Logging.Log.WriteInformationMessage(LOGTAG, "SnapshotFailed", Strings.Common.SnapshotFailedError(ex.Message));
             }
 
             return Platform.IsClientPosix ?

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -81,7 +81,7 @@ namespace Duplicati.Library.Main.Operation
             catch (Exception ex)
             {
                 if (options.SnapShotStrategy == Options.OptimizationStrategy.Required)
-                    throw new Exception("Failed to create a snapshot");
+                    throw new UserInformationException(Strings.Common.SnapshotFailedError(ex.Message), "SnapshotFailed", ex);
                 else if (options.SnapShotStrategy == Options.OptimizationStrategy.On)
                     Logging.Log.WriteWarningMessage(LOGTAG, "SnapshotFailed", ex, Strings.Common.SnapshotFailedError(ex.Message));
                 else if (options.SnapShotStrategy == Options.OptimizationStrategy.Auto)

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -81,7 +81,7 @@ namespace Duplicati.Library.Main.Operation
             catch (Exception ex)
             {
                 if (options.SnapShotStrategy == Options.OptimizationStrategy.Required)
-                    throw;
+                    throw new Exception("Failed to create a snapshot");
                 else if (options.SnapShotStrategy == Options.OptimizationStrategy.On)
                     Logging.Log.WriteWarningMessage(LOGTAG, "SnapshotFailed", ex, Strings.Common.SnapshotFailedError(ex.ToString()));
             }


### PR DESCRIPTION
If snapshot fails and policy is set to Required, show "Failed to create a snapshot" message instead of cryptic exception message like "access denied."

If snapshot policy set to Auto, record the failure in the Information log.

If USN policy set to On, write to Warning log instead of Error log.  (This is more consistent with how snapshot policy is handled.)