### PR TITLE
Fix confusing indentation

### DIFF
--- a/Duplicati/Library/Utility/WorkerThread.cs
+++ b/Duplicati/Library/Utility/WorkerThread.cs
@@ -283,23 +283,25 @@ namespace Duplicati.Library.Utility
                         m_currentTask = m_tasks.Dequeue();
 
                 if (m_currentTask == null && !m_terminate)
-                if (m_state == WorkerThread<Tx>.RunState.Run)
-                    m_event.WaitOne(); //Sleep until signaled
-                    else
                 {
-                    if (WorkerStateChanged != null)
-                        WorkerStateChanged(this, m_state);
-
-                    //Sleep for brief periods, until signaled
-                    while (!m_terminate && m_state != WorkerThread<Tx>.RunState.Run)
-                        m_event.WaitOne(1000 * 60 * 5, false);
-
-                    //If we were not terminated, we are now ready to run
-                    if (!m_terminate)
+                    if (m_state == WorkerThread<Tx>.RunState.Run)
+                        m_event.WaitOne(); //Sleep until signaled
+                    else
                     {
-                        m_state = WorkerThread<Tx>.RunState.Run;
                         if (WorkerStateChanged != null)
                             WorkerStateChanged(this, m_state);
+
+                        //Sleep for brief periods, until signaled
+                        while (!m_terminate && m_state != WorkerThread<Tx>.RunState.Run)
+                            m_event.WaitOne(1000 * 60 * 5, false);
+
+                        //If we were not terminated, we are now ready to run
+                        if (!m_terminate)
+                        {
+                            m_state = WorkerThread<Tx>.RunState.Run;
+                            if (WorkerStateChanged != null)
+                                WorkerStateChanged(this, m_state);
+                        }
                     }
                 }
 

--- a/Duplicati/Server/Scheduler.cs
+++ b/Duplicati/Server/Scheduler.cs
@@ -174,7 +174,7 @@ namespace Duplicati.Server
                     i = 50000;
                     while (!IsDateAllowed(res, allowedDays) && i-- > 0)
                         res = Timeparser.ParseTimeInterval(repetition, res);
-            }
+                }
             }
 
             if (!IsDateAllowed(res, allowedDays) || res < firstdate)


### PR DESCRIPTION
The body of an `if` statement was not indented, and a closing brace was not indented properly.