### PR TITLE
Avoid NullReferenceException if an IAsyncResult or WebRequest doesn't contain a WebResponse property

### DIFF
--- a/Duplicati/Library/Utility/AsyncHttpRequest.cs
+++ b/Duplicati/Library/Utility/AsyncHttpRequest.cs
@@ -230,11 +230,11 @@ namespace Duplicati.Library.Utility
                         {
                             WebResponse resp = null;
 
-                            try { resp = (WebResponse)r.GetType().GetProperty("Response", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(r); }
+                            try { resp = r.GetType().GetProperty("Response", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)?.GetValue(r) as WebResponse; }
                             catch {}
 
                             if (resp == null)
-                                try { resp = (WebResponse)m_owner.m_request.GetType().GetField("webResponse", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(m_owner.m_request); }
+                                try { resp = m_owner.m_request.GetType().GetField("webResponse", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)?.GetValue(m_owner.m_request) as WebResponse; }
                                 catch { }
 
                             if (resp != null)


### PR DESCRIPTION
An example of when this happens is when shutting down TrayIcon (using its context menu), at least on Windows. This is quite annoying when debugging with Visual Studio (having the default exception settings).