### PR TITLE
Remove unnecessary Tardigrade libraries from build output

### DIFF
--- a/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
+++ b/Duplicati/Library/Backend/Tardigrade/Duplicati.Library.Backend.Tardigrade.csproj
@@ -90,7 +90,6 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\packages\uplink.NET.2.3.4\build\net40\uplink.NET.targets" Condition="Exists('..\..\..\..\packages\uplink.NET.2.3.4\build\net40\uplink.NET.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>


### PR DESCRIPTION
This modifies the Tardigrade backend project so that it does not reference the `uplink.NET.targets` file from the uplink.NET NuGet package.  This targets file resulted in copies of `storj_uplink` libraries being included in the root of the build output directory.  
```
<?xml version="1.0" encoding="utf-8"?>
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <Choose>
    <When Condition="!$([MSBuild]::IsOsPlatform('Linux')) And ('$(Platform)' == 'x86' Or '$(Platform)' == 'X86')">
      <ItemGroup>
        <None Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x87\native\storj_uplink.dll">
          <Link>storj_uplink.dll</Link>
          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
        </None>
      </ItemGroup>
    </When>
  </Choose>
  <Choose>
    <When Condition="!$([MSBuild]::IsOsPlatform('Linux')) And ('$(Platform)' == 'AnyCPU' Or '$(Platform)' == 'x64' Or '$(Platform)' == 'X64')">
      <ItemGroup>
        <None Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\storj_uplink.dll">
          <Link>storj_uplink.dll</Link>
          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
        </None>
      </ItemGroup>
    </When>
  </Choose>
  <Choose>
    <When Condition="$([MSBuild]::IsOsPlatform('Linux'))">
      <ItemGroup>
        <None Include="$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\storj_uplink.so">
          <Link>libstorj_uplink.so</Link>
          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
        </None>
      </ItemGroup>
    </When>
  </Choose>
</Project>
```
However, these libraries are already included in `Duplicati/Library/Backend/Tardigrade` and copied to their proper locations in the output directory.  The extra `storj_uplink.dll` that was present when building the releases on a mac is suspected to have caused random `BadImageFormatExceptions`.

This fixes #4434.