### PR TITLE
Fix implementation of Options.PatchWithLocalBlocks

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1655,7 +1655,7 @@ namespace Duplicati.Library.Main
         /// </summary>
         public bool PatchWithLocalBlocks
         {
-            get { return m_options.ContainsKey("patch-with-local-blocks"); }
+            get { return Library.Utility.Utility.ParseBoolOption(m_options, "patch-with-local-blocks"); }
         }
 
         /// <summary>


### PR DESCRIPTION
Previously, `Options.PatchWithLocalBlocks` would return `true` as long as the key was present in the `Dictionary`, regardless of what the value parsed to.

