### PR TITLE
Change tests to work with long paths in Windows

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/FileIndex.cs
+++ b/Duplicati/CommandLine/RecoveryTool/FileIndex.cs
@@ -74,7 +74,7 @@ namespace Duplicati.CommandLine.RecoveryTool
 
                 try
                 {
-                    var p = Duplicati.Library.Main.Volumes.VolumeBase.ParseFilename(file);
+                    var p = Duplicati.Library.Main.Volumes.VolumeBase.ParseFilename(Path.GetFileName(file));
                     if (p == null)
                     {
                         Console.WriteLine(" - Not a Duplicati file, ignoring");

--- a/Duplicati/Library/Common/IO/ISystemIO.cs
+++ b/Duplicati/Library/Common/IO/ISystemIO.cs
@@ -29,7 +29,9 @@ namespace Duplicati.Library.Common.IO
     {
         IFileEntry DirectoryEntry(string path);
         void DirectoryCreate(string path);
+        void DirectoryDelete(string path, bool recursive);
         bool DirectoryExists(string path);
+        void DirectoryMove(string sourceDirName, string destDirName);
         void DirectorySetLastWriteTimeUtc(string path, DateTime time);
         void DirectorySetCreationTimeUtc(string path, DateTime time);
 
@@ -64,6 +66,7 @@ namespace Duplicati.Library.Common.IO
         DateTime GetLastWriteTimeUtc(string path);
         IEnumerable<string> EnumerateFileSystemEntries(string path);
         IEnumerable<string> EnumerateFiles(string path);
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
         IEnumerable<string> EnumerateDirectories(string path);
 
         void SetMetadata(string path, Dictionary<string, string> metdata, bool restorePermissions);

--- a/Duplicati/Library/Common/IO/SystemIOLinux.cs
+++ b/Duplicati/Library/Common/IO/SystemIOLinux.cs
@@ -32,9 +32,19 @@ namespace Duplicati.Library.Common.IO
             Directory.CreateDirectory(NormalizePath(path));
         }
 
+        public void DirectoryDelete(string path, bool recursive)
+        {
+            Directory.Delete(NormalizePath(path), recursive);
+        }
+
         public bool DirectoryExists(string path)
         {
             return Directory.Exists(NormalizePath(path));
+        }
+
+        public void DirectoryMove(string sourceDirName, string destDirName)
+        {
+            System.IO.Directory.Move(NormalizePath(sourceDirName), NormalizePath(destDirName));
         }
 
         public void FileDelete(string path)
@@ -117,6 +127,10 @@ namespace Duplicati.Library.Common.IO
             return Directory.EnumerateFiles(path);
         }
 
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateFiles(path, searchPattern, searchOption);
+        }
 
         public string PathGetFileName(string path)
         {

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -69,6 +69,15 @@ namespace Duplicati.Library.Common.IO
             }
         }
 
+        /// <summary>
+        /// Convert forward slashes to backslashes.
+        /// </summary>
+        /// <returns>Path with forward slashes replaced by backslashes.</returns>
+        private static string ConvertSlashes(string path)
+        {
+            return path.Replace("/", Util.DirectorySeparatorString);
+        }
+
         private class FileSystemAccess
         {
             // Use JsonProperty Attribute to allow readonly fields to be set by deserializer
@@ -400,11 +409,11 @@ namespace Duplicati.Library.Common.IO
         {
             if (IsPrefixedWithUNC(path))
             {
-                return System.IO.Path.GetFullPath(path);
+                return System.IO.Path.GetFullPath(ConvertSlashes(path));
             }
             else
             {
-                return StripUNCPrefix(System.IO.Path.GetFullPath(PrefixWithUNC(path)));
+                return StripUNCPrefix(System.IO.Path.GetFullPath(PrefixWithUNC(ConvertSlashes(path))));
             }
         }
 

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -174,9 +174,19 @@ namespace Duplicati.Library.Common.IO
             System.IO.Directory.CreateDirectory(PrefixWithUNC(path));
         }
 
+        public void DirectoryDelete(string path, bool recursive)
+        {
+            System.IO.Directory.Delete(PrefixWithUNC(path), recursive);
+        }
+
         public bool DirectoryExists(string path)
         {
             return System.IO.Directory.Exists(PrefixWithUNC(path));
+        }
+
+        public void DirectoryMove(string sourceDirName, string destDirName)
+        {
+            System.IO.Directory.Move(PrefixWithUNC(sourceDirName), PrefixWithUNC(destDirName));
         }
 
         public void FileDelete(string path)
@@ -264,6 +274,11 @@ namespace Duplicati.Library.Common.IO
         public IEnumerable<string> EnumerateFiles(string path)
         {
             return System.IO.Directory.EnumerateFiles(PrefixWithUNC(path)).Select(StripUNCPrefix);
+        }
+
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return System.IO.Directory.EnumerateFiles(PrefixWithUNC(path), searchPattern,  searchOption).Select(StripUNCPrefix);
         }
 
         public string PathGetFileName(string path)

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -176,9 +176,8 @@ namespace Duplicati.UnitTest
                     {
                         // By the ZIP spec, directories end in a forward slash
                         var isDirectory = entry.FullName.EndsWith("/");
-                        // Convert forward slashes to the Windows separator
-                        var fullNamePath = entry.FullName.Replace("/", Util.DirectorySeparatorString);
-                        var destination = systemIO.PathCombine(destinationDirectoryName, fullNamePath);
+                        var destination =
+                            systemIO.PathGetFullPath(systemIO.PathCombine(destinationDirectoryName, entry.FullName));
                         if (isDirectory)
                         {
                             systemIO.DirectoryCreate(destination);

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -18,6 +18,9 @@ using System;
 using NUnit.Framework;
 using System.IO;
 using System.Collections.Generic;
+using System.IO.Compression;
+using Duplicati.Library.Common;
+using Duplicati.Library.Common.IO;
 
 namespace Duplicati.UnitTest
 {
@@ -61,6 +64,8 @@ namespace Duplicati.UnitTest
         /// </summary>
         public static readonly bool DEBUG_OUTPUT = Library.Utility.Utility.ParseBool(Environment.GetEnvironmentVariable("DEBUG_OUTPUT"), false);
 
+        protected static readonly ISystemIO systemIO = SystemIO.IO_OS;
+
         /// <summary>
         /// Writes a message to TestContext.Progress and Console.Out
         /// </summary>
@@ -81,7 +86,7 @@ namespace Duplicati.UnitTest
                 Console.SetOut(TestContext.Progress);
             }
 
-            Directory.CreateDirectory(BASEFOLDER);
+            systemIO.DirectoryCreate(BASEFOLDER);
             this.TearDown();
             this.OneTimeTearDown();
         }
@@ -95,37 +100,37 @@ namespace Duplicati.UnitTest
         [SetUp]
         public virtual void SetUp()
         {
-            Directory.CreateDirectory(this.DATAFOLDER);
-            Directory.CreateDirectory(this.TARGETFOLDER);
-            Directory.CreateDirectory(this.RESTOREFOLDER);
+            systemIO.DirectoryCreate(this.DATAFOLDER);
+            systemIO.DirectoryCreate(this.TARGETFOLDER);
+            systemIO.DirectoryCreate(this.RESTOREFOLDER);
         }
 
         [TearDown]
         public virtual void TearDown()
         {
-            if (Directory.Exists(this.DATAFOLDER))
+            if (systemIO.DirectoryExists(this.DATAFOLDER))
             {
-                Directory.Delete(this.DATAFOLDER, true);
+                systemIO.DirectoryDelete(this.DATAFOLDER, true);
             }
-            if (Directory.Exists(this.TARGETFOLDER))
+            if (systemIO.DirectoryExists(this.TARGETFOLDER))
             {
-                Directory.Delete(this.TARGETFOLDER, true);
+                systemIO.DirectoryDelete(this.TARGETFOLDER, true);
             }
-            if (Directory.Exists(this.RESTOREFOLDER))
+            if (systemIO.DirectoryExists(this.RESTOREFOLDER))
             {
-                Directory.Delete(this.RESTOREFOLDER, true);
+                systemIO.DirectoryDelete(this.RESTOREFOLDER, true);
             }
-            if (File.Exists(this.LOGFILE))
+            if (systemIO.FileExists(this.LOGFILE))
             {
-                File.Delete(this.LOGFILE);
+                systemIO.FileDelete(this.LOGFILE);
             }
-            if (File.Exists(this.DBFILE))
+            if (systemIO.FileExists(this.DBFILE))
             {
-                File.Delete(this.DBFILE);
+                systemIO.FileDelete(this.DBFILE);
             }
-            if (File.Exists($"{this.DBFILE}-journal"))
+            if (systemIO.FileExists($"{this.DBFILE}-journal"))
             {
-                File.Delete($"{this.DBFILE}-journal");
+                systemIO.FileDelete($"{this.DBFILE}-journal");
             }
         }
 
@@ -153,6 +158,60 @@ namespace Duplicati.UnitTest
             }
         }
 
+        /// <summary>
+        /// Alternative to System.IO.Compression.ZipFile.ExtractToDirectory()
+        /// that handles long paths.
+        /// </summary>
+        protected static void ZipFileExtractToDirectory(string sourceArchiveFileName, string destinationDirectoryName)
+        {
+            if (Platform.IsClientWindows)
+            {
+                // Handle long paths under Windows by extracting to a
+                // temporary file and moving the resulting file to the
+                // actual destination using functions that support
+                // long paths.
+                using (var archive = ZipFile.OpenRead(sourceArchiveFileName))
+                {
+                    foreach (var entry in archive.Entries)
+                    {
+                        // By the ZIP spec, directories end in a forward slash
+                        var isDirectory = entry.FullName.EndsWith("/");
+                        // Convert forward slashes to the Windows separator
+                        var fullNamePath = entry.FullName.Replace("/", Util.DirectorySeparatorString);
+                        var destination = systemIO.PathCombine(destinationDirectoryName, fullNamePath);
+                        if (isDirectory)
+                        {
+                            systemIO.DirectoryCreate(destination);
+                        }
+                        else
+                        {
+                            // Not every directory is recorded separately,
+                            // so create directories if needed
+                            systemIO.DirectoryCreate(systemIO.PathGetDirectoryName(destination));
+                            // Extract file to temporary file, then move to
+                            // the (possibly) long path destination
+                            var tempFile = Path.GetTempFileName();
+                            try
+                            {
+                                entry.ExtractToFile(tempFile, true);
+                                systemIO.FileMove(tempFile, destination);
+                            }
+                            finally
+                            {
+                                if (systemIO.FileExists(tempFile))
+                                {
+                                    systemIO.FileDelete(tempFile);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                ZipFile.ExtractToDirectory(sourceArchiveFileName, destinationDirectoryName);
+            }
+        }
     }
 }
 

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -40,6 +40,7 @@
       <HintPath>..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Even in .NET 4.6.2
`System.IO.Compression.ZipFile.ExtractToDirectory()` cannot handle
long paths.  Replace call to
`System.IO.Compression.ZipFile.ExtractToDirectory()` with an
equivalent that extracts files to a temporary location and uses I/O
functions that support long paths to move them to their final
location.

In CommandLineOperationsTests.cs, use ISystemIO functions to handle
potentially long paths.

Add a fix to RecoveryTool for long paths that was missed by #4258.

This fixes #3863.

Note that I'm not currently set up to run unit tests in Linux, so I haven't tried my changes there.