### PR TITLE
Avoid deleting unrelated files when removing backup configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         directories:
           - $BUILD_DIR
       script:
-        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler,RepairHandler,DeleteHandler
+        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler,RepairHandler,DeleteHandler,Controller
 
     - stage: tests
       cache:

--- a/Duplicati/UnitTest/ControllerTests.cs
+++ b/Duplicati/UnitTest/ControllerTests.cs
@@ -11,7 +11,7 @@ namespace Duplicati.UnitTest
     {
         [Test]
         [Category("Controller")]
-        public void DeleteConfigurationWithSameBackend()
+        public void DeleteAllRemoteFiles()
         {
             string filePath = Path.Combine(this.DATAFOLDER, "file");
             File.WriteAllBytes(filePath, new byte[] {0, 1, 2});

--- a/Duplicati/UnitTest/ControllerTests.cs
+++ b/Duplicati/UnitTest/ControllerTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    public class ControllerTests : BasicSetupHelper
+    {
+        [Test]
+        [Category("Controller")]
+        public void DeleteConfigurationWithSameBackend()
+        {
+            string filePath = Path.Combine(this.DATAFOLDER, "file");
+            File.WriteAllBytes(filePath, new byte[] {0, 1, 2});
+
+            Dictionary<string, string> firstOptions = new Dictionary<string, string>(this.TestOptions);
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, firstOptions, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] {this.DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Keep track of the backend files from the first backup configuration so that we can
+            // check that they remain after we remove the backend files from the second backup
+            // configuration.
+            string[] firstBackupFiles = Directory.GetFiles(this.TARGETFOLDER);
+            Assert.Greater(firstBackupFiles.Length, 0);
+
+            Dictionary<string, string> secondOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dbpath"] = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+            };
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, secondOptions, null))
+            {
+                // An exception should be thrown due to unrecognized files in the target folder.
+                // ReSharper disable once AccessToDisposedClosure
+                Assert.That(() => c.Backup(new[] {this.DATAFOLDER}), Throws.Exception);
+            }
+
+            // We should be able to safely remove backend files from the second backup by referring
+            // to the local database.
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, secondOptions, null))
+            {
+                IListRemoteResults listResults = c.DeleteAllRemoteFiles();
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
+            }
+
+            // After we delete backend files from the second backup configuration, those from the first
+            // configuration should remain (see issues #2678, #3845, and #4244).
+            foreach (string file in firstBackupFiles)
+            {
+                Assert.IsTrue(File.Exists(file));
+            }
+        }
+    }
+}

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ControllerTests.cs" />
     <Compile Include="DeleteHandlerTests.cs" />
     <Compile Include="DisruptionTests.cs" />
     <Compile Include="RecoveryToolTests.cs" />


### PR DESCRIPTION
This modifies the `Controller.DeleteAllRemoteFiles` method to consider the remote files as recorded in the local database when deleting files from the backend.  This helps to avoid accidentally deleting unrelated files when removing a backup configuration.

Previously, the following steps
1. Create a backup and run it.
2. Create another backup that points to the same backend folder as in step 1 and run it.  This correctly results in an error due to the unrecognized backend files.
3. Remove the backup from step 2, and select "Delete remote files".

would result in _all_ backend files (including those from step 1) being deleted.

This also adds a test to verify that removal of backend files respects the entries in the local database, as well as the backup configuration's prefix.

This concerns issues #2678, #3845, and #4244