### PR TITLE
Feature/improve usn 2

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
@@ -20,20 +20,21 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Duplicati.Library.Utility;
+using Duplicati.Library.Snapshots;
 using CoCoL;
 
 namespace Duplicati.Library.Main.Operation.Backup
 {
     internal static class CountFilesHandler
     {
-        public static async Task Run(IEnumerable<string> sources, Snapshots.ISnapshotService snapshot, BackupResults result, Options options, IFilter sourcefilter, IFilter filter, Common.ITaskReader taskreader, System.Threading.CancellationToken token)
+        public static async Task Run(IEnumerable<string> sources, Snapshots.ISnapshotService snapshot, UsnJournalService journalService, BackupResults result, Options options, IFilter sourcefilter, IFilter filter, Common.ITaskReader taskreader, System.Threading.CancellationToken token)
         {
             // Make sure we create the enumeration process in a separate scope,
             // but keep the log channel from the parent scope
             using(Logging.Log.StartIsolatingScope(true))
             using (new IsolatedChannelScope())
             {
-                var enumeratorTask = Backup.FileEnumerationProcess.Run(sources, snapshot, null, options.FileAttributeFilter, sourcefilter, filter, options.SymlinkPolicy, options.HardlinkPolicy, options.ExcludeEmptyFolders, options.IgnoreFilenames, options.ChangedFilelist, taskreader, token);
+                var enumeratorTask = Backup.FileEnumerationProcess.Run(sources, snapshot, journalService, options.FileAttributeFilter, sourcefilter, filter, options.SymlinkPolicy, options.HardlinkPolicy, options.ExcludeEmptyFolders, options.IgnoreFilenames, options.ChangedFilelist, taskreader, token);
                 var counterTask = AutomationExtensions.RunTask(new
                 {
                     Input = Backup.Channels.SourcePaths.ForRead

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -442,17 +442,6 @@ namespace Duplicati.Library.Main.Operation
                         {
                             try
                             {
-                                // Start parallel scan, or use the database
-                                if (m_options.DisableFileScanner)
-                                {
-                                    var d = m_database.GetLastBackupFileCountAndSize();
-                                    m_result.OperationProgressUpdater.UpdatefileCount(d.Item1, d.Item2, true);
-                                }
-                                else
-                                {
-                                    parallelScanner = Backup.CountFilesHandler.Run(sources, snapshot, m_result, m_options, m_sourceFilter, m_filter, m_result.TaskReader, counterToken.Token);
-                                }
-
                                 // Make sure the database is sane
                                 await db.VerifyConsistencyAsync(m_options.Blocksize, m_options.BlockhashSize, !m_options.DisableFilelistConsistencyChecks);
 
@@ -504,6 +493,17 @@ namespace Duplicati.Library.Main.Operation
 
                                 // create USN-based scanner if enabled
                                 var journalService = GetJournalService(sources, snapshot, filter, lastfilesetid);
+
+                                // Start parallel scan, or use the database
+                                if (m_options.DisableFileScanner)
+                                {
+                                    var d = m_database.GetLastBackupFileCountAndSize();
+                                    m_result.OperationProgressUpdater.UpdatefileCount(d.Item1, d.Item2, true);
+                                }
+                                else
+                                {
+                                    parallelScanner = Backup.CountFilesHandler.Run(sources, snapshot, journalService, m_result, m_options, m_sourceFilter, m_filter, m_result.TaskReader, counterToken.Token);
+                                }
 
                                 // Run the backup operation
                                 if (await m_result.TaskReader.ProgressAsync)

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -33,6 +33,11 @@ namespace Duplicati.Library.Snapshots
 {
     public class UsnJournalService
     {
+        /// <summary>
+        /// The log tag to use
+        /// </summary>
+        private static readonly string FILTER_LOGTAG = Logging.Log.LogTagFromType(typeof(UsnJournalService));
+
         private readonly ISnapshotService m_snapshot;
         private readonly IEnumerable<string> m_sources;
         private readonly Dictionary<string, VolumeData> m_volumeDataDict;
@@ -89,6 +94,8 @@ namespace Duplicati.Library.Snapshots
             // iterate over volumes
             foreach (var sourcesPerVolume in SortByVolume(m_sources))
             {
+                Logging.Log.WriteVerboseMessage(FILTER_LOGTAG, "UsnInitialize", "Reading USN journal for volume: {0}", sourcesPerVolume.Key);
+
                 if (m_token.IsCancellationRequested) break;
 
                 var volume = sourcesPerVolume.Key;


### PR DESCRIPTION
This is an update to my previous improvement to USN. It replays the file history for each file, and removes any change sequence(s) that don't affect the backup (e.g. creation of a file, followed by deletion).

This further increases the number of times the USN can be used.

This patch also restores use of the USN by the CountFilesHandler, if available.