### PR TITLE
Do not remove Alpha VSS dependencies in installer packages

### DIFF
--- a/Installer/Makefile/Makefile
+++ b/Installer/Makefile/Makefile
@@ -37,12 +37,9 @@ package: build
 	mkdir "$(PACKAGE_DIR)/usr/share/doc/duplicati"	
 	cp -R "$(SOURCE_DIR)/Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release" "$(PACKAGE_DIR)/usr/lib/duplicati"
 
-	rm -rf "$(PKG_TARGET)/alphavss"
 	rm -rf "$(PKG_TARGET)/SQLite"
 	rm -rf "$(PKG_TARGET)/win-tools"
 	rm -rf "$(PKG_TARGET)/"*.mdb
-	rm -rf "$(PKG_TARGET)/AlphaFS.dll"
-	rm -rf "$(PKG_TARGET)/AlphaVSS.Common.dll"
 
 	cp -R "$(SOURCE_DIR)/Duplicati/Server/webroot" "$(PACKAGE_DIR)/usr/lib/duplicati/"
 	cp "$(SOURCE_DIR)/Installer/debian/duplicati-launcher.sh" "$(PACKAGE_DIR)/usr/bin/duplicati"

--- a/Installer/OSX/make-dmg.sh
+++ b/Installer/OSX/make-dmg.sh
@@ -9,7 +9,7 @@ WC_DIR=wc
 TEMPLATE_DMG=template.dmg
 OUTPUT_DMG=Duplicati.dmg
 OUTPUT_PKG=Duplicati.pkg
-UNWANTED_FILES="AlphaVSS.Common.dll AlphaFS.dll AlphaFS.dll.config AlphaVSS.Common.dll.config appindicator-sharp.dll SQLite win-tools alphavss control_dir Duplicati.sqlite Duplicati-server.sqlite run-script-example.bat lvm-scripts Duplicati.debug.log SVGIcons"
+UNWANTED_FILES="appindicator-sharp.dll SQLite win-tools control_dir Duplicati.sqlite Duplicati-server.sqlite run-script-example.bat lvm-scripts Duplicati.debug.log SVGIcons"
 
 # These are set via the macos-gatekeeper file
 CODESIGN_IDENTITY=

--- a/Installer/Synology/make-binary-package.sh
+++ b/Installer/Synology/make-binary-package.sh
@@ -72,12 +72,8 @@ rm -rf ./win-tools
 rm -rf ./SQLite/win64
 rm -rf ./SQLite/win32
 rm -rf ./MonoMac.dll
-rm -rf ./alphavss
 rm -rf ./OSX\ Icons
 rm -rf ./OSXTrayHost
-rm ./AlphaFS.dll
-rm ./AlphaVSS.Common.dll
-rm -rf ./licenses/alphavss
 rm -rf ./licenses/MonoMac
 rm -rf ./licenses/gpg
 

--- a/Installer/debian/bin-rules.sh
+++ b/Installer/debian/bin-rules.sh
@@ -52,12 +52,8 @@ override_dh_auto_install:
 	rm -rf build/lib/duplicati/SQLite/win64
 	rm -rf build/lib/duplicati/SQLite/win32
 	rm -rf build/lib/duplicati/MonoMac.dll
-	rm -rf build/lib/duplicati/alphavss
 	rm -rf build/lib/duplicati/OSX\ Icons
 	rm -rf build/lib/duplicati/OSXTrayHost
-	rm build/lib/duplicati/AlphaFS.dll
-	rm build/lib/duplicati/AlphaVSS.Common.dll
-	rm -rf build/lib/duplicati/licenses/alphavss
 	rm -rf build/lib/duplicati/licenses/MonoMac
 	rm -rf build/lib/duplicati/licenses/gpg
 	find build/lib/duplicati/* -type f | xargs chmod 644

--- a/Installer/debian/debian/rules
+++ b/Installer/debian/debian/rules
@@ -78,12 +78,8 @@ override_dh_auto_install:
 	rm -rf build/lib/duplicati/SQLite/win64
 	rm -rf build/lib/duplicati/SQLite/win32
 	rm -rf build/lib/duplicati/MonoMac.dll
-	rm -rf build/lib/duplicati/alphavss
 	rm -rf build/lib/duplicati/OSX\ Icons
 	rm -rf build/lib/duplicati/OSXTrayHost
-	rm build/lib/duplicati/AlphaFS.dll
-	rm build/lib/duplicati/AlphaVSS.Common.dll
-	rm -rf build/lib/duplicati/licenses/alphavss
 	rm -rf build/lib/duplicati/licenses/MonoMac
 	rm -rf build/lib/duplicati/licenses/gpg
 	find build/lib/duplicati/* -type f | xargs chmod 644
@@ -95,7 +91,6 @@ override_dh_auto_install:
 
 #override_dh_auto_install:
 #	rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/*.mdb
-#	rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/alphavss
 #	mkdir ${DESTDIR}/usr/lib/duplicati/
 #	cp -R Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/* ${DESTDIR}/usr/lib/duplicati/
 #	cp -R Duplicati/Server/webroot ${DESTDIR}/usr/lib/duplicati/

--- a/Installer/fedora/duplicati-binary.spec
+++ b/Installer/fedora/duplicati-binary.spec
@@ -90,12 +90,8 @@ rm -rf win-tools
 rm -rf SQLite/win64
 rm -rf SQLite/win32
 rm -rf MonoMac.dll
-rm -rf alphavss
 rm -rf OSX\ Icons
 rm -rf OSXTrayHost
-rm AlphaFS.dll
-rm AlphaVSS.Common.dll
-rm -rf licenses/alphavss
 rm -rf licenses/MonoMac
 rm -rf licenses/gpg
 

--- a/Installer/fedora/duplicati.spec
+++ b/Installer/fedora/duplicati.spec
@@ -144,13 +144,9 @@ rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/win-tools
 rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/SQLite/win64
 rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/SQLite/win32
 rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/MonoMac.dll
-rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/alphavss
 rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/OSX\ Icons
 rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/OSXTrayHost
-rm Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/AlphaFS.dll
-rm Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/AlphaVSS.Common.dll
 
-rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/licenses/alphavss
 rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/licenses/MonoMac
 rm -rf Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/licenses/gpg
 


### PR DESCRIPTION
Although these should not be needed for the Linux and OS X packages, it appears that there are times when this dependency is woken up, possibly due to issues regarding caching and static initialization of the `VssBackupComponents._vssBackupComponents` field.

This fixes #4149.