### PR TITLE
Avoid ECDSA algorithms when using SFTP with Mono

### DIFF
--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -357,6 +357,10 @@ namespace Duplicati.Library.Backend
                         client.ConnectionInfo.HostKeyAlgorithms.Remove(key);
                     }
                 }
+                catch
+                {
+                    // Ignore other exceptions and assume that we have ECDSA support.
+                }
             }
 
             client.Connect();

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -351,7 +351,7 @@ namespace Duplicati.Library.Backend
                 // See https://github.com/mono/mono/blob/mono-6.12.0.144/mcs/class/referencesource/System.Core/System/Security/Cryptography/ECDsaCng.cs
                 if (Utility.Utility.IsMono)
                 {
-                    IEnumerable<string> ecdsaKeys = client.ConnectionInfo.HostKeyAlgorithms.Keys.Where(x => x.StartsWith("ecdsa"));
+                    List<string> ecdsaKeys = client.ConnectionInfo.HostKeyAlgorithms.Keys.Where(x => x.StartsWith("ecdsa")).ToList();
                     foreach (string key in ecdsaKeys)
                     {
                         client.ConnectionInfo.HostKeyAlgorithms.Remove(key);

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -75,13 +75,9 @@ namespace Duplicati.Library.Backend
                 ECDsaCng unused = new ECDsaCng();
                 SSHv2.supportsECDSA = true;
             }
-            catch (NotImplementedException)
-            {
-                SSHv2.supportsECDSA = false;
-            }
             catch
             {
-                SSHv2.supportsECDSA = true;
+                SSHv2.supportsECDSA = false;
             }
         }
 

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -347,7 +347,7 @@ namespace Duplicati.Library.Backend
                 // See https://github.com/mono/mono/blob/mono-6.12.0.144/mcs/class/referencesource/System.Core/System/Security/Cryptography/ECDsaCng.cs
                 try
                 {
-                    ECDsa.Create(default(ECCurve));
+                    ECDsaCng unused = new ECDsaCng();
                 }
                 catch (NotImplementedException)
                 {

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -59,6 +59,8 @@ namespace Duplicati.Library.Backend
 
         private SftpClient m_con;
 
+        private readonly Lazy<bool> supportsECDSA = new Lazy<bool>(SSHv2.SupportsECDSA, true);
+
         public SSHv2()
         {
         }
@@ -334,32 +336,40 @@ namespace Duplicati.Library.Backend
             m_con = con;
         }
 
+        /// <summary>
+        /// SSH.NET relies on the System.Security.Cryptography.ECDsaCng class for
+        /// ECDSA algorithms, which is not implemented in Mono (as of 6.12.0.144).
+        /// This prevents clients from connecting if one of the ECDSA algorithms is
+        /// chosen as the host key algorithm.  In this case, we will prevent the
+        /// client from advertising support for ECDSA algorithms.
+        /// </summary>
+        /// <seealso href="https://github.com/mono/mono/blob/mono-6.12.0.144/mcs/class/referencesource/System.Core/System/Security/Cryptography/ECDsaCng.cs">Mono ECDsaCng implementation.</seealso>
+        /// <returns>Whether ECDSA algorithms are supported or not.</returns>
+        private static bool SupportsECDSA()
+        {
+            try
+            {
+                ECDsaCng unused = new ECDsaCng();
+                return true;
+            }
+            catch (NotImplementedException)
+            {
+                return false;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
         private void TryConnect(SftpClient client)
         {
-            if (Utility.Utility.IsMono)
+            if (!this.supportsECDSA.Value)
             {
-                // SSH.NET relies on the System.Security.Cryptography.ECDsaCng class for
-                // ECDSA algorithms, which is not implemented in Mono (as of 6.12.0.144).
-                // This prevents clients from connecting if one of the ECDSA algorithms is
-                // chosen as the host key algorithm.  In this case, we will prevent the
-                // client from advertising support for ECDSA algorithms.
-                //
-                // See https://github.com/mono/mono/blob/mono-6.12.0.144/mcs/class/referencesource/System.Core/System/Security/Cryptography/ECDsaCng.cs
-                try
+                List<string> ecdsaKeys = client.ConnectionInfo.HostKeyAlgorithms.Keys.Where(x => x.StartsWith("ecdsa")).ToList();
+                foreach (string key in ecdsaKeys)
                 {
-                    ECDsaCng unused = new ECDsaCng();
-                }
-                catch (NotImplementedException)
-                {
-                    List<string> ecdsaKeys = client.ConnectionInfo.HostKeyAlgorithms.Keys.Where(x => x.StartsWith("ecdsa")).ToList();
-                    foreach (string key in ecdsaKeys)
-                    {
-                        client.ConnectionInfo.HostKeyAlgorithms.Remove(key);
-                    }
-                }
-                catch
-                {
-                    // Ignore other exceptions and assume that we have ECDSA support.
+                    client.ConnectionInfo.HostKeyAlgorithms.Remove(key);
                 }
             }
 


### PR DESCRIPTION
SSH.NET [relies on](https://github.com/sshnet/SSH.NET/blob/a5bd08d655bb6a3c762306472cec354556dca3a3/src/Renci.SshNet/Security/Cryptography/EcdsaKey.cs#L357) the `System.Security.Cryptography.ECDsaCng` class for ECDSA algorithms, which is [not implemented](https://github.com/mono/mono/blob/a01309d1041ff8ae15b1f8b717420ec139e1cdb8/mcs/class/referencesource/System.Core/System/Security/Cryptography/ECDsaCng.cs#L29-L32) in Mono (as of 6.12.0.144).  This prevents clients from connecting if one of the ECDSA algorithms is chosen as the host key algorithm.  In the event that this causes a connection failure, we will prevent the client from advertising support for ECDSA algorithms and make another connection attempt.
    
