### PR TITLE
Check for errors and warnings in unit tests

### DIFF
--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
+using Duplicati.Library.Interface;
 
 namespace Duplicati.UnitTest
 {
@@ -212,8 +213,12 @@ namespace Duplicati.UnitTest
 
             var filenames = WriteTestFilesToFolder(DATAFOLDER, blocksize, basedatasize);
 
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             // After the first backup we remove the --blocksize argument as that should be auto-set
             testopts.Remove("blocksize");
@@ -222,7 +227,9 @@ namespace Duplicati.UnitTest
 
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
-                c.List("*");
+                IListResults listResults = c.List("*");
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
                 //Console.WriteLine("In first backup:");
                 //Console.WriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
             }
@@ -240,6 +247,9 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var r = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
+
                 if (!Library.Utility.Utility.ParseBoolOption(testopts, "disable-filetime-check"))
                 {
                     if (r.OpenedFiles != filenames.Count)
@@ -255,14 +265,20 @@ namespace Duplicati.UnitTest
                 rn.NextBytes(data);
                 File.WriteAllBytes(Path.Combine(DATAFOLDER, "c" + k.Key), data.Take(k.Value).ToArray());
             }
-            
 
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
-            
+
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 //ProgressWriteLine("Newest before deleting:");
                 //ProgressWriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual((filenames.Count * 3) + 1, r.Files.Count());
@@ -271,6 +287,8 @@ namespace Duplicati.UnitTest
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0, no_local_db = true }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 //ProgressWriteLine("Newest without db:");
                 //ProgressWriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual((filenames.Count * 3) + 1, r.Files.Count());
@@ -278,15 +296,26 @@ namespace Duplicati.UnitTest
 
             testopts["dbpath"] = this.recreatedDatabaseFile;
 
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Repair();
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
+            }
 
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                Assert.AreEqual(3, c.List().Filesets.Count());
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IListResults listResults = c.List();
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
+                Assert.AreEqual(3, listResults.Filesets.Count());
+            }
 
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 2 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 //ProgressWriteLine("V2 after delete:");
                 //ProgressWriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual((filenames.Count * 1) + 1, r.Files.Count());
@@ -295,6 +324,8 @@ namespace Duplicati.UnitTest
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 1 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 //ProgressWriteLine("V1 after delete:");
                 //ProgressWriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual((filenames.Count * 2) + 1, r.Files.Count());
@@ -303,6 +334,8 @@ namespace Duplicati.UnitTest
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 //ProgressWriteLine("Newest after delete:");
                 //ProgressWriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual((filenames.Count * 3) + 1, r.Files.Count());
@@ -311,6 +344,8 @@ namespace Duplicati.UnitTest
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { restore_path = RESTOREFOLDER, no_local_blocks = true }), null))
             {
                 var r = c.Restore(null);
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 Assert.AreEqual(filenames.Count * 3, r.RestoredFiles);
             }
 
@@ -321,6 +356,8 @@ namespace Duplicati.UnitTest
                 using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { restore_path = (string)tf, no_local_blocks = true }), null))
                 {
                     var r = c.Restore(new string[] { Path.Combine(DATAFOLDER, "a") + "*" });
+                    Assert.AreEqual(0, r.Errors.Count());
+                    Assert.AreEqual(0, r.Warnings.Count());
                     Assert.AreEqual(filenames.Count, r.RestoredFiles);
                 }
             }

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -217,7 +217,9 @@ namespace Duplicati.UnitTest
             {
                 IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
                 Assert.AreEqual(0, backupResults.Errors.Count());
-                Assert.AreEqual(0, backupResults.Warnings.Count());
+
+                // TODO: This sometimes results in a "No block hash found for file: C:\projects\duplicati\testdata\backup-data\a-0" warning.
+                // Assert.AreEqual(0, repairResults.Warnings.Count());
             }
 
             // After the first backup we remove the --blocksize argument as that should be auto-set
@@ -300,7 +302,9 @@ namespace Duplicati.UnitTest
             {
                 IRepairResults repairResults = c.Repair();
                 Assert.AreEqual(0, repairResults.Errors.Count());
-                Assert.AreEqual(0, repairResults.Warnings.Count());
+                
+                // TODO: This sometimes results in a "No block hash found for file: C:\projects\duplicati\testdata\backup-data\a-0" warning.
+                // Assert.AreEqual(0, repairResults.Warnings.Count());
             }
 
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -219,7 +219,7 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(0, backupResults.Errors.Count());
 
                 // TODO: This sometimes results in a "No block hash found for file: C:\projects\duplicati\testdata\backup-data\a-0" warning.
-                // Assert.AreEqual(0, repairResults.Warnings.Count());
+                // Because of this, we don't check for warnings here.
             }
 
             // After the first backup we remove the --blocksize argument as that should be auto-set
@@ -304,7 +304,7 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(0, repairResults.Errors.Count());
                 
                 // TODO: This sometimes results in a "No block hash found for file: C:\projects\duplicati\testdata\backup-data\a-0" warning.
-                // Assert.AreEqual(0, repairResults.Warnings.Count());
+                // Because of this, we don't check for warnings here.
             }
 
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))

--- a/Duplicati/UnitTest/FilterTest.cs
+++ b/Duplicati/UnitTest/FilterTest.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Duplicati.Library.Common.IO;
+using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using NUnit.Framework;
 
@@ -60,12 +61,18 @@ namespace Duplicati.UnitTest
 
             // Create a fileset with all data present
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             // Check that we have 4 files and 7 folders
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 var folders = r.Files.Count(x => x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
                 var files = r.Files.Count(x => !x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
 
@@ -79,12 +86,18 @@ namespace Duplicati.UnitTest
             System.Threading.Thread.Sleep(5000);
             testopts["ignore-filenames"] = "exclude.me";
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             // Check that we have 2 files and 6 folders after excluding the "excludefile" folder
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 var folders = r.Files.Count(x => x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
                 var files = r.Files.Count(x => !x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
 
@@ -98,12 +111,18 @@ namespace Duplicati.UnitTest
             System.Threading.Thread.Sleep(5000);
             testopts["exclude-empty-folders"] = "true";
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             // Check that the two empty folders are now removed
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 var folders = r.Files.Count(x => x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
                 var files = r.Files.Count(x => !x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
 
@@ -116,13 +135,19 @@ namespace Duplicati.UnitTest
             // Filter out one file and rerun the backup to exclude the folder
             System.Threading.Thread.Sleep(5000);
             var excludefilter = new Library.Utility.FilterExpression($"*{System.IO.Path.DirectorySeparatorChar}myfile.txt", false);
-            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null ))
-                c.Backup(new string[] { DATAFOLDER }, excludefilter);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER}, excludefilter);
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             // Check that the empty folder is now removed
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 var folders = r.Files.Count(x => x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
                 var files = r.Files.Count(x => !x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
 
@@ -136,12 +161,18 @@ namespace Duplicati.UnitTest
             System.Threading.Thread.Sleep(5000);
             File.Delete(Path.Combine(source, "toplevel", "normal", "standard.txt"));
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER }, excludefilter);
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER}, excludefilter);
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             // Check we now have only one folder and no files
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 var folders = r.Files.Count(x => x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
                 var files = r.Files.Count(x => !x.Path.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal));
 

--- a/Duplicati/UnitTest/Issue1410.cs
+++ b/Duplicati/UnitTest/Issue1410.cs
@@ -19,6 +19,7 @@ using System.IO;
 using NUnit.Framework;
 using System.Linq;
 using System.Collections.Generic;
+using Duplicati.Library.Interface;
 
 namespace Duplicati.UnitTest
 {
@@ -32,24 +33,36 @@ namespace Duplicati.UnitTest
 
             var data = new byte[1024 * 1024 * 10];
             File.WriteAllBytes(Path.Combine(DATAFOLDER, "a"), data);
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 Console.WriteLine("In first backup:");
                 Console.WriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
             }
 
             new Random().NextBytes(data);
             File.WriteAllBytes(Path.Combine(DATAFOLDER, "b"), data);
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 Console.WriteLine("Newest before deleting:");
                 Console.WriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual(3, r.Files.Count());
@@ -58,6 +71,8 @@ namespace Duplicati.UnitTest
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0, no_local_db = true }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 Console.WriteLine("Newest without db:");
                 Console.WriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual(3, r.Files.Count());
@@ -65,15 +80,26 @@ namespace Duplicati.UnitTest
 
 
             File.Delete(DBFILE);
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Repair();
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
+            }
 
-            using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                Assert.AreEqual(c.List().Filesets.Count(), 2);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IListResults listResults = c.List();
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
+                Assert.AreEqual(listResults.Filesets.Count(), 2);
+            }
 
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 1 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 Console.WriteLine("Oldest after delete:");
                 Console.WriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual(2, r.Files.Count());
@@ -82,6 +108,8 @@ namespace Duplicati.UnitTest
             using(var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 0 }), null))
             {
                 var r = c.List("*");
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
                 Console.WriteLine("Newest after delete:");
                 Console.WriteLine(string.Join(Environment.NewLine, r.Files.Select(x => x.Path)));
                 Assert.AreEqual(3, r.Files.Count());

--- a/Duplicati/UnitTest/Issue1723.cs
+++ b/Duplicati/UnitTest/Issue1723.cs
@@ -16,6 +16,7 @@
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 using System;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Duplicati.UnitTest
@@ -34,6 +35,8 @@ namespace Duplicati.UnitTest
 			using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
 			{
 				var r = c.Backup(new string[] { DATAFOLDER });
+				Assert.AreEqual(0, r.Errors.Count());
+				Assert.AreEqual(0, r.Warnings.Count());
 				var pr = (Library.Interface.IParsedBackendStatistics)r.BackendStatistics;
 				if (pr.KnownFileSize == 0 || pr.KnownFileCount != 3 || pr.BackupListCount != 1)
 					throw new Exception(string.Format("Failed to get stats from remote backend: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));

--- a/Duplicati/UnitTest/PurgeTesting.cs
+++ b/Duplicati/UnitTest/PurgeTesting.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Duplicati.Library.Common.IO;
+using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using NUnit.Framework;
 
@@ -45,6 +46,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.Backup(new string[] { DATAFOLDER }, new Library.Utility.FilterExpression(round1.Select(x => "*" + Path.DirectorySeparatorChar + x)));
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(res.AddedFiles, round1.Length);
             }
 
@@ -52,6 +55,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.Backup(new string[] { DATAFOLDER }, new Library.Utility.FilterExpression(round2.Select(x => "*" + Path.DirectorySeparatorChar + x)));
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(res.AddedFiles, round2.Length - round1.Length);
             }
 
@@ -59,6 +64,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(res.AddedFiles, filenames.Count - round2.Length);
             }
 
@@ -68,13 +75,18 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { list_sets_only = true }), null))
             {
                 var inf = c.List();
+                Assert.AreEqual(0, inf.Errors.Count());
+                Assert.AreEqual(0, inf.Warnings.Count());
                 var filesets = inf.Filesets.Count();
                 Assert.AreEqual(3, filesets, "Incorrect number of initial filesets");
             }
 
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
-                var filecount = c.List("*").Files.Count();
+                IListResults listResults = c.List("*");
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
+                var filecount = listResults.Files.Count();
                 Assert.AreEqual(filenames.Count + 1, filecount, "Incorrect number of initial files");
             }
 
@@ -84,6 +96,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.PurgeFiles(new Library.Utility.FilterExpression("*" + Path.DirectorySeparatorChar + allversion_candidate));
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(3, res.RewrittenFileLists, "Incorrect number of rewritten filesets after all-versions purge");
                 Assert.AreEqual(3, res.RemovedFileCount, "Incorrect number of removed files after all-versions purge");
             }
@@ -93,6 +107,8 @@ namespace Duplicati.UnitTest
                 using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = i }), null))
                 {
                     var res = c.PurgeFiles(new Library.Utility.FilterExpression(Path.Combine(this.DATAFOLDER, single_version_candidate)));
+                    Assert.AreEqual(0, res.Errors.Count());
+                    Assert.AreEqual(0, res.Warnings.Count());
                     Assert.AreEqual(1, res.RewrittenFileLists, "Incorrect number of rewritten filesets after single-versions purge");
                     Assert.AreEqual(1, res.RemovedFileCount, "Incorrect number of removed files after single-versions purge");
                 }
@@ -101,6 +117,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.PurgeFiles(new Library.Utility.FilterExpression(round2.Skip(round1.Length).Take(2).Select(x => "*" + Path.DirectorySeparatorChar + x)));
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(2, res.RewrittenFileLists, "Incorrect number of rewritten filesets after 2-versions purge");
                 Assert.AreEqual(4, res.RemovedFileCount, "Incorrect number of removed files after 2-versions purge");
             }
@@ -108,6 +126,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.PurgeFiles(new Library.Utility.FilterExpression(round3.Skip(round2.Length).Take(2).Select(x => "*" + Path.DirectorySeparatorChar + x)));
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(1, res.RewrittenFileLists, "Incorrect number of rewritten filesets after 1-versions purge");
                 Assert.AreEqual(2, res.RemovedFileCount, "Incorrect number of removed files after 1-versions purge");
             }
@@ -120,8 +140,12 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var listinfo = c.List("*");
+                Assert.AreEqual(0, listinfo.Errors.Count());
+                Assert.AreEqual(0, listinfo.Warnings.Count());
                 var filecount = listinfo.Files.Count();
                 listinfo = c.List();
+                Assert.AreEqual(0, listinfo.Errors.Count());
+                Assert.AreEqual(0, listinfo.Warnings.Count());
                 var filesets = listinfo.Filesets.Count();
 
                 Assert.AreEqual(3, filesets, "Incorrect number of filesets after purge");
@@ -129,14 +153,22 @@ namespace Duplicati.UnitTest
             }
 
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                c.Backup(new string[] { DATAFOLDER });
+            {
+                IBackupResults backupResults = c.Backup(new string[] {DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
 
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var listinfo = c.List("*");
+                Assert.AreEqual(0, listinfo.Errors.Count());
+                Assert.AreEqual(0, listinfo.Warnings.Count());
                 var files = listinfo.Files.ToArray();
                 var filecount = files.Length;
                 listinfo = c.List();
+                Assert.AreEqual(0, listinfo.Errors.Count());
+                Assert.AreEqual(0, listinfo.Warnings.Count());
                 var filesets = listinfo.Filesets.ToArray();
 
                 Console.WriteLine("Listing final version information");
@@ -169,6 +201,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.Backup(new string[] { DATAFOLDER }, new Library.Utility.FilterExpression(round1.Select(x => "*" + Path.DirectorySeparatorChar + x)));
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(res.AddedFiles, round1.Length);
             }
 
@@ -183,6 +217,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.Backup(new string[] { DATAFOLDER }, new Library.Utility.FilterExpression(round2.Select(x => "*" + Path.DirectorySeparatorChar + x)));
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(round2.Length - round1.Length, res.AddedFiles);
             }
 
@@ -190,6 +226,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var res = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 Assert.AreEqual(filenames.Count - round2.Length, res.AddedFiles);
             }
 
@@ -200,6 +238,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var brk = c.ListBrokenFiles(null);
+                Assert.AreEqual(0, brk.Errors.Count());
+                Assert.AreEqual(0, brk.Warnings.Count());
                 var sets = brk.BrokenFiles.Count();
                 var files = brk.BrokenFiles.Sum(x => x.Item3.Count());
                 Assert.AreEqual(3, sets);
@@ -212,6 +252,8 @@ namespace Duplicati.UnitTest
                 using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = i }), null))
                 {
                     var brk = c.ListBrokenFiles(null);
+                    Assert.AreEqual(0, brk.Errors.Count());
+                    Assert.AreEqual(0, brk.Warnings.Count());
                     var sets = brk.BrokenFiles.Count();
                     var files = brk.BrokenFiles.Sum(x => x.Item3.Count());
                     Assert.AreEqual(1, sets);
@@ -221,6 +263,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var brk = c.PurgeBrokenFiles(null);
+                Assert.AreEqual(0, brk.Errors.Count());
+                Assert.AreEqual(0, brk.Warnings.Count());
 
                 var modFilesets = 0L;
                 if (brk.DeleteResults != null)

--- a/Duplicati/UnitTest/RecoveryToolTests.cs
+++ b/Duplicati/UnitTest/RecoveryToolTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using NUnit.Framework;
 
@@ -63,7 +65,9 @@ namespace Duplicati.UnitTest
             string backendURL = "file://" + this.TARGETFOLDER;
             using (Controller c = new Controller(backendURL, options, null))
             {
-                c.Backup(new[] {this.DATAFOLDER});
+                IBackupResults backupResults = c.Backup(new[] {this.DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
             }
 
             // Download the backend files.

--- a/Duplicati/UnitTest/RepairHandlerTests.cs
+++ b/Duplicati/UnitTest/RepairHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using NUnit.Framework;
 
@@ -24,7 +25,9 @@ namespace Duplicati.UnitTest
             Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions) {["no-encryption"] = noEncryption};
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                c.Backup(new[] {this.DATAFOLDER});
+                IBackupResults backupResults = c.Backup(new[] {this.DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
             }
 
             string[] dindexFiles = Directory.EnumerateFiles(this.TARGETFOLDER, "*dindex*").ToArray();
@@ -36,7 +39,9 @@ namespace Duplicati.UnitTest
 
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                c.Repair();
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
             }
 
             foreach (string file in dindexFiles)

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -3,7 +3,9 @@ using Duplicati.Library.Main;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.AccessControl;
+using Duplicati.Library.Interface;
 
 namespace Duplicati.UnitTest
 {
@@ -31,14 +33,19 @@ namespace Duplicati.UnitTest
             Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions);
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                c.Backup(new[] {this.DATAFOLDER});
+                IBackupResults backupResults = c.Backup(new[] {this.DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
             }
 
             // First, restore without restoring permissions.
             Dictionary<string, string> restoreOptions = new Dictionary<string, string>(this.TestOptions) {["restore-path"] = this.RESTOREFOLDER};
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
             {
-                c.Restore(new[] {filePath});
+                IRestoreResults restoreResults = c.Restore(new[] {filePath});
+                Assert.AreEqual(0, restoreResults.Errors.Count());
+                Assert.AreEqual(0, restoreResults.Warnings.Count());
+
                 string restoredFilePath = Path.Combine(this.RESTOREFOLDER, "file");
                 Assert.IsTrue(File.Exists(restoredFilePath));
 
@@ -51,7 +58,10 @@ namespace Duplicati.UnitTest
             restoreOptions["restore-permissions"] = "true";
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
             {
-                c.Restore(new[] {filePath});
+                IRestoreResults restoreResults = c.Restore(new[] {filePath});
+                Assert.AreEqual(0, restoreResults.Errors.Count());
+                Assert.AreEqual(0, restoreResults.Warnings.Count());
+
                 string restoredFilePath = Path.Combine(this.RESTOREFOLDER, "file");
                 Assert.IsTrue(File.Exists(restoredFilePath));
 

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Duplicati.Library.Common;
 using Duplicati.Library.Main;
 using NUnit.Framework;
@@ -60,6 +61,10 @@ namespace Duplicati.UnitTest
             {
                 IRestoreResults restoreResults = c.Restore(new[] {filePath});
                 Assert.AreEqual(0, restoreResults.Errors.Count());
+                foreach (var warning in restoreResults.Warnings)
+                {
+                    Console.WriteLine(warning);
+                }
                 Assert.AreEqual(0, restoreResults.Warnings.Count());
 
                 string restoredFilePath = Path.Combine(this.RESTOREFOLDER, "file");

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Duplicati.Library.Common;
 using Duplicati.Library.Main;
 using NUnit.Framework;
@@ -52,6 +51,10 @@ namespace Duplicati.UnitTest
 
                 FileSecurity restoredFileSecurity = File.GetAccessControl(restoredFilePath);
                 Assert.IsFalse(restoredFileSecurity.AreAccessRulesProtected);
+
+                // Remove the restored file so that the later restore avoids the "Restore completed
+                // without errors but no files were restored" warning.
+                File.Delete(restoredFilePath);
             }
 
             // Restore with restoring permissions.
@@ -61,10 +64,6 @@ namespace Duplicati.UnitTest
             {
                 IRestoreResults restoreResults = c.Restore(new[] {filePath});
                 Assert.AreEqual(0, restoreResults.Errors.Count());
-                foreach (var warning in restoreResults.Warnings)
-                {
-                    Console.WriteLine(warning);
-                }
                 Assert.AreEqual(0, restoreResults.Warnings.Count());
 
                 string restoredFilePath = Path.Combine(this.RESTOREFOLDER, "file");

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -43,6 +43,8 @@ namespace Duplicati.UnitTest
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
             {
                 var res = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, res.Errors.Count());
+                Assert.AreEqual(0, res.Warnings.Count());
                 if (res.ParsedResult != ParsedResultType.Success)
                     throw new Exception("Unexpected result from base backup");
                 


### PR DESCRIPTION
This modifies several of the unit tests to check for errors and warnings in the `IBasicResults` objects returned by `Controller` methods.

Note that there are two places in the `BorderTests` where we do not check for warnings.  The operations in those cases result in the "No block hash found for file: /root/duplicati_testdata/backup-data/a-0" warning.