### PR TITLE
Sort file and folder listing in web UI

### DIFF
--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -65,7 +65,9 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 result[n.Name] = n.Value;
 
             result["Filesets"] = r.Filesets;
-            result["Files"] = r.Files;
+            result["Files"] = r.Files
+                .OrderByDescending(f => f.Path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+                .ThenBy(f => f.Path);
 
             info.OutputOK(result);
 

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -66,7 +66,9 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             result["Filesets"] = r.Filesets;
             result["Files"] = r.Files
-                .OrderByDescending(f => f.Path.EndsWith("/", StringComparison.Ordinal) || f.Path.EndsWith("\\", StringComparison.Ordinal))
+                // Group directories first - support either directory separator here as we may be restoring data from an alternate platform
+                .OrderByDescending(f => (f.Path.StartsWith("/", StringComparison.Ordinal) && f.Path.EndsWith("/", StringComparison.Ordinal)) || (!f.Path.StartsWith("/", StringComparison.Ordinal) && f.Path.EndsWith("\\", StringComparison.Ordinal)))
+                // Sort both groups (directories and files) alphabetically
                 .ThenBy(f => f.Path);
 
             info.OutputOK(result);

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -66,7 +66,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             result["Filesets"] = r.Filesets;
             result["Files"] = r.Files
-                .OrderByDescending(f => f.Path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+                .OrderByDescending(f => f.Path.EndsWith("/", StringComparison.Ordinal) || f.Path.EndsWith("\\", StringComparison.Ordinal))
                 .ThenBy(f => f.Path);
 
             info.OutputOK(result);

--- a/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
@@ -209,7 +209,9 @@ namespace Duplicati.Server.WebServer.RESTMethods
             };
 
             foreach (var s in SystemIO.IO_OS.EnumerateFileSystemEntries(entrypath)
+                // Group directories first
                 .OrderByDescending(f => SystemIO.IO_OS.GetFileAttributes(f) & FileAttributes.Directory)
+                // Sort both groups (directories and files) alphabetically
                 .ThenBy(f => f))
             {
                 Serializable.TreeNode tn = null;

--- a/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
@@ -208,7 +208,9 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 return false;
             };
 
-            foreach (var s in SystemIO.IO_OS.EnumerateFileSystemEntries(entrypath))
+            foreach (var s in SystemIO.IO_OS.EnumerateFileSystemEntries(entrypath)
+                .OrderByDescending(f => SystemIO.IO_OS.GetFileAttributes(f) & FileAttributes.Directory)
+                .ThenBy(f => SystemIO.IO_OS.PathGetFileName(f)))
             {
                 Serializable.TreeNode tn = null;
                 try

--- a/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Filesystem.cs
@@ -210,7 +210,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             foreach (var s in SystemIO.IO_OS.EnumerateFileSystemEntries(entrypath)
                 .OrderByDescending(f => SystemIO.IO_OS.GetFileAttributes(f) & FileAttributes.Directory)
-                .ThenBy(f => SystemIO.IO_OS.PathGetFileName(f)))
+                .ThenBy(f => f))
             {
                 Serializable.TreeNode tn = null;
                 try


### PR DESCRIPTION
When selecting source data (or selecting destination in case of local backups), the file/folder listing is not sorted and is presented in the raw order as returned by the API.

On my Debian Linux system, the ordering is completely random:
![linux-before](https://user-images.githubusercontent.com/39164691/77828506-1e7dda80-70d9-11ea-8152-2444d391f365.png)

On my Windows system, it does appear to be alphabetical but folders and files are mixed together:
![windows-before](https://user-images.githubusercontent.com/39164691/77828532-410ff380-70d9-11ea-96f5-cd9b660d64e2.png)

I suggest grouping and showing folders first before files. Both groups will be sorted alphabetically.
The following change achieves that goal but not sure if it's the most efficient. Thoughts?