### PR TITLE
Tardigrade fix download issue

### DIFF
--- a/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -43,8 +43,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="uplink.NET, Version=2.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\uplink.NET.2.3.2\lib\netstandard2.0\uplink.NET.dll</HintPath>
+    <Reference Include="uplink.NET, Version=2.3.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\uplink.NET.2.3.4\lib\netstandard2.0\uplink.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -90,11 +90,11 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\..\packages\uplink.NET.2.3.4\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.3.4\build\net40\uplink.NET.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\uplink.NET.2.3.4\build\net40\uplink.NET.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\uplink.NET.2.3.4\build\net40\uplink.NET.targets'))" />
   </Target>
-  <Import Project="..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.3.2\build\net40\uplink.NET.targets')" />
 </Project>

--- a/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
+++ b/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
@@ -106,7 +106,7 @@ namespace Duplicati.Library.Backend.Tardigrade
                 }
 
                 _access = new Access(_satellite, _api_key, _secret, new Config() { UserAgent = TARDIGRADE_PARTNER_ID });
-                }
+            }
 
             _bucketService = new BucketService(_access);
             _objectService = new ObjectService(_access);
@@ -269,7 +269,9 @@ namespace Duplicati.Library.Backend.Tardigrade
             {
                 TardigradeFile file = new TardigradeFile(obj);
                 if (prefix != "")
+                {
                     file.Name = file.Name.Replace(prefix, "");
+                }
                 files.Add(file);
             }
 

--- a/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
+++ b/Duplicati/Library/Backend/Tardigrade/TardigradeBackend.cs
@@ -268,9 +268,8 @@ namespace Duplicati.Library.Backend.Tardigrade
             foreach (var obj in objects.Items)
             {
                 TardigradeFile file = new TardigradeFile(obj);
-                var basePath = GetBasePath();
-                if (basePath != "")
-                    file.Name = file.Name.Replace(basePath, "");
+                if (prefix != "")
+                    file.Name = file.Name.Replace(prefix, "");
                 files.Add(file);
             }
 

--- a/Duplicati/Library/Backend/Tardigrade/packages.config
+++ b/Duplicati/Library/Backend/Tardigrade/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="uplink.NET" version="2.3.2" targetFramework="net471" />
+  <package id="uplink.NET" version="2.3.4" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
This PR bumps uplink.NET to the latest v2.3.4 - there one issue with downloading files is resolved that might lead to problems during recover.