### PR TITLE
Fix check for administrator group on Synology devices

### DIFF
--- a/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
+++ b/Duplicati/Server/WebServer/SynologyAuthenticationHandler.cs
@@ -193,7 +193,11 @@ namespace Duplicati.Server.WebServer
                 var groups = GetEnvArg("SYNO_GROUP_IDS");
 
                 if (string.IsNullOrWhiteSpace(groups))
+                {
                     groups = ShellExec("id", "-G '" + username.Trim().Replace("'", "\\'") + "'", exitcode: 0).Result ?? string.Empty;
+                    groups = groups.Replace(Environment.NewLine, String.Empty);
+                }
+
                 if (!groups.Split(new char[] { ' ' }).Contains("101"))
                 {
                     response.Status = System.Net.HttpStatusCode.Forbidden;


### PR DESCRIPTION
The `id` command prints a newline character after printing the group ids.  This needs to be removed before checking for the administrator group (101).  Otherwise, if group 101 was the last group printed, it would not be matched due to the trailing newline character.
```
$ id -G 'user' | cat -e
100 101$
```

This fixes #2610.