### PR TITLE
Revert incorrect disposal of IndexVolumeWriter

### DIFF
--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -653,9 +653,11 @@ namespace Duplicati.Library.Main
                     item.IndexfileUpdated = true;
                 }
 
-                var hashsize = HashAlgorithmHelper.Create(m_options.BlockHashAlgorithm).HashSize / 8;
-                using (IndexVolumeWriter wr = new IndexVolumeWriter(m_options))
+                IndexVolumeWriter wr = null;
+                try
                 {
+                    var hashsize = HashAlgorithmHelper.Create(m_options.BlockHashAlgorithm).HashSize / 8;
+                    wr = new IndexVolumeWriter(m_options);
                     using (var rd = new IndexVolumeReader(p.CompressionModule, item.Indexfile.Item2.LocalFilename, m_options, hashsize))
                         wr.CopyFrom(rd, x => x == oldname ? newname : x);
                     item.Indexfile.Item1.Dispose();
@@ -663,6 +665,15 @@ namespace Duplicati.Library.Main
                     item.Indexfile.Item2.LocalTempfile.Dispose();
                     item.Indexfile.Item2.LocalTempfile = wr.TempFile;
                     wr.Close();
+                }
+                catch
+                {
+                    if (wr != null)
+                        try { wr.Dispose(); }
+                        catch { }
+                        finally { wr = null; }
+
+                    throw;
                 }
             }
         }

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -668,11 +668,7 @@ namespace Duplicati.Library.Main
                 }
                 catch
                 {
-                    if (wr != null)
-                        try { wr.Dispose(); }
-                        catch { }
-                        finally { wr = null; }
-
+                    wr?.Dispose();
                     throw;
                 }
             }


### PR DESCRIPTION
This reverts a change made in pull request #3930 that introduced a `using` statement to dispose of an `IndexVolumeWriter` instance.  Since a reference to this `IndexVolumeWriter` is being provided to the `FileEntryItem`, we cannot safely dispose of it here.  It does appear that the local temp file will still be [deleted](https://github.com/duplicati/duplicati/blob/v2.0.5.103-2.0.5.103_canary_2020-02-18/Duplicati/Library/Main/BackendManager.cs#L608) by the `BackendManager` for PUT operations.

This fixes issue #4130.