### PR TITLE
Only store inheritance breaks in metadata when True

### DIFF
--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -490,7 +490,7 @@ namespace Duplicati.Library.Common.IO
 
             // Only include the following key when its value is True.
             // This prevents unnecessary 'metadata change' detections when upgrading from
-            //   older versions (pre-2.0.5.101) that didn't store this value at all.
+            // older versions (pre-2.0.5.101) that didn't store this value at all.
             // When key is not present, its value is presumed False by the restore code.
             if (rules.AreAccessRulesProtected)
             {

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -487,7 +487,11 @@ namespace Duplicati.Library.Common.IO
                 objs.Add(new FileSystemAccess((FileSystemAccessRule)f));
 
             dict["win-ext:accessrules"] = SerializeObject(objs);
-            dict["win-ext:accessrulesprotected"] = rules.AreAccessRulesProtected.ToString();
+
+            if (rules.AreAccessRulesProtected)
+            {
+                dict["win-ext:accessrulesprotected"] = rules.AreAccessRulesProtected.ToString();
+            }
 
             return dict;
         }

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -488,9 +488,13 @@ namespace Duplicati.Library.Common.IO
 
             dict["win-ext:accessrules"] = SerializeObject(objs);
 
+            // Only include the following key when its value is True.
+            // This prevents unnecessary 'metadata change' detections when upgrading from
+            //   older versions (pre-2.0.5.101) that didn't store this value at all.
+            // When key is not present, its value is presumed False by the restore code.
             if (rules.AreAccessRulesProtected)
             {
-                dict["win-ext:accessrulesprotected"] = rules.AreAccessRulesProtected.ToString();
+                dict["win-ext:accessrulesprotected"] = "True";
             }
 
             return dict;


### PR DESCRIPTION
See issue https://github.com/duplicati/duplicati/issues/4141

Previous pull request https://github.com/duplicati/duplicati/pull/4031 stores inheritance break information in file metadata, regardless of it being true or false.

This has a side effect of Duplicati detecting a metadata change for EVERY file the first time a backup is run with the updated version.  That first backup will take longer to complete.

I recommend the following refinement so that inheritance break information is only stored when it's actually True.  Duplicati will only detect metadata change (and therefore reprocess file contents) for files where inheritance is actually broken.  (Again, only applies to first backup after upgrading.)

There is no change in net functionality of PR 4031 because if the inheritance break information is not present in the metadata, it is assumed to be False.

It'd be best if this were merged before the next beta release so the larger Beta audience is never affected.  (Beta 2.0.5.1 does not include PR 4031.)

Canary users running 2.0.5.101 or later will experience another "longer than normal" backup as Duplicati will again see metadata changes when doing the first backup after upgrading.