### PR TITLE
Fix path to SQLite.Interop.dll

### DIFF
--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -189,8 +189,8 @@ namespace Duplicati.Library.SQLiteHelper
                     // This can be avoided if the preload in SQLite works, but it is easy to do it here as well
                     if (loadMixedModeAssembly)
                     {
-                        try { PInvoke.LoadLibraryEx(Path.Combine(basePath, "SQLite.Interop.dll"), IntPtr.Zero, 0); }
-                        catch (Exception ex) { Logging.Log.WriteExplicitMessage(LOGTAG, "LoadMixedModeSQLiteError", ex, "Failed to load the mixed mode SQLite database: {0}", Path.Combine(basePath, "SQLite.Interop.dll")); }
+                        try { PInvoke.LoadLibraryEx(Path.Combine(assemblyPath, "SQLite.Interop.dll"), IntPtr.Zero, 0); }
+                        catch (Exception ex) { Logging.Log.WriteExplicitMessage(LOGTAG, "LoadMixedModeSQLiteError", ex, "Failed to load the mixed mode SQLite database: {0}", Path.Combine(assemblyPath, "SQLite.Interop.dll")); }
                     }
                 }
                 else


### PR DESCRIPTION
This assembly lives in the `SQLite/win32` and `SQLite/win64` subdirectories, and not in the base path.

This fixes #4093.