### PR TITLE
Add Infomaniak Swiss Backup to backend

### DIFF
--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -68,6 +68,7 @@ namespace Duplicati.Library.Backend.OpenStack
             new KeyValuePair<string, string>("OVH Cloud Storage", "https://auth.cloud.ovh.net/v3"),
             new KeyValuePair<string, string>("Selectel Cloud Storage", "https://auth.selcdn.ru"),
             new KeyValuePair<string, string>("Memset Cloud Storage", "https://auth.storage.memset.com"),
+            new KeyValuePair<string, string>("Infomaniak SwissBackup", "https://swiss-backup02.infomaniak.com/identity/v3"),
         };
 
         public static readonly KeyValuePair<string, string>[] OPENSTACK_VERSIONS = {

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -56,6 +56,7 @@ namespace Duplicati.Library.Backend
             { "Wasabi Hot Storage", "s3.wasabisys.com" },
             { "Wasabi Hot Storage (US West)", "s3.us-west-1.wasabisys.com" },
             { "Wasabi Hot Storage (EU Central)", "s3.eu-central-1.wasabisys.com" },
+            { "Infomaniak SwissBackup", "s3.swiss-backup02.infomaniak.com" },
         };
 
         //Updated list: http://docs.amazonwebservices.com/general/latest/gr/rande.html#s3_region


### PR DESCRIPTION
Simply adding Infomaniak SwissBackup as a backend in OpenStack Swift and S3 Compatible.

Infomaniak SwissBackup website : https://www.infomaniak.com/fr/swiss-backup