### PR TITLE
Add indexes to improve backup query performance.

### DIFF
--- a/Duplicati/Library/Main/Database/Database schema/12. Performance Indexes.sql
+++ b/Duplicati/Library/Main/Database/Database schema/12. Performance Indexes.sql
@@ -1,0 +1,12 @@
+CREATE INDEX "nnc_Metadataset" ON Metadataset ("ID","BlocksetID")
+CREATE INDEX "nn_FilesetentryFile" on FilesetEntry ("FilesetID","FileID")
+
+-- Line 602 & 603 LocalBackupDatabase.cs 
+-- CREATE INDEX "tmpName1" ON "{0}" ("Path"),tmpName1
+-- CREATE INDEX "tmpName2" ON "{0}" ("Path"),tmpName2
+
+CREATE INDEX "nn_FileLookup_BlockMeta" ON FileLookup ("BlocksetID", "MetadataID")
+
+CREATE INDEX "nnc_BlocksetEntry" ON "BlocksetEntry" ("Index", "BlocksetID", "BlockID")
+
+UPDATE "Version" SET "Version" = 12;

--- a/Duplicati/Library/Main/Database/Database schema/Schema.sql
+++ b/Duplicati/Library/Main/Database/Database schema/Schema.sql
@@ -81,6 +81,8 @@ CREATE TABLE "FilesetEntry" (
 
 /* Improved reverse lookup for joining Fileset and File table */
 CREATE INDEX "FilesetentryFileIdIndex" on "FilesetEntry" ("FileID");
+CREATE INDEX "nn_FilesetentryFile" on FilesetEntry ("FilesetID","FileID");
+
 
 
 /*
@@ -109,6 +111,9 @@ CREATE TABLE "FileLookup" (
 
 /* Fast path based lookup, single properties are auto-indexed */
 CREATE UNIQUE INDEX "FileLookupPath" ON "FileLookup" ("PrefixID", "Path", "BlocksetID", "MetadataID");
+CREATE INDEX "nn_FileLookup_BlockMeta" ON FileLookup ("BlocksetID", "MetadataID");
+
+
 
 /*
 The File view contains an ID
@@ -167,7 +172,7 @@ CREATE TABLE "BlocksetEntry" (
 
 /* As this table is a cross table we need fast lookup */
 CREATE INDEX "BlocksetEntry_IndexIdsBackwards" ON "BlocksetEntry" ("BlockID");
-
+CREATE INDEX "nnc_BlocksetEntry" ON "BlocksetEntry" ("Index", "BlocksetID", "BlockID");
 
 /*
 The individual block hashes,
@@ -222,6 +227,8 @@ CREATE TABLE "Metadataset" (
 );
 
 CREATE INDEX "MetadatasetBlocksetID" ON "Metadataset" ("BlocksetID");
+CREATE INDEX "nnc_Metadataset" ON Metadataset ("ID","BlocksetID");
+
 
 /*
 Operations performed on the backend,
@@ -280,4 +287,4 @@ CREATE TABLE "ChangeJournalData" (
     "ConfigHash" TEXT NOT NULL  
 );
 
-INSERT INTO "Version" ("Version") VALUES (11);
+INSERT INTO "Version" ("Version") VALUES (12);

--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -601,6 +601,9 @@ namespace Duplicati.Library.Main.Database
 
                     cmd.ExecuteNonQuery(string.Format(@"CREATE TEMPORARY TABLE ""{0}"" AS " + subqueryFiles, tmpName1), lastFilesetId);
                     cmd.ExecuteNonQuery(string.Format(@"CREATE TEMPORARY TABLE ""{0}"" AS " + subqueryFiles, tmpName2), m_filesetId);
+                    cmd.ExecuteNonQuery(string.Format(@"CREATE INDEX ""nn_tmpName1"" ON ""{0}"" (""Path"")",tmpName1));
+                    cmd.ExecuteNonQuery(string.Format(@"CREATE INDEX ""nn_tmpName2"" ON ""{0}"" (""Path"")",tmpName2));
+
 
                     results.AddedFiles = cmd.ExecuteScalarInt64(string.Format(@"SELECT COUNT(*) FROM ""File"" INNER JOIN ""FilesetEntry"" ON ""File"".""ID"" = ""FilesetEntry"".""FileID"" WHERE ""FilesetEntry"".""FilesetID"" = ? AND ""File"".""BlocksetID"" != ? AND ""File"".""BlocksetID"" != ? AND NOT ""File"".""Path"" IN (SELECT ""Path"" FROM ""{0}"")", tmpName1), 0, m_filesetId, FOLDER_BLOCKSET_ID, SYMLINK_BLOCKSET_ID);
                     results.DeletedFiles = cmd.ExecuteScalarInt64(string.Format(@"SELECT COUNT(*) FROM ""{0}"" WHERE ""{0}"".""Path"" NOT IN (SELECT ""Path"" FROM ""File"" INNER JOIN ""FilesetEntry"" ON ""File"".""ID"" = ""FilesetEntry"".""FileID"" WHERE ""FilesetEntry"".""FilesetID"" = ?)", tmpName1), 0, m_filesetId);


### PR DESCRIPTION
Here is the PR for the indexes I identified to fix some query issues. I mentioned it all here: https://forum.duplicati.com/t/identified-another-slow-query-during-backup/14005

These probably should be included in the next beta release because they seem resolve some of the query issues caused by certain datasets combined with the default blocksize which almost caused me to find a different backup solution.

Let me know if you have any questions.
