### PR TITLE
Remove unused members from UnitTest project

### DIFF
--- a/Duplicati/UnitTest/RandomErrorBackend.cs
+++ b/Duplicati/UnitTest/RandomErrorBackend.cs
@@ -36,6 +36,7 @@ namespace Duplicati.UnitTest
         {
         }
 
+        // ReSharper disable once UnusedMember.Global
         public RandomErrorBackend(string url, Dictionary<string, string> options)
         {
             var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();

--- a/Duplicati/UnitTest/SVNCheckoutsTest.cs
+++ b/Duplicati/UnitTest/SVNCheckoutsTest.cs
@@ -46,22 +46,12 @@ namespace Duplicati.UnitTest
         /// </summary>
         private class LogHelper : StreamLogDestination
         {
-            private string m_backupset;
-            
             public static long WarningCount = 0;
             public static long ErrorCount = 0;
             
-            public string Backupset 
-            { 
-                get { return m_backupset; }
-                set { m_backupset = value; }
-            }
-            
             public LogHelper(string file)
                 : base(file)
-            {
-                this.Backupset = "none";
-            }
+            {}
 
             public override void WriteMessage(LogEntry entry)
             {
@@ -193,7 +183,6 @@ namespace Duplicati.UnitTest
                             }
                     }
 
-                    log.Backupset = "Backup " + folders[0];
                     string fhtempsource = null;
 
                     bool usingFHWithRestore = (!skipfullrestore || !skippartialrestore);
@@ -213,7 +202,6 @@ namespace Duplicati.UnitTest
                             //options["passphrase"] = "bad password";
                             //If the backups are too close, we can't pick the right one :(
                             System.Threading.Thread.Sleep(1000 * 5);
-                            log.Backupset = "Backup " + folders[i];
 
                             if (usingFHWithRestore)
                             {
@@ -255,7 +243,6 @@ namespace Duplicati.UnitTest
                         {
                             using (TempFolder ttf = new TempFolder())
                             {
-                                log.Backupset = "Restore " + folders[i];
                                 BasicSetupHelper.ProgressWriteLine("Restoring the copy: " + folders[i]);
 
                                 options["time"] = entries[entries.Count - i - 1].ToString();

--- a/Duplicati/UnitTest/SizeOmittingBackend.cs
+++ b/Duplicati/UnitTest/SizeOmittingBackend.cs
@@ -35,6 +35,7 @@ namespace Duplicati.UnitTest
         {
         }
 
+        // ReSharper disable once UnusedMember.Global
         public SizeOmittingBackend(string url, Dictionary<string, string> options)
         {
             var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();


### PR DESCRIPTION
This removes the `LogHelper.Backupset` property and its backing field `m_backupset`.  The property and the backing field were only set and were never referenced.

We also added some comments to ignore warnings about unused constructors that are invoked via reflection.