### PR TITLE
Disable automatic use of v2 authid for Jottacloud

### DIFF
--- a/Duplicati/Library/Backend/Jottacloud/JottacloudAuthHelper.cs
+++ b/Duplicati/Library/Backend/Jottacloud/JottacloudAuthHelper.cs
@@ -28,6 +28,7 @@ namespace Duplicati.Library.Backend
             : base(accessToken, "jottacloud")
         {
             base.AutoAuthHeader = true;
+            base.AutoV2 = false; // Jottacloud is not v2 compatible because it generates a new refresh token with every access token refresh and invalidates the old.
 
             var userinfo = GetJSONData<UserInfo>(USERINFO_URL);
             if (userinfo == null || string.IsNullOrEmpty(userinfo.Username))

--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHelper.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHelper.cs
@@ -83,6 +83,16 @@ namespace Duplicati.Library
         /// Set to true if the provider does not use refresh tokens, but only access tokens
         /// </summary>
         public bool AccessTokenOnly { get; set; }
+        /// <summary>
+        /// If true (the default), when a v1 authid is being used it will be swapped
+        /// with a v2 authid, when the OAuth service returns one (which it dypically
+        /// does after a provider token refresh has been performed). Some providers
+        /// are not compatible with v2 authid, tyically because they generate a new
+        /// refresh token with every access token refresh and invalidates the old.
+        /// If the oauth service still returns a v2 authid for such a provider,
+        /// set this property to false to make Duplicati ignore it.
+        /// </summary>
+        public bool AutoV2 { get; set; } = true;
 
         public OAuthHelper(string authid, string servicename, string useragent = null)
             : base(useragent)
@@ -134,7 +144,7 @@ namespace Duplicati.Library
                             var res = GetTokenResponse<OAuth_Service_Response>();
 
                             m_tokenExpires = DateTime.UtcNow.AddSeconds(res.expires - 30);
-                            if (!string.IsNullOrWhiteSpace(res.v2_authid))
+                            if (AutoV2 && !string.IsNullOrWhiteSpace(res.v2_authid))
                                 m_authid = res.v2_authid;
                             return m_token = res.access_token;
                         }


### PR DESCRIPTION
Hopefully fixing the authentication problems with Jottacloud after transition to OAuth.

Assuming OAuth is configured using the oauth service, with a regular (v1) authid. Duplicati then supplies the authid and asks the oauth service for an access token. If the oauth service finds it needs to refresh its stored access token it requests a token refresh from the provider, and in this case the response to Duplicati also includes a v2 authid (see [here](https://github.com/duplicati/oauth-handler/blob/4e58e68bac8a4bd52e8e96b8d186951dde33467a/main.py#L718)). Duplicati will then pick up this and use it for following requests instead of the configured original v1 authid. So there is an "auto-upgrade" to v2 authid mechanism. But next time an instance of the backend object is created in Duplicati, it will use the originally configured v1 authid again, and start from "scratch".

Now the problem with this is that Jottacloud is one of a few providers which generates a new refresh token with every access token refresh and invalidates the old. The procedure above works reasonably well in most cases. But not if the backend object not only performs one token refresh, converting the v1 authid to v2, but also a second token refresh where there is a refresh against the provider using the refresh token embedded in the v2 authid. Then the refresh token still stored in the oauth service for the original v1 authid is outdated and invalidated. Next time a backend object is created, starting from the v1 authid from backend options, the oauth service will end up sending a refresh requst to the provider using an invalidated refresh token. When this happens Jottacloud will mark the token as "stale" and within some expiration time, 12 or 24 hours I think, authentication will fail. Jottacloud will return HTTP 400 Bad Request with details `{"error":"invalid_grant","error_description":"Stale token"}`, which in turn leads to Oauth service returning 500 (Internal Server Error), and Duplicati will fail with "Failed to authorize using the OAuth service: Server error. If the problem persists, try generating a new authid...".

... at least that is the theory! If true, and we are lucky, it solves the authentication problems discussed at the end of the following thread: https://forum.duplicati.com/t/jottacloud-error-401-unauthorized/3929/173. But there may also be other issues, triggering the same error in some cases (e.g. threading issues which I have looked into in another pr), but I think this one should be part of the solution at least.

This should probably be handled in the oauth service, e.g. configuring Jottacloud to be not compatible with v2 and then avoid returning the v2 authid in the response. I will look into that. Still, I think it is not wrong to handle this in Duplicati, if nothing else an additional "safety switch", and also the ability to "beta test" and "hotfix" Duplicati is much easier than the oauth service I think!
- Edit: Done here: https://github.com/duplicati/oauth-handler/pull/10