### PR TITLE
Catch compression errors and report them

### DIFF
--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -8,6 +8,11 @@ namespace Duplicati.Library.Main.Volumes
 {
     public class FilesetVolumeWriter : VolumeWriterBase
     {
+        /// <summary>
+        /// The tag used for logging
+        /// </summary>
+        private static readonly string LOGTAG = Logging.Log.LogTagFromType<FilesetVolumeWriter>();
+
         private readonly Library.Utility.TempFile m_tempFile;
         private readonly Stream m_tempStream;
         private StreamWriter m_streamwriter;
@@ -159,11 +164,18 @@ namespace Duplicati.Library.Main.Volumes
             m_writer.Flush();
             m_streamwriter.Flush();
 
-            using (Stream sr = m_compression.CreateFile(FILELIST, CompressionHint.Compressible, DateTime.UtcNow))
+            try
             {
-                m_tempStream.Seek(0, SeekOrigin.Begin);
-                m_tempStream.CopyTo(sr);
-                sr.Flush();
+                using (Stream sr = m_compression.CreateFile(FILELIST, CompressionHint.Compressible, DateTime.UtcNow))
+                {
+                    m_tempStream.Seek(0, SeekOrigin.Begin);
+                    m_tempStream.CopyTo(sr);
+                    sr.Flush();
+                }
+            }
+            catch (System.NotSupportedException e)
+            {
+                Logging.Log.WriteErrorMessage(LOGTAG, "CompressionError", e, "Compression Error: {0}", e.Message);
             }
         }
 

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -8,11 +8,6 @@ namespace Duplicati.Library.Main.Volumes
 {
     public class FilesetVolumeWriter : VolumeWriterBase
     {
-        /// <summary>
-        /// The tag used for logging
-        /// </summary>
-        private static readonly string LOGTAG = Logging.Log.LogTagFromType<FilesetVolumeWriter>();
-
         private readonly Library.Utility.TempFile m_tempFile;
         private readonly Stream m_tempStream;
         private StreamWriter m_streamwriter;

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -170,11 +170,6 @@ namespace Duplicati.Library.Main.Volumes
                     sr.Flush();
                 }
             }
-            catch (System.NotSupportedException e)
-            {
-                Logging.Log.WriteErrorMessage(LOGTAG, "CompressionError", e, "Compression Error: {0}", e.Message);
-                throw e;
-            }
             finally
             {
                 m_writer.Close();

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -140,9 +140,6 @@ namespace Duplicati.Library.Main.Volumes
             if (m_streamwriter != null)
             {
                 this.AddFilelistFile();
-                m_writer.Close();
-                m_streamwriter.Dispose();
-                m_streamwriter = null;
             }
 
             if (m_tempStream != null)
@@ -176,6 +173,13 @@ namespace Duplicati.Library.Main.Volumes
             catch (System.NotSupportedException e)
             {
                 Logging.Log.WriteErrorMessage(LOGTAG, "CompressionError", e, "Compression Error: {0}", e.Message);
+                throw e;
+            }
+            finally
+            {
+                m_writer.Close();
+                m_streamwriter.Dispose();
+                m_streamwriter = null;
             }
         }
 


### PR DESCRIPTION
When the file list is over 4GB one needs to have the zip64 option
enabled. This commit catches the exception and reports it as an error so
that the user knows what the problem is.

Fixes duplicati/duplicati/#4206