### PR TITLE
Add $XDG_CACHE_HOME to Linux CacheFiles filter

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -547,7 +547,7 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"/sbin/");
                 yield return FilterGroups.CreateWildcardFilter(@"/var/");
             }
-                
+
             if (group.HasFlag(FilterGroup.TemporaryFiles))
             {
                 yield return FilterGroups.CreateWildcardFilter(@"*/lost+found/");
@@ -556,6 +556,11 @@ namespace Duplicati.Library.Utility
             }
             if (group.HasFlag(FilterGroup.CacheFiles))
             {
+                string cacheHome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+                if (cacheHome != null)
+                {
+                    yield return FilterGroups.CreateWildcardFilter(cacheHome);
+                }
                 yield return FilterGroups.CreateWildcardFilter(@"*/.cache/");
                 yield return FilterGroups.CreateWildcardFilter(@"*/.config/google-chrome/Default/Cookies");
                 yield return FilterGroups.CreateWildcardFilter(@"*/.config/google-chrome/Default/Cookies-journal");


### PR DESCRIPTION
This adds the path specified by the `XDG_CACHE_HOME` environment variable to the Linux `CacheFiles` filter.  This variable is used to specify a custom cache directory, and is referenced by many applications (e.g., Chromium).

> $XDG_CACHE_HOME defines the base directory relative to which user specific non-essential data files should be stored. If $XDG_CACHE_HOME is either not set or empty, a default equal to $HOME/.cache should be used.


https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

This fixes #3633.