### PR TITLE
Fix issue 4090 - Filter builder issues in web UI

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
@@ -131,7 +131,7 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
             name: gettextCatalog.getString('Exclude files whose names contain'),
             key: '-file*',
             prefix: '-[.*',
-            suffix: '[^!]*]',
+            suffix: '[^\\!]*]',    // Escape dirsep inside regexp. Required on Windows, no effect on other platforms.
             rx: '\\-\\[\\.\\*[\\^\\!\\]\\*\\]'
         }, {
             name: gettextCatalog.getString('Exclude folder'),
@@ -545,10 +545,6 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
         }
 
         function matches(txt, n) {
-            // We need to escape dirsep if it is the backslash character
-            if (dirsep == '\\')
-                dirsep = '\\\\';
-
             var pre = apputils.replace_all(n.prefix || '', '!', dirsep);
             var suf = apputils.replace_all(n.suffix || '', '!', dirsep);
 
@@ -586,10 +582,6 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
             return body;
 
         body = body || '';
-
-        // We need to escape dirsep if it is the backslash character
-        if (dirsep == '\\')
-            dirsep = '\\\\';
 
         var f = this.filterTypeMap[type];
         var pre = this.replace_all(f.prefix || '', '!', dirsep);


### PR DESCRIPTION
PR https://github.com/duplicati/duplicati/pull/3967 introduced a bug on the Windows platform where backslashes would sometimes be incorrectly added to the end of some filters, causing them to not function properly.

Example - add these four filters:
![Capture](https://user-images.githubusercontent.com/39164691/75116425-27cce080-561d-11ea-99ab-e6f128520acb.PNG)
Note that after you finish typing C:\Test.txt in that fourth filter and you click on something else, the dropdown will auto change from "Exclude File" to "Exclude Folder".

Click the triple dot menu and then "Edit as text":
![Capture2](https://user-images.githubusercontent.com/39164691/75116427-2a2f3a80-561d-11ea-9cdc-5caed2a5f3dc.PNG)

Line 1 - has an extra backslash
Line 2 - this is ok, backslash needs to be escaped inside regexp
Line 3 - has an extra backslash
Line 4 - has two backslashes, should have none since we picked Exclude File (but as noted above, it automatically changed)

The cause is related to `dirsep` being escaped in all cases when on Windows:

https://github.com/duplicati/duplicati/blob/1f1826bf7a8b2a97956d001677ce0ecf917df047/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js#L548-L550

https://github.com/duplicati/duplicati/blob/1f1826bf7a8b2a97956d001677ce0ecf917df047/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js#L590-L592

Also, use of the escaped `dirsep` here is contributing to the weird behavior:

https://github.com/duplicati/duplicati/blob/1f1826bf7a8b2a97956d001677ce0ecf917df047/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js#L568

I believe the correct solution is to only escape the directory separator when it is used inside a regular expression.  That fixes the issue that the original PR https://github.com/duplicati/duplicati/pull/3967  was trying to fix in Issue https://github.com/duplicati/duplicati/issues/2220 without any of the side effects.

I tested on both Windows and Linux and all filter types seem to be working correctly now.

After fix repeat the above test:
![Capture3](https://user-images.githubusercontent.com/39164691/75116570-a6764d80-561e-11ea-8cf9-dc4e4ac842b4.png)
![Capture4](https://user-images.githubusercontent.com/39164691/75116573-a9713e00-561e-11ea-8f6c-a94ad788dc94.png)

Can someone else test? Since it's just a change to a javascript text file it's easy to test. You may have to do a hard refresh in your browser to get it to read the updated js.

Fixes issue https://github.com/duplicati/duplicati/issues/4090