### PR TITLE
Ensure that paths exist when restoring empty files

### DIFF
--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -415,8 +415,7 @@ namespace Duplicati.Library.Main.Operation
                 // Restore empty files. They might not have any blocks so don't appear in any volume.
                 foreach (var file in database.GetFilesToRestore(true).Where(item => item.Length == 0))
                 {
-                    string folderpath = SystemIO.IO_OS.PathGetDirectoryName(file.Path);
-                    SystemIO.IO_OS.DirectoryCreate(folderpath);
+                    SystemIO.IO_OS.DirectoryCreate(SystemIO.IO_OS.PathGetDirectoryName(file.Path));
 
                     // Just create the file and close it right away, empty statement is intentional.
                     using (SystemIO.IO_OS.FileCreate(file.Path))

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -413,7 +413,11 @@ namespace Duplicati.Library.Main.Operation
                     }
 
                 // Restore empty files. They might not have any blocks so don't appear in any volume.
-                foreach (var file in database.GetFilesToRestore(true).Where(item => item.Length == 0)) {
+                foreach (var file in database.GetFilesToRestore(true).Where(item => item.Length == 0))
+                {
+                    string folderpath = SystemIO.IO_OS.PathGetDirectoryName(file.Path);
+                    SystemIO.IO_OS.DirectoryCreate(folderpath);
+
                     // Just create the file and close it right away, empty statement is intentional.
                     using (SystemIO.IO_OS.FileCreate(file.Path))
                     {

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -34,21 +34,21 @@ namespace Duplicati.UnitTest
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
             {
                 c.Restore(new[] {filePath});
-
-                // We need to strip the root part of the path.  Otherwise, Path.Combine will simply return the second argument
-                // if it's determined to be an absolute path.
-                string rootString = SystemIO.IO_OS.GetPathRoot(filePath);
-                string newPathPart = filePath.Substring(rootString.Length);
-                if (Platform.IsClientWindows)
-                {
-                    // On windows, the drive letter is included in the path when the dont-compress-restore-paths option is used.
-                    // The drive letter is assumed to be the first character of the path root (e.g., C:\).
-                    newPathPart = Path.Combine(rootString.Substring(0, 1), filePath.Substring(rootString.Length));
-                }
-
-                string restoredFilePath = Path.Combine(restoreOptions["restore-path"], newPathPart);
-                Assert.IsTrue(File.Exists(restoredFilePath));
             }
+
+            // We need to strip the root part of the path.  Otherwise, Path.Combine will simply return the second argument
+            // if it's determined to be an absolute path.
+            string rootString = SystemIO.IO_OS.GetPathRoot(filePath);
+            string newPathPart = filePath.Substring(rootString.Length);
+            if (Platform.IsClientWindows)
+            {
+                // On windows, the drive letter is included in the path when the dont-compress-restore-paths option is used.
+                // The drive letter is assumed to be the first character of the path root (e.g., C:\).
+                newPathPart = Path.Combine(rootString.Substring(0, 1), filePath.Substring(rootString.Length));
+            }
+
+            string restoredFilePath = Path.Combine(restoreOptions["restore-path"], newPathPart);
+            Assert.IsTrue(File.Exists(restoredFilePath));
         }
 
         [Test]

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -34,11 +34,18 @@ namespace Duplicati.UnitTest
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
             {
                 c.Restore(new[] {filePath});
-                string rootString = SystemIO.IO_OS.GetPathRoot(filePath);
 
                 // We need to strip the root part of the path.  Otherwise, Path.Combine will simply return the second argument
                 // if it's determined to be an absolute path.
+                string rootString = SystemIO.IO_OS.GetPathRoot(filePath);
                 string newPathPart = filePath.Substring(rootString.Length);
+                if (Platform.IsClientWindows)
+                {
+                    // On windows, the drive letter is included in the path when the dont-compress-restore-paths option is used.
+                    // The drive letter is assumed to be the first character of the path root (e.g., C:\).
+                    newPathPart = Path.Combine(rootString.Substring(0, 1), filePath.Substring(rootString.Length));
+                }
+
                 string restoredFilePath = Path.Combine(restoreOptions["restore-path"], newPathPart);
                 Assert.IsTrue(File.Exists(restoredFilePath));
             }

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -42,7 +42,7 @@ namespace Duplicati.UnitTest
             string newPathPart = filePath.Substring(rootString.Length);
             if (Platform.IsClientWindows)
             {
-                // On windows, the drive letter is included in the path when the dont-compress-restore-paths option is used.
+                // On Windows, the drive letter is included in the path when the dont-compress-restore-paths option is used.
                 // The drive letter is assumed to be the first character of the path root (e.g., C:\).
                 newPathPart = Path.Combine(rootString.Substring(0, 1), filePath.Substring(rootString.Length));
             }


### PR DESCRIPTION
This fixes an issue where the folders leading to an empty file weren't created properly during the restore process.  This also adds a test that would previously fail without this fix.

This fixes issue #4148.