### PR TITLE
Fix for Telegram backend mix backup locations when using multiple accounts

### DIFF
--- a/Duplicati/Library/Backend/Telegram/Extensions/TelegramClientExtensions.cs
+++ b/Duplicati/Library/Backend/Telegram/Extensions/TelegramClientExtensions.cs
@@ -13,7 +13,7 @@ namespace Duplicati.Library.Backend.Extensions
     {
         private static readonly BindingFlags _bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Default;
 
-        public static async Task WrapperConnectAsync(this TelegramClient client, CancellationToken cancelToken = default)
+        public static async Task WrapperConnectAsync(this TelegramClient client, CancellationToken cancelToken = default(CancellationToken))
         {
             if (client == null)
             {

--- a/Duplicati/Library/Backend/Telegram/Extensions/TelegramClientExtensions.cs
+++ b/Duplicati/Library/Backend/Telegram/Extensions/TelegramClientExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
-using System.IO;
+using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using TLSharp.Core;
 using TLSharp.Core.Network;
 
@@ -9,7 +11,32 @@ namespace Duplicati.Library.Backend.Extensions
 {
     public static class TelegramClientExtensions
     {
-        private static BindingFlags _bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Default;
+        private static readonly BindingFlags _bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Default;
+
+        public static async Task WrapperConnectAsync(this TelegramClient client, CancellationToken cancelToken = default)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var oldTransportField = client.GetTcpTransport();
+            var tcpClient = oldTransportField.GetTcpClient();
+            var handler = client.GetTcpClientConnectionHandler();
+
+            var remoteEndpoint = (IPEndPoint)tcpClient.Client.RemoteEndPoint;
+            var newTransport = new TcpTransport(remoteEndpoint.Address.ToString(), remoteEndpoint.Port, handler);
+
+            client.GetTcpTransportFieldInfo().SetValue(client, newTransport);
+
+            cancelToken.ThrowIfCancellationRequested();
+
+            await client.ConnectAsync(false, cancelToken);
+
+            cancelToken.ThrowIfCancellationRequested();
+
+            oldTransportField.Dispose();
+        }
 
         public static bool IsReallyConnected(this TelegramClient client)
         {
@@ -18,31 +45,87 @@ namespace Duplicati.Library.Backend.Extensions
                 return false;
             }
 
-            var senderFieldInfo = typeof(TelegramClient).GetField("sender", _bindingFlags);
-            var sender = (MtProtoSender)senderFieldInfo.GetValue(client);
+            var sender = GetMtProtoSender(client);
 
             if (sender == null)
             {
                 return false;
             }
 
-            var transportFieldInfo = typeof(TelegramClient).GetField("transport", _bindingFlags);
-            var transportField = (TcpTransport)transportFieldInfo.GetValue(client);
+            var tcpTransport = client.GetTcpTransport();
 
-            if (transportField == null || transportField.IsConnected == false)
+            if (tcpTransport == null || tcpTransport.IsConnected == false)
             {
                 return false;
             }
 
-            var tcpClientFieldInfo = typeof(TcpTransport).GetField("tcpClient", _bindingFlags);
-            var tcpClient = (TcpClient)tcpClientFieldInfo.GetValue(transportField);
+            var tcpClient = tcpTransport.GetTcpClient();
 
             if (tcpClient == null || tcpClient.Connected == false)
             {
                 return false;
             }
-            
+
             return true;
+        }
+
+        private static TcpClientConnectionHandler GetTcpClientConnectionHandler(this TelegramClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var handlerFieldInfo = typeof(TelegramClient).GetField("handler", _bindingFlags);
+            var handler = (TcpClientConnectionHandler)handlerFieldInfo.GetValue(client);
+
+            return handler;
+        }
+
+        private static TcpClient GetTcpClient(this TcpTransport tcpTransport)
+        {
+            if (tcpTransport == null)
+            {
+                throw new ArgumentNullException(nameof(tcpTransport));
+            }
+
+            var tcpClientFieldInfo = typeof(TcpTransport).GetField("tcpClient", _bindingFlags);
+            var tcpClient = (TcpClient)tcpClientFieldInfo.GetValue(tcpTransport);
+
+            return tcpClient;
+        }
+
+        private static FieldInfo GetTcpTransportFieldInfo(this TelegramClient client)
+        {
+            var transportFieldInfo = typeof(TelegramClient).GetField("transport", _bindingFlags);
+
+            return transportFieldInfo;
+        }
+
+        private static TcpTransport GetTcpTransport(this TelegramClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var transportFieldInfo = client.GetTcpTransportFieldInfo();
+            var oldTransportField = (TcpTransport)transportFieldInfo.GetValue(client);
+
+            return oldTransportField;
+        }
+
+        private static MtProtoSender GetMtProtoSender(this TelegramClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            var senderFieldInfo = typeof(TelegramClient).GetField("sender", _bindingFlags);
+            var sender = (MtProtoSender)senderFieldInfo.GetValue(client);
+
+            return sender;
         }
     }
 }


### PR DESCRIPTION
Telegram backend was using the account which was instantiated the first and it was using it for auth and the backup.