### PR TITLE
Fix synthetic filelist not being uploaded

### DIFF
--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -864,19 +864,19 @@ namespace Duplicati.Library.Main.Database
                     return null;
         }
 
-        public RemoteVolumeEntry GetRemoteVolumeFromID(long id, System.Data.IDbTransaction transaction = null)
+        public RemoteVolumeEntry GetRemoteVolumeFromFilesetID(long filesetID, IDbTransaction transaction = null)
         {
             using (var cmd = m_connection.CreateCommand(transaction))
-            using (var rd = cmd.ExecuteReader(@"SELECT ""Name"", ""Type"", ""Size"", ""Hash"", ""State"", ""DeleteGraceTime"" FROM ""RemoteVolume"" WHERE ""ID"" = ?", id))
+            using (var rd = cmd.ExecuteReader(@"SELECT ""RemoteVolume"".""ID"", ""Name"", ""Type"", ""Size"", ""Hash"", ""State"", ""DeleteGraceTime"" FROM ""RemoteVolume"", ""Fileset"" WHERE ""Fileset"".""VolumeID"" = ""RemoteVolume"".""ID"" AND ""Fileset"".""ID"" = ?", filesetID))
                 if (rd.Read())
                     return new RemoteVolumeEntry(
-                        id,
-                        rd.GetValue(0).ToString(),
-                        (rd.GetValue(3) == null || rd.GetValue(3) == DBNull.Value) ? null : rd.GetValue(3).ToString(),
-                        rd.ConvertValueToInt64(2, -1),
-                        (RemoteVolumeType)Enum.Parse(typeof(RemoteVolumeType), rd.GetValue(1).ToString()),
-                        (RemoteVolumeState)Enum.Parse(typeof(RemoteVolumeState), rd.GetValue(4).ToString()),
-                        new DateTime(rd.ConvertValueToInt64(5, 0), DateTimeKind.Utc)
+                        int.Parse(rd.GetValue(0).ToString()),
+                        rd.GetValue(1).ToString(),
+                        (rd.GetValue(4) == null || rd.GetValue(4) == DBNull.Value) ? null : rd.GetValue(4).ToString(),
+                        rd.ConvertValueToInt64(3, -1),
+                        (RemoteVolumeType)Enum.Parse(typeof(RemoteVolumeType), rd.GetValue(2).ToString()),
+                        (RemoteVolumeState)Enum.Parse(typeof(RemoteVolumeState), rd.GetValue(5).ToString()),
+                        new DateTime(rd.ConvertValueToInt64(6, 0), DateTimeKind.Utc)
                     );
                 else
                     return default(RemoteVolumeEntry);

--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -870,7 +870,7 @@ namespace Duplicati.Library.Main.Database
             using (var rd = cmd.ExecuteReader(@"SELECT ""RemoteVolume"".""ID"", ""Name"", ""Type"", ""Size"", ""Hash"", ""State"", ""DeleteGraceTime"" FROM ""RemoteVolume"", ""Fileset"" WHERE ""Fileset"".""VolumeID"" = ""RemoteVolume"".""ID"" AND ""Fileset"".""ID"" = ?", filesetID))
                 if (rd.Read())
                     return new RemoteVolumeEntry(
-                        int.Parse(rd.GetValue(0).ToString()),
+                        rd.ConvertValueToInt64(0, -1),
                         rd.GetValue(1).ToString(),
                         (rd.GetValue(4) == null || rd.GetValue(4) == DBNull.Value) ? null : rd.GetValue(4).ToString(),
                         rd.ConvertValueToInt64(3, -1),

--- a/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
@@ -273,9 +273,9 @@ namespace Duplicati.Library.Main.Operation.Backup
             return RunOnMain(() => m_database.RemoveRemoteVolume(remoteFilename, m_transaction));
         }
 
-        public Task<RemoteVolumeEntry> GetRemoteVolumeFromIDAsync(long fileid)
+        public Task<RemoteVolumeEntry> GetRemoteVolumeFromFilesetIDAsync(long filesetID)
         {
-            return RunOnMain(() => m_database.GetRemoteVolumeFromID(fileid, m_transaction));
+            return RunOnMain(() => m_database.GetRemoteVolumeFromFilesetID(filesetID, m_transaction));
         }
 
         public Task CreateChangeJournalDataAsync(IEnumerable<USNJournalDataEntry> journalData)

--- a/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
@@ -14,13 +14,12 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-using System;
 using CoCoL;
-using Duplicati.Library.Main.Volumes;
-using System.Threading.Tasks;
-using System.Linq;
 using Duplicati.Library.Main.Operation.Common;
-using System.IO;
+using Duplicati.Library.Main.Volumes;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Duplicati.Library.Main.Operation.Backup
 {
@@ -34,34 +33,34 @@ namespace Duplicati.Library.Main.Operation.Backup
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(UploadSyntheticFilelist));
 
-        public static Task Run(BackupDatabase database, Options options, BackupResults result, ITaskReader taskreader, string lasttempfilelist, long lasttempfileid)
+        public static Task Run(BackupDatabase database, Options options, BackupResults result, ITaskReader taskreader, string lastTempFilelist, long lastTempFilesetId)
         {
             return AutomationExtensions.RunTask(new
             {
                 UploadChannel = Channels.BackendRequest.ForWrite
             },
 
-            async self => 
-            {                
+            async self =>
+            {
                 // Check if we should upload a synthetic filelist
-                if (options.DisableSyntheticFilelist || string.IsNullOrWhiteSpace(lasttempfilelist) || lasttempfileid < 0)
+                if (options.DisableSyntheticFilelist || string.IsNullOrWhiteSpace(lastTempFilelist) || lastTempFilesetId <= 0)
                     return;
 
                 // Check that we still need to process this after the cleanup has performed its duties
-                var syntbase = await database.GetRemoteVolumeFromIDAsync(lasttempfileid);
+                var syntbase = await database.GetRemoteVolumeFromFilesetIDAsync(lastTempFilesetId);
 
                 // If we do not have a valid entry, warn and quit
-                if (syntbase.Name == null || syntbase.State != RemoteVolumeState.Uploaded)
+                if (syntbase.Name == null)
                 {
                     // TODO: If the repair succeeds, this could give a false warning?
-                    Logging.Log.WriteWarningMessage(LOGTAG, "MissingTemporaryFilelist", null, "Expected there to be a temporary fileset for synthetic filelist ({0}, {1}), but none was found?", lasttempfileid, lasttempfilelist);
+                    Logging.Log.WriteWarningMessage(LOGTAG, "MissingTemporaryFilelist", null, "Expected there to be a temporary fileset for synthetic filelist ({0}, {1}), but none was found?", lastTempFilesetId, lastTempFilelist);
                     return;
                 }
 
                 // Files is missing or repaired
-                if (syntbase.Name == null || (syntbase.State != RemoteVolumeState.Uploading && syntbase.State != RemoteVolumeState.Temporary))
+                if (syntbase.State != RemoteVolumeState.Uploading && syntbase.State != RemoteVolumeState.Temporary)
                 {
-                    Logging.Log.WriteInformationMessage(LOGTAG, "SkippingSyntheticListUpload", "Skipping synthetic upload because temporary fileset appers to be complete: ({0}, {1}, {2})", lasttempfileid, lasttempfilelist, syntbase.State);
+                    Logging.Log.WriteInformationMessage(LOGTAG, "SkippingSyntheticListUpload", "Skipping synthetic upload because temporary fileset appers to be complete: ({0}, {1}, {2})", lastTempFilesetId, lastTempFilelist, syntbase.State);
                     return;
                 }
 
@@ -69,71 +68,78 @@ namespace Duplicati.Library.Main.Operation.Backup
                 await database.CommitTransactionAsync("PreSyntheticFilelist");
                 var incompleteFilesets = (await database.GetIncompleteFilesetsAsync()).OrderBy(x => x.Value).ToList();
 
-                result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_PreviousBackupFinalize);
-                Logging.Log.WriteInformationMessage(LOGTAG, "PreviousBackupFilelistUpload", "Uploading filelist from previous interrupted backup");
+                if (!incompleteFilesets.Any())
+                {
+                    return;
+                }
 
                 if (!await taskreader.ProgressAsync)
                     return;
+
+                result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_PreviousBackupFinalize);
+                Logging.Log.WriteInformationMessage(LOGTAG, "PreviousBackupFilelistUpload", "Uploading filelist from previous interrupted backup");
 
                 var incompleteSet = incompleteFilesets.Last();
                 var badIds = from n in incompleteFilesets select n.Key;
 
                 var prevs = (from n in await database.GetFilesetTimesAsync()
-                    where 
-                    n.Key < incompleteSet.Key
-                    &&
-                    !badIds.Contains(n.Key)
-                    orderby n.Key                                                
-                    select n.Key).ToArray();
+                             where
+                             n.Key < incompleteSet.Key
+                             &&
+                             !badIds.Contains(n.Key)
+                             orderby n.Key
+                             select n.Key).ToArray();
 
                 var prevId = prevs.Length == 0 ? -1 : prevs.Last();
 
-                    try
+                FilesetVolumeWriter fsw = null;
+                try
+                {
+                    var s = 1;
+                    var fileTime = incompleteSet.Value + TimeSpan.FromSeconds(s);
+
+                    // Probe for an unused filename
+                    while (s < 60)
                     {
-                        var s = 1;
-                        var fileTime = incompleteSet.Value + TimeSpan.FromSeconds(s);
+                        var id = await database.GetRemoteVolumeIDAsync(VolumeBase.GenerateFilename(RemoteVolumeType.Files, options, null, fileTime));
+                        if (id < 0)
+                            break;
 
-                        // Probe for an unused filename
-                        while (s < 60)
-                        {
-                            var id = await database.GetRemoteVolumeIDAsync(VolumeBase.GenerateFilename(RemoteVolumeType.Files, options, null, fileTime));
-                            if (id < 0)
-                                break;
-
-                            fileTime = incompleteSet.Value + TimeSpan.FromSeconds(++s);
-                        }
-
-                        using (FilesetVolumeWriter fsw = new FilesetVolumeWriter(options, fileTime))
-                        {
-                            fsw.VolumeID = await database.RegisterRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeType.Files, RemoteVolumeState.Temporary);
-
-                            if (!string.IsNullOrEmpty(options.ControlFiles))
-                                foreach (var p in options.ControlFiles.Split(new char[] {System.IO.Path.PathSeparator}, StringSplitOptions.RemoveEmptyEntries))
-                                    fsw.AddControlFile(p, options.GetCompressionHintFromFilename(p));
-
-                            // We declare this to be a partial backup since the synthetic filelist is only created
-                            // when a backup is interrupted.
-                            fsw.CreateFilesetFile(false);
-                            var newFilesetID = await database.CreateFilesetAsync(fsw.VolumeID, fileTime);
-                            await database.LinkFilesetToVolumeAsync(newFilesetID, fsw.VolumeID);
-                            await database.AppendFilesFromPreviousSetAsync(null, newFilesetID, prevId, fileTime);
-
-                            await database.WriteFilesetAsync(fsw, newFilesetID);
-
-                            if (!await taskreader.ProgressAsync)
-                                return;
-
-                            await database.UpdateRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeState.Uploading, -1, null);
-                            await database.CommitTransactionAsync("CommitUpdateFilelistVolume");
-                            await self.UploadChannel.WriteAsync(new FilesetUploadRequest(fsw));
-                        }
+                        fileTime = incompleteSet.Value + TimeSpan.FromSeconds(++s);
                     }
-                    catch
-                    {
-                        await database.RollbackTransactionAsync();
-                        throw;
-                    }
+
+                    fsw = new FilesetVolumeWriter(options, fileTime);
+                    fsw.VolumeID = await database.RegisterRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeType.Files, RemoteVolumeState.Temporary);
+
+                    if (!string.IsNullOrEmpty(options.ControlFiles))
+                        foreach (var p in options.ControlFiles.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
+                            fsw.AddControlFile(p, options.GetCompressionHintFromFilename(p));
+
+                    // We declare this to be a partial backup since the synthetic filelist is only created
+                    // when a backup is interrupted.
+                    fsw.CreateFilesetFile(false);
+                    var newFilesetID = await database.CreateFilesetAsync(fsw.VolumeID, fileTime);
+                    await database.LinkFilesetToVolumeAsync(newFilesetID, fsw.VolumeID);
+                    await database.AppendFilesFromPreviousSetAsync(null, newFilesetID, prevId, fileTime);
+
+                    await database.WriteFilesetAsync(fsw, newFilesetID);
+                    fsw.Close();
+
+                    if (!await taskreader.ProgressAsync)
+                        return;
+
+                    await database.UpdateRemoteVolumeAsync(fsw.RemoteFilename, RemoteVolumeState.Uploading, -1, null);
+                    await database.CommitTransactionAsync("CommitUpdateFilelistVolume");
+
+                    await self.UploadChannel.WriteAsync(new FilesetUploadRequest(fsw));
                 }
+                catch
+                {
+                    await database.RollbackTransactionAsync();
+                    fsw?.Dispose();
+                    throw;
+                }
+            }
             );
         }
     }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -451,25 +451,25 @@ namespace Duplicati.Library.Main.Operation
                                 // Start the uploader process
                                 uploaderTask = uploader.Run();
 
-                                // If we have an interrupted backup, grab the 
-                                string lasttempfilelist = null;
-                                long lasttempfileid = -1;
+                                // If we have an interrupted backup, grab the fileset
+                                string lastTempFilelist = null;
+                                long lastTempFilesetId = -1;
                                 if (!m_options.DisableSyntheticFilelist)
                                 {
                                     var candidates = (await db.GetIncompleteFilesetsAsync()).OrderBy(x => x.Value).ToArray();
-                                    if (candidates.Length > 0)
+                                    if (candidates.Any())
                                     {
-                                        lasttempfileid = candidates.Last().Key;
-                                        lasttempfilelist = m_database.GetRemoteVolumeFromID(lasttempfileid).Name;
+                                        lastTempFilesetId = candidates.Last().Key;
+                                        lastTempFilelist = m_database.GetRemoteVolumeFromFilesetID(lastTempFilesetId).Name;
                                     }
                                 }
 
                                 // TODO: Rewrite to using the uploader process, or the BackendHandler interface
                                 // Do a remote verification, unless disabled
-                                PreBackupVerify(backendManager, lasttempfilelist);
+                                PreBackupVerify(backendManager, lastTempFilelist);
 
                                 // If the previous backup was interrupted, send a synthetic list
-                                await Backup.UploadSyntheticFilelist.Run(db, m_options, m_result, m_result.TaskReader, lasttempfilelist, lasttempfileid);
+                                await Backup.UploadSyntheticFilelist.Run(db, m_options, m_result, m_result.TaskReader, lastTempFilelist, lastTempFilesetId);
 
                                 // Grab the previous backup ID, if any
                                 var prevfileset = m_database.FilesetTimes.FirstOrDefault();

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -87,14 +87,16 @@ namespace Duplicati.Library.Main.Volumes
                 try { m_compression.Dispose(); }
                 finally { m_compression = null; }
 
-            m_localfile.Protected = false;
             if (m_localFileStream != null)
                 try { m_localFileStream.Dispose(); }
                 finally { m_localFileStream = null; }
 
             if (m_localfile != null)
+            {
+                m_localfile.Protected = false;
                 try { m_localfile.Dispose(); }
                 finally { m_localfile = null; }
+            }
 
             m_volumename = null;
         }

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -518,7 +518,7 @@ namespace Duplicati.UnitTest
         public void StopNow()
         {
             // Choose a dblock size that is small enough so that more than one volume is needed.
-            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions) {["dblock-size"] = "10mb"};
+            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions) {["dblock-size"] = "10mb", ["disable-synthetic-filelist"] = "true"};
 
             // Run a complete backup.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))


### PR DESCRIPTION
A synthetic filelist could not be uploaded due to the logic in UploadSyntheticFilelist. The code passing in the fileset id to the class would get the id based on if the volume was in the Temporary or Uploading states. If the volume was in the Uploading state, present on the remote backend, and of the right size it would get changed to Uploaded.

One of the first things UploadSyntheticFilelist does is throw an exception if the volume is not in the Uploaded state. Or if it is in the Uploaded state, the next check would prevent a synthetic filelist from being created if the volume was not in the Uploading or Temporary states.

Removed the check for the volume not being in the Uploaded state as the warning in the second check handles that case.

Removed the using statement as it would dispose of the FilesetVolumeWriter after passing it to the UploadChannel. The UploadChannel could not use it since it had been disposed.

Fixed the GetRemoteVolumeFromIDAsync taking a fileset id and matching it up against a volume id. Now it will use fileset id to get the volume that matches the fileset.

Change the StopNow disruption test to not use a synthetic file list. The test was written with it not working and therefore fails a check on the number of filesets after stopping a backup.

Bonus fix for a possible null exception in Dispose for VolumeWriterBase.

Fixes #2506 