### PR TITLE
Use consistent target framework for .NET 5 entry executables

### DIFF
--- a/Executables/net5/Duplicati.CommandLine/Duplicati.CommandLine.csproj
+++ b/Executables/net5/Duplicati.CommandLine/Duplicati.CommandLine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Copyright>LGPL, Copyright © Duplicati Team 2021</Copyright>
     <Description>Commandline implementation of Duplicati</Description>
   </PropertyGroup>


### PR DESCRIPTION
This modifies the target framework for the `Duplicati.CommandLine` entry executable to be consistent with the other projects. 
 Previously, the inconsistent target frameworks (net5 vs. net5.0) would lead to different output paths
```
Executables/net5/Duplicati.CommandLine.BackendTester/bin/Debug/net5.0
Executables/net5/Duplicati.CommandLine/bin/Debug/net5
```

With these changes, the path to the `Duplicati.CommandLine` executables becomes    
```
Executables/net5/Duplicati.CommandLine/bin/Debug/net5.0
```