### PR TITLE
Fix UI integration tests

### DIFF
--- a/guiTests/guiTest.py
+++ b/guiTests/guiTest.py
@@ -35,7 +35,6 @@ else:
     options = Options()
     options.set_headless(headless=True)
     driver = webdriver.Firefox(profile, firefox_options=options)
-    driver.maximize_window()
 
 
 def write_random_file(size, filename):
@@ -90,6 +89,7 @@ DIRECT_RESTORE_FOLDER = os.path.abspath("duplicati_gui_test_direct_restore")
 time.sleep(5)
 
 driver.implicitly_wait(10)
+driver.maximize_window()
 driver.get("http://localhost:8200/ngax/index.html")
 
 if "Duplicati" not in driver.title:

--- a/guiTests/guiTest.py
+++ b/guiTests/guiTest.py
@@ -12,7 +12,7 @@ from selenium.webdriver.firefox.options import Options
 
 if "TRAVIS_BUILD_NUMBER" in os.environ:
     if "SAUCE_USERNAME" not in os.environ:
-        print "No sauce labs login credentials found. Stopping tests..."
+        print("No sauce labs login credentials found. Stopping tests...")
         sys.exit(0)
 
     capabilities = {'browserName': "firefox"}
@@ -29,7 +29,7 @@ if "TRAVIS_BUILD_NUMBER" in os.environ:
     driver = webdriver.Remote(command_executor="http://%s/wd/hub" % hub_url, desired_capabilities=capabilities)
 else:
     # local
-    print "Using LOCAL webdriver"
+    print("Using LOCAL webdriver")
     profile = webdriver.FirefoxProfile()
     profile.set_preference("intl.accept_languages", "en")
     options = Options()
@@ -198,9 +198,9 @@ wait_for_text(60, "//form[@id='restore']/div[3]/h3/div[1]", "Your files and fold
 # hash direct restore files
 sha1_direct_restore = sha1_folder(DIRECT_RESTORE_FOLDER)
 
-print "Source hashes: " + str(sha1_source)
-print "Restore hashes: " + str(sha1_restore)
-print "Direct Restore hashes: " + str(sha1_direct_restore)
+print("Source hashes: " + str(sha1_source))
+print("Restore hashes: " + str(sha1_restore))
+print("Direct Restore hashes: " + str(sha1_direct_restore))
 
 # Tell Sauce Labs to stop the test
 driver.quit()

--- a/pipeline/stage_integrationtests/job.sh
+++ b/pipeline/stage_integrationtests/job.sh
@@ -2,15 +2,6 @@
 . /pipeline/docker-run/markers.sh
 . /pipeline/shared/duplicati.sh
 
-# The version of mono available within the selenium docker image is too old so
-# we will install the latest version.
-function update_mono () {
-	sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-	echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-	sudo apt update
-	sudo apt install -y mono-complete
-}
-
 function start_test () {
     pip3 install selenium
     pip3 install --upgrade urllib3
@@ -27,6 +18,5 @@ function start_test () {
 }
 
 travis_mark_begin "INTEGRATION TESTING"
-update_mono
 start_test
 travis_mark_end "INTEGRATION TESTING"

--- a/pipeline/stage_integrationtests/job.sh
+++ b/pipeline/stage_integrationtests/job.sh
@@ -12,8 +12,8 @@ function update_mono () {
 }
 
 function start_test () {
-    pip install selenium
-    pip install --upgrade urllib3
+    pip3 install selenium
+    pip3 install --upgrade urllib3
 
     # wget "https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux32.tar.gz"
     # tar -xvzf geckodriver*

--- a/pipeline/stage_integrationtests/job.sh
+++ b/pipeline/stage_integrationtests/job.sh
@@ -14,7 +14,7 @@ function start_test () {
     #echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee -a /etc/ssl/certs/ca-
     mono "${DUPLICATI_ROOT}/Duplicati/GUI/Duplicati.GUI.TrayIcon/bin/Release/Duplicati.Server.exe" &
     cd
-    python "${DUPLICATI_ROOT}/guiTests/guiTest.py"
+    python3 "${DUPLICATI_ROOT}/guiTests/guiTest.py"
 }
 
 travis_mark_begin "INTEGRATION TESTING"

--- a/pipeline/stage_integrationtests/trigger.sh
+++ b/pipeline/stage_integrationtests/trigger.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . error_handling.sh
 
-PACKAGES="python-pip rsync"
+PACKAGES="python3-pip rsync"
 docker-run --image selenium/standalone-firefox \
 --packages "$PACKAGES" \
 --asroot \

--- a/pipeline/stage_integrationtests/trigger.sh
+++ b/pipeline/stage_integrationtests/trigger.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . error_handling.sh
 
-PACKAGES="python3-pip rsync"
+PACKAGES="python3-pip rsync mono-complete"
 docker-run --image selenium/standalone-firefox \
 --packages "$PACKAGES" \
 --asroot \


### PR DESCRIPTION
The latest `selenium/standalone-firefox` Docker image is now based on Ubuntu 20.04, which doesn't support Python 2.  This updates our integration tests to maintain compatibility.

Due to the updated version of Ubuntu (which supports mono 6.8.0.105), we no longer need to explicitly install the latest version of `mono-complete`.  This also runs the tests with the browser window in a maximized state.  There are random times when the input fields cannot be found, and this seems to make the tests more robust.
