### PR TITLE
Create custom Exception for remote list verification failures

### DIFF
--- a/Duplicati/Library/Interface/CustomExceptions.cs
+++ b/Duplicati/Library/Interface/CustomExceptions.cs
@@ -183,4 +183,20 @@ namespace Duplicati.Library.Interface
             AbortReason = reason;
         }
     }
+
+    /// <summary>
+    /// An exception indicating that verification of uploaded volumes has failed
+    /// due to extra, missing, or duplicate files.
+    /// </summary>
+    [Serializable]
+    public class RemoteListVerificationException : UserInformationException
+    {
+        public RemoteListVerificationException(string message, string helpId)
+            : base(message, helpId)
+        {}
+
+        public RemoteListVerificationException(string message, string helpId, Exception innerException)
+            : base(message, helpId, innerException)
+        {}
+    }
 }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -156,7 +156,7 @@ namespace Duplicati.Library.Main.Operation
                     else
                         FilelistProcessor.VerifyRemoteList(backend, m_options, m_database, m_result.BackendWriter, new string[] { protectedfile });
                 }
-                catch (Exception ex)
+                catch (RemoteListVerificationException ex)
                 {
                     if (m_options.AutoCleanup)
                     {

--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -113,7 +113,7 @@ namespace Duplicati.Library.Main.Operation
             {
                 var s = string.Format("Found {0} remote files that are not recorded in local storage, please run repair", extraCount);
                 Logging.Log.WriteErrorMessage(LOGTAG, "ExtraRemoteFiles", null, s);
-                throw new Duplicati.Library.Interface.UserInformationException(s, "ExtraRemoteFiles");
+                throw new RemoteListVerificationException(s, "ExtraRemoteFiles");
             }
 
             ISet<string> doubles;
@@ -123,7 +123,7 @@ namespace Duplicati.Library.Main.Operation
             {
                 var s = string.Format("Found remote files reported as duplicates, either the backend module is broken or you need to manually remove the extra copies.\nThe following files were found multiple times: {0}", string.Join(", ", doubles));
                 Logging.Log.WriteErrorMessage(LOGTAG, "DuplicateRemoteFiles", null, s);
-                throw new Duplicati.Library.Interface.UserInformationException(s, "DuplicateRemoteFiles");
+                throw new RemoteListVerificationException(s, "DuplicateRemoteFiles");
             }
 
             if (missingCount > 0)
@@ -135,7 +135,7 @@ namespace Duplicati.Library.Main.Operation
                     s = string.Format("Found {0} files that are missing from the remote storage, please run repair", missingCount);
 
                 Logging.Log.WriteErrorMessage(LOGTAG, "MissingRemoteFiles", null, s);
-                throw new Duplicati.Library.Interface.UserInformationException(s, "MissingRemoteFiles");
+                throw new RemoteListVerificationException(s, "MissingRemoteFiles");
             }
         }
 
@@ -279,7 +279,7 @@ namespace Duplicati.Library.Main.Operation
                 if (e.Value == RemoteVolumeState.Uploading || e.Value == RemoteVolumeState.Temporary)
                     database.UnlinkRemoteVolume(e.Key, e.Value);
                 else
-                    throw new Exception(string.Format("The remote volume {0} appears in the database with state {1} and a deleted state, cannot continue", e.Key, e.Value.ToString()));
+                    throw new RemoteListVerificationException(string.Format("The remote volume {0} appears in the database with state {1} and a deleted state, cannot continue", e.Key, e.Value.ToString()), "AmbiguousStateRemoteFiles");
             }
 
             var locallist = database.GetRemoteVolumes();


### PR DESCRIPTION
Previously, we would catch any `Exception` thrown by `VerifyRemoteList` and perform an auto-cleanup (if specified in the options).  However, we should only perform the auto-cleanup if `VerifyRemoteList` detected an issue with the uploaded files.  Otherwise, an unrelated exception can cause the database repair to be performed unnecessarily.  In the case of a connection issue, the attempted repair (which requires listing the backend files) can leave the database in a corrupted (`RepairInProgress`) state.

This fixes #4516.