### PR TITLE
Fix endpoint for Middle East (Bahrain) S3 region

### DIFF
--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -105,7 +105,7 @@ namespace Duplicati.Library.Backend
             { "sa-east-1", "s3.sa-east-1.amazonaws.com" },
             { "cn-north-1", "s3.cn-north-1.amazonaws.com.cn" },
             { "cn-northwest-1", "s3.cn-northwest-1.amazonaws.com.cn" },
-            { "me-south-1", "s3.me-south-1.amazonaws.com.cn" },
+            { "me-south-1", "s3.me-south-1.amazonaws.com" },
         };
 
         public static readonly Dictionary<string, string> KNOWN_S3_STORAGE_CLASSES;


### PR DESCRIPTION
There appears to have been a copy/paste error in defining the endpoint for the Middle East (Bahrain) S3 region.

This fixes issue #4235.