### PR TITLE
Tardigrade-Backend: Resolve two issues

### DIFF
--- a/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -42,8 +42,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="uplink.NET, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\uplink.NET.2.2.2\lib\netstandard2.0\uplink.NET.dll</HintPath>
+    <Reference Include="uplink.NET, Version=2.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\uplink.NET.2.3.1\lib\netstandard2.0\uplink.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -75,11 +75,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\packages\uplink.NET.2.2.2\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.2.2\build\net40\uplink.NET.targets')" />
+  <Import Project="..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.2.2\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.2.2\build\net40\uplink.NET.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets'))" />
   </Target>
 </Project>

--- a/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
+++ b/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
@@ -46,7 +46,7 @@ namespace Duplicati.Library.Backend.Tardigrade
 
         static Tardigrade()
         {
-            Access.SetTempDirectory(System.IO.Path.GetTempPath());
+            Access.SetTempDirectory(Library.Utility.TempFolder.SystemTempPath);
         }
 
         // ReSharper disable once UnusedMember.Global

--- a/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
+++ b/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
@@ -44,6 +44,11 @@ namespace Duplicati.Library.Backend.Tardigrade
             { "Access grant", "Access grant" },
         };
 
+        static Tardigrade()
+        {
+            Access.SetTempDirectory(System.IO.Path.GetTempPath());
+        }
+
         // ReSharper disable once UnusedMember.Global
         // This constructor is needed by the BackendLoader.
         public Tardigrade()
@@ -55,9 +60,6 @@ namespace Duplicati.Library.Backend.Tardigrade
         public Tardigrade(string url, Dictionary<string, string> options)
         {
             var auth_method = options[TARDIGRADE_AUTH_METHOD];
-
-            Access.SetTempDirectory(System.IO.Path.GetTempPath());
-
             if (auth_method == "Access grant")
             {
                 //Create an access from the access grant
@@ -241,7 +243,9 @@ namespace Duplicati.Library.Backend.Tardigrade
             foreach (var obj in objects.Items)
             {
                 TardigradeFile file = new TardigradeFile(obj);
-                file.Name = file.Name.Replace(GetBasePath(), "");
+                var basePath = GetBasePath();
+                if (basePath != "")
+                    file.Name = file.Name.Replace(basePath, "");
                 files.Add(file);
             }
 

--- a/Duplicati/Library/Backend/Tardigrade/packages.config
+++ b/Duplicati/Library/Backend/Tardigrade/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="uplink.NET" version="2.2.2" targetFramework="net462" />
+  <package id="uplink.NET" version="2.3.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
This PR bumps the Tardigrade-Backend to v2.3.1 and solves two issues:

- we had random crashes with the uplink.Net-Library that got solved with v2.3.1. The garbage collection moved memory that the underlying uplink-c expected at a certain address.
- listing files without a folder did not work due to a small error