### PR TITLE
Update Makefile to use msbuild instead of xbuild

### DIFF
--- a/Installer/Makefile/Makefile
+++ b/Installer/Makefile/Makefile
@@ -1,4 +1,4 @@
-BUILD_TOOL=xbuild
+BUILD_TOOL=msbuild
 BUILD_ARGS=/property:Platform=Any\ CPU /property:Configuration=Release
 BUILD_ARGS_DEBUG=/property:Platform=Any\ CPU /property:Configuration=Debug
 


### PR DESCRIPTION
This updates the `Makefile` to use `msbuild` instead of `xbuild`, which fixes some build errors.  I'm not sure if we still want to maintain this, but it was a simple change and appears to run without error.

This fixes #4454.