### PR TITLE
Always exclude job-specific database files from backup

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/Backup/CountFilesHandler.cs
@@ -27,14 +27,14 @@ namespace Duplicati.Library.Main.Operation.Backup
 {
     internal static class CountFilesHandler
     {
-        public static async Task Run(IEnumerable<string> sources, Snapshots.ISnapshotService snapshot, UsnJournalService journalService, BackupResults result, Options options, IFilter sourcefilter, IFilter filter, Common.ITaskReader taskreader, System.Threading.CancellationToken token)
+        public static async Task Run(IEnumerable<string> sources, Snapshots.ISnapshotService snapshot, UsnJournalService journalService, BackupResults result, Options options, IFilter sourcefilter, IFilter filter, ISet<string> forbiddenPaths, Common.ITaskReader taskreader, System.Threading.CancellationToken token)
         {
             // Make sure we create the enumeration process in a separate scope,
             // but keep the log channel from the parent scope
             using(Logging.Log.StartIsolatingScope(true))
             using (new IsolatedChannelScope())
             {
-                var enumeratorTask = Backup.FileEnumerationProcess.Run(sources, snapshot, journalService, options.FileAttributeFilter, sourcefilter, filter, options.SymlinkPolicy, options.HardlinkPolicy, options.ExcludeEmptyFolders, options.IgnoreFilenames, options.ChangedFilelist, taskreader, token);
+                var enumeratorTask = Backup.FileEnumerationProcess.Run(sources, snapshot, journalService, options.FileAttributeFilter, sourcefilter, filter, options.SymlinkPolicy, options.HardlinkPolicy, options.ExcludeEmptyFolders, options.IgnoreFilenames, options.ChangedFilelist, forbiddenPaths, taskreader, token);
                 var counterTask = AutomationExtensions.RunTask(new
                 {
                     Input = Backup.Channels.SourcePaths.ForRead

--- a/Duplicati/Library/Main/Operation/TestFilterHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestFilterHandler.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Threading;
 using Duplicati.Library.Snapshots;
 using CoCoL;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -51,7 +52,7 @@ namespace Duplicati.Library.Main.Operation
                 var source = Operation.Backup.FileEnumerationProcess.Run(sources, snapshot, null,
                     m_options.FileAttributeFilter, sourcefilter, filter, m_options.SymlinkPolicy,
                     m_options.HardlinkPolicy, m_options.ExcludeEmptyFolders, m_options.IgnoreFilenames, null,
-                    m_result.TaskReader, token);
+                    FilterGroups.CreateForbiddenPaths(m_options.Dbpath), m_result.TaskReader, token);
 
                 var sink = CoCoL.AutomationExtensions.RunTask(
                     new { source = Operation.Backup.Channels.SourcePaths.ForRead },

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -307,6 +307,23 @@ namespace Duplicati.Library.Utility
             }
         }
 
+        public static HashSet<string> CreateForbiddenPaths(string databasePath)
+        {
+            return new HashSet<string>(FilterGroups.CreateSQLiteDatabaseFilters(databasePath));
+        }
+
+        public static IEnumerable<string> CreateSQLiteDatabaseFilters(string databasePath)
+        {
+            // These paths were gathered from https://sqlite.org/tempfiles.html.
+            return new List<string>
+            {
+                databasePath, // Database
+                $"{databasePath}-journal", // Rollback journals
+                $"{databasePath}-wal", // Write-ahead Log (WAL) files
+                $"{databasePath}-shm", // Shared-memory files
+            };
+        }
+
         /// <summary>
         /// Creates Windows filters
         /// </summary>


### PR DESCRIPTION
This excludes job-specific SQLite files from the backup.  There is no benefit to backing these up, and if the database needs to restored, it should be recreated from the backend files to ensure consistency.

The files being excluded are:

* The job-specific database file (`<database>`)
* The database rollback journals (`<database>-journal`)
* Write-ahead Log (WAL) files (`<database>-wal`)
* Shared-memory files (`<database>-shm`)

According to the [documentation](https://www.sqlite.org/draft/atomiccommit.html#_the_super_journal_file), the super journal file does not have a naming convention that is part of the specification.  As such, we do not exclude it:

> The next step in a multi-file commit is the creation of a "super-journal" file. The name of the super-journal file is the same name as the original database filename (the database that was opened using the sqlite3_open() interface, not one of the ATTACHed auxiliary databases) with the text "-mjHHHHHHHH" appended where HHHHHHHH is a random 32-bit hexadecimal number. The random HHHHHHHH suffix changes for every new super-journal.
> 
> (Nota bene: The formula for computing the super-journal filename given in the previous paragraph corresponds to the implementation as of SQLite version 3.5.0. But this formula is not part of the SQLite specification and is subject to change in future releases.)

We cannot use filters to unconditionally exclude these files, as there exists code paths where filters containing both includes and excludes have a tendency to include unmatched paths, which is probably the safer thing to do if a path is not matched by any (include or exclude) filter.

This fixes #1797 and #4308.
