### PR TITLE
Improved error messages for non-json errors

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Duplicati.CommandLine.BackendTester.csproj
+++ b/Duplicati/CommandLine/BackendTester/Duplicati.CommandLine.BackendTester.csproj
@@ -182,6 +182,18 @@
       <Project>{3F47CB0C-CEE1-447F-9C26-7F8E419E3E3F}</Project>
       <Name>Duplicati.Library.Backend.AlternativeFTP</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Library\Common\Duplicati.Library.Common.csproj">
+      <Project>{D63E53E4-A458-4C2F-914D-92F715F58ACF}</Project>
+      <Name>Duplicati.Library.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Library\Compression\Duplicati.Library.Compression.csproj">
+      <Project>{19ECCE09-B5EB-406C-8C57-BAC66997D469}</Project>
+      <Name>Duplicati.Library.Compression</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Library\SQLiteHelper\Duplicati.Library.SQLiteHelper.csproj">
+      <Project>{2C838169-B187-4B09-8768-1C24C2521C8D}</Project>
+      <Name>Duplicati.Library.SQLiteHelper</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -241,7 +241,20 @@ namespace Duplicati.Library.Backend
                         ThrowOverQuotaError();
                 }
 
-                throw new DropboxException() { errorJSON = JObject.Parse(json) };
+
+                JObject errJson = null;
+                try
+                {
+                    errJson = JObject.Parse(json);
+                }
+                catch
+                {
+                }
+
+                if (errJson != null)
+                    throw new DropboxException() { errorJSON = errJson };
+                else
+                    throw new InvalidDataException($"Non-json response: {json}");
             }
         }
     }

--- a/Duplicati/Library/Backend/OAuthHelper/JSONWebHelper.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/JSONWebHelper.cs
@@ -289,10 +289,24 @@ namespace Duplicati.Library
 
         public virtual T ReadJSONResponse<T>(HttpWebResponse resp)
         {
-            using(var rs = Duplicati.Library.Utility.AsyncHttpRequest.TrySetTimeout(resp.GetResponseStream()))
-            using(var tr = new System.IO.StreamReader(rs))
-            using(var jr = new Newtonsoft.Json.JsonTextReader(tr))
-                return new Newtonsoft.Json.JsonSerializer().Deserialize<T>(jr);
+            using (var rs = Duplicati.Library.Utility.AsyncHttpRequest.TrySetTimeout(resp.GetResponseStream()))
+            using(var ps = new StreamPeekReader(rs))
+            {
+                try
+                {
+                    using (var tr = new System.IO.StreamReader(ps))
+                    using (var jr = new Newtonsoft.Json.JsonTextReader(tr))
+                        return new Newtonsoft.Json.JsonSerializer().Deserialize<T>(jr);
+                }
+                catch (Exception ex)
+                {
+                    // If we get invalid JSON, report the peek value
+                    if (ex is Newtonsoft.Json.JsonReaderException)
+                        throw new IOException($"Invalid JSON data: \"{ps.PeekData()}\"", ex);
+                    // Otherwise, we have no additional help to offer
+                    throw;
+                }
+            }
         }
 
         /// <summary>
@@ -518,6 +532,90 @@ namespace Duplicati.Library
                 Header = header;
                 Part = part;
             }
+        }
+
+        /// <summary>
+        /// A utility class that shadows the real stream but provides access
+        /// to the first 2kb of the stream to use in error reporting
+        /// </summary>
+        protected class StreamPeekReader : Stream
+        {
+            private readonly Stream m_base;
+            private readonly byte[] m_peekbuffer = new byte[1024 * 2];
+            private int m_peekbytes = 0;
+
+            public StreamPeekReader(Stream source)
+            {
+                m_base = source;
+            }
+
+            public string PeekData()
+            {
+                if (m_peekbuffer.Length == 0)
+                    return string.Empty;
+
+                return Encoding.UTF8.GetString(m_peekbuffer, 0, m_peekbytes);
+            }
+
+            public override bool CanRead => m_base.CanRead;
+            public override bool CanSeek => m_base.CanSeek;
+            public override bool CanWrite => m_base.CanWrite;
+            public override long Length => m_base.Length;
+            public override long Position { get => m_base.Position; set => m_base.Position = value; }
+            public override void Flush() => m_base.Flush();
+            public override long Seek(long offset, SeekOrigin origin) => m_base.Seek(offset, origin);
+            public override void SetLength(long value) => m_base.SetLength(value);
+            public override void Write(byte[] buffer, int offset, int count) => m_base.Write(buffer, offset, count);
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => m_base.BeginRead(buffer, offset, count, callback, state);
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => m_base.BeginWrite(buffer, offset, count, callback, state);
+            public override bool CanTimeout => m_base.CanTimeout;
+            public override void Close() => m_base.Close();
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => m_base.CopyToAsync(destination, bufferSize, cancellationToken);
+            protected override void Dispose(bool disposing) => base.Dispose(disposing);
+            public override int EndRead(IAsyncResult asyncResult) => m_base.EndRead(asyncResult);
+            public override void EndWrite(IAsyncResult asyncResult) => m_base.EndWrite(asyncResult);
+            public override Task FlushAsync(CancellationToken cancellationToken) => m_base.FlushAsync(cancellationToken);
+            public override int ReadTimeout { get => m_base.ReadTimeout; set => m_base.ReadTimeout = value; }
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => m_base.WriteAsync(buffer, offset, count, cancellationToken);
+            public override int WriteTimeout { get => m_base.WriteTimeout; set => m_base.WriteTimeout = value; }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                var br = 0;
+                if (m_peekbytes < m_peekbuffer.Length - 1)
+                {
+                    var maxb = Math.Min(count, m_peekbuffer.Length - m_peekbytes);
+                    br = await m_base.ReadAsync(m_peekbuffer, m_peekbytes, maxb, cancellationToken);
+                    Array.Copy(m_peekbuffer, m_peekbytes, buffer, offset, br);
+                    m_peekbytes += br;
+                    offset += br;
+                    count -= br;
+                    if (count == 0 || br < maxb)
+                        return br;
+                }
+
+                return await m_base.ReadAsync(buffer, offset, count, cancellationToken) + br;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var br = 0;
+                if (m_peekbytes < m_peekbuffer.Length - 1)
+                {
+                    var maxb = Math.Min(count, m_peekbuffer.Length - m_peekbytes);
+                    br = m_base.Read(m_peekbuffer, m_peekbytes, maxb);
+                    Array.Copy(m_peekbuffer, m_peekbytes, buffer, offset, br);
+                    m_peekbytes += br;
+                    offset += br;
+                    count -= br;
+
+                    if (count == 0 || br < maxb)
+                        return br;
+                }
+
+                return m_base.Read(buffer, offset, count) + br;
+            }
+
         }
     }
 }


### PR DESCRIPTION
Some servers respond with a text-only (or HTML) output when an error occurs.
In several places, Duplicati expects to read JSON data, and then fails due to the non-JSON text.
In this case, the error message that the server sent is hidden, and only an "invalid json" error message is reported.

This PR improves this by peeking into the response, and stores the first 2kb of the response.
In case the JSON parsing fails, these 2kb of data are then reported to the user.

This also fixes a case where the Dropbox backend returns invalid JSON, but this is attempted parsed without guards.