### PR TITLE
Abort with error if run-script-before script returns unsupported code

### DIFF
--- a/Duplicati/Library/Modules/Builtin/RunScript.cs
+++ b/Duplicati/Library/Modules/Builtin/RunScript.cs
@@ -286,11 +286,15 @@ namespace Duplicati.Library.Modules.Builtin
                                 {
                                     switch (p.ExitCode)
                                     {
-                                        case 1:
+                                        case 0: // OK, run operation
+                                        case 2: // Warning, run operation
+                                        case 4: // Error, run operation
+                                            break;
+                                        case 1: // OK, don't run operation
                                             throw new OperationAbortException(OperationAbortReason.Normal, Strings.RunScript.InvalidExitCodeError(scriptpath, p.ExitCode));
-                                        case 3:
+                                        case 3: // Warning, don't run operation
                                             throw new OperationAbortException(OperationAbortReason.Warning, Strings.RunScript.InvalidExitCodeError(scriptpath, p.ExitCode));
-                                        case 5:
+                                        default: // Error don't run operation
                                             throw new OperationAbortException(OperationAbortReason.Error, Strings.RunScript.InvalidExitCodeError(scriptpath, p.ExitCode));
                                     }
                                 }

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -89,7 +89,7 @@ namespace Duplicati.UnitTest
                 if (res.ExaminedFiles <= 0)
                     throw new Exception("Backup did not examine any files for code 4?");
 
-                foreach (int exitCode in new[] {-1, 5, 10})
+                foreach (int exitCode in new[] {5, 6, 10, 99})
                 {
                     System.Threading.Thread.Sleep(PAUSE_TIME);
                     options["run-script-before"] = CreateScript(exitCode);

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -88,15 +88,17 @@ namespace Duplicati.UnitTest
                     throw new Exception("Unexpected result from backup with return code 4");
                 if (res.ExaminedFiles <= 0)
                     throw new Exception("Backup did not examine any files for code 4?");
-                
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(5);
-                res = c.Backup(new string[] { DATAFOLDER });
-                if (res.ParsedResult != ParsedResultType.Error)
-                    throw new Exception("Unexpected result from backup with return code 5");
-                if (res.ExaminedFiles > 0)
-                    throw new Exception("Backup did examine files for code 5?");
 
+                foreach (int exitCode in new[] {-1, 5, 10})
+                {
+                    System.Threading.Thread.Sleep(PAUSE_TIME);
+                    options["run-script-before"] = CreateScript(exitCode);
+                    res = c.Backup(new string[] {DATAFOLDER});
+                    if (res.ParsedResult != ParsedResultType.Error)
+                        throw new Exception($"Unexpected result from backup with return code {exitCode}");
+                    if (res.ExaminedFiles > 0)
+                        throw new Exception($"Backup did examine files for code {exitCode}?");
+                }
 
                 System.Threading.Thread.Sleep(PAUSE_TIME);
                 options["run-script-before"] = CreateScript(2, "TEST WARNING MESSAGE");


### PR DESCRIPTION
This makes the code more consistent with the documentation in the example scripts.  Previously, the process would not be aborted if an unsupported code was encountered.

https://github.com/duplicati/duplicati/blob/338f467111f6bdcde971f93b8376daba42827498/Duplicati/Library/Modules/Builtin/run-script-example.sh#L21-L27

This also adds some tests to verify the behavior.

