### PR TITLE
Changed the help output to not show deprecated options.

### DIFF
--- a/Duplicati/CommandLine/Help.cs
+++ b/Duplicati/CommandLine/Help.cs
@@ -490,7 +490,8 @@ namespace Duplicati.CommandLine
 
             List<string> lines = new List<string>();
             foreach(Duplicati.Library.Interface.ICommandLineArgument arg in args)
-                lines.Add(PrintArgSimple(arg, arg.Name));
+                if (!arg.Deprecated)
+                    lines.Add(PrintArgSimple(arg, arg.Name));
 
             return string.Join(Environment.NewLine, lines.ToArray());
         }

--- a/Duplicati/CommandLine/help.txt
+++ b/Duplicati/CommandLine/help.txt
@@ -390,6 +390,16 @@ Options:
 
 
 # =============================================================================
+> duplicati.commandline.exe help azure
+
+Duplicati can use Azure blob storage to store backups. The following target URL format is used:
+  azure://bucketname
+
+Options:
+%MODULEOPTIONS%
+
+
+# =============================================================================
 > duplicati.commandline.exe help onedrive
 
 Duplicati can use Microsoft Onedrive to store backups. The following target URL format is used:


### PR DESCRIPTION
Commandline help for azure now shows a little cleaner