### PR TITLE
Remove unused members from Duplicati.Library.Common

### DIFF
--- a/Duplicati/Library/Common/IO/DefineDosDevice.cs
+++ b/Duplicati/Library/Common/IO/DefineDosDevice.cs
@@ -71,11 +71,6 @@ namespace Duplicati.Library.Common.IO
         public string Drive { get { return m_drive; } }
 
         /// <summary>
-        /// Gets the path that this mapping represents
-        /// </summary>
-        public string Targetpath { get { return m_targetPath; } }
-
-        /// <summary>
         /// Creates a new mapping, using default settings
         /// </summary>
         /// <param name="path">The path to map</param>

--- a/Duplicati/Library/Common/IO/ISystemIO.cs
+++ b/Duplicati/Library/Common/IO/ISystemIO.cs
@@ -28,15 +28,10 @@ namespace Duplicati.Library.Common.IO
     public interface ISystemIO
     {
         IFileEntry DirectoryEntry(string path);
-        void DirectoryDelete(string path);
-        void DirectoryDelete(string path, bool recursive);
         void DirectoryCreate(string path);
         bool DirectoryExists(string path);
         void DirectorySetLastWriteTimeUtc(string path, DateTime time);
         void DirectorySetCreationTimeUtc(string path, DateTime time);
-        DateTime DirectoryGetLastWriteTimeUtc(string path);
-        DateTime DirectoryGetCreationTimeUtc(string path);
-
 
         IFileEntry FileEntry(string path);
         void FileMove(string source, string target);
@@ -50,7 +45,6 @@ namespace Duplicati.Library.Common.IO
         long FileLength(string path);
         FileStream FileOpenRead(string path);
         FileStream FileOpenWrite(string path);
-        FileStream FileOpenReadWrite(string path);
         FileStream FileCreate(string path);
         FileAttributes GetFileAttributes(string path);
         void SetFileAttributes(string path, FileAttributes attributes);

--- a/Duplicati/Library/Common/IO/SystemIOLinux.cs
+++ b/Duplicati/Library/Common/IO/SystemIOLinux.cs
@@ -26,10 +26,6 @@ namespace Duplicati.Library.Common.IO
     public struct SystemIOLinux : ISystemIO
     {
         #region ISystemIO implementation
-        public void DirectoryDelete(string path)
-        {
-            Directory.Delete(NormalizePath(path));
-        }
 
         public void DirectoryCreate(string path)
         {
@@ -79,11 +75,6 @@ namespace Duplicati.Library.Common.IO
         public FileStream FileOpenWrite(string path)
         {
             return File.OpenWrite(path);
-        }
-
-        public FileStream FileOpenReadWrite(string path)
-        {
-            return File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
         }
 
         public FileStream FileCreate(string path)
@@ -157,16 +148,6 @@ namespace Duplicati.Library.Common.IO
             Directory.SetCreationTimeUtc(NormalizePath(path), time);
         }
 
-        public DateTime DirectoryGetLastWriteTimeUtc(string path)
-        {
-            return Directory.GetLastWriteTimeUtc(NormalizePath(path));
-        }
-
-        public DateTime DirectoryGetCreationTimeUtc(string path)
-        {
-            return Directory.GetCreationTimeUtc(NormalizePath(path));
-        }
-
         public void FileMove(string source, string target)
         {
             File.Move(source, target);
@@ -175,11 +156,6 @@ namespace Duplicati.Library.Common.IO
         public long FileLength(string path)
         {
             return new FileInfo(path).Length;
-        }
-
-        public void DirectoryDelete(string path, bool recursive)
-        {
-            Directory.Delete(NormalizePath(path), recursive);
         }
 
         public Dictionary<string, string> GetMetadata(string file, bool isSymlink, bool followSymlink)

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -192,12 +192,6 @@ namespace Duplicati.Library.Common.IO
         }
 
         #region ISystemIO implementation
-        public void DirectoryDelete(string path)
-        {
-            PathTooLongActionWrapper(System.IO.Directory.Delete,
-                                     Alphaleonis.Win32.Filesystem.Directory.Delete, path, true);
-        }
-
         public void DirectoryCreate(string path)
         {
             PathTooLongVoidFuncWrapper(System.IO.Directory.CreateDirectory,
@@ -258,12 +252,6 @@ namespace Duplicati.Library.Common.IO
             return !FileExists(path)
                 ? FileCreate(path)
                 : PathTooLongFuncWrapper(System.IO.File.OpenWrite, Alphaleonis.Win32.Filesystem.File.OpenWrite, path, true);
-        }
-
-        public System.IO.FileStream FileOpenReadWrite(string path)
-        {
-            return PathTooLongFuncWrapper(p => System.IO.File.Open(p, System.IO.FileMode.OpenOrCreate, System.IO.FileAccess.ReadWrite, System.IO.FileShare.Read),
-                                   p => Alphaleonis.Win32.Filesystem.File.Open(p, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read), path, true);
         }
 
         public System.IO.FileStream FileCreate(string path)
@@ -356,18 +344,6 @@ namespace Duplicati.Library.Common.IO
                                      p => Alphaleonis.Win32.Filesystem.File.SetCreationTimeUtc(p, time), path, true);
         }
 
-        public DateTime DirectoryGetLastWriteTimeUtc(string path)
-        {
-            return PathTooLongFuncWrapper(System.IO.Directory.GetLastWriteTimeUtc,
-                                          Alphaleonis.Win32.Filesystem.Directory.GetLastWriteTimeUtc, path, true);
-        }
-
-        public DateTime DirectoryGetCreationTimeUtc(string path)
-        {
-            return PathTooLongFuncWrapper(System.IO.Directory.GetCreationTimeUtc,
-                                          Alphaleonis.Win32.Filesystem.Directory.GetCreationTimeUtc, path, true);
-        }
-
         public void FileMove(string source, string target)
         {
             // We do not check if path is too long on target. If so, then we catch an exception.
@@ -381,13 +357,6 @@ namespace Duplicati.Library.Common.IO
             return PathTooLongFuncWrapper(p => new System.IO.FileInfo(p).Length,
                                           p => new Alphaleonis.Win32.Filesystem.FileInfo(p).Length,
                                           path, true);
-        }
-
-        public void DirectoryDelete(string path, bool recursive)
-        {
-            PathTooLongActionWrapper(p => System.IO.Directory.Delete(p, recursive),
-                                     p => Alphaleonis.Win32.Filesystem.Directory.Delete(p, recursive),
-                                     path, true);
         }
 
         public string GetPathRoot(string path)


### PR DESCRIPTION
This removes unused members from the `Duplicati.Library.Common` namespace.