### PR TITLE
Fix bug in repairing multiple missing blocklist hashes

### DIFF
--- a/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
@@ -342,7 +342,6 @@ namespace Duplicati.Library.Main.Database
             var blockhasher = Library.Utility.HashAlgorithmHelper.Create(blockhashalgorithm);
             var hashsize = blockhasher.HashSize / 8;
             var blocklistbuffer = new byte[blocksize];
-            int blocklistoffset = 0;
 
             blockhasher.Initialize();
 
@@ -371,6 +370,7 @@ namespace Duplicati.Library.Main.Database
                         {
                             var blocksetid = e.ConvertValueToInt64(0);
                             var ix = 0L;
+                            int blocklistoffset = 0;
 
                             c2.ExecuteNonQuery(@"DELETE FROM ""BlocklistHash"" WHERE ""BlocksetID"" = ?", blocksetid);
 

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -40,6 +40,7 @@
       <HintPath>..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Web" />

--- a/Duplicati/UnitTest/RepairHandlerTests.cs
+++ b/Duplicati/UnitTest/RepairHandlerTests.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
+using Duplicati.Library.Main.Database;
+using Duplicati.Library.SQLiteHelper;
 using NUnit.Framework;
 
 namespace Duplicati.UnitTest
@@ -14,6 +18,97 @@ namespace Duplicati.UnitTest
         {
             base.SetUp();
             File.WriteAllBytes(Path.Combine(this.DATAFOLDER, "file"), new byte[] {0});
+        }
+
+        [Test]
+        [Category("RepairHandler")]
+        public void RepairMissingBlocklistHashes()
+        {
+            byte[] data = new byte[150 * 1024];
+            Random rng = new Random();
+            for (int k = 0; k < 2; k++)
+            {
+                rng.NextBytes(data);
+                File.WriteAllBytes(Path.Combine(this.DATAFOLDER, $"{k}"), data);
+            }
+
+            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions);
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] {this.DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Mimic a damaged database that needs to be repaired.
+            const string selectStatement = @"SELECT BlocksetID, ""Index"", Hash FROM BlocklistHash ORDER BY Hash ASC";
+            List<int> expectedBlocksetIDs = new List<int>();
+            List<int> expectedIndexes = new List<int>();
+            List<string> expectedHashes = new List<string>();
+            using (IDbConnection connection = SQLiteLoader.LoadConnection(options["dbpath"]))
+            {
+                // Read the contents of the BlocklistHash table so that we can
+                // compare them to the contents after the repair operation.
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    using (IDataReader reader = command.ExecuteReader(selectStatement))
+                    {
+                        while (reader.Read())
+                        {
+                            expectedBlocksetIDs.Add(reader.GetInt32(0));
+                            expectedIndexes.Add(reader.GetInt32(1));
+                            expectedHashes.Add(reader.GetString(2));
+                        }
+                    }
+                }
+
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    command.ExecuteNonQuery(@"DELETE FROM BlocklistHash");
+                    using (IDataReader reader = command.ExecuteReader(selectStatement))
+                    {
+                        Assert.IsFalse(reader.Read());
+                    }
+                }
+            }
+
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
+            }
+
+            List<int> repairedBlocksetIDs = new List<int>();
+            List<int> repairedIndexes = new List<int>();
+            List<string> repairedHashes = new List<string>();
+            using (IDbConnection connection = SQLiteLoader.LoadConnection(options["dbpath"]))
+            {
+                using (IDbCommand command = connection.CreateCommand())
+                {
+                    using (IDataReader reader = command.ExecuteReader(selectStatement))
+                    {
+                        while (reader.Read())
+                        {
+                            repairedBlocksetIDs.Add(reader.GetInt32(0));
+                            repairedIndexes.Add(reader.GetInt32(1));
+                            repairedHashes.Add(reader.GetString(2));
+                        }
+                    }
+                }
+            }
+
+            CollectionAssert.AreEqual(expectedBlocksetIDs, repairedBlocksetIDs);
+            CollectionAssert.AreEqual(expectedIndexes, repairedIndexes);
+            CollectionAssert.AreEqual(expectedHashes, repairedHashes);
+
+            // A subsequent backup should run without errors.
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] {this.DATAFOLDER});
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
         }
 
         [Test]


### PR DESCRIPTION
This fixes a bug where an attempt to repair a database with multiple missing blocklist hashes would fail.  If there is more than one missing blocklist hash, we must reset the offset index before copying hashes from the next blocklist into the buffer.

This also adds a test that would fail without this fix.

This fixes #4397.

Thanks to @ts678 for the detailed bug report and suggested fix.
