### PR TITLE
Disable "legacy path handling" for executables

### DIFF
--- a/Installer/AssemblyRedirects.xml
+++ b/Installer/AssemblyRedirects.xml
@@ -1,6 +1,7 @@
 <configuration>
     <runtime>
         <loadFromRemoteSources enabled="true"/>
+        <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
 
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 


### PR DESCRIPTION
This disables legacy path handling by changing the
`AssemblyRedirects.xml` that's deployed as the app.config files in the
installation image.

Issue #4295 appears to be a result of legacy path handling being
enabled globally.