### PR TITLE
Remove unnecessary call to Path.Combine

### DIFF
--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Duplicati.UnitTest
             // Issue #4148 described a situation where the folders containing the empty file were not recreated properly.
             Dictionary<string, string> restoreOptions = new Dictionary<string, string>(this.TestOptions)
             {
-                ["restore-path"] = Path.Combine(this.RESTOREFOLDER),
+                ["restore-path"] = this.RESTOREFOLDER,
                 ["dont-compress-restore-paths"] = "true"
             };
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))


### PR DESCRIPTION
This removes an unnecessary call to `Path.Combine` that was only provided a single argument.