### PR TITLE
Fix issue where remote URL defined using run-script-before was ignored

### DIFF
--- a/Duplicati/Library/Modules/Builtin/RunScript.cs
+++ b/Duplicati/Library/Modules/Builtin/RunScript.cs
@@ -153,16 +153,17 @@ namespace Duplicati.Library.Modules.Builtin
 
         public void OnStart(string operationname, ref string remoteurl, ref string[] localpath)
         {
+            if (!string.IsNullOrEmpty(m_requiredScript))
+                Execute(m_requiredScript, "BEFORE", operationname, ref remoteurl, ref localpath, m_timeout, true, m_options, null, null);
+
+            if (!string.IsNullOrEmpty(m_startScript))
+                Execute(m_startScript, "BEFORE", operationname, ref remoteurl, ref localpath, m_timeout, false, m_options, null, null);
+
+            // Save options that might be set by a --run-script-before script so that the OnFinish method
+            // references the same values.
             m_operationName = operationname;
             m_remoteurl = remoteurl;
             m_localpath = localpath;
-
-
-            if (!string.IsNullOrEmpty(m_requiredScript))
-                Execute(m_requiredScript, "BEFORE", m_operationName, ref m_remoteurl, ref m_localpath, m_timeout, true, m_options, null, null);
-
-            if (!string.IsNullOrEmpty(m_startScript))
-                Execute(m_startScript, "BEFORE", m_operationName, ref m_remoteurl, ref m_localpath, m_timeout, false, m_options, null, null);
         }
 
         public void OnFinish (object result)

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -148,12 +148,12 @@ namespace Duplicati.UnitTest
         }
 
 
-        private string CreateScript(int exitcode, string stderr = null, string stdout = null, int sleeptime = 0)
+        private string CreateScript(int exitcode, string stderr = null, string stdout = null, int sleeptime = 0, List<string> customCommands = null)
         {
             var id = Guid.NewGuid().ToString("N").Substring(0, 6);
             if (Platform.IsClientWindows)
             {
-                var commands = new List<string>();
+                var commands = customCommands ?? new List<string>();
                 if (!string.IsNullOrWhiteSpace(stdout))
                     commands.Add($@"echo {stdout}");
                 if (!string.IsNullOrWhiteSpace(stderr))
@@ -172,6 +172,11 @@ namespace Duplicati.UnitTest
             {
                 var commands = new List<string>();
                 commands.Add("#!/bin/sh");
+
+                if (customCommands != null)
+                {
+                    commands.AddRange(customCommands);
+                }
 
                 if (!string.IsNullOrWhiteSpace(stdout))
                     commands.Add($@"echo {stdout}");


### PR DESCRIPTION
Previously, we were declaring that the `RunScript.m_remoteurl` field be passed by reference to the `Execute` method.  However, the `OnStart` method declared that the local `remoteurl` variable was to be passed by reference.  As a result, the caller method (`Controller.SetupCommonOptions`) never received the updated value.

Now, the variables being passed by reference are made consistent.  This also adds a test to verify that the backend files are written to the custom destination folder.

This fixes #3651.
