### PR TITLE
Added delay to purge-broken-files unittest.

### DIFF
--- a/Duplicati/UnitTest/PurgeTesting.cs
+++ b/Duplicati/UnitTest/PurgeTesting.cs
@@ -233,6 +233,7 @@ namespace Duplicati.UnitTest
             }
 
             File.Delete(dblock_file);
+            var last_ts = DateTime.Now;
 
             long[] affectedfiles;
 
@@ -284,6 +285,12 @@ namespace Duplicati.UnitTest
 
                 Assert.AreEqual(3, modFilesets);
             }
+
+
+            // Since we make the operations back-to-back, the purge timestamp can drift beyond the current time
+            var wait_target = last_ts.AddSeconds(10) - DateTime.Now;
+            if (wait_target.TotalMilliseconds > 0)
+                System.Threading.Thread.Sleep(wait_target);
 
             // A subsequent backup should be successful.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, testopts, null))


### PR DESCRIPTION
Since the repair introduces artifical filelists, there is sometimes a race in CI where the purge is faster than a second causing the time sequences to not line up during testing.