### PR TITLE
Added null check to fix exception reading vhd settings xml.

### DIFF
--- a/Duplicati/Library/Snapshots/HyperVUtility.cs
+++ b/Duplicati/Library/Snapshots/HyperVUtility.cs
@@ -302,7 +302,16 @@ namespace Duplicati.Library.Snapshots
                                        select ((string[])systemBaseObj["Connection"])[0]).ToList();
 
                         foreach (var vhd in tempvhd)
-                            result.Add(vhd);
+                        {
+                            if (File.Exists(vhd))
+                            {
+                                result.Add(vhd);
+                            }
+                            else
+                            {
+                                Logging.Log.WriteWarningMessage(LOGTAG, "HyperVInvalidVhd", null, "Invalid VHD file detected, file does not exist: {0}", vhd);
+                            }
+                        }
                     }
             }
 

--- a/Duplicati/Library/Snapshots/HyperVUtility.cs
+++ b/Duplicati/Library/Snapshots/HyperVUtility.cs
@@ -319,11 +319,16 @@ namespace Duplicati.Library.Snapshots
                         if (outParams != null)
                         {
                             var doc = new System.Xml.XmlDocument();
-                            doc.LoadXml((string)outParams[_wmiv2Namespace ? "SettingData" : "Info"]);
-                            var node = doc.SelectSingleNode("//PROPERTY[@NAME = 'ParentPath']/VALUE/child::text()");
+                            var propertyValue = (string)outParams[_wmiv2Namespace ? "SettingData" : "Info"];
 
-                            if (node != null && File.Exists(node.Value))
-                                ParentPaths.Add(node.Value);
+                            if (propertyValue != null)
+                            {
+                                doc.LoadXml(propertyValue);
+                                var node = doc.SelectSingleNode("//PROPERTY[@NAME = 'ParentPath']/VALUE/child::text()");
+
+                                if (node != null && File.Exists(node.Value))
+                                    ParentPaths.Add(node.Value);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
When I attempted to backup a single Hyper-V VM on my Win10 machine it failed with the following error:
**System.ArgumentNullException: Value cannot be null.
Parameter name: s**

This was caused by outParams["SettingsData"] being null for one of the vhds.
**doc.LoadXml((string)outParams[_wmiv2Namespace ? "SettingData" : "Info"]);**

For this particular vhd multiple paths were returned an invalid path twice:
U:\vhds\NetBSD PXE Test.vhdx
and the actual path once: 
U:\vhds\NetBSD_PXE_Test.vhdx 

When the path was invalid the null occurred.
Adding the null check for outParams prevents this ArgumentNullException from occurring when reading the XML.