### PR TITLE
Enable BulkData tests in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ test_script:
             .\packages\OpenCover.4.7.922\tools\OpenCover.Console.exe `
             -register:user `
             -target:.\packages\NUnit.ConsoleRunner.3.10.0\tools\nunit3-console.exe `
-            "-targetargs:""$elem"" /where:cat!=BulkData /result:""$testResultsFile""" `
+            "-targetargs:""$elem"" /result:""$testResultsFile""" `
             "-filter:+[Duplicati.Library.Main]* -[UnitTest]*" `
             -output:opencover.xml `
             -returntargetcode `


### PR DESCRIPTION
These were originally skipped to avoid running into AppVeyor's time limit restriction of 60 minutes.  At some point the time limit was no longer a concern to us, but the existence of long paths in the test data prevented these tests from running successfully on Windows.  Support for long paths was added in pull requests #4256 and #4270.  The host for the test data was changed in pull request #4352 to reduce S3 transfer charges, which hopefully means that we can now run the tests in AppVeyor without much worry.

This concerns issue #3863.