### PR TITLE
Install gtk-sharp2 to fix GitHub workflow builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,10 @@ jobs:
     - name: Restore NuGet Packages
       run: nuget restore Duplicati.sln
 
+    - name: Install additional dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install gtk-sharp2
+
     - name: Build Duplicati (Linux and macOS)
       if: matrix.os != 'windows-latest'
       run: msbuild -p:Configuration=Release -p:DefineConstants=ENABLE_GTK Duplicati.sln
@@ -68,6 +72,9 @@ jobs:
 
     - name: Restore NuGet Packages
       run: nuget restore Duplicati.sln
+
+    - name: Install additional dependencies
+      run: sudo apt-get install gtk-sharp2
 
     - name: Build Duplicati
       run: msbuild -p:Configuration=Release -p:DefineConstants=ENABLE_GTK Duplicati.sln

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,10 +66,11 @@ jobs:
     - name: Install NuGet
       uses: nuget/setup-nuget@v1.0.5
 
+    - name: Restore NuGet Packages
+      run: nuget restore Duplicati.sln
+
     - name: Build Duplicati
-      run: |
-        nuget restore Duplicati.sln
-        msbuild -p:Configuration=Release -p:DefineConstants=ENABLE_GTK Duplicati.sln
+      run: msbuild -p:Configuration=Release -p:DefineConstants=ENABLE_GTK Duplicati.sln
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Restore NuGet Packages
       run: nuget restore Duplicati.sln
 
-    - name: Install additional dependencies
+    - name: Install Additional Dependencies
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install gtk-sharp2
 
@@ -73,7 +73,7 @@ jobs:
     - name: Restore NuGet Packages
       run: nuget restore Duplicati.sln
 
-    - name: Install additional dependencies
+    - name: Install Additional Dependencies
       run: sudo apt-get install gtk-sharp2
 
     - name: Build Duplicati


### PR DESCRIPTION
The jobs running on ubuntu-latest were failing due to missing gtk-sharp libraries.  The builds used to run fine on Ubuntu
18.04.5.  However, now that they run on Ubuntu 20.04.2, the gtk-sharp libraries need to be installed explicitly.