### PR TITLE
Enhanced error reporting for all Google Services & fix to Google Drive 403 (forbidden) error relating to malware and spam

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/Strings.cs
+++ b/Duplicati/Library/Backend/GoogleServices/Strings.cs
@@ -45,6 +45,8 @@ namespace Duplicati.Library.Backend.Strings
         public static string MultipleEntries(string folder, string parent) { return LC.L(@"There is more than one item named ""{0}"" in the folder ""{1}""", folder, parent); }
         public static string TeamDriveIdShort { get { return LC.L("Team drive ID"); } }
         public static string TeamDriveIdLong { get { return LC.L("This option sets the team drive to use. Leaving it empty uses the personal drive"); } }
+        public static string AcknowledgeAbuseShort { get { return LC.L("Acknowledge Abuse Flag"); } }
+        public static string AcknowledgeAbuseLong { get { return LC.L("This option allows a file that Google drive believes contains spam or malware to be retrieved"); } }
     }
 }
 

--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -55,14 +55,14 @@ namespace Duplicati.Library.Backend.WebApi
 
         public static string DeleteUrl(string bucketId, string objectId)
         {
-            var path = BucketObjectPath(bucketId, objectId);
+            string path = BucketObjectPath(bucketId, objectId);
 
             return Uri.UriBuilder(Url.API, path);
         }
 
         public static string CreateFolderUrl(string projectId)
         {
-            var queryParams = new NameValueCollection
+            NameValueCollection queryParams = new NameValueCollection
             {
                 { QueryParam.Project, projectId }
             };
@@ -82,7 +82,7 @@ namespace Duplicati.Library.Backend.WebApi
 
         public static string ListUrl(string bucketId, string prefix, string token)
         {
-            var queryParams = new NameValueCollection {
+            NameValueCollection queryParams = new NameValueCollection {
                     { QueryParam.Prefix, prefix }
                 };
 
@@ -96,22 +96,22 @@ namespace Duplicati.Library.Backend.WebApi
 
         public static string PutUrl(string bucketId)
         {
-            var queryParams = new NameValueCollection
+            NameValueCollection queryParams = new NameValueCollection
             {
                 { QueryParam.UploadType, QueryValue.Resumable }
             };
-            var path = UrlPath.Create(Path.Bucket).Append(bucketId).Append(Path.Object).ToString();
+            string path = UrlPath.Create(Path.Bucket).Append(bucketId).Append(Path.Object).ToString();
             return Uri.UriBuilder(Url.UPLOAD, path, queryParams);
         }
 
         public static string GetUrl(string bucketId, string objectId)
         {
-            var queryParams = new NameValueCollection
+            NameValueCollection queryParams = new NameValueCollection
                 {
                     { QueryParam.Alt
                             , QueryValue.Media }
                 };
-            var path = BucketObjectPath(bucketId, objectId);
+            string path = BucketObjectPath(bucketId, objectId);
 
             return Uri.UriBuilder(Url.API, path, queryParams);
         }
@@ -160,11 +160,15 @@ namespace Duplicati.Library.Backend.WebApi
 
         }
 
-        public static string GetUrl(string fileId)
+        public static string GetUrl(string fileId, bool acknowledgeAbuseGranted)
         {
-            return FileQueryUrl(fileId, new NameValueCollection{
-                { QueryParam.Alt, QueryValue.Media }
-            });
+            NameValueCollection queryParams = new NameValueCollection {
+                { QueryParam.Alt, QueryValue.Media } };
+
+            if (acknowledgeAbuseGranted)
+                queryParams.Add(QueryParam.AcknowledgeAbuse, QueryValue.True);
+
+            return FileQueryUrl(fileId, queryParams);
         }
 
         public static string DeleteUrl(string fileId, string teamDriveId)
@@ -174,7 +178,7 @@ namespace Duplicati.Library.Backend.WebApi
 
         public static string PutUrl(string fileId, bool useTeamDrive)
         {
-            var queryParams = new NameValueCollection {
+            NameValueCollection queryParams = new NameValueCollection {
                 { QueryParam.UploadType,
                     QueryValue.Resumable } };
 
@@ -195,7 +199,7 @@ namespace Duplicati.Library.Backend.WebApi
         
         public static string ListUrl(string fileQuery, string teamDriveId, string token)
         {
-            var queryParams = new NameValueCollection
+            NameValueCollection queryParams = new NameValueCollection
             {
                 { QueryParam.File,
                     fileQuery }
@@ -243,6 +247,7 @@ namespace Duplicati.Library.Backend.WebApi
             public const string PageToken = "pageToken";
             public const string UploadType = "uploadType";
             public const string Alt = "alt";
+            public const string AcknowledgeAbuse = "acknowledgeAbuse";
         }
 
         private static class QueryValue


### PR DESCRIPTION
Enhanced error reporting for all Google Services by unpacking and displaying the HTTP response that Google Drive and Google API returns. These changes have been made across all Google web methods.

In addition to this I have looked further into the 403 (forbidden) error being returned from Google Drive. In my case the error being returned was "This file has been identified as malware or spam and cannot be downloaded". It appears that Google Drive checks files before allowing them to be downloaded. In order to bypass this error Google Drive has a query string parameter called "acknowledgeAbuse" that must be set if a file is detected as having spam/malware (the flag can't be set generally, it can only be set for files detected as having spam/malware). I have modified the code to add this flag if this error is detected but only if a new Google Drive Duplicati option called "acknowledge-abuse" is also enabled.

Finally I have replaced (automatically) all "var" statements with their native types. The "var" statements were making the code difficult to read particularly from GitHub because it created uncertainty around variable types, removing the use of "var" makes the code let ambiguous.