### PR TITLE
Handle Windows source paths starting with "\\?\"

### DIFF
--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -17,6 +17,7 @@
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Snapshots
@@ -54,6 +55,18 @@ namespace Duplicati.Library.Snapshots
         public override long GetFileSize (string localPath)
         {
             return SystemIO.IO_WIN.FileLength(localPath);
+        }
+
+        /// <summary>
+        /// Enumerates all files and folders in the snapshot, restricted to sources
+        /// </summary>
+        /// <param name="sources">Sources to enumerate</param>
+        /// <param name="callback">The callback to invoke with each found path</param>
+        /// <param name="errorCallback">The callback used to report errors</param>
+        public override IEnumerable<string> EnumerateFilesAndFolders(IEnumerable<string> sources, Utility.Utility.EnumerationFilterDelegate callback, Utility.Utility.ReportAccessError errorCallback)
+        {
+            // For Windows, ensure we don't store paths with UNC prefix
+            return base.EnumerateFilesAndFolders(sources.Select(SystemIOWindows.StripUNCPrefix), callback, errorCallback);
         }
 
         /// <summary>
@@ -138,7 +151,8 @@ namespace Duplicati.Library.Snapshots
         /// <inheritdoc />
         public override string ConvertToSnapshotPath(string localPath)
         {
-            return localPath;
+            // For Windows, ensure we don't store paths with UNC prefix
+            return SystemIOWindows.StripUNCPrefix(localPath);
         }
     }
 }

--- a/Duplicati/Library/Snapshots/SnapshotBase.cs
+++ b/Duplicati/Library/Snapshots/SnapshotBase.cs
@@ -48,7 +48,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="sources">Source paths to enumerate</param>
         /// <param name="callback">The callback to invoke with each found path</param>
         /// <param name="errorCallback">The callback used to report errors</param>
-        public IEnumerable<string> EnumerateFilesAndFolders(IEnumerable<string> sources, Utility.Utility.EnumerationFilterDelegate callback, Utility.Utility.ReportAccessError errorCallback)
+        public virtual IEnumerable<string> EnumerateFilesAndFolders(IEnumerable<string> sources, Utility.Utility.EnumerationFilterDelegate callback, Utility.Utility.ReportAccessError errorCallback)
         {
             return sources.SelectMany(s => Utility.Utility.EnumerateFileSystemEntries(s, callback, ListFolders, ListFiles, GetAttributes, errorCallback));
         }

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -53,6 +53,8 @@ namespace Duplicati.Library.Snapshots
         /// <param name="options">A set of commandline options</param>
         public WindowsSnapshot(IEnumerable<string> sources, IDictionary<string, string> options)
         {
+            // For Windows, ensure we don't store paths with UNC prefix
+            sources = sources.Select(SystemIOWindows.StripUNCPrefix);
             try
             {
                 _vssBackupComponents = new VssBackupComponents();
@@ -152,6 +154,18 @@ namespace Duplicati.Library.Snapshots
         #endregion
 
         #region ISnapshotService Members
+
+        /// <summary>
+        /// Enumerates all files and folders in the snapshot, restricted to sources
+        /// </summary>
+        /// <param name="sources">Sources to enumerate</param>
+        /// <param name="callback">The callback to invoke with each found path</param>
+        /// <param name="errorCallback">The callback used to report errors</param>
+        public override IEnumerable<string> EnumerateFilesAndFolders(IEnumerable<string> sources, Utility.Utility.EnumerationFilterDelegate callback, Utility.Utility.ReportAccessError errorCallback)
+        {
+            // For Windows, ensure we don't store paths with UNC prefix
+            return base.EnumerateFilesAndFolders(sources.Select(SystemIOWindows.StripUNCPrefix), callback, errorCallback);
+        }
 
         /// <summary>
         /// Gets the last write time of a given file in UTC
@@ -260,6 +274,9 @@ namespace Duplicati.Library.Snapshots
         /// <inheritdoc />
         public override string ConvertToSnapshotPath(string localPath)
         {
+            // For Windows, ensure we don't store paths with UNC prefix
+            localPath = SystemIOWindows.StripUNCPrefix(localPath);
+
             if (!Path.IsPathRooted(localPath))
                 throw new InvalidOperationException();
 


### PR DESCRIPTION
Under Windows, strip paths of any `\\?\` prefix to prevent Duplicati
from storing paths prefixed with `\\?\`.

This fixes an inconsistency in the stored data where, if the user
provided a prefixed path to back up (e.g., `\\?\C:\Temp`), Duplicati
would store an entry with the prefixed path (e.g., `\\?\C:\Temp`)
along with entries with paths stripped of their prefix (e.g.,
`C:\Temp\file.txt`).  By only storing non-prefixed paths, this also
avoids an error reported by the GUI when it would encounter a prefixed
path:
```
Filter for list-folder-contents must be a path prefix with no wildcards Parameter name: filter
```