### PR TITLE
Fix snapshots broken by #4256

### DIFF
--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -266,6 +266,10 @@ namespace Duplicati.Library.Snapshots
             var root = SystemIO.IO_WIN.GetPathRoot(localPath);
             var volumePath = _vssBackupComponents.GetVolumeFromCache(root);
 
+            // Note that using a simple Path.Combine() for the following code
+            // can result in invalid snapshot paths; e.g., if localPath is
+            // @"C:\", mappedPath would not have the required trailing
+            // directory separator.
             var subPath = localPath.Substring(root.Length);
             if (!subPath.StartsWith(Util.DirectorySeparatorString, StringComparison.Ordinal))
             {

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -265,8 +265,14 @@ namespace Duplicati.Library.Snapshots
 
             var root = SystemIO.IO_WIN.GetPathRoot(localPath);
             var volumePath = _vssBackupComponents.GetVolumeFromCache(root);
+
             var subPath = localPath.Substring(root.Length);
-            var mappedPath = SystemIO.IO_WIN.PathCombine(volumePath, subPath);
+            if (!subPath.StartsWith(Util.DirectorySeparatorString, StringComparison.Ordinal))
+            {
+                volumePath = Util.AppendDirSeparator(volumePath, Util.DirectorySeparatorString);
+            }
+
+            var mappedPath = volumePath + subPath;
             return mappedPath;
         }
 


### PR DESCRIPTION
Revert the change made to `WindowsSnapshot.ConvertToSnapshotPath()`
by pull request #4256.

The change in #4256 replaced some existing manual path construction
code with a call to `SystemIO.IO_WIN.PathCombine()`, but calling
`SystemIO.IO_WIN.PathCombine()` this way did not always result in
valid VSS paths.  For example, trying to back up a root volume like
"`C:\`" would result in the following error:
```
The filename, directory name, or volume label syntax is incorrect.
```

This commit addresses the problem reported in the forum, [Warning with 2.0.5.109](https://forum.duplicati.com/t/warning-with-2-0-5-109/10448).  That specific problem was that trying to back up the root of a drive, like "`D:\`", would result in a VSS path that looked something like this:
```
\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5
```
This lacks a directory separator at the end.  The valid VSS path would look like this:
```
\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5\
```
This might not be the only thing that would not work with the change to `WindowsSnapshot.ConvertToSnapshotPath()`.  This revert restores the original behavior of `WindowsSnapshot.ConvertToSnapshotPath()`.

Note that in the revert, I have left out this comment since, as of #4256, it is no longer true:
```csharp
// Note: Do NOT use Path.Combine as it strips the UNC path prefix
```
