### PR TITLE
Update login.js

### DIFF
--- a/Duplicati/Server/webroot/login/login.js
+++ b/Duplicati/Server/webroot/login/login.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
                 data: {'password': noncedpwd }
             })
             .done(function(data) {
-                window.location = '/';
+                window.location = './';
             })
             .fail(function(data) {
                 var txt = data;


### PR DESCRIPTION
Fix login with revese proxy with base uri

I have duplicati on hostname/duplicati/, ./login.cgi requests to auth were working, sent to /duplicati/login.cgi which proxies to duplicati docker instance, however it was redirected to hostname/ instead of hostname/duplicati/. Changing / to ./ fixes it