### PR TITLE
Fix issue where multiple backups could occur after pause

### DIFF
--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -215,6 +215,11 @@ namespace Duplicati.Server
 
         private void OnStartingWork(WorkerThread<Runner.IRunnerData> worker, Runner.IRunnerData task)
         {
+            if (task is null)
+            {
+                return;
+            }
+            
             lock(m_lock)
             {
                 if (m_updateTasks.TryGetValue(task, out Tuple<ISchedule, DateTime, DateTime> scheduleInfo))

--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -81,6 +81,7 @@ namespace Duplicati.Server
             m_thread = new Thread(new ThreadStart(Runner));
             m_worker = worker;
             m_worker.CompletedWork += OnCompleted;
+            m_worker.StartingWork += OnStartingWork;
             m_schedule = new KeyValuePair<DateTime, ISchedule>[0];
             m_terminate = false;
             m_event = new AutoResetEvent(false);
@@ -211,7 +212,20 @@ namespace Duplicati.Server
             }
             
         }
-                
+
+        private void OnStartingWork(WorkerThread<Runner.IRunnerData> worker, Runner.IRunnerData task)
+        {
+            lock(m_lock)
+            {
+                if (m_updateTasks.TryGetValue(task, out Tuple<ISchedule, DateTime, DateTime> scheduleInfo))
+                {
+                    // Item2 is the scheduled start time (Time in the Schedule table).
+                    // Item3 is the actual start time (LastRun in the Schedule table).
+                    m_updateTasks[task] = Tuple.Create(scheduleInfo.Item1, scheduleInfo.Item2, DateTime.UtcNow);
+                }
+            }
+        }
+
         /// <summary>
         /// The actual scheduling procedure
         /// </summary>
@@ -308,10 +322,15 @@ namespace Duplicati.Server
                             
                             Server.Runner.IRunnerData lastJob = jobsToRun.LastOrDefault();
                             if (lastJob != null)
-                                lock(m_lock)
+                            {
+                                lock (m_lock)
+                                {
+                                    // The actual last run time will be updated when the StartingWork event is raised.
                                     m_updateTasks[lastJob] = new Tuple<ISchedule, DateTime, DateTime>(sc, start, DateTime.UtcNow);
-                            
-                            foreach(var job in jobsToRun)
+                                }
+                            }
+
+                            foreach (var job in jobsToRun)
                                 m_worker.AddTask(job);
                             
                             if (start < DateTime.UtcNow)


### PR DESCRIPTION
Previously, the value of the `LastRun` field in the `Schedule` table was updated to be (approximately) the time that the job was added to the worker's list of tasks.  However, if the backup was missed (via pause or system suspend), this value would be incorrect.  If the next scheduled backup was also missed, then after the backup was finally run, the computed next start time would be based on the (incorrect) last run time of the first missed backup.  This would then immediately trigger an unnecessary second backup since the repetition internal has been exceeded.

Now, we add a handler for the `WorkerThread.StartingWork` event to set a more accurate value for the `LastRun` field in the `Schedule` table.

This fixes issue #2249.