### PR TITLE
Bump the Tardigrade-Backend to NetFramework 4.7.1

### DIFF
--- a/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -9,11 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Duplicati.Library.Backend.Tardigrade</RootNamespace>
     <AssemblyName>Duplicati.Library.Backend.Tardigrade</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
The Tardigrade-Backend uses the uplink.NET-library which is on NetStandard 2.0. If this one gets included in a project targeting NetFramework prio to 4.7.1, many DLL-files get added to the output-dir and clutter the installer (see issue #4234).

This PR simply changes the Tardigrade-Backend to 4.7.1 as this seems to solve that issue and does not break anything else. It might be that the Tardigrade-Backend won't work for some users that don't have NetFramework 4.7.1.