### PR TITLE
Add mono-complete to Docker image to fix netstandard errors

### DIFF
--- a/Installer/Docker/context/Dockerfile
+++ b/Installer/Docker/context/Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=$TARGETPLATFORM mono:5-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
+        mono-complete \
         libmono-sqlite4.0-cil \
         libmono-system-drawing4.0-cil \
         libmono-system-net-http-webrequest4.0-cil \


### PR DESCRIPTION
After we started [targeting .NET 4.7.1](https://github.com/duplicati/duplicati/pull/4269), some users started encountering errors like:

`Could not find method '.ctor' due to a type load error: Could not load file or assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. assembly:/opt/duplicati/SharpAESCrypt.exe type:SharpAESCrypt member:(null)`

The TencentCOS and Tardigrade backends are built on .NET Standard 2.0, and it appears that the dependencies can be awoken even if these backends are not used.

While this potentially introduces some unnecessary packages, the discussion below seems to indicate that this is the cleanest solution:

https://github.com/mono/mono/issues/17148

This fixes #4289.