### PR TITLE
Add default nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <add key="repositoryPath" value="packages" />
+    </config>
+</configuration>


### PR DESCRIPTION
This is to ensure any system-wide nuget config for the package location is ignored and packages are still downloaded to the packages directory inside the solution.