### PR TITLE
[DO NOT MERGE YET] Feature/speed up append files from previous set with predicate

### DIFF
--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -720,14 +720,10 @@ namespace Duplicati.Library.Main.Database
                       FROM (  SELECT DISTINCT ""FileID"", ""Lastmodified""
 		                      FROM ""FilesetEntry""
 		                      WHERE ""FilesetID"" = ?
-		                      AND ""FileID"" NOT IN (
-			                      SELECT ""FileID""
-			                      FROM ""FilesetEntry""
-			                      WHERE ""FilesetID"" = ?
-		                      )) AS fs
+		                      ) AS fs
                       LEFT JOIN ""File"" AS f ON fs.""FileID"" = f.""ID""
                       LEFT JOIN ""Blockset"" AS bs ON f.""BlocksetID"" = bs.""ID"";",
-                    lastFilesetId, fileSetId))
+                    lastFilesetId))
                 {
                     var path = row.GetString(0);
                     var size = row.GetInt64(3);

--- a/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
@@ -20,20 +20,21 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Duplicati.Library.Utility;
+using Duplicati.Library.Snapshots;
 using CoCoL;
 
 namespace Duplicati.Library.Main.Operation.Backup
 {
     internal static class CountFilesHandler
     {
-        public static async Task Run(IEnumerable<string> sources, Snapshots.ISnapshotService snapshot, BackupResults result, Options options, IFilter sourcefilter, IFilter filter, Common.ITaskReader taskreader, System.Threading.CancellationToken token)
+        public static async Task Run(IEnumerable<string> sources, Snapshots.ISnapshotService snapshot, UsnJournalService journalService, BackupResults result, Options options, IFilter sourcefilter, IFilter filter, Common.ITaskReader taskreader, System.Threading.CancellationToken token)
         {
             // Make sure we create the enumeration process in a separate scope,
             // but keep the log channel from the parent scope
             using(Logging.Log.StartIsolatingScope(true))
             using (new IsolatedChannelScope())
             {
-                var enumeratorTask = Backup.FileEnumerationProcess.Run(sources, snapshot, null, options.FileAttributeFilter, sourcefilter, filter, options.SymlinkPolicy, options.HardlinkPolicy, options.ExcludeEmptyFolders, options.IgnoreFilenames, options.ChangedFilelist, taskreader, token);
+                var enumeratorTask = Backup.FileEnumerationProcess.Run(sources, snapshot, journalService, options.FileAttributeFilter, sourcefilter, filter, options.SymlinkPolicy, options.HardlinkPolicy, options.ExcludeEmptyFolders, options.IgnoreFilenames, options.ChangedFilelist, taskreader, token);
                 var counterTask = AutomationExtensions.RunTask(new
                 {
                     Input = Backup.Channels.SourcePaths.ForRead

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -442,17 +442,6 @@ namespace Duplicati.Library.Main.Operation
                         {
                             try
                             {
-                                // Start parallel scan, or use the database
-                                if (m_options.DisableFileScanner)
-                                {
-                                    var d = m_database.GetLastBackupFileCountAndSize();
-                                    m_result.OperationProgressUpdater.UpdatefileCount(d.Item1, d.Item2, true);
-                                }
-                                else
-                                {
-                                    parallelScanner = Backup.CountFilesHandler.Run(sources, snapshot, m_result, m_options, m_sourceFilter, m_filter, m_result.TaskReader, counterToken.Token);
-                                }
-
                                 // Make sure the database is sane
                                 await db.VerifyConsistencyAsync(m_options.Blocksize, m_options.BlockhashSize, !m_options.DisableFilelistConsistencyChecks);
 
@@ -504,6 +493,17 @@ namespace Duplicati.Library.Main.Operation
 
                                 // create USN-based scanner if enabled
                                 var journalService = GetJournalService(sources, snapshot, filter, lastfilesetid);
+
+                                // Start parallel scan, or use the database
+                                if (m_options.DisableFileScanner)
+                                {
+                                    var d = m_database.GetLastBackupFileCountAndSize();
+                                    m_result.OperationProgressUpdater.UpdatefileCount(d.Item1, d.Item2, true);
+                                }
+                                else
+                                {
+                                    parallelScanner = Backup.CountFilesHandler.Run(sources, snapshot, journalService, m_result, m_options, m_sourceFilter, m_filter, m_result.TaskReader, counterToken.Token);
+                                }
 
                                 // Run the backup operation
                                 if (await m_result.TaskReader.ProgressAsync)

--- a/Duplicati/Library/Snapshots/USNJournal.cs
+++ b/Duplicati/Library/Snapshots/USNJournal.cs
@@ -560,9 +560,9 @@ namespace Duplicati.Library.Snapshots
                     resultRecords.Add(rec);
                 }
                 else if (!(rec.FileName.Length == 24
-                           && rec.UsnRecord.FileReferenceNumber.ToString("X16") == rec.FileName.Substring(0, 16))
+                           && rec.UsnRecord.FileReferenceNumber.ToString("X16") == rec.FileName.Substring(0, 16)
                     || rec.FileName.Equals("$TxfLog")
-                    || rec.FileName.Equals("$TxfLog.blf"))
+                    || rec.FileName.Equals("$TxfLog.blf")))
                 {
                     throw new UsnJournalSoftFailureException(Strings.USNHelper.PathResolveError);
                 }

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -33,6 +33,11 @@ namespace Duplicati.Library.Snapshots
 {
     public class UsnJournalService
     {
+        /// <summary>
+        /// The log tag to use
+        /// </summary>
+        private static readonly string FILTER_LOGTAG = Logging.Log.LogTagFromType(typeof(UsnJournalService));
+
         private readonly ISnapshotService m_snapshot;
         private readonly IEnumerable<string> m_sources;
         private readonly Dictionary<string, VolumeData> m_volumeDataDict;
@@ -89,6 +94,8 @@ namespace Duplicati.Library.Snapshots
             // iterate over volumes
             foreach (var sourcesPerVolume in SortByVolume(m_sources))
             {
+                Logging.Log.WriteVerboseMessage(FILTER_LOGTAG, "UsnInitialize", "Reading USN journal for volume: {0}", sourcesPerVolume.Key);
+
                 if (m_token.IsCancellationRequested) break;
 
                 var volume = sourcesPerVolume.Key;


### PR DESCRIPTION
This is related to https://forum.duplicati.com/t/untraceable-long-operation-query-during-backup/9007/24. Instead of **adding** changes files one-by-one, this fix uses the faster `AppendFilesFromPreviousSet()`, and then **deletes** any unneeded entries from the file set.