### PR TITLE
Fix Recovery Tool handling of paths with dashes

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Index.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Index.cs
@@ -64,7 +64,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 try
                 {
-                    var p = Library.Main.Volumes.VolumeBase.ParseFilename(file);
+                    var p = Library.Main.Volumes.VolumeBase.ParseFilename(Path.GetFileName(file));
                     if (p == null)
                     {
                         Console.WriteLine(" - Not a Duplicati file, ignoring");

--- a/Duplicati/CommandLine/RecoveryTool/List.cs
+++ b/Duplicati/CommandLine/RecoveryTool/List.cs
@@ -51,7 +51,7 @@ namespace Duplicati.CommandLine.RecoveryTool
             {
                 var file = SelectListFile(args[2], folder);
 
-                var p = Library.Main.Volumes.VolumeBase.ParseFilename(file);
+                var p = Library.Main.Volumes.VolumeBase.ParseFilename(Path.GetFileName(file));
 
                 Library.Main.Volumes.VolumeReaderBase.UpdateOptionsFromManifest(p.CompressionModule, file, new Duplicati.Library.Main.Options(options));
 
@@ -64,7 +64,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
         public static IEnumerable<Duplicati.Library.Main.Volumes.IFileEntry> EnumerateFilesInDList(string file, Duplicati.Library.Utility.IFilter filter, Dictionary<string, string> options)
         {
-            var p = Library.Main.Volumes.VolumeBase.ParseFilename(file);
+            var p = Library.Main.Volumes.VolumeBase.ParseFilename(Path.GetFileName(file));
             using (var fs = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var cm = Library.DynamicLoader.CompressionLoader.GetModule(p.CompressionModule, fs, Library.Interface.ArchiveMode.Read, options))
             using (var filesetreader = new Library.Main.Volumes.FilesetVolumeReader(cm, new Duplicati.Library.Main.Options(options)))
@@ -112,7 +112,7 @@ namespace Duplicati.CommandLine.RecoveryTool
         {
             return (
                 from v in Directory.EnumerateFiles(folder)
-                let p = Library.Main.Volumes.VolumeBase.ParseFilename(v)
+                let p = Library.Main.Volumes.VolumeBase.ParseFilename(Path.GetFileName(v))
                 where p != null && p.FileType == Duplicati.Library.Main.RemoteVolumeType.Files
                 orderby p.Time descending
                 select new KeyValuePair<DateTime, string>(p.Time, v)).ToArray();


### PR DESCRIPTION
In Duplicati.CommandLine.RecoveryTool, the `index` and `list` commands
do not recognize Duplicati backup files when those files are in paths
containing dashes.

For example, without this change, if you call
```
Duplicati.CommandLine.RecoveryTool index C:\Temp\duplicati-tests\recovery-tool\backup-files
```
the Duplicati backup files are displayed, but the recovery tool
reports "Not a Duplicati file, ignoring" for each of them.

The problem was that `Library.Main.Volumes.VolumeBase.ParseFilename()` was being called with the entire path to the Duplicati backup files; e.g., "`C:\Temp\duplicati-tests\recovery-tool\backup-files\duplicati-20200720T005143Z.dlist.zip`", but `Library.Main.Volumes.VolumeBase.ParseFilename()` only expects the file name portion.  This change uses `Path.GetFileName()` to pass the file name to `Library.Main.Volumes.VolumeBase.ParseFilename()` where appropriate.