### PR TITLE
Avoid null reference exception when building Sia error messages

### DIFF
--- a/Duplicati/Library/Backend/Sia/Sia.cs
+++ b/Duplicati/Library/Backend/Sia/Sia.cs
@@ -83,13 +83,13 @@ namespace Duplicati.Library.Backend.Sia
 
         private string getResponseBodyOnError(string context, System.Net.WebException wex)
         {
-            if (wex.Response is null)
+            HttpWebResponse response = wex.Response as HttpWebResponse;
+            if (response is null)
             {
                 return $"{context} failed with error: {wex.Message}";
             }
 
             string body = "";
-            System.Net.HttpWebResponse response = (System.Net.HttpWebResponse)wex.Response;
             using (System.IO.Stream data = response.GetResponseStream())
             using (var reader = new System.IO.StreamReader(data))
             {

--- a/Duplicati/Library/Backend/Sia/Sia.cs
+++ b/Duplicati/Library/Backend/Sia/Sia.cs
@@ -83,6 +83,11 @@ namespace Duplicati.Library.Backend.Sia
 
         private string getResponseBodyOnError(string context, System.Net.WebException wex)
         {
+            if (wex.Response is null)
+            {
+                return $"{context} failed with error: {wex.Message}";
+            }
+
             string body = "";
             System.Net.HttpWebResponse response = (System.Net.HttpWebResponse)wex.Response;
             using (System.IO.Stream data = response.GetResponseStream())


### PR DESCRIPTION
If the resource does not provide an error response, the `WebException.Response` property will be null.

https://docs.microsoft.com/en-us/dotnet/api/system.net.webexception.response?view=netframework-4.7.1

This fixes #4193.