### PR TITLE
Fix setup/teardown for CommandLineOperationsTests

### DIFF
--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -54,9 +54,9 @@ namespace Duplicati.UnitTest
             }
         }
 
-        public override void OneTimeSetUp()
+        public override void SetUp()
         {
-            base.OneTimeSetUp();
+            base.SetUp();
 
             if (!File.Exists(zipAlternativeFilepath))
             {


### PR DESCRIPTION
Change Duplicati.UnitTest.CommandLineOperationsTests to use `Setup()`
instead of `OneTimeSetUp()` to make sure the test files are in place
for each test.

This fixes #4273.