### PR TITLE
Always log filename if error occurs during retrieval

### DIFF
--- a/Duplicati/Library/Main/AsyncDownloader.cs
+++ b/Duplicati/Library/Main/AsyncDownloader.cs
@@ -13,6 +13,8 @@ namespace Duplicati.Library.Main
 
     internal class AsyncDownloader : IEnumerable<IAsyncDownloadedFile>
     {
+        private static readonly string LOGTAG = Logging.Log.LogTagFromType<AsyncDownloader>();
+
         private class AsyncDownloaderEnumerator : IEnumerator<IAsyncDownloadedFile>
         {
             private class AsyncDownloadedFile : IAsyncDownloadedFile
@@ -110,6 +112,7 @@ namespace Duplicati.Library.Main
                 }
                 catch (Exception ex)
                 {
+                    Logging.Log.WriteErrorMessage(LOGTAG, "FailedToRetrieveFile", ex, "Failed to retrieve file {0}", m_volumes[m_index].Name);
                     exception = ex;
                 }
                 


### PR DESCRIPTION
This modifies `AsyncDownloader` so that a log entry with the name of the problematic file is always created.  Previously, we relied on individual usages of `AsyncDownloader` to log entries.  For example, if there was a decryption error during compacting, the default log level would not indicate which file caused the error.

**Before:**
```
Backup started at 1/8/2022 11:56:50 AM
Checking remote backup ...
  Listing remote folder ...
Scanning local files ...
  0 files need to be examined (0 bytes)
  Uploading file (845 bytes) ...
  Uploading file (877 bytes) ...
  Uploading file (1.08 KB) ...
  Deleting file duplicati-20220108T195618Z.dlist.zip.aes (1.23 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
Fatal error => Failed to decrypt data (invalid passphrase?): Message has been altered, do not trust content
```

**After:**
```
Backup started at 1/8/2022 11:47:17 AM
Checking remote backup ...
  Listing remote folder ...
Scanning local files ...
  0 files need to be examined (0 bytes)
  Uploading file (845 bytes) ...
  Uploading file (877 bytes) ...
  Uploading file (1.09 KB) ...
  Deleting file duplicati-20220108T194634Z.dlist.zip.aes (1.23 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
Failed to retrieve file duplicati-ba4f281d6b0794315b36e689a097494c5.dblock.zip.aes => Failed to decrypt data (invalid passphrase?): Message has been altered, do not trust content
  Downloading file (1.73 KB) ...
Fatal error => Failed to decrypt data (invalid passphrase?): Message has been altered, do not trust content
```

Some operation handlers create their own log entries, so this can now result in duplicated entries.  For example during verification:
```
  Listing remote folder ...
  Downloading file (1.08 KB) ...
  Downloading file (1.01 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
  Downloading file (1.73 KB) ...
Failed to retrieve file duplicati-b52937a24fca448e0baf826bf08511c9a.dblock.zip.aes => Failed to decrypt data (invalid passphrase?): Message has been altered, do not trust content
Failed to process file duplicati-b52937a24fca448e0baf826bf08511c9a.dblock.zip.aes => Failed to decrypt data (invalid passphrase?): Message has been altered, do not trust content
duplicati-b52937a24fca448e0baf826bf08511c9a.dblock.zip.aes: 1 errors
        Error: Failed to decrypt data (invalid passphrase?): Message has been altered, do not trust content
```
However, I think it still makes sense for `AsyncDownloader` to log the error for completeness.

This fixes #4658.