### PR TITLE
Remove unused Strings.Common members

### DIFF
--- a/Duplicati/Library/Interface/Strings.cs
+++ b/Duplicati/Library/Interface/Strings.cs
@@ -18,26 +18,8 @@ namespace Duplicati.Library.Interface.Strings {
         public static string Unknown { get { return LC.L(@"Unknown"); } }
     }
     internal static class Common {
-        public static string ConfigurationIsMissingItemError(string fieldname) { return LC.L(@"The configuration for the backend is not valid, it is missing the {0} field", fieldname); }
-        public static string ConfirmTestConnectionQuestion { get { return LC.L(@"Do you want to test the connection?"); } }
-        public static string ConnectionFailure(string message) { return LC.L(@"Connection Failed: {0}", message); }
-        public static string ConnectionSuccess { get { return LC.L(@"Connection succeeded!"); } }
-        public static string DefaultDirectoryWarning { get { return LC.L(@"You have not entered a path. This will store all backups in the default directory. Is this what you want?"); } }
-        public static string EmptyPasswordError { get { return LC.L(@"You must enter a password"); } }
-        public static string EmptyPasswordWarning { get { return LC.L(@"You have not entered a password.
-Proceed without a password?"); } }
-        public static string EmptyServernameError { get { return LC.L(@"You must enter the name of the server"); } }
-        public static string EmptyUsernameError { get { return LC.L(@"You must enter a username"); } }
-        public static string EmptyUsernameWarning { get { return LC.L(@"You have not entered a username.
-This is fine if the server allows anonymous uploads, but likely a username is required
-Proceed without a username?"); } }
-        public static string ExistingBackupDetectedQuestion { get { return LC.L(@"The connection succeeded but another backup was found in the destination folder. It is possible to configure Duplicati to store multiple backups in the same folder, but it is not recommended.
-
-Do you want to use the selected folder?"); } }
         public static string FolderAlreadyExistsError { get { return LC.L(@"The folder cannot be created because it already exists"); } }
-        public static string FolderCreated { get { return LC.L(@"Folder created!"); } }
         public static string FolderMissingError { get { return LC.L(@"The requested folder does not exist"); } }
-        public static string InvalidServernameError(string servername) { return LC.L(@"The server name ""{0}"" is not valid", servername); }
         public static string CancelExceptionError { get { return LC.L(@"Cancelled"); } }
     }
 }


### PR DESCRIPTION
The last references were removed in 5170c6ad1d ("Remove unused CommonStrings class"), but the last real usages were removed in revision 62c75d9af9 ("Removed all informs code (no more 1.3.x UI)").