### PR TITLE
RPM package - change minimum required mono-runtime version

### DIFF
--- a/Installer/fedora/duplicati.spec
+++ b/Installer/fedora/duplicati.spec
@@ -49,7 +49,7 @@ Requires:	bash
 Requires:	sqlite >= 3.6.12
 Requires:	mono(appindicator-sharp)
 Requires:	libappindicator
-Requires:	mono-core >= 3.0
+Requires:	mono-core >= 5.0
 Requires:	mono-data-sqlite
 Requires:	mono(System)
 Requires:	mono(System.Configuration)


### PR DESCRIPTION
Duplicati now requires mono >= 5.0 to operate correctly. Changing the dependency in the rpm package will flag old mono version issues prior to Duplicati install. Hopefully this will reduce the reports of strange errors that turn out to be caused by old mono versions.

Can someone test this please?  I don't know how to actually build an rpm package, so I haven't tested it myself.  But I believe it should work.