### PR TITLE
Fix typo in example scripts

### DIFF
--- a/Duplicati/Library/Modules/Builtin/run-script-example.bat
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.bat
@@ -67,7 +67,7 @@ REM will be ignored:
 REM echo "Hello! -- test, this line is ignored"
 REM echo --new-option=This will be a setting
 
-REM Filters are supplied in the DUPLICAT__FILTER variable.
+REM Filters are supplied in the DUPLICATI__FILTER variable.
 REM The variable contains all filters supplied with --include and --exclude,
 REM combined into a single string, separated with semicolon (;).
 REM Filters set with --include will be prefixed with a plus (+),

--- a/Duplicati/Library/Modules/Builtin/run-script-example.sh
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.sh
@@ -66,7 +66,7 @@
 # echo "Hello! -- test, this line is ignored"
 # echo "--new-option=\"This will be a setting\""
 
-# Filters are supplied in the DUPLICAT__FILTER variable.
+# Filters are supplied in the DUPLICATI__FILTER variable.
 # The variable contains all filters supplied with --include and --exclude,
 # combined into a single string, separated with colon (:).
 # Filters set with --include will be prefixed with a plus (+),


### PR DESCRIPTION
This fixes a small typo in the `run-script-example` scripts.