### PR TITLE
Fix bug in handling deprecated Azure and S3 options

### DIFF
--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -53,10 +53,14 @@ namespace Duplicati.Library.Backend.AzureBlob
                 storageAccountName = options["auth-username"];
             if (options.ContainsKey("auth-password"))
                 accessKey = options["auth-password"];
-            if (options.ContainsKey("azure_account_name") || options.ContainsKey("azure-account-name"))
-                storageAccountName = options["azure_account_name"] ?? options["azure-account-name"];
-            if (options.ContainsKey("azure_access_key") || options.ContainsKey("azure-access-key"))
-                accessKey = options["azure_access_key"] ?? options["azure-access-key"];
+            if (options.ContainsKey("azure_account_name"))
+                storageAccountName = options["azure_account_name"];
+            if (options.ContainsKey("azure-account-name"))
+                storageAccountName = options["azure-account-name"];
+            if (options.ContainsKey("azure_access_key"))
+                accessKey = options["azure_access_key"];
+            if (options.ContainsKey("azure-access-key"))
+                accessKey = options["azure-access-key"];
             if (!string.IsNullOrEmpty(uri.Username))
                 storageAccountName = uri.Username;
             if (!string.IsNullOrEmpty(uri.Password))

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -185,10 +185,14 @@ namespace Duplicati.Library.Backend
             if (options.ContainsKey("auth-password"))
                 awsKey = options["auth-password"];
 
-            if (options.ContainsKey("aws_access_key_id") || options.ContainsKey("aws-access-key-id"))
-                awsID = options["aws_access_key_id"] ?? options["aws-access-key-id"];
-            if (options.ContainsKey("aws_secret_access_key") || options.ContainsKey("aws-secret-access-key"))
-                awsKey = options["aws_secret_access_key"] ?? options["aws-secret-access-key"];
+            if (options.ContainsKey("aws_access_key_id"))
+                awsID = options["aws_access_key_id"];
+            if (options.ContainsKey("aws-access-key-id"))
+                awsID = options["aws-access-key-id"];
+            if (options.ContainsKey("aws_secret_access_key"))
+                awsKey = options["aws_secret_access_key"];
+            if (options.ContainsKey("aws-secret-access-key"))
+                awsKey = options["aws-secret-access-key"];
             if (!string.IsNullOrEmpty(uri.Username))
                 awsID = uri.Username;
             if (!string.IsNullOrEmpty(uri.Password))


### PR DESCRIPTION
In pull request #4443, we renamed some of the Azure and S3 options to use dashes `-` instead of underscores `_` for consistency.  However, our treatment of the options in the backend constructors still required that the underscore versions be present even if the dashed version was provided.

Now, we allow for either option to be present, but the value for the dashed version will take precedence if both are provided.

Thanks to @sergethedev17 for noticing this.