### PR TITLE
Added detection of access token types to Dropbox backend.

### DIFF
--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -18,7 +18,9 @@ namespace Duplicati.Library.Backend
             : base(accessToken, "dropbox")
         {
             base.AutoAuthHeader = true;
-            base.AccessTokenOnly = true;
+            // Pre 2022 tokens are direct Dropbox tokens (no ':')
+            // Post 2022-02-21 tokens are regular authid tokens (with a ':')
+            base.AccessTokenOnly = !accessToken.Contains(":");
         }
 
         public ListFolderResult ListFiles(string path)


### PR DESCRIPTION
This adds detection for the type of `--authid` supplied after Dropbox OAuth was updated to use refresh tokens.
Issue is explained in #4667.