### PR TITLE
Fix error encountered during dry-run of purge-broken-files

### DIFF
--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -85,6 +85,11 @@ namespace Duplicati.Library.Main.Operation
                         SetCount = db.GetFilesetFileCount(x.Item2, tr)
                     }).ToArray();
 
+                    if (m_options.Dryrun)
+                        tr.Rollback();
+                    else
+                        tr.Commit();
+
                     var fully_emptied = compare_list.Where(x => x.RemoveCount == x.SetCount).ToArray();
                     var to_purge = compare_list.Where(x => x.RemoveCount != x.SetCount).ToArray();
 
@@ -166,11 +171,6 @@ namespace Duplicati.Library.Main.Operation
                         }
                     }
                 }
-
-                if (m_options.Dryrun)
-                    tr.Rollback();
-                else
-                    tr.Commit();
 
                 m_result.OperationProgressUpdater.UpdateProgress(0.95f);
 


### PR DESCRIPTION
This is an attempt to avoid an error that is encountered during a dry-run of `purge-broken-files`.

The `PurgeFilesHandler` begins new transactions using the same database connection as the `PurgeBrokenFilesHandler`.  During a  dry-run, these transactions are rolled back, and a subsequent attempt to rollback in the `PurgeBrokenFilesHandler` then resulted in an exception.  To avoid this, we perform the rollback in the `PurgeBrokenFilesHandler` as soon as we can, before new transactions are created and rolled back.

This also adds a situation to the `PurgeBrokenFilesTest` test to illustrate the issue described in issue #4379. 

This fixes #4379.
