### PR TITLE
Switch to uplink.Net v2.1.5 to correctly support Tardigrade-Backend on Linux

### DIFF
--- a/Duplicati.Library.Backend.Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati.Library.Backend.Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -42,8 +42,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="uplink.NET, Version=2.1.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\uplink.NET.2.1.3\lib\netstandard2.0\uplink.NET.dll</HintPath>
+    <Reference Include="uplink.NET, Version=2.1.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\uplink.NET.2.1.5\lib\netstandard2.0\uplink.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -75,11 +75,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\uplink.NET.2.1.3\build\net40\uplink.NET.targets" Condition="Exists('..\packages\uplink.NET.2.1.3\build\net40\uplink.NET.targets')" />
+  <Import Project="..\packages\uplink.NET.2.1.5\build\net40\uplink.NET.targets" Condition="Exists('..\packages\uplink.NET.2.1.5\build\net40\uplink.NET.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\uplink.NET.2.1.3\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\uplink.NET.2.1.3\build\net40\uplink.NET.targets'))" />
+    <Error Condition="!Exists('..\packages\uplink.NET.2.1.5\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\uplink.NET.2.1.5\build\net40\uplink.NET.targets'))" />
   </Target>
 </Project>

--- a/Duplicati.Library.Backend.Tardigrade/packages.config
+++ b/Duplicati.Library.Backend.Tardigrade/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="uplink.NET" version="2.1.3" targetFramework="net462" />
+  <package id="uplink.NET" version="2.1.5" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
The uplink.Net-Library had a small error with the handling of the listorj_uplink.so on NetFramework. It deployed the windows-DLL instead of the linux-so. This got fixed in uplink.NET v2.1.5 and therefore I'll update the reference here.

I could successfully Test the Tardigrade-Backend and Windows and Linux now.