### PR TITLE
Add indices to Block table to improve query performance

### DIFF
--- a/Duplicati/Library/Main/Database/Database schema/11. Add Block indices.sql
+++ b/Duplicati/Library/Main/Database/Database schema/11. Add Block indices.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS "BlockSize" ON "Block" ("Size");
+CREATE UNIQUE INDEX IF NOT EXISTS "BlockHashVolumeID" ON "Block" ("Hash", "VolumeID");
+
+UPDATE "Version" SET "Version" = 11;

--- a/Duplicati/Library/Main/Duplicati.Library.Main.csproj
+++ b/Duplicati/Library/Main/Duplicati.Library.Main.csproj
@@ -205,6 +205,8 @@
     <EmbeddedResource Include="Database\Database schema\7. Add index.sql" />
     <EmbeddedResource Include="Database\Database schema\8. Add volume USN.sql" />
     <EmbeddedResource Include="Database\Database schema\9. Refactor Paths.sql" />
+    <EmbeddedResource Include="Database\Database schema\10. Add IsFullBackup to Fileset table.sql" />
+    <EmbeddedResource Include="Database\Database schema\11. Add Block indices.sql" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
@@ -215,7 +217,6 @@
   </Target>
   -->
   <ItemGroup>
-    <EmbeddedResource Include="Database\Database schema\10. Add IsFullBackup to Fileset table.sql" />
     <Content Include="default_compressed_extensions.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
The index on `Block.Size` improves the performance of the [query](https://github.com/duplicati/duplicati/blob/v2.0.5.104-2.0.5.104_canary_2020-03-25/Duplicati/Library/Main/Database/LocalDatabase.cs#L723) that checks that the user has not altered the block size of the backup configuration.

The index on `Block.Hash` and `Block.VolumeID` improves the performance of the [query](https://github.com/duplicati/duplicati/blob/v2.0.5.104-2.0.5.104_canary_2020-03-25/Duplicati/Library/Main/Database/LocalDatabase.cs#L1284) that obtains the blocklists.

There are anecdotes that these indices can drastically improve performance (queries that used to take **hours** completed in **seconds** with the index):

https://forum.duplicati.com/t/repairing-a-big-database/8174/4
https://github.com/duplicati/duplicati/issues/3884#issuecomment-612296016

This fixes issue #3884.