### PR TITLE
Use SeBackupPrivilege on Windows

### DIFF
--- a/Duplicati/Library/Utility/Win32.cs
+++ b/Duplicati/Library/Utility/Win32.cs
@@ -33,8 +33,14 @@ namespace Duplicati.Library.Utility
     {
 
         #region Consts
+        internal const int SE_PRIVILEGE_DISABLED = 0x00000000;
+        internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
+        internal const int TOKEN_QUERY = 0x00000008;
+        internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
 
         public const int ATTACH_PARENT_PROCESS = -1;
+
+        internal const string SE_BACKUP_NAME = "SeBackupPrivilege";
 
         #endregion
 
@@ -185,6 +191,24 @@ namespace Duplicati.Library.Utility
 
         #endregion
 
+        #region Structs
+
+        /// <summary>
+        /// The TOKEN_PRIVILEGES structure contains information about a set of privileges for an access token.
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_privileges.
+        /// </remarks>
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        internal struct TOKEN_PRIVILEGES
+        {
+            public int Count;
+            public long Luid;
+            public int Attr;
+        }
+
+        #endregion
+
         #region Function calls
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
@@ -249,6 +273,63 @@ namespace Duplicati.Library.Utility
         [DllImport("ntdll.dll")]
         public static extern PHCM_VALUES RtlSetProcessPlaceholderCompatibilityMode(PHCM_VALUES pcm);
 
+
+
+        /// <summary>
+        /// The AdjustTokenPrivileges function enables or disables privileges in the specified access token.
+        /// Enabling or disabling privileges in an access token requires TOKEN_ADJUST_PRIVILEGES access.
+        /// </summary>
+        /// <param name="htok"></param>
+        /// <param name="disall"></param>
+        /// <param name="newst"></param>
+        /// <param name="len"></param>
+        /// <param name="prev"></param>
+        /// <param name="relen"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// See https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges.
+        /// </remarks>
+        [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+        internal static extern bool AdjustTokenPrivileges(IntPtr htok, bool disall,
+        ref TOKEN_PRIVILEGES newst, int len, IntPtr prev, IntPtr relen);
+
+        /// <summary>
+        /// Retrieves a pseudo handle for the current process.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// See https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess
+        /// </remarks>
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        internal static extern IntPtr GetCurrentProcess();
+
+        /// <summary>
+        /// The OpenProcessToken function opens the access token associated with a process.
+        /// </summary>
+        /// <param name="h"></param>
+        /// <param name="acc"></param>
+        /// <param name="phtok"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// See https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocesstoken.
+        /// </remarks>
+        [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+        internal static extern bool OpenProcessToken(IntPtr h, int acc, ref IntPtr
+        phtok);
+
+        /// <summary>
+        /// The LookupPrivilegeValue function retrieves the locally unique identifier (LUID) used on a specified system to locally represent the specified privilege name.
+        /// </summary>
+        /// <param name="host"></param>
+        /// <param name="name"></param>
+        /// <param name="pluid"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-lookupprivilegevaluea.
+        /// </remarks>
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool LookupPrivilegeValue(string host, string name,
+        ref long pluid);
         #endregion
     }
 }


### PR DESCRIPTION
On Windows platforms, try to enable `SeBackupPrivilege` before running backup operations.

In Windows platforms, the `SeBackupPrivilege` privilege allows a process to bypass file and directory object permissions for the purposes of backing up the system.

The privilege is available to processes that run under security context of accounts specified in the **Back up files and directories** group policy (GPO => Computer Configuration => Windows Settings => Security Settings => Local Policies => User Rights Assignment). By default, the **Administrators** and **Backup Operators** security groups are specified in this group policy.

To take advantage of this functionality, configure the Duplicati service to use its own dedicated user account, and add the user account to the **Backup Operators** security group. The process will be able to access all files on the system and will not have any other administrative permissions.


![2021-03-21 22_07_18-Computer Management](https://user-images.githubusercontent.com/8523760/111902522-fded2400-8a91-11eb-8bc3-bf0d3dc7da6c.png)

![2021-03-21 21_47_55-Duplicati Server exe_18300 Properties](https://user-images.githubusercontent.com/8523760/111902341-34766f00-8a91-11eb-92f7-f9da433c0411.png)


![2021-03-21 21_47_50-Duplicati Server exe_18300 Properties](https://user-images.githubusercontent.com/8523760/111902351-3e986d80-8a91-11eb-8716-6c7edaab643e.png)

