### PR TITLE
Remove newline characters from HTML strings to fix some translations

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/localdatabase.html
+++ b/Duplicati/Server/webroot/ngax/templates/localdatabase.html
@@ -5,12 +5,12 @@
     </h1>
 
     <div>
-        {{'Each backup has a local database associated with it, which stores information about the remote backup on the local machine.\nThis makes it faster to perform many operations, and reduces the amount of data that needs to be downloaded for each operation.' | translate}}
+        {{'Each backup has a local database associated with it, which stores information about the remote backup on the local machine.  This makes it faster to perform many operations, and reduces the amount of data that needs to be downloaded for each operation.' | translate}}
     </div>
 
     <h2 translate>Maintenance</h2>
     <div>
-        {{'If the backup and the remote storage is out of sync, Duplicati will require that you perform a repair operation to synchronize the database.\nIf the repair is unsuccesful, you can delete the local database and re-generate.' | translate}}
+        {{'If the backup and the remote storage is out of sync, Duplicati will require that you perform a repair operation to synchronize the database.  If the repair is unsuccesful, you can delete the local database and re-generate.' | translate}}
     </div>
     <div>&nbsp;</div>
 


### PR DESCRIPTION
These don't get interpreted as line breaks, and the resulting characters get converted to `\\n` in the `localization_webroot.pot` translation source file, which prevents translation of these strings.

This concerns this [comment](https://github.com/duplicati/duplicati/issues/2209#issuecomment-590856779) in issue #2209, where the extra backslash was preventing some strings from being translated.
