### PR TITLE
Add support for mega.nz two factor authentication

### DIFF
--- a/Duplicati/Library/Backend/Mega/Duplicati.Library.Backend.Mega.csproj
+++ b/Duplicati/Library/Backend/Mega/Duplicati.Library.Backend.Mega.csproj
@@ -31,11 +31,14 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MegaApiClient, Version=1.7.1.495, Culture=neutral, PublicKeyToken=0480d311efbeb4e2, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\MegaApiClient.1.7.1\lib\net46\MegaApiClient.dll</HintPath>
+    <Reference Include="MegaApiClient, Version=1.9.0.0, Culture=neutral, PublicKeyToken=0480d311efbeb4e2">
+      <HintPath>..\..\..\..\packages\MegaApiClient.1.9.0\lib\net46\MegaApiClient.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Otp.NET, Version=1.2.2.0, Culture=neutral, PublicKeyToken=38a48df817e173a6">
+      <HintPath>..\..\..\..\packages\Otp.NET.1.2.2\lib\net45\Otp.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />

--- a/Duplicati/Library/Backend/Mega/Strings.cs
+++ b/Duplicati/Library/Backend/Mega/Strings.cs
@@ -6,8 +6,8 @@ namespace Duplicati.Library.Backend.Strings {
         public static string AuthPasswordDescriptionShort { get { return LC.L(@"Supplies the password used to connect to the server"); } }
         public static string AuthUsernameDescriptionLong { get { return LC.L(@"The username used to connect to the server. This may also be supplied as the environment variable ""AUTH_USERNAME""."); } }
         public static string AuthUsernameDescriptionShort { get { return LC.L(@"Supplies the username used to connect to the server"); } }
-        public static string AuthTwoFactorKeyDescriptionShort { get { return LC.L(@"Supplies the two-factor key used to connect to the server"); } }
-        public static string AuthTwoFactorKeyDescriptionLong { get { return LC.L(@"The two-factor authentication key used to connect to the server."); } }
+        public static string AuthTwoFactorKeyDescriptionShort { get { return LC.L(@"The shared secret used to generate two-factor TOTP codes."); } }
+        public static string AuthTwoFactorKeyDescriptionLong { get { return LC.L(@"For accounts with two-factor authentication enabled, this is the shared secret used to generate the two-factor TOTP codes."); } }
         public static string NoPasswordError { get { return LC.L(@"No password given"); } }
         public static string NoUsernameError { get { return LC.L(@"No username given"); } }
         public static string Description { get { return LC.L(@"This backend can read and write data to Mega.co.nz. Allowed formats are: ""mega://folder/subfolder"""); } }

--- a/Duplicati/Library/Backend/Mega/Strings.cs
+++ b/Duplicati/Library/Backend/Mega/Strings.cs
@@ -6,6 +6,8 @@ namespace Duplicati.Library.Backend.Strings {
         public static string AuthPasswordDescriptionShort { get { return LC.L(@"Supplies the password used to connect to the server"); } }
         public static string AuthUsernameDescriptionLong { get { return LC.L(@"The username used to connect to the server. This may also be supplied as the environment variable ""AUTH_USERNAME""."); } }
         public static string AuthUsernameDescriptionShort { get { return LC.L(@"Supplies the username used to connect to the server"); } }
+        public static string AuthTwoFactorKeyDescriptionShort { get { return LC.L(@"Supplies the two-factor key used to connect to the server"); } }
+        public static string AuthTwoFactorKeyDescriptionLong { get { return LC.L(@"The two-factor authentication key used to connect to the server."); } }
         public static string NoPasswordError { get { return LC.L(@"No password given"); } }
         public static string NoUsernameError { get { return LC.L(@"No username given"); } }
         public static string Description { get { return LC.L(@"This backend can read and write data to Mega.co.nz. Allowed formats are: ""mega://folder/subfolder"""); } }

--- a/Duplicati/Library/Backend/Mega/packages.config
+++ b/Duplicati/Library/Backend/Mega/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MegaApiClient" version="1.7.1" targetFramework="net471" />
+  <package id="MegaApiClient" version="1.9.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
+  <package id="Otp.NET" version="1.2.2" targetFramework="net471" />
 </packages>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -72,12 +72,15 @@
     </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\Otp.NET\license.txt">
       <Link>licenses\Otp.NET\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\Otp.NET\licensedata.json">
       <Link>licenses\Otp.NET\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SharpCompress\download.txt">
       <Link>licenses\SharpCompress\download.txt</Link>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -70,6 +70,15 @@
       <Link>licenses\gpg\License.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
+      <Link>licenses\Otp.NET\Homepage.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\Otp.NET\license.txt">
+      <Link>licenses\Otp.NET\license.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\Otp.NET\licensedata.json">
+      <Link>licenses\Otp.NET\licensedata.json</Link>
+    </Content>
     <Content Include="..\..\thirdparty\SharpCompress\download.txt">
       <Link>licenses\SharpCompress\download.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/thirdparty/Otp.NET/Homepage.txt
+++ b/thirdparty/Otp.NET/Homepage.txt
@@ -1,0 +1,1 @@
+https://github.com/kspearrin/Otp.NET

--- a/thirdparty/Otp.NET/license.txt
+++ b/thirdparty/Otp.NET/license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Kyle Spearrin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/thirdparty/Otp.NET/licensedata.json
+++ b/thirdparty/Otp.NET/licensedata.json
@@ -1,0 +1,7 @@
+{
+    "name": "Otp.NET",
+    "description": "An implementation TOTP RFC 6238 and HOTP RFC 4226 in C#.",
+    "link": "https://github.com/kspearrin/Otp.NET",
+    "license": "MIT",
+    "notes": ""
+}


### PR DESCRIPTION
Fixes #3696

How it works:
- I've added an option called `auth-two-factor-key` in which you set the TOTP generation key given by mega.nz
- I've added a reference to the NuGet package `Otp.NET` to generate a valid TOTP code using the `auth-two-factor-key` when we create the `MegaApiClient`

I have tested with my personal mega.nz account and it's working fine!

I believe the only downside of the PR is that we are adding a new external library and I don't know what your policy is on this. Maybe we should add it on a "higher level" csproj so other backends could use it too?