### PR TITLE
Improve some notification messages

### DIFF
--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -795,13 +795,24 @@ namespace Duplicati.Server
 
                 if (r.FilesWithError > 0 || r.Warnings.Any() || r.Errors.Any())
                 {
+                    string message;
+                    if (r.FilesWithError > 0)
+                    {
+                        message = $"Errors affected {r.FilesWithError} file(s).";
+                    }
+                    else if (r.Errors.Any())
+                    {
+                        message = r.Errors.Count() == 1 ? r.Errors.Single() : $"Encountered {r.Errors.Count()} errors.";
+                    }
+                    else
+                    {
+                        message = r.Warnings.Count() == 1 ? r.Warnings.Single() : $"Encountered {r.Warnings.Count()} warnings.";
+                    }
+
                     Program.DataConnection.RegisterNotification(
                         r.FilesWithError == 0 && !r.Errors.Any() ? NotificationType.Warning : NotificationType.Error,
                         backup.IsTemporary ? "Warning" : string.Format("Warning while running {0}", backup.Name),
-                        r.FilesWithError > 0 ? string.Format("Errors affected {0} file(s) ", r.FilesWithError) :
-                                (
-                                    r.Errors.Any() ? string.Format("Got {0} error(s)", r.Errors.Count()) : string.Format("Got {0} warning(s)", r.Warnings.Count())
-                                ),
+                        message,
                         null,
                         backup.ID,
                         "backup:show-log",

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -796,16 +796,12 @@ namespace Duplicati.Server
                 if (r.FilesWithError > 0 || r.Warnings.Any() || r.Errors.Any())
                 {
                     Program.DataConnection.RegisterNotification(
-                         r.FilesWithError == 0 && !r.Errors.Any() ? NotificationType.Warning : NotificationType.Error,
-                        backup.IsTemporary ?
-                            "Warning" : string.Format("Warning while running {0}", backup.Name),
-                            r.FilesWithError > 0 ?
-                                string.Format("Errors affected {0} file(s) ", r.FilesWithError) :
-                                (r.Errors.Any() ?
-                                 string.Format("Got {0} error(s)", r.Errors.Count()) :
-                                 string.Format("Got {0} warning(s)", r.Warnings.Count())
-                                )
-                            ,
+                        r.FilesWithError == 0 && !r.Errors.Any() ? NotificationType.Warning : NotificationType.Error,
+                        backup.IsTemporary ? "Warning" : string.Format("Warning while running {0}", backup.Name),
+                        r.FilesWithError > 0 ? string.Format("Errors affected {0} file(s) ", r.FilesWithError) :
+                                (
+                                    r.Errors.Any() ? string.Format("Got {0} error(s)", r.Errors.Count()) : string.Format("Got {0} warning(s)", r.Warnings.Count())
+                                ),
                         null,
                         backup.ID,
                         "backup:show-log",

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -796,22 +796,26 @@ namespace Duplicati.Server
                 if (r.FilesWithError > 0 || r.Warnings.Any() || r.Errors.Any())
                 {
                     string message;
+                    string titleType;
                     if (r.FilesWithError > 0)
                     {
                         message = $"Errors affected {r.FilesWithError} file(s).";
+                        titleType = "Error";
                     }
                     else if (r.Errors.Any())
                     {
                         message = r.Errors.Count() == 1 ? r.Errors.Single() : $"Encountered {r.Errors.Count()} errors.";
+                        titleType = "Error";
                     }
                     else
                     {
                         message = r.Warnings.Count() == 1 ? r.Warnings.Single() : $"Encountered {r.Warnings.Count()} warnings.";
+                        titleType = "Warning";
                     }
 
                     Program.DataConnection.RegisterNotification(
                         r.FilesWithError == 0 && !r.Errors.Any() ? NotificationType.Warning : NotificationType.Error,
-                        backup.IsTemporary ? "Warning" : string.Format("Warning while running {0}", backup.Name),
+                        backup.IsTemporary ? "Warning" : $"{titleType} while running {backup.Name}",
                         message,
                         null,
                         backup.ID,


### PR DESCRIPTION
This improves some of the warning and error notification messages shown to the user.  If there is a just a single warning or error, the details are now presented to the user.

For example, when the user interrupts a backup they would previously see:

![image](https://user-images.githubusercontent.com/17345532/99200071-1baf2300-2758-11eb-89f7-102aa9b014d4.png)

Now, they will see:

![image](https://user-images.githubusercontent.com/17345532/99200119-4d27ee80-2758-11eb-920e-ccc8baccb3ac.png)

While some may find this a little too verbose, it can save the user from having to go to the logs to find out more about what happened.