### PR TITLE
Avoid clock issues when quickly running successive backups in tests

### DIFF
--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -140,6 +140,9 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(directories.Count, backupResults.ExaminedFiles);
             }
 
+            // Block for a small amount of time to avoid clock issues when quickly running successive backups.
+            System.Threading.Thread.Sleep(1000);
+
             // Backup with verbatim asterisk in include filter should include
             // one directory in Linux and zero directories in Windows.
             filter = new FilterExpression("@" + SystemIO.IO_OS.PathCombine(dirWithAsterisk, file));


### PR DESCRIPTION
This is an attempt to avoid errors like

```
"System.Exception : The previous backup has time 9/27/2020 5:25:56 PM, but this backup has time 9/27/2020 5:25:55 PM. Something is wrong with the clock."
```
We are seeing these errors often recently in AppVeyor.