### PR TITLE
Don't explicitly call reload() in BackupList

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/BackupList.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/BackupList.js
@@ -54,6 +54,4 @@ backupApp.service('BackupList', function($rootScope, $timeout, AppService, AppUt
 
     $rootScope.$on('serverstatechanged.lastDataUpdateId', reload);
     $rootScope.$on('serverstatechanged.proposedSchedule', updateNextRunStamp);
-
-    reload();
 });


### PR DESCRIPTION
serverstatechanged.lastDataUpdateId is already triggered, so reload() was called twice.

This also caused the backup list to always "flicker" (show - hide - show) upon opening the web gui.