### PR TITLE
Removed references to `__MonoCS__`

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/AppIndicatorRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/AppIndicatorRunner.cs
@@ -14,7 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
 using System;
 using AppIndicator;
 using Gtk;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/GtkRunner.cs
@@ -14,7 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
 using System;
 using System.Collections.Generic;
 using Duplicati.Library.Common;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -47,7 +47,7 @@ namespace Duplicati.GUI.TrayIcon
             if (Platform.IsClientOSX)
                 return TOOLKIT_RUMPS;
 
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
             if (Platform.IsClientPosix)
             {
                 if (SupportsAppIndicator)
@@ -115,7 +115,7 @@ namespace Duplicati.GUI.TrayIcon
             string toolkit;
             if (!options.TryGetValue(TOOLKIT_OPTION, out toolkit))
             {
-#if !(__MonoCS__ || __WindowsGTK__ || ENABLE_GTK)
+#if !(__WindowsGTK__ || ENABLE_GTK)
                 if (Platform.IsClientPosix && !Platform.IsClientOSX)
                     Console.WriteLine("Warning: this build does not support GTK, rebuild with ENABLE_GTK defined");
 #endif
@@ -125,7 +125,7 @@ namespace Duplicati.GUI.TrayIcon
             {
                 if (TOOLKIT_WINDOWS_FORMS.Equals(toolkit, StringComparison.OrdinalIgnoreCase))
                     toolkit = TOOLKIT_WINDOWS_FORMS;
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
                 else if (TOOLKIT_GTK.Equals(toolkit, StringComparison.OrdinalIgnoreCase))
                     toolkit = TOOLKIT_GTK;
                 else if (TOOLKIT_GTK_APP_INDICATOR.Equals(toolkit, StringComparison.OrdinalIgnoreCase))
@@ -296,7 +296,7 @@ namespace Duplicati.GUI.TrayIcon
         {
             if (toolkit == TOOLKIT_WINDOWS_FORMS)
                 return GetWinformsInstance();
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
             else if (toolkit == TOOLKIT_GTK)
                 return GetGtkInstance();
             else if (toolkit == TOOLKIT_GTK_APP_INDICATOR)
@@ -319,7 +319,7 @@ namespace Duplicati.GUI.TrayIcon
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static TrayIconBase GetWinformsInstance() { return new Windows.WinFormsRunner(); }
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static TrayIconBase GetGtkInstance() { return new GtkRunner(); }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
@@ -339,7 +339,7 @@ namespace Duplicati.GUI.TrayIcon
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static bool TryGetGtk()
         {
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
             return typeof(Gtk.StatusIcon) != null && typeof(Gdk.Image) != null;
 #else
             return false;
@@ -355,7 +355,7 @@ namespace Duplicati.GUI.TrayIcon
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static bool TryGetAppIndicator()
         {
-#if __MonoCS__ || __WindowsGTK__ || ENABLE_GTK
+#if __WindowsGTK__ || ENABLE_GTK
             return typeof(AppIndicator.ApplicationIndicator) != null;
 #else
             return false;

--- a/build-release.sh
+++ b/build-release.sh
@@ -156,7 +156,7 @@ rm -rf "Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release"
 
 "${XBUILD}" /p:Configuration=Release /target:Clean "Duplicati.sln"
 find "Duplicati" -type d -name "Release" | xargs rm -rf
-"${XBUILD}" /p:DefineConstants=__MonoCS__ /p:DefineConstants=ENABLE_GTK /p:Configuration=Release "Duplicati.sln"
+"${XBUILD}" /p:DefineConstants=ENABLE_GTK /p:Configuration=Release "Duplicati.sln"
 BUILD_STATUS=$?
 
 if [ "${BUILD_STATUS}" -ne 0 ]; then


### PR DESCRIPTION
The compiler directive `__MonoCS__` was being set by the Mono compiler, but removed some years ago.
The Duplicati code "fixed" the removal by setting the directive during builds, but this causes the debugging and released versions to differ a bit. Also, the use of the compiler directive suggests we are using a functionality that does not exist.

This commit removes all references to `__MonoCS__` (except for one, which is removed in #4212).