### PR TITLE
Add test for run-script-after option

### DIFF
--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -42,7 +42,7 @@ namespace Duplicati.UnitTest
             string expectedFile = Path.Combine(this.RESTOREFOLDER, "hello.txt");
             List<string> customCommands = new List<string>
             {
-                $"echo {expectedMessage} > \"{expectedFile}\""
+                $"echo {expectedMessage}>\"{expectedFile}\""
             };
 
             Dictionary<string, string> options = this.TestOptions;

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -42,7 +42,7 @@ namespace Duplicati.UnitTest
             string expectedFile = Path.Combine(this.RESTOREFOLDER, "hello.txt");
             List<string> customCommands = new List<string>
             {
-                $"echo \"{expectedMessage}\" > \"{expectedFile}\""
+                $"echo {expectedMessage} > \"{expectedFile}\""
             };
 
             Dictionary<string, string> options = this.TestOptions;


### PR DESCRIPTION
This adds a simple test for the `run-script-after` option, where a script that writes a message to a file is run with various exit codes.