### PR TITLE
Make dot in filter regex match newline characters

### DIFF
--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -81,14 +81,15 @@ namespace Duplicati.Library.Utility
             /// The multiple wildcard character (DOS style)
             /// </summary>
             private const char MULTIPLE_WILDCARD = '*';
-            
+
             /// <summary>
             /// The regular expression flags
             /// </summary>
             private static readonly RegexOptions REGEXP_OPTIONS =
                 RegexOptions.Compiled |
                 RegexOptions.ExplicitCapture |
-                (Utility.IsFSCaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
+                (Utility.IsFSCaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase) |
+                RegexOptions.Singleline;
 
             // Since we might need to get the regex for a particular filter group multiple times
             // (e.g., when combining multiple FilterExpressions together, which discards the existing FilterEntries and recreates them from the Filter representations),

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -274,6 +274,8 @@ namespace Duplicati.UnitTest
             }
 
             Dictionary<string, string> restoreOptions = new Dictionary<string, string>(this.TestOptions) {["restore-path"] = this.RESTOREFOLDER};
+
+            // Restore just the file.
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
             {
                 IRestoreResults restoreResults = c.Restore(new[] {filePath});
@@ -283,6 +285,18 @@ namespace Duplicati.UnitTest
 
             string restoreFilePath = SystemIO.IO_OS.PathCombine(this.RESTOREFOLDER, pathComponent);
             TestUtils.AssertFilesAreEqual(filePath, restoreFilePath, true, pathComponent);
+            SystemIO.IO_OS.FileDelete(restoreFilePath);
+
+            // Restore the entire directory.
+            string pathSpec = $"[{Util.AppendDirSeparator(this.DATAFOLDER)}.*]";
+            using (Controller c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+            {
+                IRestoreResults restoreResults = c.Restore(new[] {pathSpec});
+                Assert.AreEqual(0, restoreResults.Errors.Count());
+                Assert.AreEqual(0, restoreResults.Warnings.Count());
+            }
+
+            TestUtils.AssertDirectoryTreesAreEquivalent(this.DATAFOLDER, this.RESTOREFOLDER, true, pathComponent);
         }
     }
 }

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -282,15 +282,7 @@ namespace Duplicati.UnitTest
             }
 
             string restoreFilePath = SystemIO.IO_OS.PathCombine(this.RESTOREFOLDER, pathComponent);
-            Assert.IsTrue(SystemIO.IO_OS.FileExists(restoreFilePath));
-
-            MemoryStream restoredStream = new MemoryStream();
-            using (FileStream fileStream = SystemIO.IO_OS.FileOpenRead(restoreFilePath))
-            {
-                Utility.CopyStream(fileStream, restoredStream);
-            }
-
-            Assert.AreEqual(fileBytes, restoredStream.ToArray());
+            TestUtils.AssertFilesAreEqual(filePath, restoreFilePath, true, pathComponent);
         }
     }
 }


### PR DESCRIPTION
By default the dot `.` character in a regular expression matches [any character except](https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions) `\n`.  As such, paths that contain newline characters might not be successfully matched by typical regular expression patterns (for example, those containing `.*`).  This causes Duplicati to skip such files with newline characters in their names when restoring the containing directory, where we select files using a `/path/to/directory/.*` filter.

This pull request proposes that we use the [Singleline](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options#single-line-mode) option, which changes the behavior of `.` to match newline characters.  This also adds a test to verify the behavior.

This fixes #4508.