### PR TITLE
Replace agsXMPP package with S22.Xmpp package

### DIFF
--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -38,9 +38,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="agsXMPP, Version=1.1.1.0, Culture=neutral, PublicKeyToken=ff839b81f1debe86, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\agsXMPP.1.1.1.0\lib\agsXMPP.dll</HintPath>
-    </Reference>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.5.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
       <HintPath>..\..\..\..\packages\BouncyCastle.1.8.5\lib\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
@@ -52,6 +49,10 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="S22.Xmpp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\packages\S22.Xmpp.1.0.0.0\lib\net45\S22.Xmpp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net" />

--- a/Duplicati/Library/Modules/Builtin/packages.config
+++ b/Duplicati/Library/Modules/Builtin/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="agsXMPP" version="1.1.1.0" targetFramework="net462" />
   <package id="BouncyCastle" version="1.8.5" targetFramework="net462" />
   <package id="MailKit" version="2.3.1.6" targetFramework="net462" />
   <package id="MimeKit" version="2.3.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
+  <package id="S22.Xmpp" version="1.0.0.0" targetFramework="net462" />
 </packages>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -68,6 +68,15 @@
       <Link>licenses\gpg\License.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\S22.Xmpp\download.txt">
+      <Link>licenses\S22.Xmpp\download.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\S22.Xmpp\license.txt">
+      <Link>licenses\S22.Xmpp\license.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\S22.Xmpp\licensedata.json">
+      <Link>licenses\S22.Xmpp\licensedata.json</Link>
+    </Content>
     <Content Include="..\..\thirdparty\SharpCompress\download.txt">
       <Link>licenses\SharpCompress\download.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -216,18 +225,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="acknowledgements.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\agsXMPP\download.txt">
-      <Link>licenses\agsXMPP\download.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\agsXMPP\license.txt">
-      <Link>licenses\agsXMPP\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\agsXMPP\licensedata.json">
-      <Link>licenses\agsXMPP\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SharpAESCrypt\download.txt">
@@ -406,7 +403,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <EmbeddedResource Include="VersionTag.txt" />
   </ItemGroup>

--- a/thirdparty/S22.Xmpp/download.txt
+++ b/thirdparty/S22.Xmpp/download.txt
@@ -1,0 +1,1 @@
+https://github.com/smiley22/S22.Xmpp

--- a/thirdparty/S22.Xmpp/license.txt
+++ b/thirdparty/S22.Xmpp/license.txt
@@ -1,0 +1,22 @@
+### The MIT License
+
+Copyright (c) 2013-2014 Torben Könke
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/thirdparty/S22.Xmpp/licensedata.json
+++ b/thirdparty/S22.Xmpp/licensedata.json
@@ -1,0 +1,7 @@
+{
+  "name": "S22.Xmpp",
+  "description": "S22.Xmpp is an easy-to-use and well-documented .NET assembly for communicating with an XMPP server. It supports basic Instant Messaging and Presence funtionality as well as a variety of XMPP extensions.",
+  "link": "https://github.com/smiley22/S22.Xmpp",
+  "license": "LGPL",
+  "notes": ""
+}


### PR DESCRIPTION
The [agsXMPP package](https://www.nuget.org/packages/agsXMPP) has been removed from NuGet and is no longer available for install/restore.  This attempts to replace the functionality with the [S22.Xmpp package](https://www.nuget.org/packages/S22.Xmpp).

This concerns issue #4189.