### PR TITLE
Update SSH.NET to version 2020.0.1

### DIFF
--- a/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
+++ b/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
@@ -36,8 +36,9 @@
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Renci.SshNet, Version=2016.1.0.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\SSH.NET.2016.1.0\lib\net40\Renci.SshNet.dll</HintPath>
+    <Reference Include="Renci.SshNet, Version=2020.0.0.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106">
+      <HintPath>..\..\..\..\packages\SSH.NET.2020.0.0\lib\net40\Renci.SshNet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
+++ b/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
@@ -36,8 +36,8 @@
     <AssemblyOriginatorKeyFile>Duplicati.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Renci.SshNet, Version=2020.0.0.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106">
-      <HintPath>..\..\..\..\packages\SSH.NET.2020.0.0\lib\net40\Renci.SshNet.dll</HintPath>
+    <Reference Include="Renci.SshNet, Version=2020.0.1.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106">
+      <HintPath>..\..\..\..\packages\SSH.NET.2020.0.1\lib\net40\Renci.SshNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Duplicati/Library/Backend/SSHv2/packages.config
+++ b/Duplicati/Library/Backend/SSHv2/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SSH.NET" version="2020.0.0" targetFramework="net471" />
+  <package id="SSH.NET" version="2020.0.1" targetFramework="net471" />
 </packages>

--- a/Duplicati/Library/Backend/SSHv2/packages.config
+++ b/Duplicati/Library/Backend/SSHv2/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SSH.NET" version="2016.1.0" targetFramework="net471" />
+  <package id="SSH.NET" version="2020.0.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
This updates our version of SSH.NET to [version 2020.0.1](https://github.com/sshnet/SSH.NET/releases/tag/2020.0.1).

This includes support for additional key exchange algorithms, host key algorithms, and private key formats.

A few things to note:
* ECDSA keys are only supported in OpenSSL PEM format.  `ecdsa-sha2-nistp521` keys are [not supported yet](https://github.com/sshnet/SSH.NET/issues/728).
* Newer versions of OpenSSH create private keys enciphered with aes256-ctr, which [isn't supported yet](https://github.com/sshnet/SSH.NET/issues/742).
* **The host key algorithm selection has changed**, and stronger keys are likely to be preferred now<sup>[1]</sup>.  This means that the host key fingerprint presented by the server may be different than previously expected, and client configurations may have to be updated accordingly.  **This can be disruptive.**
    * <sup>[1]</sup> There are also some nuanced issues with how the algorithm is selected:
        * https://github.com/sshnet/SSH.NET/issues/719
        * https://mattjameschampion.com/2020/08/24/changing-host-key-algorithm-in-ssh-net/


This fixes #2808, #2950, #3360, #4378, and #4413.