### PR TITLE
Allow MS Graph backends (e.g., OneDrive v2) to use OAuthHelper instead of OAuthHttpClient

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -394,6 +394,30 @@ namespace Duplicati.CommandLine.BackendTester
                             Console.WriteLine("*** Remote folder contains {0} after cleanup", fe.Name);
                         }
 
+                    // Test some error cases
+                    Console.WriteLine("Checking retrieval of non-existent file...");
+                    bool caughtExpectedException = false;
+                    try
+                    {
+                        using (Duplicati.Library.Utility.TempFile tempFile = new Duplicati.Library.Utility.TempFile())
+                        {
+                            backend.Get(string.Format("NonExistentFile-{0}", Guid.NewGuid()), tempFile.Name);
+                        }
+                    }
+                    catch (FileMissingException ex)
+                    {
+                        Console.WriteLine("Caught expected FileMissingException");
+                        caughtExpectedException = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine("*** Retrieval of non-existent file failed: {0}", ex);
+                    }
+
+                    if (!caughtExpectedException)
+                    {
+                        Console.WriteLine("*** Retrieval of non-existent file should have failed with FileMissingException");
+                    }
                 }
 
                 // Test quota retrieval

--- a/Duplicati/Library/Backend/OAuthHelper/JSONWebHelper.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/JSONWebHelper.cs
@@ -365,12 +365,12 @@ namespace Duplicati.Library
             if (method == null && requestdata != null)
                 method = "POST";
 
-            return await GetResponseWithoutExceptionAsync(CreateRequest(url, method), cancelToken, requestdata);
+            return await GetResponseWithoutExceptionAsync(CreateRequest(url, method), cancelToken, requestdata).ConfigureAwait(false);
         }
 
         public async Task<HttpWebResponse> GetResponseWithoutExceptionAsync(HttpWebRequest req, CancellationToken cancelToken, object requestdata = null)
         {
-            return await GetResponseWithoutExceptionAsync(new AsyncHttpRequest(req), cancelToken, requestdata);
+            return await GetResponseWithoutExceptionAsync(new AsyncHttpRequest(req), cancelToken, requestdata).ConfigureAwait(false);
         }
 
         public async Task<HttpWebResponse> GetResponseWithoutExceptionAsync(AsyncHttpRequest req, CancellationToken cancelToken, object requestdata = null)
@@ -386,7 +386,7 @@ namespace Duplicati.Library
                             req.Request.ContentType = "application/octet-stream";
 
                         using (var rs = req.GetRequestStream())
-                            await Utility.Utility.CopyStreamAsync(stream, rs, cancelToken);
+                            await Utility.Utility.CopyStreamAsync(stream, rs, cancelToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -395,7 +395,7 @@ namespace Duplicati.Library
                         req.Request.ContentType = "application/json; charset=UTF-8";
 
                         using (var rs = req.GetRequestStream())
-                            await rs.WriteAsync(data, 0, data.Length, cancelToken);
+                            await rs.WriteAsync(data, 0, data.Length, cancelToken).ConfigureAwait(false);
                     }
                 }
 
@@ -486,7 +486,7 @@ namespace Duplicati.Library
                             req.Request.ContentType = "application/octet-stream";
 
                         using (var rs = req.GetRequestStream())
-                            await Utility.Utility.CopyStreamAsync(stream, rs, cancelToken);
+                            await Utility.Utility.CopyStreamAsync(stream, rs, cancelToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -495,7 +495,7 @@ namespace Duplicati.Library
                         req.Request.ContentType = "application/json; charset=UTF-8";
 
                         using (var rs = req.GetRequestStream())
-                            await rs.WriteAsync(data, 0, data.Length, cancelToken);
+                            await rs.WriteAsync(data, 0, data.Length, cancelToken).ConfigureAwait(false);
                     }
                 }
 

--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHelper.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHelper.cs
@@ -105,8 +105,13 @@ namespace Duplicati.Library
 
         public override HttpWebRequest CreateRequest(string url, string method = null)
         {
+            return this.CreateRequest(url, method, false);
+        }
+
+        public HttpWebRequest CreateRequest(string url, string method, bool noAuthorization)
+        {
             var r = base.CreateRequest(url, method);
-            if (AutoAuthHeader && !string.Equals(OAuthContextSettings.ServerURL, url))
+            if (!noAuthorization && AutoAuthHeader && !string.Equals(OAuthContextSettings.ServerURL, url))
                 r.Headers["Authorization"] = string.Format("Bearer {0}", AccessToken);
             return r;
         } 

--- a/Duplicati/Library/Backend/OneDrive/Exceptions.cs
+++ b/Duplicati/Library/Backend/OneDrive/Exceptions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -13,6 +15,9 @@ namespace Duplicati.Library.Backend.MicrosoftGraph
     {
         private static readonly Regex authorizationHeaderRemover = new Regex(@"Authorization:\s*Bearer\s+\S+", RegexOptions.IgnoreCase);
 
+        private readonly HttpResponseMessage responseMessage;
+        private readonly HttpWebResponse webResponse;
+
         public MicrosoftGraphException(HttpResponseMessage response)
             : this(string.Format("{0}: {1} error from request {2}", response.StatusCode, response.ReasonPhrase, response.RequestMessage.RequestUri), response)
         {
@@ -26,10 +31,55 @@ namespace Duplicati.Library.Backend.MicrosoftGraph
         public MicrosoftGraphException(string message, HttpResponseMessage response, Exception innerException)
             : base(BuildFullMessage(message, response), innerException)
         {
-            this.Response = response;
+            this.responseMessage = response;
         }
 
-        public string RequestUrl => this.Response.RequestMessage.RequestUri.ToString();
+        public MicrosoftGraphException(HttpWebResponse response)
+            : this(string.Format("{0}: {1} error from request {2}", response.StatusCode, response.StatusDescription, response.ResponseUri), response)
+        {
+        }
+
+        public MicrosoftGraphException(string message, HttpWebResponse response)
+            : this(message, response, null)
+        {
+        }
+
+        public MicrosoftGraphException(string message, HttpWebResponse response, Exception innerException)
+            : base(BuildFullMessage(message, response), innerException)
+        {
+            this.webResponse = response;
+        }
+
+        public string RequestUrl
+        {
+            get
+            {
+                if (this.responseMessage != null)
+                {
+                    return this.responseMessage.RequestMessage.RequestUri.ToString();
+                }
+                else
+                {
+                    return this.webResponse.ResponseUri.ToString();
+                }
+            }
+        }
+
+        public HttpStatusCode StatusCode
+        {
+            get
+            {
+                if (this.responseMessage != null)
+                {
+                    return this.responseMessage.StatusCode;
+                }
+                else
+                {
+                    return this.webResponse.StatusCode;
+                }
+            }
+        }
+
         public HttpResponseMessage Response { get; private set; }
 
         protected static string ResponseToString(HttpResponseMessage response)
@@ -37,13 +87,14 @@ namespace Duplicati.Library.Backend.MicrosoftGraph
             if (response != null)
             {
                 // Start to read the content
-                Task<string> content = response.Content.ReadAsStringAsync();
-
-                // Since the exception message may be saved / sent in logs, we want to prevent the authorization header from being included.
-                // it wouldn't be as bad as recording the username/password in logs, since the token will expire, but it doesn't hurt to be safe.
-                // So we replace anything in the request that looks like the auth header with a safe version.
-                string requestMessage = authorizationHeaderRemover.Replace(response.RequestMessage.ToString(), "Authorization: Bearer ABC...XYZ");
-                return string.Format("{0}\n{1}\n{2}", requestMessage, response, JsonConvert.SerializeObject(JsonConvert.DeserializeObject(content.Await()), Formatting.Indented));
+                using (Task<string> content = response.Content.ReadAsStringAsync())
+                {
+                    // Since the exception message may be saved / sent in logs, we want to prevent the authorization header from being included.
+                    // it wouldn't be as bad as recording the username/password in logs, since the token will expire, but it doesn't hurt to be safe.
+                    // So we replace anything in the request that looks like the auth header with a safe version.
+                    string requestMessage = authorizationHeaderRemover.Replace(response.RequestMessage.ToString(), "Authorization: Bearer ABC...XYZ");
+                    return string.Format("{0}\n{1}\n{2}", requestMessage, response, PrettifyJson(content.Await()));
+                }
             }
             else
             {
@@ -62,12 +113,71 @@ namespace Duplicati.Library.Backend.MicrosoftGraph
                 return message;
             }
         }
+
+        protected static string ResponseToString(HttpWebResponse response)
+        {
+            if (response != null)
+            {
+                // Start to read the content
+                using (var responseStream = response.GetResponseStream())
+                using (var textReader = new StreamReader(responseStream))
+                {
+                    return string.Format("{0}\n{1}", response, PrettifyJson(textReader.ReadToEnd()));
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private static string BuildFullMessage(string message, HttpWebResponse response)
+        {
+            if (response != null)
+            {
+                return string.Format("{0}\n{1}", message, ResponseToString(response));
+            }
+            else
+            {
+                return message;
+            }
+        }
+
+        private static string PrettifyJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return json;
+            }
+
+            if (json[0] == '<')
+            {
+                // It looks like some errors return xml bodies instead of JSON.
+                // If this looks like it might be one of those, don't even bother parsing the JSON.
+                return json;
+            }
+
+            try
+            {
+                return JsonConvert.SerializeObject(JsonConvert.DeserializeObject(json), Formatting.Indented);
+            }
+            catch (Exception)
+            {
+                // Maybe this wasn't JSON..
+                return json;
+            }
+        }
     }
 
     public class DriveItemNotFoundException : MicrosoftGraphException
     {
         public DriveItemNotFoundException(HttpResponseMessage response)
             : base(string.Format("Item at {0} was not found", response?.RequestMessage?.RequestUri?.ToString() ?? "<unknown>"), response)
+        {
+        }
+
+        public DriveItemNotFoundException(HttpWebResponse response)
+            : base(string.Format("Item at {0} was not found", response?.ResponseUri?.ToString() ?? "<unknown>"), response)
         {
         }
     }
@@ -89,13 +199,23 @@ namespace Duplicati.Library.Backend.MicrosoftGraph
             this.InnerException = fragmentException;
         }
 
-        public string CreateSessionRequestUrl => this.RequestUrl;
-        public HttpResponseMessage CreateSessionResponse => this.Response;
+        public UploadSessionException(
+            HttpWebResponse originalResponse,
+            int fragment,
+            int fragmentCount,
+            MicrosoftGraphException fragmentException)
+            : base(
+                  string.Format("Error uploading fragment {0} of {1} for {2}", fragment, fragmentCount, originalResponse?.ResponseUri?.ToString() ?? "<unknown>"),
+                  originalResponse,
+                  fragmentException)
+        {
+            this.Fragment = fragment;
+            this.FragmentCount = fragmentCount;
+            this.InnerException = fragmentException;
+        }
 
         public int Fragment { get; private set; }
         public int FragmentCount { get; private set; }
-        public string FragmentRequestUrl => this.InnerException.RequestUrl;
-        public HttpResponseMessage FragmentResponse => this.InnerException.Response;
 
         public new MicrosoftGraphException InnerException { get; private set; }
     }

--- a/Duplicati/Library/Backend/OneDrive/Strings.cs
+++ b/Duplicati/Library/Backend/OneDrive/Strings.cs
@@ -12,6 +12,8 @@ namespace Duplicati.Library.Backend.Strings
         public static string FragmentRetryCountLong { get { return LC.L(@"Number of retry attempts made for each fragment before failing the overall file upload"); } }
         public static string FragmentRetryDelayShort { get { return LC.L(@"Millisecond delay between fragment errors"); } }
         public static string FragmentRetryDelayLong { get { return LC.L(@"Amount of time (in milliseconds) to wait between failures when uploading fragments"); } }
+        public static string UseHttpClientShort { get { return LC.L(@"Whether the HttpClient class should be used"); } }
+        public static string UseHttpClientLong { get { return LC.L(@"Whether the HttpClient class should be used to perform HTTP requests"); } }
     }
 
     internal static class OneDriveV2


### PR DESCRIPTION
When I originally wrote the Microsoft Graph backends (OneDrive v2, SharePoint v2, etc.), I also wrote a new OAuthHttpClient class based on the standard HttpClient class, rather than using the existing OAuthHelper class. I did this partially out of having more familiarity with the HttpClient based code, but also because that seemed to be the newer API, as opposed to the HttpWebRequest pattern most other backends used.

This change adds support to these backends for using the 'standard' OAuthHelper instead of the OAuthHttpClient by way of the new `--use-http-client=false` parameter. This logic lives in parallel to the original implementation that uses the OAuthHttpClient class,

This is intended primarily to see if this helps resolve the memory leaks seen in some versions of Mono (see #4108), since the main difference between these backends and others that don't seem to have any problems is the use of the HttpClient APIs. For this reason, the new behavior (using OAuthHelper) is the default on Mono, while the original behavior (using OAuthHttpClient) is the default otherwise.

I've tested both version of this using the OneDrive v2 backend on Windows, but don't have a good way to test on Mono. At any rate, the behavior for both should be the same (barring any bugs in either the backend or the framework). I'm not currently sure what performance differences there might be between the two either.