### PR TITLE
Check contents of written test file

### DIFF
--- a/Duplicati/Library/Backend/AlternativeFTP/AlternativeFTPBackend.cs
+++ b/Duplicati/Library/Backend/AlternativeFTP/AlternativeFTPBackend.cs
@@ -446,15 +446,6 @@ namespace Duplicati.Library.Backend.AlternativeFTP
             get { return new string[] { new Uri(_url).Host }; }
         }
 
-        private static Stream StringToStream(string str)
-        {
-            var stream = new MemoryStream();
-            var writer = new StreamWriter(stream) { AutoFlush = true };
-            writer.Write(str);
-            stream.Position = 0;
-            return stream;
-        }
-
         /// <summary>
         /// Test FTP access permissions.
         /// </summary>
@@ -476,7 +467,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
             }
 
             // Test write permissions
-            using (var testStream = StringToStream(TEST_FILE_CONTENT))
+            using (var testStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(TEST_FILE_CONTENT)))
             {
                 try
                 {
@@ -494,7 +485,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
                 try
                 {
                     Get(TEST_FILE_NAME, testStream);
-                    var readValue = System.Text.Encoding.Default.GetString(testStream.ToArray());
+                    var readValue = System.Text.Encoding.UTF8.GetString(testStream.ToArray());
                     if (readValue != TEST_FILE_CONTENT)
                         throw new Exception("Test file corrupted.");
                 }

--- a/Duplicati/Library/Backend/AlternativeFTP/AlternativeFTPBackend.cs
+++ b/Duplicati/Library/Backend/AlternativeFTP/AlternativeFTPBackend.cs
@@ -451,6 +451,7 @@ namespace Duplicati.Library.Backend.AlternativeFTP
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream) { AutoFlush = true };
             writer.Write(str);
+            stream.Position = 0;
             return stream;
         }
 
@@ -488,11 +489,14 @@ namespace Duplicati.Library.Backend.AlternativeFTP
             }
 
             // Test read permissions
-            using (var stream = new MemoryStream())
+            using (var testStream = new MemoryStream())
             {
                 try
                 {
-                    Get(TEST_FILE_NAME, stream);
+                    Get(TEST_FILE_NAME, testStream);
+                    var readValue = System.Text.Encoding.Default.GetString(testStream.ToArray());
+                    if (readValue != TEST_FILE_CONTENT)
+                        throw new Exception("Test file corrupted.");
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Before performing test write, reset stream Position to 0, otherwise test performs zero-byte write.
When performing test read, verify that file was written correctly.