### PR TITLE
Support Windows source paths starting with "\\?\"

### DIFF
--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -93,12 +93,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name='localFolderPath'>The folder to examinate</param>
         protected override string[] ListFiles (string localFolderPath)
         {
-            string[] tmp = SystemIO.IO_WIN.GetFiles(localFolderPath);
-            string[] res = new string[tmp.Length];
-            for(int i = 0; i < tmp.Length; i++)
-                res[i] = SystemIOWindows.StripUNCPrefix(tmp[i]);
-
-            return res;
+            return SystemIO.IO_WIN.GetFiles(localFolderPath);
         }
 
         
@@ -109,12 +104,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name='localFolderPath'>The folder to examinate</param>
         protected override string[] ListFolders (string localFolderPath)
         {
-            string[] tmp = SystemIO.IO_WIN.GetDirectories(SystemIOWindows.PrefixWithUNC(localFolderPath));
-            string[] res = new string[tmp.Length];
-            for (int i = 0; i < tmp.Length; i++)
-                res[i] = SystemIOWindows.StripUNCPrefix(tmp[i]);
-
-            return res;
+            return SystemIO.IO_WIN.GetDirectories(localFolderPath);
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -20,6 +20,8 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Globalization;
+using Duplicati.Library.Common;
+using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Utility
 {
@@ -121,7 +123,7 @@ namespace Duplicati.Library.Utility
                 }
                 else
                 {
-                    this.Type = (filter.Contains(MULTIPLE_WILDCARD) || filter.Contains(SINGLE_WILDCARD)) ? FilterType.Wildcard : FilterType.Simple;
+                    this.Type = ContainsWildcards(filter) ? FilterType.Wildcard : FilterType.Simple;
                     this.Filter = (!Utility.IsFSCaseSensitive && this.Type == FilterType.Wildcard) ? filter.ToUpper(CultureInfo.InvariantCulture) : filter;
                     this.Regexp = new Regex(Utility.ConvertGlobbingToRegExp(filter), REGEXP_OPTIONS);
                 }
@@ -254,7 +256,19 @@ namespace Duplicati.Library.Utility
                 }
                 return matched;
             }
-            
+
+            /// <summary>
+            /// Tests for presence of wildcard characters in filter.
+            /// </summary>
+            /// <returns>True if filter contains wildcards.</returns>
+            private static bool ContainsWildcards(string filter)
+            {
+                // Question mark in Windows UNC prefix ("\\?\") will look
+                // like a wildcard, so strip it before looking for wildcards
+                var strippedFilter = SystemIOWindows.StripUNCPrefix(filter);
+                return (strippedFilter.Contains(MULTIPLE_WILDCARD) || strippedFilter.Contains(SINGLE_WILDCARD));
+            }
+
             /// <summary>
             /// Gets a value indicating if the filter matches the path
             /// </summary>


### PR DESCRIPTION
Under Windows, when a backup path has been specified that uses the
"`\\?\`" prefix, change Duplicati to consistently record all files and
folders with that prefix.  Change the GUI so that it does not mistake
the question mark in the "`\\?\`" prefix with a wildcard.

Without this change, if you manually enter, for example, "`\\?\C:\Temp\`" in the source data:
1. The resulting Duplicati backup data will contain an entry for the path "`\\?\C:\Temp\`", but the entries for subdirectories and files will not include the "`\\?\`" prefix; e.g., you might see "`C:\Temp\file.txt`".
1. When you go to restore via the GUI, you see entries for both "`\\?\C:\Temp\`" and "`C:\Temp\`" in the file picker
1. In the file pickter, if you try to expand one of the entries with the "`\\?\`" prefix, you get this error:
```
Filter for list-folder-contents must be a path prefix with no wildcards Parameter name: filter
```

To fix these problems, this commit changes `ListFiles()` and `ListFolders()` in NoSnapshotWindows.cs to not unconditionally strip UNC prefixes from the results.

It also changes the `FilterExpression` class in FilterExpression.cs to stop identifying the question mark in the "`\\?\`" prefix as a wildcard.  Note that the question mark in the "`\\?\`" prefix is ignored on Linux, too, to allow for the possibility of restoring a Windows backup using Duplicati running on Linux.

Things I've tested:
1. In Windows, used the GUI and Duplicati.CommandLine to perform backups with the "`\\?\`" prefix
1. In Windows and Ubuntu, used the GUI, Duplicati.CommandLine and Duplicati.CommandLine.Recoverytool to perform the restores of Windows backups that used the "`\\?\`" prefix
1. Performed snapshot and non-snapshot backups with the "`\\?\`" prefix
