### PR TITLE
Remove misleading comment

### DIFF
--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -281,7 +281,6 @@ namespace Duplicati.Library.Main.Operation
 
     /// <summary>
     /// Remove backups according to the --retention-policy option.
-    /// Backups that are not within any of the specified time frames will will NOT be deleted.
     /// Partial backups are not removed.
     /// </summary>
     public class RetentionPolicyRemover : FilesetRemover


### PR DESCRIPTION
The retention policy logic was changed at one point, and this comment was leftover from the old implementation.

https://forum.duplicati.com/t/new-retention-policy-deletes-old-backups-in-a-smart-way/2195/34?u=ts678

This fixes #3306.