### PR TITLE
Add missing test categories to local test runner script

### DIFF
--- a/pipeline/start.sh
+++ b/pipeline/start.sh
@@ -6,6 +6,6 @@ SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 ${ROOT_DIR}/pipeline/jobs/build_job.sh
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNormal
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNoSize
-${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData,RecoveryTool
+${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData,RecoveryTool,ProblematicPath
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Border
-${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler,RepairHandler,DeleteHandler
+${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler,RepairHandler,DeleteHandler,Controller


### PR DESCRIPTION
We forgot to add these when introducing the new test categories.