### PR TITLE
Add symlink policy tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
         directories:
           - $BUILD_DIR
       script:
-        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData,RecoveryTool,ProblematicPath
+        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData,RecoveryTool,ProblematicPath,SymLink
     - stage: tests
       cache:
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
         directories:
           - $BUILD_DIR
       script:
-        - ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Border
+        - travis_wait ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Border
     - stage: tests
       cache:
         directories:

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO.Compression;
 using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.UnitTest
 {
@@ -209,6 +210,17 @@ namespace Duplicati.UnitTest
             else
             {
                 ZipFile.ExtractToDirectory(sourceArchiveFileName, destinationDirectoryName);
+            }
+        }
+
+        /// <summary>
+        /// Write file <paramref name="path"/> with <paramref name="contents"/>.
+        /// </summary>
+        protected static void WriteFile(string path, byte[] contents)
+        {
+            using (FileStream fileStream = SystemIO.IO_OS.FileOpenWrite(path))
+            {
+                Utility.CopyStream(new MemoryStream(contents), fileStream);
             }
         }
     }

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -212,17 +212,6 @@ namespace Duplicati.UnitTest
                 ZipFile.ExtractToDirectory(sourceArchiveFileName, destinationDirectoryName);
             }
         }
-
-        /// <summary>
-        /// Write file <paramref name="path"/> with <paramref name="contents"/>.
-        /// </summary>
-        protected static void WriteFile(string path, byte[] contents)
-        {
-            using (FileStream fileStream = SystemIO.IO_OS.FileOpenWrite(path))
-            {
-                Utility.CopyStream(new MemoryStream(contents), fileStream);
-            }
-        }
     }
 }
 

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -353,7 +353,7 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(filenames.Count * 3, r.RestoredFiles);
             }
 
-            TestUtils.VerifyDir(DATAFOLDER, RESTOREFOLDER, !Library.Utility.Utility.ParseBoolOption(testopts, "skip-metadata"));
+            TestUtils.AssertDirectoryTreesAreEquivalent(DATAFOLDER, RESTOREFOLDER, !Library.Utility.Utility.ParseBoolOption(testopts, "skip-metadata"), "Restore");
 
             using(var tf = new Library.Utility.TempFolder())
             {

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -216,7 +216,7 @@ namespace Duplicati.UnitTest
 
             ProgressWriteLine("Verifying partial restore ...");
             using (new Library.Logging.Timer(LOGTAG, "VerifiationOfPartialRestore", "Verification of partial restored files"))
-                TestUtils.VerifyDir(rf, RESTOREFOLDER, true);
+                TestUtils.AssertDirectoryTreesAreEquivalent(rf, RESTOREFOLDER, true, "VerifiationOfPartialRestore");
 
             systemIO.DirectoryDelete(RESTOREFOLDER, true);
 
@@ -226,7 +226,7 @@ namespace Duplicati.UnitTest
 
             ProgressWriteLine("Verifying partial restore ...");
             using (new Library.Logging.Timer(LOGTAG, "VerificationOfPartialRestore", "Verification of partial restored files"))
-                TestUtils.VerifyDir(rf, RESTOREFOLDER, true);
+                TestUtils.AssertDirectoryTreesAreEquivalent(rf, RESTOREFOLDER, true, "VerificationOfPartialRestore");
 
             systemIO.DirectoryDelete(RESTOREFOLDER, true);
 
@@ -237,7 +237,7 @@ namespace Duplicati.UnitTest
             ProgressWriteLine("Verifying full restore ...");
             using (new Library.Logging.Timer(LOGTAG, "VerificationOfFullRestore", "Verification of restored files"))
                 foreach (var s in systemIO.EnumerateDirectories(DATAFOLDER))
-                    TestUtils.VerifyDir(s, Path.Combine(RESTOREFOLDER, Path.GetFileName(s)), true);
+                    TestUtils.AssertDirectoryTreesAreEquivalent(s, Path.Combine(RESTOREFOLDER, Path.GetFileName(s)), true, "VerificationOfFullRestore");
 
             systemIO.DirectoryDelete(RESTOREFOLDER, true);
 
@@ -248,7 +248,7 @@ namespace Duplicati.UnitTest
             ProgressWriteLine("Verifying full restore ...");
             using (new Library.Logging.Timer(LOGTAG, "VerificationOfFullRestoreWithoutDb", "Verification of restored files"))
                 foreach (var s in systemIO.EnumerateDirectories(DATAFOLDER))
-                    TestUtils.VerifyDir(s, Path.Combine(RESTOREFOLDER, Path.GetFileName(s)), true);
+                    TestUtils.AssertDirectoryTreesAreEquivalent(s, Path.Combine(RESTOREFOLDER, Path.GetFileName(s)), true, "VerificationOfFullRestoreWithoutDb");
 
             ProgressWriteLine("Testing data ...");
             using (new Library.Logging.Timer(LOGTAG, "TestRemoteData", "Test remote data"))

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -215,8 +215,8 @@ namespace Duplicati.UnitTest
                 Duplicati.CommandLine.Program.RealMain((new string[] { "restore", target, rf + "*", "--restore-path=\"" + RESTOREFOLDER + "\"" }.Union(opts)).ToArray());
 
             ProgressWriteLine("Verifying partial restore ...");
-            using (new Library.Logging.Timer(LOGTAG, "VerifiationOfPartialRestore", "Verification of partial restored files"))
-                TestUtils.AssertDirectoryTreesAreEquivalent(rf, RESTOREFOLDER, true, "VerifiationOfPartialRestore");
+            using (new Library.Logging.Timer(LOGTAG, "VerificationOfPartialRestore", "Verification of partial restored files"))
+                TestUtils.AssertDirectoryTreesAreEquivalent(rf, RESTOREFOLDER, true, "VerificationOfPartialRestore");
 
             systemIO.DirectoryDelete(RESTOREFOLDER, true);
 

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -527,7 +527,7 @@ namespace Duplicati.UnitTest
                 foreach (string filepath in partialVersionFiles)
                 {
                     string filename = Path.GetFileName(filepath);
-                    Assert.IsTrue(TestUtils.CompareFiles(filepath, Path.Combine(this.RESTOREFOLDER, filename ?? String.Empty), filename, false));
+                    TestUtils.AssertFilesAreEqual(filepath, Path.Combine(this.RESTOREFOLDER, filename ?? String.Empty), false, filename);
                 }
             }
 
@@ -572,7 +572,7 @@ namespace Duplicati.UnitTest
                 foreach (string filepath in fullVersionFiles)
                 {
                     string filename = Path.GetFileName(filepath);
-                    Assert.IsTrue(TestUtils.CompareFiles(filepath, Path.Combine(this.RESTOREFOLDER, filename ?? String.Empty), filename, false));
+                    TestUtils.AssertFilesAreEqual(filepath, Path.Combine(this.RESTOREFOLDER, filename ?? String.Empty), false, filename);
                 }
             }
         }
@@ -639,7 +639,7 @@ namespace Duplicati.UnitTest
                 foreach (string filepath in fullVersionFiles)
                 {
                     string filename = Path.GetFileName(filepath);
-                    Assert.IsTrue(TestUtils.CompareFiles(filepath, Path.Combine(this.RESTOREFOLDER, filename ?? String.Empty), filename, false));
+                    TestUtils.AssertFilesAreEqual(filepath, Path.Combine(this.RESTOREFOLDER, filename ?? String.Empty), false, filename);
                 }
             }
         }

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SymLinkTests.cs" />
     <Compile Include="ControllerTests.cs" />
     <Compile Include="DeleteHandlerTests.cs" />
     <Compile Include="DisruptionTests.cs" />

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -32,7 +32,7 @@ namespace Duplicati.UnitTest
             if (!Platform.IsClientWindows)
             {
                 SystemIO.IO_OS.DirectoryCreate(dirWithAsterisk);
-                WriteFile(SystemIO.IO_OS.PathCombine(dirWithAsterisk, file), new byte[] {0});
+                TestUtils.WriteFile(SystemIO.IO_OS.PathCombine(dirWithAsterisk, file), new byte[] {0});
                 directories.Add(dirWithAsterisk);
                 questionMarkWildcardShouldMatchCount++;
                 verbatimAsteriskShouldMatchCount++;
@@ -44,7 +44,7 @@ namespace Duplicati.UnitTest
             if (!Platform.IsClientWindows)
             {
                 SystemIO.IO_OS.DirectoryCreate(dirWithQuestionMark);
-                WriteFile(SystemIO.IO_OS.PathCombine(dirWithQuestionMark, file), new byte[] { 1 });
+                TestUtils.WriteFile(SystemIO.IO_OS.PathCombine(dirWithQuestionMark, file), new byte[] { 1 });
                 directories.Add(dirWithQuestionMark);
                 questionMarkWildcardShouldMatchCount++;
             }
@@ -54,14 +54,14 @@ namespace Duplicati.UnitTest
             const string singleCharacterDir = "X";
             string dirWithSingleCharacter = Path.Combine(this.DATAFOLDER, singleCharacterDir);
             SystemIO.IO_OS.DirectoryCreate(dirWithSingleCharacter);
-            WriteFile(SystemIO.IO_OS.PathCombine(dirWithSingleCharacter, file), new byte[] { 2 });
+            TestUtils.WriteFile(SystemIO.IO_OS.PathCombine(dirWithSingleCharacter, file), new byte[] { 2 });
             directories.Add(dirWithSingleCharacter);
             questionMarkWildcardShouldMatchCount++;
 
             const string dir = "dir";
             string normalDir = Path.Combine(this.DATAFOLDER, dir);
             SystemIO.IO_OS.DirectoryCreate(normalDir);
-            WriteFile(SystemIO.IO_OS.PathCombine(normalDir, file), new byte[] {3});
+            TestUtils.WriteFile(SystemIO.IO_OS.PathCombine(normalDir, file), new byte[] {3});
             directories.Add(normalDir);
 
             // Backup all files.
@@ -88,7 +88,7 @@ namespace Duplicati.UnitTest
                     {
                         string fileName = SystemIO.IO_OS.PathGetFileName(expectedFilePath);
                         string restoredFilePath = SystemIO.IO_OS.PathCombine(this.RESTOREFOLDER, directoryName, fileName);
-                        Assert.IsTrue(TestUtils.CompareFiles(expectedFilePath, restoredFilePath, expectedFilePath, false));
+                        TestUtils.AssertFilesAreEqual(expectedFilePath, restoredFilePath, false, expectedFilePath);
                     }
                 }
 
@@ -132,7 +132,7 @@ namespace Duplicati.UnitTest
 
                         string fileName = SystemIO.IO_OS.PathGetFileName(expectedFilePath);
                         string restoredFilePath = SystemIO.IO_OS.PathCombine(this.RESTOREFOLDER, fileName);
-                        Assert.IsTrue(TestUtils.CompareFiles(expectedFilePath, restoredFilePath, expectedFilePath, false));
+                        TestUtils.AssertFilesAreEqual(expectedFilePath, restoredFilePath, false, expectedFilePath);
 
                         SystemIO.IO_OS.FileDelete(restoredFilePath);
                     }
@@ -171,7 +171,7 @@ namespace Duplicati.UnitTest
 
             // A long path to exclude.
             string longFile = SystemIO.IO_OS.PathCombine(this.DATAFOLDER, new string('y', 255));
-            WriteFile(longFile, new byte[] {0, 1});
+            TestUtils.WriteFile(longFile, new byte[] {0, 1});
 
             // A folder that ends with a dot to exclude.
             string folderWithDot = Path.Combine(this.DATAFOLDER, "folder_with_dot.");
@@ -183,11 +183,11 @@ namespace Duplicati.UnitTest
 
             // A file that ends with a dot to exclude.
             string fileWithDot = Path.Combine(this.DATAFOLDER, "file_with_dot.");
-            WriteFile(fileWithDot, new byte[] {0, 1});
+            TestUtils.WriteFile(fileWithDot, new byte[] {0, 1});
 
             // A file that ends with a space to exclude.
             string fileWithSpace = Path.Combine(this.DATAFOLDER, "file_with_space ");
-            WriteFile(fileWithSpace, new byte[] {0, 1});
+            TestUtils.WriteFile(fileWithSpace, new byte[] {0, 1});
 
             FilterExpression filter = new FilterExpression(longFile, false);
             filter = FilterExpression.Combine(filter, new FilterExpression(Util.AppendDirSeparator(folderWithDot), false));
@@ -226,7 +226,7 @@ namespace Duplicati.UnitTest
             string fileName = new string('y', 255);
             string filePath = SystemIO.IO_OS.PathCombine(folderPath, fileName);
             byte[] fileBytes = {0, 1, 2};
-            WriteFile(filePath, fileBytes);
+            TestUtils.WriteFile(filePath, fileBytes);
 
             Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions);
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
@@ -269,7 +269,7 @@ namespace Duplicati.UnitTest
 
             string filePath = SystemIO.IO_OS.PathCombine(folderPath, pathComponent);
             byte[] fileBytes = {0, 1, 2};
-            WriteFile(filePath, fileBytes);
+            TestUtils.WriteFile(filePath, fileBytes);
 
             Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions);
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -81,12 +81,7 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(0, restoreResults.Errors.Count());
                 Assert.AreEqual(0, restoreResults.Warnings.Count());
 
-                foreach (string directory in directories)
-                {
-                    string directoryName = SystemIO.IO_OS.PathGetFileName(directory);
-                    string restoredDirectory = SystemIO.IO_OS.PathCombine(this.RESTOREFOLDER, directoryName);
-                    TestUtils.AssertDirectoryTreesAreEquivalent(directory, restoredDirectory, true, "Restore");
-                }
+                TestUtils.AssertDirectoryTreesAreEquivalent(this.DATAFOLDER, this.RESTOREFOLDER, true, "Restore");
 
                 // List results using * should return a match for each directory.
                 IListResults listResults = c.List(SystemIO.IO_OS.PathCombine(dirWithAsterisk, file));

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -84,12 +84,8 @@ namespace Duplicati.UnitTest
                 foreach (string directory in directories)
                 {
                     string directoryName = SystemIO.IO_OS.PathGetFileName(directory);
-                    foreach (string expectedFilePath in SystemIO.IO_OS.EnumerateFiles(directory))
-                    {
-                        string fileName = SystemIO.IO_OS.PathGetFileName(expectedFilePath);
-                        string restoredFilePath = SystemIO.IO_OS.PathCombine(this.RESTOREFOLDER, directoryName, fileName);
-                        TestUtils.AssertFilesAreEqual(expectedFilePath, restoredFilePath, false, expectedFilePath);
-                    }
+                    string restoredDirectory = SystemIO.IO_OS.PathCombine(this.RESTOREFOLDER, directoryName);
+                    TestUtils.AssertDirectoryTreesAreEquivalent(directory, restoredDirectory, true, "Restore");
                 }
 
                 // List results using * should return a match for each directory.

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -13,14 +13,6 @@ namespace Duplicati.UnitTest
     [TestFixture]
     public class ProblematicPathTests : BasicSetupHelper
     {
-        private static void WriteFile(string path, byte[] contents)
-        {
-            using (FileStream fileStream = SystemIO.IO_OS.FileOpenWrite(path))
-            {
-                Utility.CopyStream(new MemoryStream(contents), fileStream);
-            }
-        }
-
         [Test]
         [Category("ProblematicPath")]
         public void ExcludeProblematicPaths()

--- a/Duplicati/UnitTest/RecoveryToolTests.cs
+++ b/Duplicati/UnitTest/RecoveryToolTests.cs
@@ -93,13 +93,13 @@ namespace Duplicati.UnitTest
             foreach (string filepath in Directory.EnumerateFiles(this.DATAFOLDER))
             {
                 string filename = Path.GetFileName(filepath);
-                Assert.IsTrue(TestUtils.CompareFiles(filepath, Path.Combine(restoreFolder, baseFolder, filename ?? String.Empty), filename, false));
+                TestUtils.AssertFilesAreEqual(filepath, Path.Combine(restoreFolder, baseFolder, filename ?? String.Empty), false, filename);
             }
 
             foreach (string filepath in Directory.EnumerateFiles(subdirectoryPath))
             {
                 string filename = Path.GetFileName(filepath);
-                Assert.IsTrue(TestUtils.CompareFiles(filepath, Path.Combine(restoreFolder, baseFolder, subdirectoryName, filename ?? String.Empty), filename, false));
+                TestUtils.AssertFilesAreEqual(filepath, Path.Combine(restoreFolder, baseFolder, subdirectoryName, filename ?? String.Empty), false, filename);
             }
         }
     }

--- a/Duplicati/UnitTest/SVNCheckoutsTest.cs
+++ b/Duplicati/UnitTest/SVNCheckoutsTest.cs
@@ -421,11 +421,7 @@ namespace Duplicati.UnitTest
                             throw new Exception("Unittest is broken");
                         }
 
-                        if (!TestUtils.CompareFiles(sourcename, restoredname, s, verifymetadata))
-                        {
-                            Log.WriteErrorMessage(LOGTAG, "PartialRestoreWrongFile", null, "Partial restore file differs: {0}", s);
-                            BasicSetupHelper.ProgressWriteLine("Partial restore file differs: " + s);
-                        }
+                        TestUtils.AssertFilesAreEqual(sourcename, restoredname, verifymetadata, $"Partial restore file differs: {s}");
                     }
                 }
         }
@@ -435,7 +431,7 @@ namespace Duplicati.UnitTest
             using (new Timer(LOGTAG, "SourceVerification", "Verification of " + source))
             {
                 for (int j = 0; j < actualfolders.Length; j++)
-                    TestUtils.VerifyDir(actualfolders[j], restorefoldernames[j], verifymetadata);
+                    TestUtils.AssertDirectoryTreesAreEquivalent(actualfolders[j], restorefoldernames[j], verifymetadata, "VerifyFullRestore");
             }
         }
 

--- a/Duplicati/UnitTest/SymLinkTests.cs
+++ b/Duplicati/UnitTest/SymLinkTests.cs
@@ -14,7 +14,10 @@ namespace Duplicati.UnitTest
     {
         [Test]
         [Category("SymLink")]
-        public void SymLinkPolicy()
+        [TestCase(Options.SymlinkStrategy.Store)]
+        [TestCase(Options.SymlinkStrategy.Follow)]
+        [TestCase(Options.SymlinkStrategy.Ignore)]
+        public void SymLinkPolicy(Options.SymlinkStrategy symlinkPolicy)
         {
             // Create symlink target directory
             const string targetDirName = "target";
@@ -41,65 +44,42 @@ namespace Duplicati.UnitTest
                 Assert.Ignore($"Client could not create a symbolic link.  Error reported: {e.Message}");
             }
 
-            // Perform backups using all symlink policies and verify restores
-            var symlinkPolicies = new[] { Options.SymlinkStrategy.Store, Options.SymlinkStrategy.Follow, Options.SymlinkStrategy.Ignore };
+            // Backup all files with given symlink policy
             Dictionary<string, string> restoreOptions = new Dictionary<string, string>(this.TestOptions) { ["restore-path"] = this.RESTOREFOLDER };
-            foreach (var symlinkPolicy in symlinkPolicies)
+            Dictionary<string, string> backupOptions = new Dictionary<string, string>(this.TestOptions) { ["symlink-policy"] = symlinkPolicy.ToString() };
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
             {
-                // Backup all files with given symlink policy
-                Dictionary<string, string> backupOptions = new Dictionary<string, string>(this.TestOptions) { ["symlink-policy"] = symlinkPolicy.ToString() };
-                using (Controller c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
-                {
-                    IBackupResults backupResults = c.Backup(new[] { this.DATAFOLDER });
-                    Assert.AreEqual(0, backupResults.Errors.Count());
-                    Assert.AreEqual(0, backupResults.Warnings.Count());
-                }
-                // Restore all files
-                using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
-                {
-                    IRestoreResults restoreResults = c.Restore(null);
-                    Assert.AreEqual(0, restoreResults.Errors.Count());
-                    Assert.AreEqual(0, restoreResults.Warnings.Count());
+                IBackupResults backupResults = c.Backup(new[] { this.DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+            // Restore all files
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+            {
+                IRestoreResults restoreResults = c.Restore(null);
+                Assert.AreEqual(0, restoreResults.Errors.Count());
+                Assert.AreEqual(0, restoreResults.Warnings.Count());
 
-                    // Verify that symlink policy was followed
-                    var restoreSymlinkDir = systemIO.PathCombine(this.RESTOREFOLDER, symlinkDirName);
-                    switch (symlinkPolicy)
-                    {
-                        case Options.SymlinkStrategy.Store:
-                            // Restore should contain an actual symlink to the original target
-                            Assert.That(systemIO.IsSymlink(restoreSymlinkDir), Is.True);
-                            var restoredSymlinkFullPath = systemIO.PathGetFullPath(systemIO.GetSymlinkTarget(restoreSymlinkDir));
-                            var symlinkTargetFullPath = systemIO.PathGetFullPath(targetDir);
-                            Assert.That(restoredSymlinkFullPath, Is.EqualTo(symlinkTargetFullPath));
-                            break;
-                        case Options.SymlinkStrategy.Follow:
-                            // Restore should contain a regular directory with copies of the files in the symlink target
-                            Assert.That(systemIO.IsSymlink(restoreSymlinkDir), Is.False);
-                            TestUtils.AssertDirectoryTreesAreEquivalent(targetDir, restoreSymlinkDir, true, $"Symlink policy: {Options.SymlinkStrategy.Store}");
-                            break;
-                        case Options.SymlinkStrategy.Ignore:
-                            // Restore should not contain the symlink at all
-                            Assert.That(systemIO.DirectoryExists(restoreSymlinkDir), Is.False);
-                            break;
-                    }
-                    // Prepare for a fresh backup and restore cycle
-                    foreach (var dir in systemIO.EnumerateDirectories(this.RESTOREFOLDER))
-                    {
-                        systemIO.DirectoryDelete(dir, true);
-                    }
-                    foreach (var file in systemIO.EnumerateFiles(this.RESTOREFOLDER))
-                    {
-                        systemIO.FileDelete(file);
-                    }
-                    c.DeleteAllRemoteFiles();
-                    if (systemIO.FileExists(this.DBFILE))
-                    {
-                        systemIO.FileDelete(this.DBFILE);
-                    }
-                    if (systemIO.FileExists($"{this.DBFILE}-journal"))
-                    {
-                        systemIO.FileDelete($"{this.DBFILE}-journal");
-                    }
+                // Verify that symlink policy was followed
+                var restoreSymlinkDir = systemIO.PathCombine(this.RESTOREFOLDER, symlinkDirName);
+                switch (symlinkPolicy)
+                {
+                    case Options.SymlinkStrategy.Store:
+                        // Restore should contain an actual symlink to the original target
+                        Assert.That(systemIO.IsSymlink(restoreSymlinkDir), Is.True);
+                        var restoredSymlinkFullPath = systemIO.PathGetFullPath(systemIO.GetSymlinkTarget(restoreSymlinkDir));
+                        var symlinkTargetFullPath = systemIO.PathGetFullPath(targetDir);
+                        Assert.That(restoredSymlinkFullPath, Is.EqualTo(symlinkTargetFullPath));
+                        break;
+                    case Options.SymlinkStrategy.Follow:
+                        // Restore should contain a regular directory with copies of the files in the symlink target
+                        Assert.That(systemIO.IsSymlink(restoreSymlinkDir), Is.False);
+                        TestUtils.AssertDirectoryTreesAreEquivalent(targetDir, restoreSymlinkDir, true, $"Symlink policy: {Options.SymlinkStrategy.Store}");
+                        break;
+                    case Options.SymlinkStrategy.Ignore:
+                        // Restore should not contain the symlink at all
+                        Assert.That(systemIO.DirectoryExists(restoreSymlinkDir), Is.False);
+                        break;
                 }
             }
         }

--- a/Duplicati/UnitTest/SymLinkTests.cs
+++ b/Duplicati/UnitTest/SymLinkTests.cs
@@ -77,8 +77,9 @@ namespace Duplicati.UnitTest
                         TestUtils.AssertDirectoryTreesAreEquivalent(targetDir, restoreSymlinkDir, true, $"Symlink policy: {Options.SymlinkStrategy.Store}");
                         break;
                     case Options.SymlinkStrategy.Ignore:
-                        // Restore should not contain the symlink at all
+                        // Restore should not contain the symlink or directory at all
                         Assert.That(systemIO.DirectoryExists(restoreSymlinkDir), Is.False);
+                        Assert.That(systemIO.FileExists(restoreSymlinkDir), Is.False);
                         break;
                 }
             }

--- a/Duplicati/UnitTest/SymLinkTests.cs
+++ b/Duplicati/UnitTest/SymLinkTests.cs
@@ -74,12 +74,15 @@ namespace Duplicati.UnitTest
                     case Options.SymlinkStrategy.Follow:
                         // Restore should contain a regular directory with copies of the files in the symlink target
                         Assert.That(systemIO.IsSymlink(restoreSymlinkDir), Is.False);
-                        TestUtils.AssertDirectoryTreesAreEquivalent(targetDir, restoreSymlinkDir, true, $"Symlink policy: {Options.SymlinkStrategy.Store}");
+                        TestUtils.AssertDirectoryTreesAreEquivalent(targetDir, restoreSymlinkDir, true, "Restore");
                         break;
                     case Options.SymlinkStrategy.Ignore:
                         // Restore should not contain the symlink or directory at all
                         Assert.That(systemIO.DirectoryExists(restoreSymlinkDir), Is.False);
                         Assert.That(systemIO.FileExists(restoreSymlinkDir), Is.False);
+                        break;
+                    default:
+                        Assert.Fail($"Unexpected symlink policy");
                         break;
                 }
             }

--- a/Duplicati/UnitTest/SymLinkTests.cs
+++ b/Duplicati/UnitTest/SymLinkTests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Main;
+using Duplicati.Library.Snapshots;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    [TestFixture]
+    public class SymLinkTests : BasicSetupHelper
+    {
+        [Test]
+        [Category("SymLink")]
+        public void SymLinkPolicy()
+        {
+            // Create symlink target directory
+            const string targetDirName = "target";
+            var targetDir = systemIO.PathCombine(this.DATAFOLDER, targetDirName);
+            systemIO.DirectoryCreate(targetDir);
+            // Create files in symlink target directory
+            var fileNames = new[] { "a.txt", "b.txt", "c.txt" };
+            foreach (var file in fileNames)
+            {
+                var targetFile = systemIO.PathCombine(targetDir, file);
+                WriteFile(targetFile, Encoding.Default.GetBytes(file));
+            }
+
+            // Create actual symlink directory linking to the target directory
+            const string symlinkDirName = "symlink";
+            var symlinkDir = systemIO.PathCombine(this.DATAFOLDER, symlinkDirName);
+            try
+            {
+                systemIO.CreateSymlink(symlinkDir, targetDir, asDir: true);
+            }
+            catch (Exception e)
+            {
+                // If client cannot create symlinks, mark test as ignored
+                Assert.Ignore($"Client could not create a symbolic link.  Error reported: {e.Message}");
+            }
+
+            // Perform backups using all symlink policies and verify restores
+            var symlinkPolicies = new[] { Options.SymlinkStrategy.Store, Options.SymlinkStrategy.Follow, Options.SymlinkStrategy.Ignore };
+            Dictionary<string, string> restoreOptions = new Dictionary<string, string>(this.TestOptions) { ["restore-path"] = this.RESTOREFOLDER };
+            foreach (var symlinkPolicy in symlinkPolicies)
+            {
+                // Backup all files with given symlink policy
+                Dictionary<string, string> backupOptions = new Dictionary<string, string>(this.TestOptions) { ["symlink-policy"] = symlinkPolicy.ToString() };
+                using (Controller c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
+                {
+                    IBackupResults backupResults = c.Backup(new[] { this.DATAFOLDER });
+                    Assert.AreEqual(0, backupResults.Errors.Count());
+                    Assert.AreEqual(0, backupResults.Warnings.Count());
+                }
+                // Restore all files
+                using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+                {
+                    IRestoreResults restoreResults = c.Restore(null);
+                    Assert.AreEqual(0, restoreResults.Errors.Count());
+                    Assert.AreEqual(0, restoreResults.Warnings.Count());
+
+                    // Verify that symlink policy was followed
+                    var restoreSymlinkDir = systemIO.PathCombine(this.RESTOREFOLDER, symlinkDirName);
+                    switch (symlinkPolicy)
+                    {
+                        case Options.SymlinkStrategy.Store:
+                            // Restore should contain an actual symlink to the original target
+                            Assert.That(systemIO.IsSymlink(restoreSymlinkDir), Is.True);
+                            var restoredSymlinkFullPath = systemIO.PathGetFullPath(systemIO.GetSymlinkTarget(restoreSymlinkDir));
+                            var symlinkTargetFullPath = systemIO.PathGetFullPath(targetDir);
+                            Assert.That(restoredSymlinkFullPath, Is.EqualTo(symlinkTargetFullPath));
+                            break;
+                        case Options.SymlinkStrategy.Follow:
+                            // Restore should contain a regular directory with copies of the files in the symlink target
+                            Assert.That(systemIO.IsSymlink(restoreSymlinkDir), Is.False);
+                            AssertDirectoryTreesAreEquivalent(targetDir, restoreSymlinkDir, $"Symlink policy: {Options.SymlinkStrategy.Store}");
+                            break;
+                        case Options.SymlinkStrategy.Ignore:
+                            // Restore should not contain the symlink at all
+                            Assert.That(systemIO.DirectoryExists(restoreSymlinkDir), Is.False);
+                            break;
+                    }
+                    // Prepare for a fresh backup and restore cycle
+                    foreach (var dir in systemIO.EnumerateDirectories(this.RESTOREFOLDER))
+                    {
+                        systemIO.DirectoryDelete(dir, true);
+                    }
+                    foreach (var file in systemIO.EnumerateFiles(this.RESTOREFOLDER))
+                    {
+                        systemIO.FileDelete(file);
+                    }
+                    c.DeleteAllRemoteFiles();
+                    if (systemIO.FileExists(this.DBFILE))
+                    {
+                        systemIO.FileDelete(this.DBFILE);
+                    }
+                    if (systemIO.FileExists($"{this.DBFILE}-journal"))
+                    {
+                        systemIO.FileDelete($"{this.DBFILE}-journal");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asserts that the two directories are equivalent; i.e., they they contain the same subdirectories and files, recursively.
+        /// </summary>
+        private static void AssertDirectoryTreesAreEquivalent(string expectedDir, string actualDir, string contextMessage)
+        {
+            var localMessage = $"{contextMessage}, in directories {expectedDir} and {actualDir}";
+            var expectedSubdirs = systemIO.EnumerateDirectories(expectedDir).OrderBy(systemIO.PathGetFileName);
+            var actualSubdirs = systemIO.EnumerateDirectories(actualDir).OrderBy(systemIO.PathGetFileName);
+            Assert.That(expectedSubdirs.Select(systemIO.PathGetFileName), Is.EquivalentTo(actualSubdirs.Select(systemIO.PathGetFileName)), localMessage);
+            var expectedSubdirsEnumerator = expectedSubdirs.GetEnumerator();
+            var actualSubdirsEnumerator = actualSubdirs.GetEnumerator();
+            while (expectedSubdirsEnumerator.MoveNext() && actualSubdirsEnumerator.MoveNext())
+            {
+                AssertDirectoryTreesAreEquivalent(expectedSubdirsEnumerator.Current, actualSubdirsEnumerator.Current, contextMessage);
+            }
+            var expectedFiles = systemIO.EnumerateFiles(expectedDir).OrderBy(systemIO.PathGetFileName);
+            var actualFiles = systemIO.EnumerateFiles(actualDir).OrderBy(systemIO.PathGetFileName);
+            Assert.That(expectedFiles.Select(systemIO.PathGetFileName), Is.EquivalentTo(actualFiles.Select(systemIO.PathGetFileName)), localMessage);
+            var expectedFilesEnumerator = expectedFiles.GetEnumerator();
+            var actualFilesEnumerator = actualFiles.GetEnumerator();
+            while (expectedFilesEnumerator.MoveNext() && actualFilesEnumerator.MoveNext())
+            {
+                AssertFilesAreEqual(expectedFilesEnumerator.Current, actualFilesEnumerator.Current, contextMessage);
+            }
+        }
+
+        /// <summary>
+        /// Asserts that two files are the same by comparing their size and their contents.
+        /// </summary>
+        private static void AssertFilesAreEqual(string expectedFile, string actualFile, string contextMessage)
+        {
+            using (var expectedFileStream = systemIO.FileOpenRead(expectedFile))
+            using (var actualFileStream = systemIO.FileOpenRead(actualFile))
+            {
+                Assert.That(expectedFileStream.Length, Is.EqualTo(actualFileStream.Length), $"{contextMessage}, file size mismatch for {expectedFile} and {actualFile}");
+                for (long i = 0; i < expectedFileStream.Length; i++)
+                {
+                    var expectedByte = expectedFileStream.ReadByte();
+                    var actualByte = actualFileStream.ReadByte();
+                    // Only generate message if byte comparison fails
+                    if (expectedByte != actualByte)
+                    {
+                        var message =
+                            $"{contextMessage}, file contents mismatch at position {i} for {expectedFile} and {actualFile}";
+                        Assert.That(actualByte, Is.EqualTo(expectedByte), message);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -224,6 +224,9 @@ namespace Duplicati.UnitTest
                 // The byte-by-byte compare is dog-slow, so we use a fast(-er) check, and then report the first byte diff if required
                 if (!Utility.CompareStreams(expectedFileStream, actualFileStream, true))
                 {
+                    // Reset stream positions
+                    expectedFileStream.Position = 0;
+                    actualFileStream.Position = 0;
                     for (long i = 0; i < expectedFileStreamLength; i++)
                     {
                         var expectedByte = expectedFileStream.ReadByte();

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -221,16 +221,20 @@ namespace Duplicati.UnitTest
                 var actualFileStreamLength = actualFileStream.Length;
                 Assert.That(actualFileStreamLength, Is.EqualTo(expectedFileStreamLength), $"{contextMessage}, file size mismatch for {expectedFile} and {actualFile}");
                 // Compare file contents
-                for (long i = 0; i < expectedFileStreamLength; i++)
+                // The byte-by-byte compare is dog-slow, so we use a fast(-er) check, and then report the first byte diff if required
+                if (!Utility.CompareStreams(expectedFileStream, actualFileStream, true))
                 {
-                    var expectedByte = expectedFileStream.ReadByte();
-                    var actualByte = actualFileStream.ReadByte();
-                    // For performance reasons, only generate message if byte comparison fails
-                    if (expectedByte != actualByte)
+                    for (long i = 0; i < expectedFileStreamLength; i++)
                     {
-                        var message =
-                            $"{contextMessage}, file contents mismatch at position {i} for {expectedFile} and {actualFile}";
-                        Assert.That(actualByte, Is.EqualTo(expectedByte), message);
+                        var expectedByte = expectedFileStream.ReadByte();
+                        var actualByte = actualFileStream.ReadByte();
+                        // For performance reasons, only exercise Assert mechanism and generate message if byte comparison fails
+                        if (expectedByte != actualByte)
+                        {
+                            var message =
+                                $"{contextMessage}, file contents mismatch at position {i} for {expectedFile} and {actualFile}";
+                            Assert.That(actualByte, Is.EqualTo(expectedByte), message);
+                        }
                     }
                 }
             }

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -237,8 +237,14 @@ namespace Duplicati.UnitTest
             // Compare file metadata
             if (verifymetadata)
             {
-                Assert.That(SystemIO.IO_OS.GetLastWriteTimeUtc(actualFile), Is.EqualTo(SystemIO.IO_OS.GetLastWriteTimeUtc(expectedFile)), $"{contextMessage}, last write time mismatch for {expectedFile} and {actualFile}");
-                Assert.That(SystemIO.IO_OS.GetCreationTimeUtc(actualFile), Is.EqualTo(SystemIO.IO_OS.GetCreationTimeUtc(expectedFile)), $"{contextMessage}, creation time mismatch for {expectedFile} and {actualFile}");
+                Assert.That(
+                    SystemIO.IO_OS.GetLastWriteTimeUtc(actualFile),
+                    Is.EqualTo(SystemIO.IO_OS.GetLastWriteTimeUtc(expectedFile)).Within(1).Milliseconds,
+                    $"{contextMessage}, last write time mismatch for {expectedFile} and {actualFile}");
+                Assert.That(
+                    SystemIO.IO_OS.GetCreationTimeUtc(actualFile),
+                    Is.EqualTo(SystemIO.IO_OS.GetCreationTimeUtc(expectedFile)).Within(1).Milliseconds,
+                    $"{contextMessage}, creation time mismatch for {expectedFile} and {actualFile}");
             }
         }
 

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -234,8 +234,7 @@ namespace Duplicati.UnitTest
                         // For performance reasons, only exercise Assert mechanism and generate message if byte comparison fails
                         if (expectedByte != actualByte)
                         {
-                            var message =
-                                $"{contextMessage}, file contents mismatch at position {i} for {expectedFile} and {actualFile}";
+                            var message = $"{contextMessage}, file contents mismatch at position {i} for {expectedFile} and {actualFile}";
                             Assert.That(actualByte, Is.EqualTo(expectedByte), message);
                         }
                     }

--- a/pipeline/start.sh
+++ b/pipeline/start.sh
@@ -6,6 +6,6 @@ SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 ${ROOT_DIR}/pipeline/jobs/build_job.sh
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNormal
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories BulkNoSize
-${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData,RecoveryTool,ProblematicPath
+${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories SVNDataLong,SVNData,RecoveryTool,ProblematicPath,SymLink
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Border
 ${ROOT_DIR}/pipeline/jobs/unittest_job.sh --testcategories Filter,Targeted,Purge,Serialization,WebApi,Utility,UriUtility,IO,ImportExport,Disruption,RestoreHandler,RepairHandler,DeleteHandler,Controller


### PR DESCRIPTION
This adds a basic symlink policy test that performs backups using each
symlink policy.

If you don't have the required privilege in Windows, you can get an
exception trying to create a symbolic link.  If an exception is thrown
trying to create a symbolic link, the exception is trapped and the
test is marked as "Ignored"; e.g.,
```
1) Ignored : Duplicati.UnitTest.SymLinkTests.SymLinkPolicy
Client could not create a symbolic link.  Error reported: (1314) A required privilege is not held by the client. | Read: [C:\td\backup-data\target] | Write: [C:\td\backup-data\symlink]
```