### PR TITLE
Avoid decoding URL parameters when removing passwords

### DIFF
--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -444,7 +444,8 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>The parsed query string</returns>
         /// <param name="query">The query to parse</param>
-        public static NameValueCollection ParseQueryString(string query)
+        /// <param name="decodeValues">Whether to the parameter values should be decoded or not.</param>
+        public static NameValueCollection ParseQueryString(string query, bool decodeValues = true)
         {
             if (query == null)
                 throw new ArgumentNullException(nameof(query));
@@ -455,7 +456,15 @@ namespace Duplicati.Library.Utility
 
             var result = new NameValueCollection(StringComparer.OrdinalIgnoreCase);
             foreach (System.Text.RegularExpressions.Match m in RE_URLPARAM.Matches(query))
-                result.Add(UrlDecode(m.Groups["key"].Value), UrlDecode(m.Groups["value"].Success ? m.Groups["value"].Value : ""));
+            {
+                string value = m.Groups["value"].Success ? m.Groups["value"].Value : "";
+                if (decodeValues)
+                {
+                    value = UrlDecode(value);
+                }
+
+                result.Add(UrlDecode(m.Groups["key"].Value), value);
+            }
 
             return result;
         }

--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -19,7 +19,6 @@ using System;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
-using System.Web;
 
 namespace Duplicati.Library.Utility
 {
@@ -444,8 +443,19 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>The parsed query string</returns>
         /// <param name="query">The query to parse</param>
+        public static NameValueCollection ParseQueryString(string query)
+        {
+            return Library.Utility.Uri.ParseQueryString(query, true);
+        }
+
+        /// <summary>
+        /// Parses the query string.
+        /// This is a duplicate of the System.Web.HttpUtility.ParseQueryString that does not work well on Mono
+        /// </summary>
+        /// <returns>The parsed query string</returns>
+        /// <param name="query">The query to parse</param>
         /// <param name="decodeValues">Whether to the parameter values should be decoded or not.</param>
-        public static NameValueCollection ParseQueryString(string query, bool decodeValues = true)
+        public static NameValueCollection ParseQueryString(string query, bool decodeValues)
         {
             if (query == null)
                 throw new ArgumentNullException(nameof(query));

--- a/Duplicati/Server/WebServer/RESTMethods/Backup.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/Backup.cs
@@ -122,6 +122,12 @@ namespace Duplicati.Server.WebServer.RESTMethods
             info.OutputOK(new { inuse = Library.Main.DatabaseLocator.IsDatabasePathInUse(backup.DBPath) });
         }
 
+        public static void RemovePasswords(IBackup backup)
+        {
+            backup.SanitizeSettings();
+            backup.SanitizeTargetUrl();
+        }
+
         private void Export(IBackup backup, RequestInfo info)
         {
             var cmdline = Library.Utility.Utility.ParseBool(info.Request.QueryString["cmdline"].Value, false);
@@ -129,8 +135,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
             var exportPasswords = Library.Utility.Utility.ParseBool(info.Request.QueryString["export-passwords"].Value, false);
             if (!exportPasswords)
             {
-                backup.SanitizeSettings();
-                backup.SanitizeTargetUrl();
+                Backup.RemovePasswords(backup);
             }
 
             if (cmdline)

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ControllerTests.cs" />

--- a/Duplicati/UnitTest/ImportExportTests.cs
+++ b/Duplicati/UnitTest/ImportExportTests.cs
@@ -75,7 +75,6 @@ namespace Duplicati.UnitTest
         [TestCase(false)]
         public void ExportToJSONEncoding(bool removePasswords)
         {
-            Dictionary<string, string> metadata = new Dictionary<string, string>();
             Dictionary<string, string> advancedOptions = new Dictionary<string, string> {{"server-datafolder", this.serverDatafolder}};
 
             string usernameKey = "auth-username";


### PR DESCRIPTION
The use of `Uri.QueryParameters` when removing passwords resulted in exporting decoded parameter values, which violated some assumptions made by the `decode_uri` function in `AppUtils.js`.  When a user chose not to export passwords, the username in the JSON would contain `@` instead of `%40`, which led to incorrect decomposition of the target URL into its components when importing in the UI.

This also adds a simple test to verify the encoding of the exported JSON.

Since there are users with exported configurations containing `@` in the username, we should also fix the import code to handle both encodings in order to fully address issue #3619.
