### PR TITLE
Fix unwanted password manager autofill

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -56,11 +56,11 @@
 
                     <div class="input password" ng-hide="checkGpgAsymmetric() || (Options['encryption-module'] || '').length == 0">
                         <label for="passphrase" translate>Passphrase</label>
-                        <input type="{{ShowPassphrase ? 'text' : 'password'}}" name="passphrase" id="passphrase" ng-model="Options['passphrase']" />
+                        <input autocomplete="new-password" type="{{ShowPassphrase ? 'text' : 'password'}}" name="passphrase" id="passphrase" ng-model="Options['passphrase']" />
                     </div>
                     <div class="input password" ng-hide="checkGpgAsymmetric() || (Options['encryption-module'] || '').length == 0">
                         <label for="repeat-passphrase" translate>Repeat Passphrase</label>
-                        <input type="{{ShowPassphrase ? 'text' : 'password'}}" name="repeat-passphrase" id="repeat-passphrase" ng-model="RepeatPasshrase"/>
+                        <input autocomplete="new-password" type="{{ShowPassphrase ? 'text' : 'password'}}" name="repeat-passphrase" id="repeat-passphrase" ng-model="RepeatPasshrase"/>
 
                         <div class="tools">
                             <ul>

--- a/Duplicati/Server/webroot/ngax/templates/backends/azure.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/azure.html
@@ -9,5 +9,5 @@
 </div>
 <div class="input password">
     <label for="azure_password" translate>Access Key</label>
-    <input type="password" name="azure_password" id="azure_password" ng-model="$parent.Password" placeholder="{{'Enter access key' | translate}}" />
+    <input autocomplete="new-password" type="password" name="azure_password" id="azure_password" ng-model="$parent.Password" placeholder="{{'Enter access key' | translate}}" />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/b2.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/b2.html
@@ -14,5 +14,5 @@
 </div>
 <div class="input password">
     <label for="b2_password" translate>B2 Application Key</label>
-    <input type="password" name="b2_password" id="b2_password" ng-model="$parent.Password" placeholder="{{'B2 Cloud Storage Application Key' | translate}}" />
+    <input autocomplete="new-password" type="password" name="b2_password" id="b2_password" ng-model="$parent.Password" placeholder="{{'B2 Cloud Storage Application Key' | translate}}" />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/cos.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/cos.html
@@ -12,7 +12,7 @@
 
 <div class="input password">
     <label for="cos_secret_key" translate>COS Secret Key</label>
-    <input type="password" name="cos_secret_key" id="cos_secret_key" ng-model="$parent.cos_secret_key"
+    <input autocomplete="new-password" type="password" name="cos_secret_key" id="cos_secret_key" ng-model="$parent.cos_secret_key"
            placeholder="{{'Cloud API Secret Key' | translate}}"/>
 </div>
 

--- a/Duplicati/Server/webroot/ngax/templates/backends/file.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/file.html
@@ -31,5 +31,5 @@
 </div>
 <div class="input password">
     <label for="file_password" translate>Password</label>
-    <input type="password" name="file_password" id="file_password" ng-model="$parent.Password" placeholder="{{'Optional authentication password' | translate}}"  />
+    <input autocomplete="new-password" type="password" name="file_password" id="file_password" ng-model="$parent.Password" placeholder="{{'Optional authentication password' | translate}}"  />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/generic.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/generic.html
@@ -20,5 +20,5 @@
 </div>
 <div class="input password">
     <label for="generic_password" translate>Password</label>
-    <input type="password" name="generic_password" id="generic_password" ng-model="$parent.Password" placeholder="{{'Authentication password' | translate}}"  />
+    <input autocomplete="new-password" type="password" name="generic_password" id="generic_password" ng-model="$parent.Password" placeholder="{{'Authentication password' | translate}}"  />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/jottacloud.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/jottacloud.html
@@ -9,5 +9,5 @@
 </div>
 <div class="input password">
     <label for="jottacloud_password" translate>Password</label>
-    <input type="password" name="jottacloud_password" id="jottacloud_password" ng-model="$parent.Password" placeholder="{{'Password' | translate}}" />
+    <input autocomplete="new-password" type="password" name="jottacloud_password" id="jottacloud_password" ng-model="$parent.Password" placeholder="{{'Password' | translate}}" />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/mega.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/mega.html
@@ -9,5 +9,5 @@
 </div>
 <div class="input password">
     <label for="mega_password" translate>Password</label>
-    <input type="password" name="mega_password" id="mega_password" ng-model="$parent.Password" placeholder="{{'Password' | translate}}" />
+    <input autocomplete="new-password" type="password" name="mega_password" id="mega_password" ng-model="$parent.Password" placeholder="{{'Password' | translate}}" />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/openstack.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/openstack.html
@@ -32,7 +32,7 @@
 </div>
 <div class="input password">
     <label for="openstack_password" translate>Password</label>
-    <input type="password" name="openstack_password" id="openstack_password" ng-model="$parent.Password" placeholder="{{'Authentication password' | translate}}"  />
+    <input autocomplete="new-password" type="password" name="openstack_password" id="openstack_password" ng-model="$parent.Password" placeholder="{{'Authentication password' | translate}}"  />
 </div>
 
 <div class="input text">

--- a/Duplicati/Server/webroot/ngax/templates/backends/s3.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/s3.html
@@ -70,7 +70,7 @@
 </div>
 <div class="input password">
     <label for="s3_password" translate>AWS Access Key</label>
-    <input type="password" name="s3_password" id="s3_password" ng-model="$parent.Password"
+    <input autocomplete="new-password" type="password" name="s3_password" id="s3_password" ng-model="$parent.Password"
            placeholder="{{'AWS Access Key' | translate}}"/>
 </div>
 

--- a/Duplicati/Server/webroot/ngax/templates/backends/sia.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/sia.html
@@ -8,7 +8,7 @@
 </div>
 <div class="input password">
     <label for="sia_password" translate>Server password</label>
-    <input type="password" name="sia_password" id="sia_password" ng-model="$parent.sia_password" placeholder="{{'Sia server password' | translate}}" />
+    <input autocomplete="new-password" type="password" name="sia_password" id="sia_password" ng-model="$parent.sia_password" placeholder="{{'Sia server password' | translate}}" />
 </div>
 <div class="input text">
     <label for="sia_redundancy" translate>Minimum redundancy</label>

--- a/Duplicati/Server/webroot/ngax/templates/backends/tardigrade.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/tardigrade.html
@@ -23,7 +23,7 @@
 </div>
 <div class="input password" ng-show="$parent.tardigrade_auth_method == 'API key'">
     <label for="tardigrade_secret" translate>Encryption passphrase</label>
-    <input type="password" name="tardigrade_secret" id="tardigrade_secret" ng-model="$parent.tardigrade_secret" placeholder="{{'The encryption passphrase' | translate}}" />
+    <input autocomplete="new-password" type="password" name="tardigrade_secret" id="tardigrade_secret" ng-model="$parent.tardigrade_secret" placeholder="{{'The encryption passphrase' | translate}}" />
 </div>
 <div class="input text" ng-show="$parent.tardigrade_auth_method == 'Access grant'">
     <label for="tardigrade_shared_access" translate>Access grant</label>

--- a/Duplicati/Server/webroot/ngax/templates/backends/telegram.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/telegram.html
@@ -20,5 +20,5 @@
 </div>
 <div class="input password">
     <label for="auth_password" translate>The 2FA password</label>
-    <input type="password" name="auth_password" id="auth_password" ng-model="$parent.auth_password" />
+    <input autocomplete="new-password" type="password" name="auth_password" id="auth_password" ng-model="$parent.auth_password" />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/restore.html
+++ b/Duplicati/Server/webroot/ngax/templates/restore.html
@@ -134,7 +134,7 @@
                     or, in case of GPG encryption, leave blank to let gpg retrieve the passphrase by
                     invoking your system's keychain.
                 </p>
-                <input type="password" name="restore_path" id="passphrase" ng-model="passphrase"
+                <input autocomplete="new-password" type="password" name="restore_path" id="passphrase" ng-model="passphrase"
                 placeholder="{{'Type passphrase here.' | translate}}" />
             </div>
 


### PR DESCRIPTION
This attempts to fix an issue where users get this error when restoring:

`Failed to decrypt data (invalid passphrase?): Invalid password or corrupted data`

The root problem seems to be the password manager autofilling the (normally, always?) hidden encryption passphrase field when restoring using the web UI.

This change provides a hint to password managers that they should **not** autofill this field.

Reference:
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#Preventing_autofilling_with_autocompletenew-password

Supported by all modern browsers:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Browser_compatibility

I have tested this using built in password managers for Edge, Chrome, and Firefox and it resolves the issue.

Note - to fully resolve https://github.com/duplicati/duplicati/issues/4102 ~~we may need to add this fix/workaround to other html files.  Needs more research.  In the meantime I wanted to submit this partial fix for the most common issue we see on the forum.~~  With the third commit issue 4102 should be fully resolved.