### PR TITLE
Support problematic Windows paths

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -25,6 +25,8 @@ namespace Duplicati.CommandLine.RecoveryTool
 {
     public static class Restore
     {
+        private static readonly ISystemIO systemIO = SystemIO.IO_OS;
+
         public static int Run(List<string> args, Dictionary<string, string> options, Library.Utility.IFilter filter)
         {
             if (args.Count != 2 && args.Count != 3)
@@ -158,8 +160,8 @@ namespace Duplicati.CommandLine.RecoveryTool
                         try
                         {
                             var targetfile = MapToRestorePath(f.Path, largestprefix, targetpath);
-                            if (!Directory.Exists(Path.GetDirectoryName(targetfile)))
-                                Directory.CreateDirectory(Path.GetDirectoryName(targetfile));
+                            if (!systemIO.DirectoryExists(systemIO.PathGetDirectoryName(targetfile)))
+                                systemIO.DirectoryCreate(systemIO.PathGetDirectoryName(targetfile));
 
                             Console.Write("{0}: {1} ({2})", i, targetfile, Library.Utility.Utility.FormatSizeString(f.Size));
 
@@ -214,12 +216,12 @@ namespace Duplicati.CommandLine.RecoveryTool
                                 if (fh == f.Hash)
                                 {
                                     Console.WriteLine(" done!");
-                                    File.Copy(tf, targetfile, true);
+                                    systemIO.FileCopy(tf, targetfile, true);
                                 }
                                 else
                                 {
                                     Console.Write(" - Restored file hash mismatch");
-                                    if (File.Exists(targetfile))
+                                    if (systemIO.FileExists(targetfile))
                                         Console.WriteLine(" - not overwriting existing file: {0}", targetfile);
                                     else
                                         Console.WriteLine(" - restoring file in damaged condition");
@@ -254,10 +256,10 @@ namespace Duplicati.CommandLine.RecoveryTool
                 if (path.Substring(1, 1) == ":")
                     prefixpath = path.Substring(0, 1) + path.Substring(2);
 
-                return Path.Combine(restorepath, prefixpath);
+                return systemIO.PathCombine(restorepath, prefixpath);
             }
 
-            return Path.Combine(restorepath, path.Substring(prefixpath.Length));
+            return systemIO.PathCombine(restorepath, path.Substring(prefixpath.Length));
         }
 
 

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -53,12 +53,12 @@ namespace Duplicati.Library.Common.IO
 
         public static string StripUNCPrefix(string path)
         {
-            if (path.StartsWith(UNCPREFIX_SERVER))
+            if (path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal))
             {
                 // @"\\?\UNC\example.com\share\file.txt" to @"\\example.com\share\file.txt"
                 return PATHPREFIX_SERVER + path.Substring(UNCPREFIX_SERVER.Length);
             }
-            else if (path.StartsWith(UNCPREFIX))
+            else if (path.StartsWith(UNCPREFIX, StringComparison.Ordinal))
             {
                 // @"\\?\C:\file.txt" to @"C:\file.txt"
                 return path.Substring(UNCPREFIX.Length);

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -34,28 +34,39 @@ namespace Duplicati.Library.Common.IO
         private const string PATHPREFIX_SERVER = @"\\";
         private static readonly string DIRSEP = Util.DirectorySeparatorString;
 
-        private static bool IsPathTooLong(string path)
-        {
-            // Use 258 for length check instead of 260 (MAX_PATH) - we need to leave room for the 16-bit (wide) null terminator
-            return path.StartsWith(UNCPREFIX, StringComparison.Ordinal) || path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal) || path.Length > 258;
-        }
-
         public static string PrefixWithUNC(string path)
         {
-            if (path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal))
+            if (IsPrefixedWithUNC(path))
+            {
                 return path;
-
-            if (path.StartsWith(UNCPREFIX, StringComparison.Ordinal))
-                return path;
-
+            }
             return path.StartsWith(PATHPREFIX_SERVER, StringComparison.Ordinal)
-                ? UNCPREFIX_SERVER + path.Remove(0, PATHPREFIX_SERVER.Length)
+                ? UNCPREFIX_SERVER + path.Substring(PATHPREFIX_SERVER.Length)
                 : UNCPREFIX + path;
+        }
+
+        private static bool IsPrefixedWithUNC(string path)
+        {
+            return path.StartsWith(UNCPREFIX_SERVER, StringComparison.Ordinal) ||
+                path.StartsWith(UNCPREFIX, StringComparison.Ordinal);
         }
 
         public static string StripUNCPrefix(string path)
         {
-            return path.StartsWith(UNCPREFIX, StringComparison.Ordinal) ? path.Substring(UNCPREFIX.Length) : path;
+            if (path.StartsWith(UNCPREFIX_SERVER))
+            {
+                // @"\\?\UNC\example.com\share\file.txt" to @"\\example.com\share\file.txt"
+                return PATHPREFIX_SERVER + path.Substring(UNCPREFIX_SERVER.Length);
+            }
+            else if (path.StartsWith(UNCPREFIX))
+            {
+                // @"\\?\C:\file.txt" to @"C:\file.txt"
+                return path.Substring(UNCPREFIX.Length);
+            }
+            else
+            {
+                return path;
+            }
         }
 
         private class FileSystemAccess
@@ -139,135 +150,90 @@ namespace Duplicati.Library.Common.IO
 
         private System.Security.AccessControl.FileSystemSecurity GetAccessControlDir(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.Directory.GetAccessControl,
-                                          Alphaleonis.Win32.Filesystem.Directory.GetAccessControl, path, true);
+            return System.IO.Directory.GetAccessControl(PrefixWithUNC(path));
         }
 
         private System.Security.AccessControl.FileSystemSecurity GetAccessControlFile(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.File.GetAccessControl,
-                                          Alphaleonis.Win32.Filesystem.File.GetAccessControl, path, true);
+            return System.IO.File.GetAccessControl(PrefixWithUNC(path));
         }
 
         private void SetAccessControlFile(string path, FileSecurity rules)
         {
-            PathTooLongActionWrapper(p => System.IO.File.SetAccessControl(p, rules),
-                                     p => Alphaleonis.Win32.Filesystem.File.SetAccessControl(p, rules, AccessControlSections.All),
-                                     path, true);
+            System.IO.File.SetAccessControl(PrefixWithUNC(path), rules);
         }
 
         private void SetAccessControlDir(string path, DirectorySecurity rules)
         {
-            PathTooLongActionWrapper(p => System.IO.Directory.SetAccessControl(p, rules),
-                                     p => Alphaleonis.Win32.Filesystem.Directory.SetAccessControl(p, rules, AccessControlSections.All),
-                                     path, true);
-        }
-
-        private static void PathTooLongVoidFuncWrapper<U, T>(Func<string, T> nativeIOFunc,
-                                                    Func<string, U> alternativeIOFunc,
-                                                    string path, bool prefixWithUnc = false)
-        {
-            // Wrap void into bool return type to avoid code duplication. Code at anytime available for replacement.
-            PathTooLongFuncWrapper(p => { nativeIOFunc(p); return true; }, p => { alternativeIOFunc(p); return true; } , path, prefixWithUnc);
-        }
-
-        private static void PathTooLongActionWrapper(Action<string> nativeIOFunc,
-                                                     Action<string> alternativeIOFunc,
-                                                     string path, bool prefixWithUnc = false)
-        {
-            // Wrap void into bool return type to avoid code duplication. Code at anytime available for replacement.
-            PathTooLongFuncWrapper(p => { nativeIOFunc(p); return true; }, p => { alternativeIOFunc(p); return true; }, path, prefixWithUnc);
-        }
-
-        private static T PathTooLongFuncWrapper<T>(Func<string, T> nativeIOFunc,
-                                                   Func<string, T> alternativeIOFunc,
-                                                   string path, bool prefixWithUnc = false)
-        {
-            if (!IsPathTooLong(path))
-                try { return nativeIOFunc(path); }
-                catch (System.IO.PathTooLongException) { }
-                catch (System.ArgumentException) { }
-
-            return !prefixWithUnc ? alternativeIOFunc(path) : alternativeIOFunc(PrefixWithUNC(path));
+            System.IO.Directory.SetAccessControl(PrefixWithUNC(path), rules);
         }
 
         #region ISystemIO implementation
         public void DirectoryCreate(string path)
         {
-            PathTooLongVoidFuncWrapper(System.IO.Directory.CreateDirectory,
-                                       Alphaleonis.Win32.Filesystem.Directory.CreateDirectory, path, true);
+            System.IO.Directory.CreateDirectory(PrefixWithUNC(path));
         }
 
         public bool DirectoryExists(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.Directory.Exists,
-                                          Alphaleonis.Win32.Filesystem.Directory.Exists, path, true);
+            return System.IO.Directory.Exists(PrefixWithUNC(path));
         }
 
         public void FileDelete(string path)
         {
-            PathTooLongActionWrapper(System.IO.File.Delete,
-                                     Alphaleonis.Win32.Filesystem.File.Delete, path, true);
+            System.IO.File.Delete(PrefixWithUNC(path));
         }
 
         public void FileSetLastWriteTimeUtc(string path, DateTime time)
         {
-            PathTooLongActionWrapper(p => System.IO.File.SetLastWriteTimeUtc(p, time),
-                                     p => Alphaleonis.Win32.Filesystem.File.SetLastWriteTimeUtc(p, time), path, true);
+            System.IO.File.SetLastWriteTimeUtc(PrefixWithUNC(path), time);
         }
 
         public void FileSetCreationTimeUtc(string path, DateTime time)
         {
-            PathTooLongActionWrapper(p => System.IO.File.SetCreationTimeUtc(p, time),
-                                     p => Alphaleonis.Win32.Filesystem.File.SetCreationTimeUtc(p, time), path, true);
+            System.IO.File.SetCreationTimeUtc(PrefixWithUNC(path), time);
         }
 
         public DateTime FileGetLastWriteTimeUtc(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.File.GetLastWriteTimeUtc,
-                                          Alphaleonis.Win32.Filesystem.File.GetLastWriteTimeUtc, path, true);
+            return System.IO.File.GetLastWriteTimeUtc(PrefixWithUNC(path));
         }
 
         public DateTime FileGetCreationTimeUtc(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.File.GetCreationTimeUtc,
-                                          Alphaleonis.Win32.Filesystem.File.GetCreationTimeUtc, path, true);
+            return System.IO.File.GetCreationTimeUtc(PrefixWithUNC(path));
         }
 
         public bool FileExists(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.File.Exists,
-                                          Alphaleonis.Win32.Filesystem.File.Exists, path, true);
+            return System.IO.File.Exists(PrefixWithUNC(path));
         }
 
         public System.IO.FileStream FileOpenRead(string path)
         {
-            return PathTooLongFuncWrapper(p => System.IO.File.Open(p, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite),
-                                   p => Alphaleonis.Win32.Filesystem.File.Open(p, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite),
-                                   path, true);
+            return System.IO.File.Open(PrefixWithUNC(path), System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite);
         }
 
         public System.IO.FileStream FileOpenWrite(string path)
         {
             return !FileExists(path)
                 ? FileCreate(path)
-                : PathTooLongFuncWrapper(System.IO.File.OpenWrite, Alphaleonis.Win32.Filesystem.File.OpenWrite, path, true);
+                : System.IO.File.OpenWrite(PrefixWithUNC(path));
         }
 
         public System.IO.FileStream FileCreate(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.File.Create, Alphaleonis.Win32.Filesystem.File.Create, path, true);
+            return System.IO.File.Create(PrefixWithUNC(path));
         }
 
         public System.IO.FileAttributes GetFileAttributes(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.File.GetAttributes, AlphaFS.File.GetAttributes, path, true);
+            return System.IO.File.GetAttributes(PrefixWithUNC(path));
         }
 
         public void SetFileAttributes(string path, System.IO.FileAttributes attributes)
         {
-            PathTooLongActionWrapper(p => System.IO.File.SetAttributes(p, attributes),
-                                      p => Alphaleonis.Win32.Filesystem.File.SetAttributes(p, attributes), path, true);
+            System.IO.File.SetAttributes(PrefixWithUNC(path), attributes);
         }
 
         /// <summary>
@@ -279,7 +245,7 @@ namespace Duplicati.Library.Common.IO
         {
             try
             {
-                return PathTooLongFuncWrapper(AlphaFS.File.GetLinkTargetInfo, AlphaFS.File.GetLinkTargetInfo, file, true).PrintName;
+                return AlphaFS.File.GetLinkTargetInfo(PrefixWithUNC(file)).PrintName;
             }
             catch (AlphaFS.NotAReparsePointException) { }
             catch (AlphaFS.UnrecognizedReparsePointException) { }
@@ -292,156 +258,154 @@ namespace Duplicati.Library.Common.IO
 
         public IEnumerable<string> EnumerateFileSystemEntries(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.Directory.EnumerateFileSystemEntries,
-                                          Alphaleonis.Win32.Filesystem.Directory.GetFileSystemEntries,
-                                          path, true).Select(StripUNCPrefix).AsEnumerable();
+            return System.IO.Directory.EnumerateFileSystemEntries(PrefixWithUNC(path)).Select(StripUNCPrefix);
         }
 
         public IEnumerable<string> EnumerateFiles(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.Directory.EnumerateFiles,
-                                          Alphaleonis.Win32.Filesystem.Directory.GetFiles, path,
-                                          true).Select(StripUNCPrefix).AsEnumerable();
+            return System.IO.Directory.EnumerateFiles(PrefixWithUNC(path)).Select(StripUNCPrefix);
         }
 
         public string PathGetFileName(string path)
         {
-            return StripUNCPrefix(PathTooLongFuncWrapper(System.IO.Path.GetFileName,
-                                                         Alphaleonis.Win32.Filesystem.Path.GetFileName,
-                                                         path, true));
+            return StripUNCPrefix(System.IO.Path.GetFileName(PrefixWithUNC(path)));
         }
 
         public string PathGetDirectoryName(string path)
         {
-            return StripUNCPrefix(PathTooLongFuncWrapper(System.IO.Path.GetDirectoryName,
-                                                         Alphaleonis.Win32.Filesystem.Path.GetDirectoryName,
-                                                         path, true));
+            return StripUNCPrefix(System.IO.Path.GetDirectoryName(PrefixWithUNC(path)));
         }
 
         public string PathGetExtension(string path)
         {
-            return StripUNCPrefix(PathTooLongFuncWrapper(System.IO.Path.GetExtension,
-                                                         Alphaleonis.Win32.Filesystem.Path.GetExtension,
-                                                         path, true));
+            return StripUNCPrefix(System.IO.Path.GetExtension(PrefixWithUNC(path)));
         }
 
         public string PathChangeExtension(string path, string extension)
         {
-            return StripUNCPrefix(PathTooLongFuncWrapper(p => System.IO.Path.ChangeExtension(p, extension),
-                                                         p => Alphaleonis.Win32.Filesystem.Path.ChangeExtension(p, extension),
-                                                         path, true));
+            return StripUNCPrefix(System.IO.Path.ChangeExtension(PrefixWithUNC(path), extension));
         }
 
         public void DirectorySetLastWriteTimeUtc(string path, DateTime time)
         {
-            PathTooLongActionWrapper(p => System.IO.Directory.SetLastWriteTimeUtc(p, time),
-                                     p => Alphaleonis.Win32.Filesystem.File.SetLastWriteTimeUtc(p, time), path, true);
+            System.IO.Directory.SetLastWriteTimeUtc(PrefixWithUNC(path), time);
         }
 
         public void DirectorySetCreationTimeUtc(string path, DateTime time)
         {
-            PathTooLongActionWrapper(p => System.IO.Directory.SetCreationTimeUtc(p, time),
-                                     p => Alphaleonis.Win32.Filesystem.File.SetCreationTimeUtc(p, time), path, true);
+            System.IO.Directory.SetCreationTimeUtc(PrefixWithUNC(path), time);
         }
 
         public void FileMove(string source, string target)
         {
-            // We do not check if path is too long on target. If so, then we catch an exception.
-            PathTooLongActionWrapper(p => System.IO.File.Move(p, target),
-                                     p => Alphaleonis.Win32.Filesystem.File.Move(p, PrefixWithUNC(target)),
-                                     source, true);
+            System.IO.File.Move(PrefixWithUNC(source), PrefixWithUNC(target));
         }
 
         public long FileLength(string path)
         {
-            return PathTooLongFuncWrapper(p => new System.IO.FileInfo(p).Length,
-                                          p => new Alphaleonis.Win32.Filesystem.FileInfo(p).Length,
-                                          path, true);
+            return new System.IO.FileInfo(PrefixWithUNC(path)).Length;
         }
 
         public string GetPathRoot(string path)
         {
-            return PathTooLongFuncWrapper(Path.GetPathRoot, AlphaFS.Path.GetPathRoot, path, false);
+            if (IsPrefixedWithUNC(path))
+            {
+                return Path.GetPathRoot(path);
+            }
+            else
+            {
+                return StripUNCPrefix(Path.GetPathRoot(PrefixWithUNC(path)));
+            }
         }
 
         public string[] GetDirectories(string path)
         {
-            return PathTooLongFuncWrapper(Directory.GetDirectories, AlphaFS.Directory.GetDirectories, path, false);
+            if (IsPrefixedWithUNC(path))
+            {
+                return Directory.GetDirectories(path);
+            }
+            else
+            {
+                return Directory.GetDirectories(PrefixWithUNC(path)).Select(StripUNCPrefix).ToArray();
+            }
         }
 
         public string[] GetFiles(string path)
         {
-            return PathTooLongFuncWrapper(Directory.GetFiles, AlphaFS.Directory.GetFiles, path, false);
+            if (IsPrefixedWithUNC(path))
+            {
+                return Directory.GetFiles(path);
+            }
+            else
+            {
+                return Directory.GetFiles(PrefixWithUNC(path)).Select(StripUNCPrefix).ToArray();
+            }
         }
 
         public string[] GetFiles(string path, string searchPattern)
         {
-            return PathTooLongFuncWrapper(p => Directory.GetFiles(p, searchPattern), p => AlphaFS.Directory.GetFiles(p, searchPattern), path, false);
+            if (IsPrefixedWithUNC(path))
+            {
+                return Directory.GetFiles(path, searchPattern);
+            }
+            else
+            {
+                return Directory.GetFiles(PrefixWithUNC(path), searchPattern).Select(StripUNCPrefix).ToArray();
+            }
         }
 
         public DateTime GetCreationTimeUtc(string path)
         {
-            return PathTooLongFuncWrapper(Directory.GetCreationTimeUtc, AlphaFS.File.GetCreationTimeUtc, path, false);
+            return Directory.GetCreationTimeUtc(PrefixWithUNC(path));
         }
 
         public DateTime GetLastWriteTimeUtc(string path)
         {
-            return PathTooLongFuncWrapper(Directory.GetLastWriteTimeUtc, AlphaFS.File.GetLastWriteTimeUtc, path, false);
+            return Directory.GetLastWriteTimeUtc(PrefixWithUNC(path));
         }
 
         public IEnumerable<string> EnumerateDirectories(string path)
         {
-            return PathTooLongFuncWrapper(Directory.EnumerateDirectories, AlphaFS.Directory.EnumerateDirectories, path, false);
+            if (IsPrefixedWithUNC(path))
+            {
+                return Directory.EnumerateDirectories(path);
+            }
+            else
+            {
+                return Directory.EnumerateDirectories(PrefixWithUNC(path)).Select(StripUNCPrefix);
+            }
         }
 
         public void FileCopy(string source, string target, bool overwrite)
         {
-            // We do not check if path is too long on target. If so, then we catch an exception.
-            PathTooLongActionWrapper(p => File.Copy(p, target, overwrite), p => AlphaFS.File.Copy(p, target, overwrite), source, false);
+            File.Copy(PrefixWithUNC(source), PrefixWithUNC(target), overwrite);
         }
 
         public string PathGetFullPath(string path)
         {
-            return PathTooLongFuncWrapper(System.IO.Path.GetFullPath, AlphaFS.Path.GetFullPath, path, false);
+            if (IsPrefixedWithUNC(path))
+            {
+                return System.IO.Path.GetFullPath(path);
+            }
+            else
+            {
+                return StripUNCPrefix(System.IO.Path.GetFullPath(PrefixWithUNC(path)));
+            }
         }
 
         public IFileEntry DirectoryEntry(string path)
         {
-            IFileEntry DirectoryEntryNative(string p) {
-                var dInfo = new DirectoryInfo(p);
-                return new FileEntry(dInfo.Name, 0, dInfo.LastAccessTime, dInfo.LastWriteTime)
-                {
-                    IsFolder = true
-                };
-            }
-
-            IFileEntry DirectoryEntryAlphaFS(string p)
+            var dInfo = new DirectoryInfo(PrefixWithUNC(path));
+            return new FileEntry(dInfo.Name, 0, dInfo.LastAccessTime, dInfo.LastWriteTime)
             {
-                var dInfoAlphaFS = new AlphaFS.DirectoryInfo(p);
-                return new FileEntry(dInfoAlphaFS.Name, 0, dInfoAlphaFS.LastAccessTime, dInfoAlphaFS.LastWriteTime)
-                {
-                    IsFolder = true
-                };
-            }
-
-            return PathTooLongFuncWrapper(DirectoryEntryNative, DirectoryEntryAlphaFS, path, false);
+                IsFolder = true
+            };
         }
 
         public IFileEntry FileEntry(string path)
         {
-            IFileEntry FileEntryNative(string p)
-            {
-                var fileInfo = new FileInfo(p);
-                return new FileEntry(fileInfo.Name, fileInfo.Length, fileInfo.LastAccessTime, fileInfo.LastWriteTime);
-            }
-
-            IFileEntry FileEntryAlphaFS(string p)
-            {
-                var fInfoAlphaFS = new AlphaFS.FileInfo(p);
-                return new FileEntry(fInfoAlphaFS.Name, fInfoAlphaFS.Length, fInfoAlphaFS.LastAccessTime, fInfoAlphaFS.LastWriteTime);
-            }
-
-            return PathTooLongFuncWrapper(FileEntryNative, FileEntryAlphaFS, path, false);
+            var fileInfo = new FileInfo(PrefixWithUNC(path));
+            return new FileEntry(fileInfo.Name, fileInfo.Length, fileInfo.LastAccessTime, fileInfo.LastWriteTime);
         }
 
         public Dictionary<string, string> GetMetadata(string path, bool isSymlink, bool followSymlink)
@@ -522,31 +486,7 @@ namespace Duplicati.Library.Common.IO
 
         public string PathCombine(params string[] paths)
         {
-            var combinedPath = "";
-            for (int i = 0; i < paths.Length; i++)
-            {
-                if (i == 0)
-                {
-                    combinedPath = paths[i];
-                }
-                else
-                {
-                    if (!IsPathTooLong(combinedPath + "\\" + paths[i]))
-                    {
-                        try
-                        {
-                            combinedPath = Path.Combine(combinedPath, paths[i]);
-                        }
-                        catch (Exception ex) when (ex is System.IO.PathTooLongException || ex is System.ArgumentException)
-                        {
-                            //TODO: Explain why we need to keep prefixing and stripping UNC's.
-                            combinedPath = StripUNCPrefix(Alphaleonis.Win32.Filesystem.Path.Combine(PrefixWithUNC(combinedPath), paths[i]));
-                        }
-                    }
-                }
-            }
-
-            return combinedPath;
+            return Path.Combine(paths);
         }
 
         public void CreateSymlink(string symlinkfile, string target, bool asDir)

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -266,7 +266,7 @@ namespace Duplicati.Library.Snapshots
             var root = SystemIO.IO_WIN.GetPathRoot(localPath);
             var volumePath = _vssBackupComponents.GetVolumeFromCache(root);
             var subPath = localPath.Substring(root.Length);
-            var mappedPath = Path.Combine(volumePath, subPath);
+            var mappedPath = SystemIO.IO_WIN.PathCombine(volumePath, subPath);
             return mappedPath;
         }
 

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -110,17 +110,7 @@ namespace Duplicati.Library.Snapshots
         {
             string[] tmp = null;
             var spath = ConvertToSnapshotPath(localFolderPath);
-
-            try
-            {
-                tmp = SystemIO.IO_WIN.GetDirectories(spath); 
-            }
-            catch (DirectoryNotFoundException) //TODO: Do we really need this??
-            {
-                spath = SystemIOWindows.PrefixWithUNC(spath);
-                tmp = SystemIO.IO_WIN.GetDirectories(spath);
-            }
-
+            tmp = SystemIO.IO_WIN.GetDirectories(spath); 
             var root = Util.AppendDirSeparator(SystemIO.IO_WIN.GetPathRoot(localFolderPath));
             var volumePath = Util.AppendDirSeparator(ConvertToSnapshotPath(root));
             volumePath = SystemIOWindows.PrefixWithUNC(volumePath);
@@ -145,17 +135,7 @@ namespace Duplicati.Library.Snapshots
 
             string[] files = null;
             var spath = ConvertToSnapshotPath(localFolderPath);
-
-            // First try without long UNC prefixed
-            try
-            {
-                files = SystemIO.IO_WIN.GetFiles(spath);
-            }
-            catch (DirectoryNotFoundException) //TODO: Do we really need this??
-            {
-                spath = SystemIOWindows.PrefixWithUNC(spath);
-                files = SystemIO.IO_WIN.GetFiles(spath);
-            }
+            files = SystemIO.IO_WIN.GetFiles(spath);
 
             // convert back to non-shadow, i.e., non-vss version
             var root = Util.AppendDirSeparator(SystemIO.IO_WIN.GetPathRoot(localFolderPath));
@@ -285,15 +265,8 @@ namespace Duplicati.Library.Snapshots
 
             var root = SystemIO.IO_WIN.GetPathRoot(localPath);
             var volumePath = _vssBackupComponents.GetVolumeFromCache(root);
-
-            // Note: Do NOT use Path.Combine as it strips the UNC path prefix
             var subPath = localPath.Substring(root.Length);
-            if (!subPath.StartsWith(Util.DirectorySeparatorString, StringComparison.Ordinal))
-            {
-                volumePath = Util.AppendDirSeparator(volumePath, Util.DirectorySeparatorString);
-            }
-
-            var mappedPath = volumePath + subPath;
+            var mappedPath = Path.Combine(volumePath, subPath);
             return mappedPath;
         }
 

--- a/Duplicati/UnitTest/IOTests.cs
+++ b/Duplicati/UnitTest/IOTests.cs
@@ -44,16 +44,16 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void TestUncBehaviourOfAlphaFS()
+        public void TestUncBehaviourOfGetPathRoot()
         {
             if (!Platform.IsClientWindows)
             {
                 return;
             }
 
-            var root = @"C:";
+            var root = @"C:" + Util.DirectorySeparatorString;
             var filename = "test.txt";
-            var filePath = root + Util.DirectorySeparatorString + filename;
+            var filePath = root + filename;
             var filePathWithUNC = SystemIOWindows.PrefixWithUNC(filePath);
 
             var filePathWithUNCRoot = SystemIO.IO_WIN.GetPathRoot(filePathWithUNC);
@@ -63,7 +63,7 @@ namespace Duplicati.UnitTest
 
             //Without UNC prefixed, no prefix. 
             var filePathRoot = SystemIO.IO_WIN.GetPathRoot(filePath);
-            Assert.AreEqual(root + Util.DirectorySeparatorString, filePathRoot);
+            Assert.AreEqual(root, filePathRoot);
         }
 
         [Test]


### PR DESCRIPTION
Allow historically problematic Windows paths (i.e., files or
directories that end in a dot or a space) to be backed up with
Duplicati in Windows.

This fixes #3839.

I've taken a stab at changing Duplicati to support files and directories that end in a dot or a space.

Just a quick recap of some things that weren't working in Duplicati under Windows as I tested out changes for #4251:
1. Paths that include directories that end in one or more spaces ("` `") or one or more dots ("`.`") can trigger a UNIQUE CONSTRAINT violation in Duplicati (and from reading #3839, other kinds of exceptions)
1. Files that end in one or more spaces ("` `") or one or more dots ("`.`") could appear to have been successfully backed up and you could even select the files during a restore, but the contents of those files never actually made it into the back up so they could not actually be restored

These kinds of files and directories trip up the AlphaFS library (and, historically, .NET).  For example, this call
```cs
AlphaFS.Directory.GetDirectories(@"\\?\C:\Temp\dir.")
```
can trigger an exception about the path not being found, or, if a path without the trailing dot exists (e.g., plain "`C:\Temp\dir`"), it can silently send AlphaFS down into the wrong directory.

.NET 4.6.2 has added support for using the "`\\?\`" prefix, so long paths can now be handled with the native .NET functions.  Plus the .NET 4.6.2 functions do not have problems with trailing dots and spaces.

I changed SystemIOWindows.cs to rely on the new behavior of .NET 4.6.2.

At this point, unit tests pass, I can back up combinations of directories and files that end in dots or spaces, I can continue to back up files with long paths, and everything successfully restores.  I've also tried snapshot (VSS) backups against locked files, and I've tried backups of network shares (e.g., "`\\example.com\share\file.txt`").

I would like to know what else I should look at to make sure things are working -- I don't have a feel for how comprehensive the unit tests are in that regard.  Also, I'm wondering if I should try creating unit tests for any of this.

As far as the source code changes themselves, I removed the uses of the `PathTooLong...()` wrappers.  For calls where the "`prefixWithUnc`" parameter was true, I replaced them with calls to the native .NET functions where the path parameters are passed through `PrefixWithUNC()`.  For example, this
```cs
public bool DirectoryExists(string path)
{
    return PathTooLongFuncWrapper(System.IO.Directory.Exists,
                                  Alphaleonis.Win32.Filesystem.Directory.Exists, path, true);
}
```
was replaced with
```cs
public bool DirectoryExists(string path)
{
    return System.IO.Directory.Exists(PrefixWithUNC(path));
}
```

For calls where the "`prefixWithUnc`" parameter was false, I still want to protect each path with a UNC prefix.  At the same time I want the return values to be UNC prefixed or not depending whether the given path was prefixed.  So, for example, this
```cs
public string GetPathRoot(string path)
{
    return PathTooLongFuncWrapper(Path.GetPathRoot, AlphaFS.Path.GetPathRoot, path, false);
}
```
was replaced with
```cs
public string GetPathRoot(string path)
{
    if (IsPrefixedWithUNC(path))
    {
        return Path.GetPathRoot(path);
    }
    else
    {
        return StripUNCPrefix(Path.GetPathRoot(PrefixWithUNC(path)));
    }
}
```

I also changed `StripUNCPrefix()` to correctly handle the "`\\?\UNC\`" case.
