### PR TITLE
Delay creation of database directory until we know it is needed

### DIFF
--- a/Duplicati/Library/Main/DatabaseLocator.cs
+++ b/Duplicati/Library/Main/DatabaseLocator.cs
@@ -73,9 +73,6 @@ namespace Duplicati.Library.Main
 					folder = newlocation;
 			}
 
-            if (!System.IO.Directory.Exists(folder))
-                System.IO.Directory.CreateDirectory(folder);
-                
             var file = System.IO.Path.Combine(folder, "dbconfig.json");
             List<BackendEntry> configs;
             if (!System.IO.File.Exists(file))
@@ -179,7 +176,10 @@ namespace Duplicati.Library.Main
                     Databasepath = newpath, 
                     ParameterFile = null
                 });
-                
+
+                if (!System.IO.Directory.Exists(folder))
+                    System.IO.Directory.CreateDirectory(folder);
+
                 var settings = new Newtonsoft.Json.JsonSerializerSettings();
                 settings.Formatting = Newtonsoft.Json.Formatting.Indented;
                 System.IO.File.WriteAllText(file, Newtonsoft.Json.JsonConvert.SerializeObject(configs, settings), System.Text.Encoding.UTF8);


### PR DESCRIPTION
This avoids creating directory %LocalAppData%\Duplicati when it would just be left
empty, and it makes running portable mode (e.g. debug builds) stealthier.