### PR TITLE
Bypass auto-update when running in a debug environment

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Common;
+using System.Diagnostics;
 
 namespace Duplicati.Library.AutoUpdater
 {
@@ -56,7 +57,7 @@ namespace Duplicati.Library.AutoUpdater
             ? System.IO.Path.GetDirectoryName(Duplicati.Library.Utility.Utility.getEntryAssembly().Location)
             : Environment.ExpandEnvironmentVariables(System.Environment.GetEnvironmentVariable(string.Format(BASEINSTALLDIR_ENVNAME_TEMPLATE, APPNAME)));
 
-        private static readonly bool DISABLE_UPDATE_DOMAIN = Utility.Utility.ParseBool(Environment.GetEnvironmentVariable(string.Format(SKIPUPDATE_ENVNAME_TEMPLATE, APPNAME)), false);
+        private static readonly bool DISABLE_UPDATE_DOMAIN = Debugger.IsAttached || Utility.Utility.ParseBool(Environment.GetEnvironmentVariable(string.Format(SKIPUPDATE_ENVNAME_TEMPLATE, APPNAME)), false);
 
         public static bool RequiresRespawn { get; set; }
 


### PR DESCRIPTION
Debugging the source won't work unless `AUTOUPDATER_Duplicati_SKIP_UPDATE=1` is set as an environment variable. This is not an obvious step for those new to the codebase. This change would check whether the code is running in a debugger and bypass the auto-update feature allowing users to debug the code.