### PR TITLE
S3 configurations result in warnings about deprecated options

### DIFF
--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -391,9 +391,9 @@ namespace Duplicati.Library.Backend
 
 
                 var normal = new ICommandLineArgument[] {
-                    new CommandLineArgument("aws_secret_access_key", CommandLineArgument.ArgumentType.Password, Strings.S3Backend.AMZKeyDescriptionShort, Strings.S3Backend.AMZKeyDescriptionLong, null, new string[] {"auth-password"},null,"This is deprecated, use aws-secret-access-key instead"),
+                    new CommandLineArgument("aws_secret_access_key", CommandLineArgument.ArgumentType.Password, Strings.S3Backend.AMZKeyDescriptionShort, Strings.S3Backend.AMZKeyDescriptionLong, null, null, null,"This is deprecated, use aws-secret-access-key instead"),
                     new CommandLineArgument("aws-secret-access-key", CommandLineArgument.ArgumentType.Password, Strings.S3Backend.AMZKeyDescriptionShort, Strings.S3Backend.AMZKeyDescriptionLong,null, new string[] {"auth-password"}, null ),
-                    new CommandLineArgument("aws_access_key_id", CommandLineArgument.ArgumentType.String, Strings.S3Backend.AMZUserIDDescriptionShort, Strings.S3Backend.AMZUserIDDescriptionLong,null, new string[] {"auth-username"}, null, "This is deprecated, use aws-access-key-id instead"),
+                    new CommandLineArgument("aws_access_key_id", CommandLineArgument.ArgumentType.String, Strings.S3Backend.AMZUserIDDescriptionShort, Strings.S3Backend.AMZUserIDDescriptionLong,null, null, null, "This is deprecated, use aws-access-key-id instead"),
                     new CommandLineArgument("aws-access-key-id", CommandLineArgument.ArgumentType.String, Strings.S3Backend.AMZUserIDDescriptionShort, Strings.S3Backend.AMZUserIDDescriptionLong, null, new string[] {"auth-username"}, null),
                     new CommandLineArgument(EU_BUCKETS_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.S3Backend.S3EurobucketDescriptionShort, Strings.S3Backend.S3EurobucketDescriptionLong, "false", null, null, Strings.S3Backend.S3EurobucketDeprecationDescription(LOCATION_OPTION, S3_EU_REGION_NAME)),
                     new CommandLineArgument(RRS_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.S3Backend.S3UseRRSDescriptionShort, Strings.S3Backend.S3UseRRSDescriptionLong, "false", null, null, Strings.S3Backend.S3RRSDeprecationDescription(STORAGECLASS_OPTION, S3_RRS_CLASS_NAME)),

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -339,10 +339,10 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
     ];
 
     EditUriBackendConfig.parsers['s3'] = function (scope, module, server, port, path, options) {
-        if (options['--aws_access_key_id'])
-            scope.Username = options['--aws_access_key_id'];
-        if (options['--aws_secret_access_key'])
-            scope.Password = options['--aws_secret_access_key'];
+        if (options['--aws-access-key-id'])
+            scope.Username = options['--aws-access-key-id'];
+        if (options['--aws-secret-access-key'])
+            scope.Password = options['--aws-secret-access-key'];
 
         if (options['--s3-use-rrs'] && !options['--s3-storage-class']) {
             delete options['--s3-use-rrs'];
@@ -371,7 +371,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         
         scope.s3_storageclass = scope.s3_storageclass_custom = options['--s3-storage-class'];
 
-        var nukeopts = ['--aws_access_key_id', '--aws_secret_access_key', '--s3-use-rrs', '--s3-server-name', '--s3-location-constraint', '--s3-storage-class', '--s3-client'];
+        var nukeopts = ['--aws-access-key-id', '--aws-secret-access-key', '--s3-use-rrs', '--s3-server-name', '--s3-location-constraint', '--s3-storage-class', '--s3-client'];
         for (var x in nukeopts)
             delete options[nukeopts[x]];
     };


### PR DESCRIPTION
The old option names (`aws_access_key_id` and `aws_secret_access_key`) were deprecated in favor of their respective hyphen-separated versions (`aws-access-key-id` and `aws-secret-access-key`) in pull request #4443. However, both the old and new options were mapped to the same alias, which resulted in the `Controller` class issuing a warning below:

https://github.com/duplicati/duplicati/blob/f145b9fcc2f93aaa606bc939373afbb566034647/Duplicati/Library/Main/Controller.cs#L774-L789

This pull request reserves the alias for just the new option name, and removes the alias from the deprecated option.

This also replaces some usages of the old option names in the UI code.

This fixes #4461.