### PR TITLE
Throw TimeoutException upon HTTP timeout for GET operations

### DIFF
--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
@@ -65,6 +65,26 @@ namespace Duplicati.Library
         }
 
         /// <summary>
+        /// Hide the base GetAsync method to throw a TimeoutException when an HTTP timeout occurs.
+        /// </summary>
+        public new async Task<System.Net.Http.HttpResponseMessage> GetAsync(string requestUri)
+        {
+            // The HttpClient.GetAsync method throws an OperationCanceledException when the timeout is exceeded.
+            // In order to provide a more informative exception, we will detect this case and throw a TimeoutException
+            // instead.
+            try
+            {
+                return await base.GetAsync(requestUri).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Since there is no CancellationToken, we will assume that the OperationCanceledException
+                // is due to an HTTP timeout.
+                throw new TimeoutException($"HTTP timeout {this.Timeout} exceeded.");
+            }
+        }
+
+        /// <summary>
         /// Sends an async request with optional authentication.
         /// </summary>
         /// <param name="request">Http request</param>


### PR DESCRIPTION
The `HttpClient.GetAsync` method throws an `OperationCanceledException` when the timeout is exceeded.  In order to provide a more informative exception, we will detect this case and throw a `TimeoutException` instead.  Since there is no `CancellationToken`, we will assume that the `OperationCanceledException` is due to a timeout.

This is related to issue #3772.  Pull request #3778 handled a similar issue, but only for PUT operations.

See the following for more information:

https://stackoverflow.com/questions/10547895/how-can-i-tell-when-httpclient-has-timed-out/32230327#32230327
https://github.com/dotnet/runtime/issues/21965

It appears that .NET Core will be handling this a bit better:

https://github.com/dotnet/runtime/pull/2281