### PR TITLE
Make File backend truncate existing files when overwriting

### DIFF
--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -187,7 +187,7 @@ namespace Duplicati.Library.Backend
         private static Random random = new Random();
         public async Task Put(string remotename, System.IO.Stream stream, CancellationToken cancelToken)
         {
-            using(System.IO.FileStream writestream = systemIO.FileOpenWrite(GetRemoteName(remotename)))
+            using(System.IO.FileStream writestream = systemIO.FileCreate(GetRemoteName(remotename)))
             {
                 if (random.NextDouble() > 0.6666)
                     throw new Exception("Random upload failure");
@@ -197,7 +197,7 @@ namespace Duplicati.Library.Backend
 #else
         public async Task PutAsync(string remotename, System.IO.Stream stream, CancellationToken cancelToken)
         {
-            using (System.IO.FileStream writestream = systemIO.FileOpenWrite(GetRemoteName(remotename)))
+            using (System.IO.FileStream writestream = systemIO.FileCreate(GetRemoteName(remotename)))
                 await Utility.Utility.CopyStreamAsync(stream, writestream, true, cancelToken, m_copybuffer);
         }
 #endif


### PR DESCRIPTION
The implementations of `ISystemIO.FileOpenWrite` call `File.OpenWrite`, which [does not truncate](https://docs.microsoft.com/en-us/dotnet/api/system.io.file.openwrite?view=netframework-4.7.1#remarks) an existing file.  As such, if we overwrite a larger file with a smaller one, tail remnants of the existing file will remain.

This fixes a regression introduced in revision 71c6aca8a7 ("Fixed IO calls in Filebackend") from pull request #3456.  The previous implementation called `File.Open` with `FileMode.Create`, which truncates existing files.

Since most of the put operations involve unique filenames, this is only a problem when overwriting existing files (e.g.,
`duplicati-verification.json`).

This fixes #4486.