### PR TITLE
Support Windows source paths starting with "\\?\"

### DIFF
--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -29,7 +29,7 @@ namespace Duplicati.Library.Main.Operation
 
         public void Run(IEnumerable<string> filterstrings = null, Library.Utility.IFilter compositefilter = null)
         {
-            var parsedfilter = new Library.Utility.FilterExpression(filterstrings);
+            var parsedfilter = new Library.Utility.FilterExpression(filterstrings, true, m_options.ListFilterLiteral);
             var filter = Library.Utility.JoinedFilterExpression.Join(parsedfilter, compositefilter);
             var simpleList = !((filter is FilterExpression expression && expression.Type == Library.Utility.FilterType.Simple) || m_options.AllVersions);
 

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -263,6 +263,7 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("list-prefix-only", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ListprefixonlyShort, Strings.Options.ListprefixonlyLong, "false"),
                     new CommandLineArgument("list-folder-contents", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ListfoldercontentsShort, Strings.Options.ListfoldercontentsLong, "false"),
                     new CommandLineArgument("list-sets-only", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ListsetsonlyShort, Strings.Options.ListsetsonlyLong, "false"),
+                    new CommandLineArgument("list-filter-literal", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ListfilterliteralShort, Strings.Options.ListfilterliteralLong, "false"),
                     new CommandLineArgument("disable-autocreate-folder", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisableautocreatefolderShort, Strings.Options.DisableautocreatefolderLong, "false"),
                     new CommandLineArgument("allow-missing-source", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AllowmissingsourceShort, Strings.Options.AllowmissingsourceLong, "false"),
 
@@ -550,6 +551,11 @@ namespace Duplicati.Library.Main
         /// A value indicating that only filesets are returned
         /// </summary>
         public bool ListSetsOnly { get { return GetBool("list-sets-only"); } }
+
+        /// <summary>
+        /// A value indicating whether list filters should be considered literally
+        /// </summary>
+        public bool ListFilterLiteral { get { return GetBool("list-filter-literal"); } }
 
         /// <summary>
         /// A value indicating if file time checks are skipped

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -63,6 +63,8 @@ namespace Duplicati.Library.Main.Strings
         public static string ListprefixonlyShort { get { return LC.L(@"Show largest prefix"); } }
         public static string ListfoldercontentsLong { get { return LC.L(@"When searching for files, all matching files are returned. Use this option to return only the entries found in the folder specified as filter."); } }
         public static string ListfoldercontentsShort { get { return LC.L(@"Show folder contents"); } }
+        public static string ListfilterliteralShort { get { return LC.L(@"Take filters literally"); } }
+        public static string ListfilterliteralLong { get { return LC.L(@"When analyzing filters, do not try to identify regular expressions, groups, or wildcards; instead take the filter literally."); } }
         public static string RetrydelayLong { get { return LC.L(@"After a failed transmission, Duplicati will wait a short period before attempting again. This is useful if the network drops out occasionally during transmissions."); } }
         public static string RetrydelayShort { get { return LC.L(@"Time to wait between retries"); } }
         public static string ControlfilesLong { get { return LC.L(@"Use this option to attach extra files to the newly uploaded filelists."); } }

--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -93,12 +93,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name='localFolderPath'>The folder to examinate</param>
         protected override string[] ListFiles (string localFolderPath)
         {
-            string[] tmp = SystemIO.IO_WIN.GetFiles(localFolderPath);
-            string[] res = new string[tmp.Length];
-            for(int i = 0; i < tmp.Length; i++)
-                res[i] = SystemIOWindows.StripUNCPrefix(tmp[i]);
-
-            return res;
+            return SystemIO.IO_WIN.GetFiles(localFolderPath);
         }
 
         
@@ -109,12 +104,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name='localFolderPath'>The folder to examinate</param>
         protected override string[] ListFolders (string localFolderPath)
         {
-            string[] tmp = SystemIO.IO_WIN.GetDirectories(SystemIOWindows.PrefixWithUNC(localFolderPath));
-            string[] res = new string[tmp.Length];
-            for (int i = 0; i < tmp.Length; i++)
-                res[i] = SystemIOWindows.StripUNCPrefix(tmp[i]);
-
-            return res;
+            return SystemIO.IO_WIN.GetDirectories(localFolderPath);
         }
 
         /// <summary>

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -167,7 +167,7 @@ namespace Duplicati.Server
             };
         }
 
-        public static IRunnerData CreateListTask(Duplicati.Server.Serialization.Interface.IBackup backup, string[] filters, bool onlyPrefix, bool allVersions, bool folderContents, DateTime time)
+        public static IRunnerData CreateListTask(Duplicati.Server.Serialization.Interface.IBackup backup, string[] filters, bool onlyPrefix, bool allVersions, bool folderContents, bool filterLiteral, DateTime time)
         {
             var dict = new Dictionary<string, string>();
             if (onlyPrefix)
@@ -178,6 +178,8 @@ namespace Duplicati.Server
                 dict["time"] = Duplicati.Library.Utility.Utility.SerializeDateTime(time.ToUniversalTime());
             if (folderContents)
                 dict["list-folder-contents"] = "true";
+            if (filterLiteral)
+                dict["list-filter-literal"] = "true";
 
             return CreateTask(
                 DuplicatiOperation.List,

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -53,11 +53,12 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             var prefixonly = Duplicati.Library.Utility.Utility.ParseBool(info.Request.QueryString["prefix-only"].Value, false);
             var foldercontents = Duplicati.Library.Utility.Utility.ParseBool(info.Request.QueryString["folder-contents"].Value, false);
+            var filterliteral = Duplicati.Library.Utility.Utility.ParseBool(info.Request.QueryString["filter-literal"].Value, false);
             var time = new DateTime();
             if (!allversion)
                 time = Duplicati.Library.Utility.Timeparser.ParseTimeInterval(timestring, DateTime.Now);
 
-            var r = Runner.Run(Runner.CreateListTask(backup, new string[] { filter }, prefixonly, allversion, foldercontents, time), false) as Duplicati.Library.Interface.IListResults;
+            var r = Runner.Run(Runner.CreateListTask(backup, new string[] { filter }, prefixonly, allversion, foldercontents, filterliteral, time), false) as Duplicati.Library.Interface.IListResults;
 
             var result = new Dictionary<string, object>();
 

--- a/Duplicati/Server/webroot/ngax/scripts/directives/restoreFilePicker.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/restoreFilePicker.js
@@ -35,7 +35,7 @@ backupApp.directive('restoreFilePicker', function() {
                 if (!node.children && !node.loading) {
                     node.loading = true;
 
-                    AppService.get('/backup/' + $scope.ngBackupId + '/files/' + encodeURIComponent(node.id) + '?prefix-only=false&folder-contents=true&time=' + encodeURIComponent($scope.ngTimestamp) + '&filter=' + encodeURIComponent(node.id)).then(function(data) {
+                    AppService.get('/backup/' + $scope.ngBackupId + '/files/' + encodeURIComponent(node.id) + '?prefix-only=false&folder-contents=true&filter-literal=true&time=' + encodeURIComponent($scope.ngTimestamp) + '&filter=' + encodeURIComponent(node.id)).then(function(data) {
                         var children = []
 
                          for(var n in data.data.Files)


### PR DESCRIPTION
Under Windows, when a backup path has been specified that uses the
"`\\?\`" prefix, change Duplicati to consistently record all files and
folders with that prefix.

Add option `--list-filter-literal` to the Duplicati.CommandLine.exe
"find" command to disable the check for regex, group, and wildcard
characters in the "`<filename>`" argument.

Change the GUI so that it does not mistake the question mark in the
"`\\?\`" prefix with a wildcard by changing the restore picker to pass
`--list-filter-literal=true` when obtaining folder contents.