### PR TITLE
Add tests for restoring without local data

### DIFF
--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -130,10 +130,6 @@ namespace Duplicati.UnitTest
             string file2Path = Path.Combine(this.DATAFOLDER, "file2");
             File.WriteAllBytes(file2Path, new byte[] { 3, 4, 6 });
 
-            string folderPath = Path.Combine(this.DATAFOLDER, "folder");
-            Directory.CreateDirectory(folderPath);
-            systemIO.FileCopy(file1Path, Path.Combine(folderPath, "file1 copy"), true);
-
             using (Controller c = new Controller("file://" + this.TARGETFOLDER, new Dictionary<string, string>(this.TestOptions), null))
             {
                 IBackupResults backupResults = c.Backup(new[] { this.DATAFOLDER });


### PR DESCRIPTION
This adds some tests for restoring files without local data (local database, local blocks, patching with local blocks).  This revealed an issue when `no-local-db` and `no-local-blocks` are "true" and two source files contain the same contents (see issue #4593).  Once that issue is fixed, we can revert revision 75a6efddf09a7ce1f26f195e96c01690457e19f9 to test the additional code paths.