### PR TITLE
Tardigrade - Some fixes

### DIFF
--- a/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="storj_uplink.dylib">
+    <None Include="libstorj_uplink.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="libstorj_uplink.so">

--- a/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -90,12 +90,10 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets'))" />
   </Target>
   <Import Project="..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets')" />

--- a/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -43,8 +43,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="uplink.NET, Version=2.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\uplink.NET.2.3.1\lib\netstandard2.0\uplink.NET.dll</HintPath>
+    <Reference Include="uplink.NET, Version=2.3.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\uplink.NET.2.3.2\lib\netstandard2.0\uplink.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -73,13 +73,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="libstorj_uplink.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="libstorj_uplink.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="win-x64\storj_uplink.dll">
@@ -96,5 +96,7 @@
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.3.1\build\net40\uplink.NET.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets'))" />
   </Target>
+  <Import Project="..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets')" />
 </Project>

--- a/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
+++ b/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
@@ -24,6 +24,7 @@ namespace Duplicati.Library.Backend.Tardigrade
         private const string TARDIGRADE_BUCKET = "tardigrade-bucket";
         private const string TARDIGRADE_FOLDER = "tardigrade-folder";
         private const string PROTOCOL_KEY = "tardigrade";
+        private const string TARDIGRADE_PARTNER_ID = "duplicati";
 
         private readonly string _satellite;
         private readonly string _api_key;
@@ -86,7 +87,7 @@ namespace Duplicati.Library.Backend.Tardigrade
             {
                 //Create an access from the access grant
                 var shared_access = options[TARDIGRADE_SHARED_ACCESS];
-                _access = new Access(shared_access);
+                _access = new Access(shared_access, new Config() { UserAgent = TARDIGRADE_PARTNER_ID });
             }
             else
             {
@@ -102,8 +103,8 @@ namespace Duplicati.Library.Backend.Tardigrade
                     _secret = options[TARDIGRADE_SECRET];
                 }
 
-                _access = new Access(_satellite, _api_key, _secret);
-            }
+                _access = new Access(_satellite, _api_key, _secret, new Config() { UserAgent = TARDIGRADE_PARTNER_ID });
+                }
 
             _bucketService = new BucketService(_access);
             _objectService = new ObjectService(_access);

--- a/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
+++ b/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
@@ -38,7 +38,9 @@ namespace Duplicati.Library.Backend.Tardigrade
         public static readonly Dictionary<string, string> KNOWN_TARDIGRADE_SATELLITES = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase){
             { "US Central 1", "us-central-1.tardigrade.io:7777" },
             { "Asia East 1", "asia-east-1.tardigrade.io:7777" },
+            { "Saltlake", "saltlake.tardigrade.io:7777" },
             { "Europe West 1", "europe-west-1.tardigrade.io:7777" },
+            { "Europe North 1", "europe-north-1.tardigrade.io:7777" },
         };
 
         public static readonly Dictionary<string, string> KNOWN_AUTHENTICATION_METHODS = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase){

--- a/Duplicati/Library/Backend/Tardigrade/packages.config
+++ b/Duplicati/Library/Backend/Tardigrade/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="uplink.NET" version="2.3.1" targetFramework="net462" />
+  <package id="uplink.NET" version="2.3.2" targetFramework="net462" />
 </packages>

--- a/Duplicati/Library/Backend/Tardigrade/packages.config
+++ b/Duplicati/Library/Backend/Tardigrade/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="uplink.NET" version="2.3.2" targetFramework="net462" />
+  <package id="uplink.NET" version="2.3.2" targetFramework="net471" />
 </packages>

--- a/Installer/OSX/make-dmg.sh
+++ b/Installer/OSX/make-dmg.sh
@@ -9,7 +9,7 @@ WC_DIR=wc
 TEMPLATE_DMG=template.dmg
 OUTPUT_DMG=Duplicati.dmg
 OUTPUT_PKG=Duplicati.pkg
-UNWANTED_FILES="appindicator-sharp.dll SQLite win-tools control_dir Duplicati.sqlite Duplicati-server.sqlite run-script-example.bat lvm-scripts Duplicati.debug.log SVGIcons storj_uplink.dll libstorj_uplink.so"
+UNWANTED_FILES="appindicator-sharp.dll SQLite win-tools control_dir Duplicati.sqlite Duplicati-server.sqlite run-script-example.bat lvm-scripts Duplicati.debug.log SVGIcons storj_uplink.dll libstorj_uplink.so win-x64 win-x86"
 
 # These are set via the macos-gatekeeper file
 CODESIGN_IDENTITY=

--- a/Installer/Synology/make-binary-package.sh
+++ b/Installer/Synology/make-binary-package.sh
@@ -79,7 +79,7 @@ rm -rf ./licenses/gpg
 rm -rf ./win-x64/storj_uplink.dll
 rm -rf ./win-x86/storj_uplink.dll
 rm -rf ./storj_uplink.dll
-rm -rf ./storj_uplink.dylib
+rm -rf ./libstorj_uplink.dylib
 
 # Install extra items for Synology
 cp -R ../web-extra/* webroot/

--- a/Installer/Windows/WixInstaller.wixproj
+++ b/Installer/Windows/WixInstaller.wixproj
@@ -67,7 +67,7 @@
     </WixExtension>
   </ItemGroup>
   <ItemGroup>
-    <BinFiles Include="..\Duplicati\**" Exclude="..\**\*.pdb;..\**\SVGIcons\**\*.*;..\**\OSX Icons\**\*.*;..\**\lvm-scripts\**\*.*;..\**\libstorj_uplink.so;..\**\storj_uplink.dylib" />
+    <BinFiles Include="..\Duplicati\**" Exclude="..\**\*.pdb;..\**\SVGIcons\**\*.*;..\**\OSX Icons\**\*.*;..\**\lvm-scripts\**\*.*;..\**\libstorj_uplink.so;..\**\libstorj_uplink.dylib" />
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <Target Name="BeforeBuild">

--- a/Installer/Windows/WixInstaller.wixproj
+++ b/Installer/Windows/WixInstaller.wixproj
@@ -67,7 +67,7 @@
     </WixExtension>
   </ItemGroup>
   <ItemGroup>
-    <BinFiles Include="..\Duplicati\**" Exclude="..\**\*.pdb;..\**\SVGIcons\**\*.*;..\**\OSX Icons\**\*.*;..\**\lvm-scripts\**\*.*;..\**\libstorj_uplink.so;..\**\libstorj_uplink.dylib" />
+    <BinFiles Include="..\Duplicati\**" Exclude="..\**\*.pdb;..\**\SVGIcons\**\*.*;..\**\OSX Icons\**\*.*;..\**\lvm-scripts\**\*.*;..\**\libstorj_uplink.so;..\**\libstorj_uplink.dylib;..\**\storj_uplink.dll" />
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <Target Name="BeforeBuild">

--- a/Installer/debian/bin-rules.sh
+++ b/Installer/debian/bin-rules.sh
@@ -59,7 +59,7 @@ override_dh_auto_install:
 	rm -rf build/lib/duplicati/win-x64/storj_uplink.dll
 	rm -rf build/lib/duplicati/win-x86/storj_uplink.dll
 	rm -rf build/lib/duplicati/storj_uplink.dll
-	rm -rf build/lib/duplicati/storj_uplink.dylib
+	rm -rf build/lib/duplicati/libstorj_uplink.dylib
 	find build/lib/duplicati/* -type f | xargs chmod 644
 	find build/lib/duplicati/* -type d | xargs chmod 755
 	find build/lib/duplicati/* -type f -name \*.exe | xargs chmod 755

--- a/Installer/fedora/duplicati-binary.spec
+++ b/Installer/fedora/duplicati-binary.spec
@@ -97,7 +97,7 @@ rm -rf licenses/gpg
 rm -rf win-x64\storj_uplink.dll
 rm -rf win-x86\storj_uplink.dll
 rm -rf storj_uplink.dll
-rm -rf storj_uplink.dylib
+rm -rf libstorj_uplink.dylib
 
 
 %install


### PR DESCRIPTION
This PR fixes the following things with the Tardigrade-Backend:
- it correctly deploys the MacOS-binaries. The name has been wrong. Instead of "storj_uplink.dylib" the file has to be named "libstorj_uplink.dylib". I've also adjusted the installer-scripts to reflect that change.
- The MacOS-installer distributed the storj_uplink-windows-dlls - I've adjusted that.
- The backend switches to the latest Nuget (uplink.NET v2.3.2)
- The partner-ID has been added so that Duplicati is now officially part of the OSS-program from Storj and receives a portion of the revenue.