### PR TITLE
Added a missing option for minutes in the regex

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -298,11 +298,11 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         }
 
         var retentionPolicy = (opts['retention-policy'] || '');
-        var valid_chars = /^((\d+[shDWMY]|U):(\d+[shDWMY]|U),?)+$/;
+        var valid_chars = /^((\d+[smhDWMY]|U):(\d+[smhDWMY]|U),?)+$/;
         var valid_commas = /^(\d*\w:\d*\w,)*\d*\w:\d*\w$/;
         if ($scope.KeepType == 'custom' && (retentionPolicy.indexOf(':') <= 0 || valid_chars.test(retentionPolicy) === false || valid_commas.test(retentionPolicy) === false))
         {
-            DialogService.dialog(gettextCatalog.getString('Invalid retention time'), gettextCatalog.getString('You must enter a valid rentention policy string'));
+            DialogService.dialog(gettextCatalog.getString('Invalid retention time'), gettextCatalog.getString('You must enter a valid retention policy string'));
             $scope.CurrentStep = 4;
             return;
         }


### PR DESCRIPTION
This fixes a bug introduced in #3775 and reported [on the forum](https://forum.duplicati.com/t/retention-string-seems-to-be-broken-in-2020-01-18-update/9155)

The regex string was missing the minute option. 

Also fixing a typo in the error message.