### PR TITLE
Remove boilerplate code in calls to VerifyRemoteList

### DIFF
--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -98,11 +98,9 @@ namespace Duplicati.Library.Main.Operation
 				using(var bk = sharedBackend == null ? new BackendManager(m_backendurl, m_options, m_result.BackendWriter, db) : null)
                 {
                     var backend = bk ?? sharedBackend;
-                    if (!hasVerifiedBackend && !m_options.NoBackendverification)
+                    if (!hasVerifiedBackend)
                     {
-                        var backupDatabase = new LocalBackupDatabase(db, m_options);
-                        var latestFilelist = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: true, transaction: transaction);
-                        FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter, latestFilelist);
+                        FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter, true, transaction);
                     }
 
                     BlockVolumeWriter newvol = new BlockVolumeWriter(m_options);

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -87,11 +87,9 @@ namespace Duplicati.Library.Main.Operation
             {
                 var backend = bk ?? sharedManager;
 
-                if (!hasVerifiedBacked && !m_options.NoBackendverification)
+                if (!hasVerifiedBacked)
                 {
-                    var backupDatabase = new LocalBackupDatabase(db, m_options);
-                    var latestFilelist = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: true, transaction: transaction);
-                    FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter, latestFilelist);
+                    FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter, true, transaction);
                 }
 
                 IListResultFileset[] filesets = db.FilesetsWithBackupVersion.ToArray();

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -80,14 +80,14 @@ namespace Duplicati.Library.Main.Operation
             }
         }
 
-        public void DoRun(Database.LocalDeleteDatabase db, ref System.Data.IDbTransaction transaction, bool hasVerifiedBacked, bool forceCompact, BackendManager sharedManager)
+        public void DoRun(Database.LocalDeleteDatabase db, ref System.Data.IDbTransaction transaction, bool hasVerifiedBackend, bool forceCompact, BackendManager sharedManager)
         {
             // Workaround where we allow a running backendmanager to be used
             using(var bk = sharedManager == null ? new BackendManager(m_backendurl, m_options, m_result.BackendWriter, db) : null)
             {
                 var backend = bk ?? sharedManager;
 
-                if (!hasVerifiedBacked)
+                if (!hasVerifiedBackend)
                 {
                     FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_result.BackendWriter, true, transaction);
                 }

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -72,13 +72,13 @@ namespace Duplicati.Library.Main.Operation
             }
         }
 
-        public static void VerifyRemoteList(BackendManager backend, Options options, LocalDatabase database, IBackendWriter log, bool latestVolumesOnly, IDbTransaction transaction)
+        public static void VerifyRemoteList(BackendManager backend, Options options, LocalDatabase database, IBackendWriter backendWriter, bool latestVolumesOnly, IDbTransaction transaction)
         {
             if (!options.NoBackendverification)
             {
                 LocalBackupDatabase backupDatabase = new LocalBackupDatabase(database, options);
                 IEnumerable<string> protectedFiles = backupDatabase.GetTemporaryFilelistVolumeNames(latestVolumesOnly, transaction);
-                FilelistProcessor.VerifyRemoteList(backend, options, database, log, protectedFiles);
+                FilelistProcessor.VerifyRemoteList(backend, options, database, backendWriter, protectedFiles);
             }
         }
 

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -18,6 +18,7 @@
 using System;
 using Duplicati.Library.Main.Database;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using Duplicati.Library.Interface;
 
@@ -68,6 +69,16 @@ namespace Duplicati.Library.Main.Operation
                 }
 
                 backend.FlushDbMessages();
+            }
+        }
+
+        public static void VerifyRemoteList(BackendManager backend, Options options, LocalDatabase database, IBackendWriter log, bool latestVolumesOnly, IDbTransaction transaction)
+        {
+            if (!options.NoBackendverification)
+            {
+                LocalBackupDatabase backupDatabase = new LocalBackupDatabase(database, options);
+                IEnumerable<string> protectedFiles = backupDatabase.GetTemporaryFilelistVolumeNames(latestVolumesOnly, transaction);
+                FilelistProcessor.VerifyRemoteList(backend, options, database, log, protectedFiles);
             }
         }
 

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -333,10 +333,7 @@ namespace Duplicati.Library.Main.Operation
                 if (!m_options.NoBackendverification)
                 {
                     m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Restore_PreRestoreVerify);
-
-                    var backupDatabase = new LocalBackupDatabase(database, m_options);
-                    var tempFilelistVolumes = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: false);
-                    FilelistProcessor.VerifyRemoteList(backend, m_options, database, result.BackendWriter, tempFilelistVolumes);
+                    FilelistProcessor.VerifyRemoteList(backend, m_options, database, result.BackendWriter, false, null);
                 }
 
                 //Figure out what files are to be patched, and what blocks are needed

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -53,14 +53,8 @@ namespace Duplicati.Library.Main.Operation
                 Utility.UpdateOptionsFromDb(db, m_options);
                 Utility.VerifyParameters(db, m_options);
                 db.VerifyConsistency(m_options.Blocksize, m_options.BlockhashSize, true, null);
+                FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_results.BackendWriter, true, null);
 
-                if (!m_options.NoBackendverification)
-                {
-                    var backupDatabase = new LocalBackupDatabase(db, m_options);
-                    var latestFilelist = backupDatabase.GetTemporaryFilelistVolumeNames(latestOnly: true);
-                    FilelistProcessor.VerifyRemoteList(backend, m_options, db, m_results.BackendWriter, latestFilelist);
-                }
-                    
                 DoRun(samples, db, backend);
                 db.WriteResults();
             }


### PR DESCRIPTION
This adds a new overload for the `FilelistProcessor.VerifyRemoteList` method that allows us to remove some boilerplate code that appeared with each of the invocations.
