### PR TITLE
Fix incorrect sslcert warning on Mono

### DIFF
--- a/Duplicati/Library/Modules/Builtin/CheckMonoSSL.cs
+++ b/Duplicati/Library/Modules/Builtin/CheckMonoSSL.cs
@@ -133,8 +133,12 @@ namespace Duplicati.Library.Modules.Builtin
             if (!commandlineOptions.ContainsKey("main-action") || !Library.Utility.Utility.IsMono)
                 return;
 
-			if (CheckForInstalledCerts() == 0)
-				Duplicati.Library.Logging.Log.WriteWarningMessage(LOGTAG, "MissingCerts", null, Strings.CheckMonoSSL.ErrorMessage);
+            if (CheckForInstalledCerts() == 0)
+            {
+                // Do not output this warning, recent Mono packages seems to work
+                if (Library.Utility.Utility.MonoVersion < new Version(6, 0))
+                    Duplicati.Library.Logging.Log.WriteWarningMessage(LOGTAG, "MissingCerts", null, Strings.CheckMonoSSL.ErrorMessage);
+            }
         }
 #endregion
 

--- a/Duplicati/Library/Modules/Builtin/CheckMonoSSL.cs
+++ b/Duplicati/Library/Modules/Builtin/CheckMonoSSL.cs
@@ -54,13 +54,53 @@ namespace Duplicati.Library.Modules.Builtin
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private int CheckMonoCerts()
         {
-            return
-#if __MonoCS__
-                Mono.Security.X509.X509StoreManager.LocalMachine.TrustedRoot.Certificates.Count +
-                Mono.Security.X509.X509StoreManager.CurrentUser.TrustedRoot.Certificates.Count +
-                Mono.Security.X509.X509StoreManager.TrustedRootCertificates.Count +
-#endif
-                0;
+            // The __MonoCS__ compiler directive is no longer supported.
+            // We would like to query the x509 store, but this will make it
+            // hard to compile the project on Windows.
+            // For this reason, we use reflection to extract the counts
+
+            // Code without reflection looks like:
+
+            //return
+            //    Mono.Security.X509.X509StoreManager.LocalMachine.TrustedRoot.Certificates.Count +
+            //    Mono.Security.X509.X509StoreManager.CurrentUser.TrustedRoot.Certificates.Count +
+            //    Mono.Security.X509.X509StoreManager.TrustedRootCertificates.Count +
+            //    0;
+
+            System.Reflection.Assembly asm = null;
+
+            try { asm = System.Reflection.Assembly.Load("Mono.Security"); }
+            catch { }
+
+            var x509Store = asm?.GetType("Mono.Security.X509.X509StoreManager");
+            if (x509Store == null)
+                return 0;
+
+            var localMachine = x509Store.GetProperty("LocalMachine")?.GetValue(null);
+            var currentUser = x509Store.GetProperty("CurrentUser")?.GetValue(null);
+            var trustedRoot = x509Store.GetProperty("TrustedRootCertificates")?.GetValue(null);
+
+            var count = 0;
+
+            var tr = localMachine?.GetType().GetProperty("TrustedRoot")?.GetValue(localMachine);
+            var crt = tr?.GetType().GetProperty("Certificates").GetValue(tr);
+            var cnt = crt?.GetType().GetProperty("Count")?.GetValue(crt);
+            if (cnt is int)
+                count += (int)cnt;
+
+            tr = currentUser?.GetType().GetProperty("TrustedRoot")?.GetValue(currentUser);
+            crt = tr?.GetType().GetProperty("Certificates").GetValue(tr);
+            cnt = crt?.GetType().GetProperty("Count")?.GetValue(crt);
+            if (cnt is int)
+                count += (int)cnt;
+
+
+            cnt = trustedRoot?.GetType().GetProperty("Count")?.GetValue(trustedRoot);
+            if (cnt is int)
+                count += (int)cnt;
+
+            return count;
+
         }
 
         private int CheckForInstalledCerts()


### PR DESCRIPTION
Due to a flood of support requests related to incorrect certificate stores, Duplicati includes a check to see if the system has valid certificates, and outputs a helpful warning that the system might not work as expected.

At some point, the Mono runtime decided to change how the TLS handling was performed and this means that there are no longer any certificates reported in the way that Duplicati checks for them. Since the certificate issue seems to be fixed in recent Mono version, this warning adds more confusion to users than help.

This commit removes the use of `__MonoCS__` to compile the x509 certificate checking, and also supresses the warning message if the Mono version is `v6.0` or higher.