### PR TITLE
Disable "legacy path handling" for executables

### DIFF
--- a/Duplicati/CommandLine/BackendTester/app.config
+++ b/Duplicati/CommandLine/BackendTester/app.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Duplicati/CommandLine/BackendTool/app.config
+++ b/Duplicati/CommandLine/BackendTool/app.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>  
   <runtime>  
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">  
             <dependentAssembly>  
                  <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />  

--- a/Duplicati/CommandLine/ConfigurationImporter/app.config
+++ b/Duplicati/CommandLine/ConfigurationImporter/app.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>  
   <runtime>  
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">  
             <dependentAssembly>  
                  <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />  

--- a/Duplicati/CommandLine/app.config
+++ b/Duplicati/CommandLine/app.config
@@ -4,6 +4,7 @@
       <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/app.config
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/app.config
@@ -2,6 +2,7 @@
 <configuration>
   <startup useLegacyV2RuntimeActivationPolicy="true"><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" /></startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Duplicati/Library/AutoUpdater/app.config
+++ b/Duplicati/Library/AutoUpdater/app.config
@@ -3,4 +3,7 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
   </startup>
+  <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
+  </runtime>
 </configuration>

--- a/Duplicati/Library/Snapshots/app.config
+++ b/Duplicati/Library/Snapshots/app.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="AlphaVSS.Common" publicKeyToken="959d3993561034e3" culture="neutral"/>

--- a/Duplicati/Server/app.config
+++ b/Duplicati/Server/app.config
@@ -2,6 +2,7 @@
 <configuration>
   <startup useLegacyV2RuntimeActivationPolicy="true"><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" /></startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Duplicati/Service/app.config
+++ b/Duplicati/Service/app.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Duplicati/WindowsService/App.config
+++ b/Duplicati/WindowsService/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
     </startup>
+  <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
+  </runtime>
 </configuration>


### PR DESCRIPTION
This is a defensive measure in case legacy path handling has been
enabled at the system level.  Duplicati requires that legacy path
handling be _disabled_ to function properly.

Issue #4295 appears to be a result of legacy path handling being
enabled globally.

This pull request changes the shipped app.config files for Duplicati EXEs to explicitly disable legacy path handling.  I did some very light testing that consisted of _enabling_ legacy path handling via the Windows registry (i.e., putting my system in a state that would trigger the exception reported in #4295), then confirming that each EXE worked at a very basic level.  Also, specifically for `Duplicati.CommandLine.exe` and `Duplicati.GUI.TrayIcon.exe`, I did confirm that without the app.config setting, both get the exception reported in #4295 with legacy path handling enabled globally, but do not get the exception with the app.config settings in this pull request.

At this point, I don't think we know if a change like this would actually fix the issue mentioned, but I thought I'd provide this in case it helps with investigating it.