### PR TITLE
Fix restore GUI handling of folders with * or ?

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Duplicati.Library.Common.IO;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.CommandLine
 {
@@ -254,7 +255,7 @@ namespace Duplicati.CommandLine
             if (!containsSeparators && arg.StartsWith("@", StringComparison.Ordinal))
             {
                 // Convert to Regexp filter and prefix with ".*/"
-                return $"[.*{Regex.Escape(Util.DirectorySeparatorString + arg.Substring(1))}]";
+                return $"[.*{Utility.ConvertLiteralToRegExp(Util.DirectorySeparatorString + arg.Substring(1))}]";
             }
             else if (!containsSeparators && !containsWildcards && !arg.StartsWith("[", StringComparison.Ordinal))
             {
@@ -281,12 +282,12 @@ namespace Duplicati.CommandLine
         private static string SuffixArgWithAsterisk(string arg)
         {
             var containsWildcards = ContainsWildcards(arg);
-            var endsWithSeparator = arg.EndsWith(Util.DirectorySeparatorString);
+            var endsWithSeparator = arg.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal);
 
             if (endsWithSeparator && arg.StartsWith("@", StringComparison.Ordinal))
             {
                 // Convert to Regexp filter and suffix with ".*"
-                return $"[{Regex.Escape(arg.Substring(1))}.*]";
+                return $"[{Utility.ConvertLiteralToRegExp(arg.Substring(1))}.*]";
             }
             else if (endsWithSeparator && !containsWildcards && !arg.StartsWith("[", StringComparison.Ordinal))
             {
@@ -304,16 +305,14 @@ namespace Duplicati.CommandLine
         /// <summary>
         /// Returns true if <paramref name="s"/> contains directory separator characters.
         /// </summary>
-        public static bool ContainsDirectorySeparators(string s) =>
-            s.IndexOfAny(pathSeparatorsCharacters) >= 0;
+        public static bool ContainsDirectorySeparators(string s) => s.IndexOfAny(pathSeparatorsCharacters) >= 0;
 
         private static readonly char[] wildcardCharacters = new[] { '*', '?' };
 
         /// <summary>
         /// Returns true if <paramref name="s"/> contains wildcard characters.
         /// </summary>
-        public static bool ContainsWildcards(string s) =>
-            s.IndexOfAny(wildcardCharacters) >= 0;
+        public static bool ContainsWildcards(string s) => s.IndexOfAny(wildcardCharacters) >= 0;
 
         public static int List(TextWriter outwriter, Action<Duplicati.Library.Main.Controller> setup, List<string> args, Dictionary<string, string> options, Library.Utility.IFilter filter)
         {

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -239,7 +239,8 @@ namespace Duplicati.CommandLine
             // Prefix all filenames with "*/" so we search all folders
             var specialArgChars = new[] { '*', '?', Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
             return argList.Select(arg => arg.IndexOfAny(specialArgChars) < 0
-                 && !arg.StartsWith("[", StringComparison.Ordinal) ? "*" + Util.DirectorySeparatorString + arg : arg).ToList();
+                 && !arg.StartsWith("[", StringComparison.Ordinal)
+                 && !arg.StartsWith("@", StringComparison.Ordinal) ? "*" + Util.DirectorySeparatorString + arg : arg).ToList();
         }
 
         public static int List(TextWriter outwriter, Action<Duplicati.Library.Main.Controller> setup, List<string> args, Dictionary<string, string> options, Library.Utility.IFilter filter)
@@ -267,7 +268,7 @@ namespace Duplicati.CommandLine
                             options["version"] = v.ToString();
                         }
                     }
-                    else if (args[0].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[0].StartsWith("[", StringComparison.Ordinal))
+                    else if (args[0].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[0].StartsWith("[", StringComparison.Ordinal) && !args[0].StartsWith("@", StringComparison.Ordinal))
                     {
                         try
                         {
@@ -452,7 +453,7 @@ namespace Duplicati.CommandLine
 
             // suffix all folders with "*" so we restore all contents in the folder
             for (var ix = 0; ix < args.Count; ix++)
-                if (args[ix].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[ix].StartsWith("[", StringComparison.Ordinal) && args[ix].EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal))
+                if (args[ix].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[ix].StartsWith("[", StringComparison.Ordinal) && args[ix].EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal) && !args[ix].StartsWith("@", StringComparison.Ordinal))
                     args[ix] += "*";
 
             using(var output = new ConsoleOutput(outwriter, options))

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -236,15 +236,15 @@ namespace Duplicati.CommandLine
         }
 
         /// <summary>
-        /// For bare file names with no wildcards, replace with the
-        /// equivalent of prefixing with "*/" so we search all folders.
+        /// For bare file names with no wildcards, replace argument with
+        /// the equivalent of prefixing with "*/" so we search all folders.
         /// </summary>
         public static IEnumerable<string> PrefixArgsWithAsterisk(IEnumerable<string> argList) =>
             argList.Select(PrefixArgWithAsterisk);
 
         /// <summary>
-        /// For bare file names with no wildcards, replace with the
-        /// equivalent of prefixing with "*/" so we search all folders.
+        /// For bare file names with no wildcards, return argument with
+        /// the equivalent of prefixing with "*/" so we search all folders.
         /// </summary>
         private static string PrefixArgWithAsterisk(string arg)
         {
@@ -268,15 +268,15 @@ namespace Duplicati.CommandLine
         }
 
         /// <summary>
-        /// For folders, replace with the equivalent of suffixing with "/*"
-        /// so we restore contents in the folder.
+        /// For folders, replace argument with the equivalent of suffixing
+        /// with "*" so we restore contents in the folder.
         /// </summary>
         public static IEnumerable<string> SuffixArgsWithAsterisk(IEnumerable<string> argList) =>
             argList.Select(SuffixArgWithAsterisk);
 
         /// <summary>
-        /// For folders, replace with the equivalent of suffixing with "/*"
-        /// so we restore contents in the folder.
+        /// For folders, return argument with the equivalent of suffixing
+        /// with "*" so we restore contents in the folder.
         /// </summary>
         private static string SuffixArgWithAsterisk(string arg)
         {
@@ -285,12 +285,12 @@ namespace Duplicati.CommandLine
 
             if (endsWithSeparator && arg.StartsWith("@", StringComparison.Ordinal))
             {
-                // Convert to Regexp filter and suffix with "/.*"
+                // Convert to Regexp filter and suffix with ".*"
                 return $"[{Regex.Escape(arg.Substring(1))}.*]";
             }
             else if (endsWithSeparator && !containsWildcards && !arg.StartsWith("[", StringComparison.Ordinal))
             {
-                // Suffix with "/*"
+                // Suffix with "*"
                 return arg + "*";
             }
             else

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -240,7 +240,7 @@ namespace Duplicati.CommandLine
         /// equivalent of prefixing with "*/" so we search all folders.
         /// </summary>
         public static IEnumerable<string> PrefixArgsWithAsterisk(IEnumerable<string> argList) =>
-            argList.Select(PrefixArgWithAsterisk).ToList();
+            argList.Select(PrefixArgWithAsterisk);
 
         /// <summary>
         /// For bare file names with no wildcards, replace with the
@@ -272,7 +272,7 @@ namespace Duplicati.CommandLine
         /// so we restore contents in the folder.
         /// </summary>
         public static IEnumerable<string> SuffixArgsWithAsterisk(IEnumerable<string> argList) =>
-            argList.Select(SuffixArgWithAsterisk).ToList();
+            argList.Select(SuffixArgWithAsterisk);
 
         /// <summary>
         /// For folders, replace with the equivalent of suffixing with "/*"

--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -240,8 +240,7 @@ namespace Duplicati.CommandLine
         /// For bare file names with no wildcards, replace argument with
         /// the equivalent of prefixing with "*/" so we search all folders.
         /// </summary>
-        public static IEnumerable<string> PrefixArgsWithAsterisk(IEnumerable<string> argList) =>
-            argList.Select(PrefixArgWithAsterisk);
+        public static IEnumerable<string> PrefixArgsWithAsterisk(IEnumerable<string> argList) => argList.Select(PrefixArgWithAsterisk);
 
         /// <summary>
         /// For bare file names with no wildcards, return argument with
@@ -272,8 +271,7 @@ namespace Duplicati.CommandLine
         /// For folders, replace argument with the equivalent of suffixing
         /// with "*" so we restore contents in the folder.
         /// </summary>
-        public static IEnumerable<string> SuffixArgsWithAsterisk(IEnumerable<string> argList) =>
-            argList.Select(SuffixArgWithAsterisk);
+        public static IEnumerable<string> SuffixArgsWithAsterisk(IEnumerable<string> argList) => argList.Select(SuffixArgWithAsterisk);
 
         /// <summary>
         /// For folders, return argument with the equivalent of suffixing
@@ -339,7 +337,7 @@ namespace Duplicati.CommandLine
                             options["version"] = v.ToString();
                         }
                     }
-                    else if (args[0].IndexOfAny(new char[] { '*', '?' }) < 0 && !args[0].StartsWith("[", StringComparison.Ordinal) && !args[0].StartsWith("@", StringComparison.Ordinal))
+                    else if (!ContainsWildcards(args[0]) && !args[0].StartsWith("[", StringComparison.Ordinal) && !args[0].StartsWith("@", StringComparison.Ordinal))
                     {
                         try
                         {

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1190,7 +1190,7 @@ ORDER BY
                     var args = new List<object>();
                     foreach (var f in ((Library.Utility.FilterExpression)filter).GetSimpleList())
                     {
-                        if (f.Contains('*') || f.Contains('?'))
+                        if (type == FilterType.Wildcard)
                         {
                             sb.Append(@"""Path"" LIKE ? OR ");
                             args.Add(f.Replace('*', '%').Replace('?', '_'));

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -119,6 +119,13 @@ namespace Duplicati.Library.Utility
                     this.Filter = filter.Substring(1, filter.Length - 2);
                     this.Regexp = GetFilterGroupRegex(this.Filter);
                 }
+                else if (filter.StartsWith("@", StringComparison.Ordinal))
+                {
+                    // Take filter literally; i.e., don't treat wildcard characters as glogging characters
+                    this.Type = FilterType.Simple;
+                    this.Filter = filter.Substring(1);
+                    this.Regexp = new Regex(Utility.ConvertLiteralToRegExp(this.Filter), REGEXP_OPTIONS);
+                }
                 else
                 {
                     this.Type = (filter.Contains(MULTIPLE_WILDCARD) || filter.Contains(SINGLE_WILDCARD)) ? FilterType.Wildcard : FilterType.Simple;
@@ -149,6 +156,10 @@ namespace Duplicati.Library.Utility
                         if (filterString.StartsWith("[", StringComparison.Ordinal) && filterString.EndsWith("]", StringComparison.Ordinal))
                         {
                             return filterString.Substring(1, filterString.Length - 2);
+                        }
+                        else if (filterString.StartsWith("@", StringComparison.Ordinal))
+                        {
+                            return Utility.ConvertLiteralToRegExp(filterString.Substring(1));
                         }
                         else
                         {

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -123,7 +123,7 @@ namespace Duplicati.Library.Utility
                 {
                     // Take filter literally; i.e., don't treat wildcard
                     // characters as globbing characters
-                    this.Type = FilterType.Simple;
+                    this.Type = FilterType.Regexp;
                     this.Filter = filter.Substring(1);
                     this.Regexp = new Regex(Utility.ConvertLiteralToRegExp(this.Filter), REGEXP_OPTIONS);
                 }

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -123,7 +123,7 @@ namespace Duplicati.Library.Utility
                 {
                     // Take filter literally; i.e., don't treat wildcard
                     // characters as globbing characters
-                    this.Type = FilterType.Regexp;
+                    this.Type = FilterType.Simple;
                     this.Filter = filter.Substring(1);
                     this.Regexp = new Regex(Utility.ConvertLiteralToRegExp(this.Filter), REGEXP_OPTIONS);
                 }
@@ -296,6 +296,8 @@ namespace Duplicati.Library.Utility
                         return "[" + this.Filter + "]";
                     case FilterType.Group:
                         return "{" + this.Filter + "}";
+                    case FilterType.Simple:
+                        return "@" + this.Filter;
                     default:
                         return this.Filter;
                 }

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -121,7 +121,8 @@ namespace Duplicati.Library.Utility
                 }
                 else if (filter.StartsWith("@", StringComparison.Ordinal))
                 {
-                    // Take filter literally; i.e., don't treat wildcard characters as glogging characters
+                    // Take filter literally; i.e., don't treat wildcard
+                    // characters as globbing characters
                     this.Type = FilterType.Simple;
                     this.Filter = filter.Substring(1);
                     this.Regexp = new Regex(Utility.ConvertLiteralToRegExp(this.Filter), REGEXP_OPTIONS);

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -165,6 +165,15 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// Convert literal path to the equivalent regular expression.
+        /// </summary>
+        public static string ConvertLiteralToRegExp(string literalPath)
+        {
+            // Escape all special characters
+            return Regex.Escape(literalPath);
+        }
+
+        /// <summary>
         /// Returns a list of all files found in the given folder.
         /// The search is recursive.
         /// </summary>

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -346,7 +346,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
         var paths = [];
         for(var n in $scope.Selected) {
             var item = $scope.Selected[n];
-            if (item.indexOf('*') >= 0 || item.indexOf('?')) {
+            if (item.indexOf('*') >= 0 || item.indexOf('?') >= 0) {
                 // Handle paths with literal wildcard characters
                 // specially
                 if (item.substr(item.length - 1) == dirsep) {

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -346,26 +346,21 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
         var paths = [];
         for(var n in $scope.Selected) {
             var item = $scope.Selected[n];
-            if (item.indexOf('*') >= 0 || item.indexOf('?') >= 0) {
-                // Handle paths with literal wildcard characters
-                // specially
-                if (item.substr(item.length - 1) == dirsep) {
-                    // Switch to a regular expression filter so we can
-                    // preserve the literal wildcard characters and
-                    // also support the equivalent of a globbing '*'
-                    // suffix.
+            if (item.substr(item.length - 1) == dirsep) {
+                // To support the possibility of encountering paths
+                // with literal wildcard characters, but also being
+                // able to add the globbing "*" suffix, use a regular
+                // expression filter
 
-                    // Escape regular expression metacharacters
-                    var itemRegex = item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                    paths.push('[' + itemRegex  + '.*]');
-                } else {
-                    paths.push('@' + item);
-                }
+                // Escape regular expression metacharacters
+                var itemRegex = item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                // Add "globbing" suffix
+                paths.push('[' + itemRegex  + '.*]');
             } else {
-                if (item.substr(item.length - 1) == dirsep)
-                    paths.push(item + '*');
-                else
-                    paths.push(item);
+                // To support the possibility of encountering paths
+                // with literal wildcard characters, create a literal
+                // filter
+                paths.push('@' + item);
             }
         }
 

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -346,10 +346,27 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
         var paths = [];
         for(var n in $scope.Selected) {
             var item = $scope.Selected[n];
-            if (item.substr(item.length - 1) == dirsep)
-                paths.push(item + '*');
-            else
-                paths.push(item);
+            if (item.indexOf('*') >= 0 || item.indexOf('?')) {
+                // Handle paths with literal wildcard characters
+                // specially
+                if (item.substr(item.length - 1) == dirsep) {
+                    // Switch to a regular expression filter so we can
+                    // preserve the literal wildcard characters and
+                    // also support the equivalent of a globbing '*'
+                    // suffix.
+
+                    // Escape regular expression metacharacters
+                    var itemRegex = item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                    paths.push('[' + itemRegex  + '.*]');
+                } else {
+                    paths.push('@' + item);
+                }
+            } else {
+                if (item.substr(item.length - 1) == dirsep)
+                    paths.push(item + '*');
+                else
+                    paths.push(item);
+            }
         }
 
         if (paths.length > 0)

--- a/Duplicati/Server/webroot/ngax/scripts/directives/restoreFilePicker.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/restoreFilePicker.js
@@ -35,7 +35,10 @@ backupApp.directive('restoreFilePicker', function() {
                 if (!node.children && !node.loading) {
                     node.loading = true;
 
-                    AppService.get('/backup/' + $scope.ngBackupId + '/files/' + encodeURIComponent(node.id) + '?prefix-only=false&folder-contents=true&time=' + encodeURIComponent($scope.ngTimestamp) + '&filter=' + encodeURIComponent(node.id)).then(function(data) {
+                    // Prefix filter with "@" to prevent Duplicati from
+                    // mistaking literal '*' and '?' characters in paths
+                    // for glob wildcard characters
+                    AppService.get('/backup/' + $scope.ngBackupId + '/files/' + encodeURIComponent(node.id) + '?prefix-only=false&folder-contents=true&time=' + encodeURIComponent($scope.ngTimestamp) + '&filter=' + encodeURIComponent('@' + node.id)).then(function(data) {
                         var children = []
 
                          for(var n in data.data.Files)

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -62,14 +62,14 @@ namespace Duplicati.UnitTest
             const string singleCharacterDir = "X";
             string dirWithSingleCharacter = Path.Combine(this.DATAFOLDER, singleCharacterDir);
             SystemIO.IO_OS.DirectoryCreate(dirWithSingleCharacter);
-            WriteFile(SystemIO.IO_OS.PathCombine(dirWithSingleCharacter, file), new byte[] { 1 });
+            WriteFile(SystemIO.IO_OS.PathCombine(dirWithSingleCharacter, file), new byte[] { 2 });
             directories.Add(dirWithSingleCharacter);
             questionMarkWildcardShouldMatchCount++;
 
             const string dir = "dir";
             string normalDir = Path.Combine(this.DATAFOLDER, dir);
             SystemIO.IO_OS.DirectoryCreate(normalDir);
-            WriteFile(SystemIO.IO_OS.PathCombine(normalDir, file), new byte[] {2});
+            WriteFile(SystemIO.IO_OS.PathCombine(normalDir, file), new byte[] {3});
             directories.Add(normalDir);
 
             // Backup all files.


### PR DESCRIPTION
Add new filter syntax, prefixing with an "at sign"; i.e., `@...`, that
disables glob expansion, treating `*` and `?` wildcard characters as
literal characters.

In the GUI, change the restore file picker to prefix paths with `@`
when expanding a node to avoid mistaking literal `*` or `?` characters
for wildcards characters and triggering the following error:
```
Filter for list-folder-contents must be a path prefix with no wildcards Parameter name: filter
```

This fixes #4300.