### PR TITLE
Update most of python2 scripts throughout to make them compatible with both python2 and python3

### DIFF
--- a/Tools/Verification/DuplicatiVerify.py
+++ b/Tools/Verification/DuplicatiVerify.py
@@ -1,13 +1,14 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
-This file is a standalone python script that is tested with python 2.7
+This file is a standalone python script that is tested with python 2.7 & python 3.8
 If Duplicati is producing a backup with the option --upload-verification-file,
 it will produce a *-verification.json file on the backend, which can be verified
 by this script. Simply run this script with the path to the backup
 folder as input, and it will verify all *-verification.json files in the folder.
 """
 
+from __future__ import print_function
 import sys
 import os
 import string
@@ -22,8 +23,9 @@ def bytes_from_file(filename, chunksize=8192):
         while True:
             chunk = f.read(chunksize)
             if chunk:
-                for b in chunk:
-                    yield b
+                #for b in chunk:
+                #    yield b
+                yield chunk
             else:
                 break
 
@@ -33,7 +35,7 @@ def verifyHashes(filename):
     checked = 0
 
     if (not os.path.exists(filename)):
-        print "Specified file does not exist: ", filename
+        print("Specified file does not exist:", filename)
         return -1
     
     folder = os.path.dirname(filename)
@@ -47,34 +49,35 @@ def verifyHashes(filename):
         
         fullpath = os.path.join(folder, filename)
         if not os.path.exists(fullpath):
-            print "File missing: ", fullpath
+            print("File missing:", fullpath)
             errorCount += 1
         else:
             checked += 1
-            print "Verifying file ", filename
+            print("Verifying file", filename)
             hashalg = sha256()
             for b in bytes_from_file(fullpath):
                 hashalg.update(b)
             hashval =  base64.b64encode(hashalg.digest())
+            hashval = hashval.decode('utf-8')
             if hashval != hash:
-                print "*** Hash check failed for file: ", fullpath
+                print("*** Hash check failed for file:", fullpath)
                 errorCount += 1
                 
     
     if errorCount > 0:
-        print "Errors were found"
+        print("Errors were found")
     else:
-        print "No errors found" 
+        print("No errors found")
         
     return errorCount
     
 
 if __name__ == "__main__":
     if len(sys.argv) != 1 and len(sys.argv) != 2:
-        print "Usage:", len(sys.argv)
-        print "DuplicatiVerify.py <path to verification file>"
-        print "DuplicatiVerify.py <folder with verification files>"
-        print "DuplicatiVerify.py (no arguments, uses current dir)"
+        print("Usage:", len(sys.argv))
+        print("DuplicatiVerify.py <path to verification file>")
+        print("DuplicatiVerify.py <folder with verification files>")
+        print("DuplicatiVerify.py (no arguments, uses current dir)")
     else:
         if len(sys.argv) == 1:
             argument = os.getcwd()
@@ -82,7 +85,7 @@ if __name__ == "__main__":
             argument = sys.argv[1]
         
         if not os.path.exists(argument):
-            print "No such file or directory: ", argument
+            print("No such file or directory: ", argument)
         else:
             if os.path.isfile(argument):
                 verifyHashes(argument)
@@ -90,9 +93,9 @@ if __name__ == "__main__":
                 files = 0
                 for f in os.listdir(argument):
                     if (f.endswith("-verification.json")):
-                        print "Verifying file: ", f
+                        print("Verifying file:", f)
                         files += 1
                         verifyHashes(os.path.join(argument, f))
                         
                 if files == 0:
-                    print "No verification files in folder: ", argument
+                    print("No verification files in folder:", argument)

--- a/Tools/Verification/DuplicatiVerify.py
+++ b/Tools/Verification/DuplicatiVerify.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 """
-This file is a standalone python script that is tested with python 2.7 & python 3.8
+This file is a standalone python script that is tested with python 2.7 & 
+python 3.8
 If Duplicati is producing a backup with the option --upload-verification-file,
 it will produce a *-verification.json file on the backend, which can be verified
 by this script. Simply run this script with the path to the backup
@@ -16,9 +17,10 @@ import json
 import base64
 import codecs
 from hashlib import sha256
+import argparse
 
 """ Utility function to return byte chunks from a binary file """
-def bytes_from_file(filename, chunksize=8192):
+def bytes_from_file(filename, chunksize=8192*1024):
     with open(filename, "rb") as f:
         while True:
             chunk = f.read(chunksize)
@@ -30,30 +32,31 @@ def bytes_from_file(filename, chunksize=8192):
                 break
 
 """ Verifies a single -verification.json file """               
-def verifyHashes(filename):
+def verifyHashes(filename, quiet):
     errorCount = 0
     checked = 0
 
     if (not os.path.exists(filename)):
         print("Specified file does not exist:", filename)
         return -1
-    
+
     folder = os.path.dirname(filename)
     with codecs.open(filename, "r", "utf-8-sig") as f:
         doc = json.load(f)
-    
+
     for file in doc:
         filename = file["Name"]
         hash = file["Hash"]
         size = file["Size"]
-        
+
         fullpath = os.path.join(folder, filename)
         if not os.path.exists(fullpath):
             print("File missing:", fullpath)
             errorCount += 1
         else:
             checked += 1
-            print("Verifying file", filename)
+            if not quiet:
+                print("Verifying file", filename)
             hashalg = sha256()
             for b in bytes_from_file(fullpath):
                 hashalg.update(b)
@@ -62,40 +65,38 @@ def verifyHashes(filename):
             if hashval != hash:
                 print("*** Hash check failed for file:", fullpath)
                 errorCount += 1
-                
-    
+
+
     if errorCount > 0:
         print("Errors were found")
     else:
         print("No errors found")
-        
+
     return errorCount
     
 
 if __name__ == "__main__":
-    if len(sys.argv) != 1 and len(sys.argv) != 2:
-        print("Usage:", len(sys.argv))
-        print("DuplicatiVerify.py <path to verification file>")
-        print("DuplicatiVerify.py <folder with verification files>")
-        print("DuplicatiVerify.py (no arguments, uses current dir)")
+    parser = argparse.ArgumentParser(description='Verify hashes of backup files.')
+    parser.add_argument("--quiet", action='store_true', help="Be noisy about each file being verified")
+    parser.add_argument("path", type=str, nargs='?',
+                    help="""path to the verification fole or folder containing the verification folder.\
+                        Defaulf is curent path""")
+    args = parser.parse_args()
+
+    if args.path is None:
+        args.path = os.getcwd()
+
+    if not os.path.exists(args.path):
+        print("No such file or directory: ", args.path)
     else:
-        if len(sys.argv) == 1:
-            argument = os.getcwd()
+        if os.path.isfile(args.path):
+            verifyHashes(args.path, args.quiet)
         else:
-            argument = sys.argv[1]
-        
-        if not os.path.exists(argument):
-            print("No such file or directory: ", argument)
-        else:
-            if os.path.isfile(argument):
-                verifyHashes(argument)
-            else:
-                files = 0
-                for f in os.listdir(argument):
-                    if (f.endswith("-verification.json")):
-                        print("Verifying file:", f)
-                        files += 1
-                        verifyHashes(os.path.join(argument, f))
-                        
-                if files == 0:
-                    print("No verification files in folder:", argument)
+            files = 0
+            for f in os.listdir(args.path):
+                if (f.endswith("-verification.json")):
+                    print("Verifying file:", f)
+                    files += 1
+                    verifyHashes(os.path.join(args.path, f), args.quiet)
+            if files == 0:
+                print("No verification files in folder:", args.path)

--- a/Tools/Verification/DuplicatiVerify.py
+++ b/Tools/Verification/DuplicatiVerify.py
@@ -25,8 +25,6 @@ def bytes_from_file(filename, chunksize=8192*1024):
         while True:
             chunk = f.read(chunksize)
             if chunk:
-                #for b in chunk:
-                #    yield b
                 yield chunk
             else:
                 break
@@ -79,7 +77,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Verify hashes of backup files.')
     parser.add_argument("--quiet", action='store_true', help="Be noisy about each file being verified")
     parser.add_argument("path", type=str, nargs='?',
-                    help="""path to the verification fole or folder containing the verification folder.\
+                    help="""path to the verification file or folder containing the verification file.\
                         Defaulf is curent path""")
     args = parser.parse_args()
 

--- a/fix-sln.py
+++ b/fix-sln.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env python
+from __future__ import print_function
 import re
 import io
 
-f = open('Duplicati.sln')
-c = f.read()
-f.close()
+with open('Duplicati.sln', 'r') as f:
+    c = f.read()
 
 p = re.compile(r"\{[0-9a-fA-F\-]*\}")
 
@@ -19,4 +20,4 @@ for n in tags:
 
 for n in d:
     if d[n] > 7:
-        print n
+        print(n)

--- a/unix2dos.py
+++ b/unix2dos.py
@@ -1,15 +1,14 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import sys
 
 for fname in sys.argv[1:]:
-    infile = open( fname, "rb" )
-    instr = infile.read()
-    infile.close()
-    outstr = instr.replace( "\r\n", "\n" ).replace( "\r", "\n" ).replace( "\n", "\r\n" )
+    with open(fname, 'rb') as infile:
+        instr = infile.read()
+
+    outstr = instr.replace( b"\r\n", b"\n" ).replace( b"\r", b"\n" ).replace( b"\n", b"\r\n" )
 
     if len(outstr) == len(instr):
         continue
     
-    outfile = open( fname, "wb" )
-    outfile.write( outstr )
-    outfile.close()
+    with open( fname, "wb" ) as outfile:
+        outfile.write( outstr )


### PR DESCRIPTION
Python2 has reached EoL
Python3 is the only supported version of python. 

This PR update the code of most python2 code in the duplicati repository to make it compatible with python3 (whilst maintaining backward compatibility with python 2 in case this is needed)

1 exception (which I left untouched) is the osX tray icon project as I don't have access to a mac to test this