### PR TITLE
Fix compile for vs mac

### DIFF
--- a/Duplicati/Library/Backend/Idrivee2/Duplicati.Library.Backend.Idrivee2.csproj
+++ b/Duplicati/Library/Backend/Idrivee2/Duplicati.Library.Backend.Idrivee2.csproj
@@ -40,10 +40,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.37\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.71\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.25\lib\net45\AWSSDK.S3.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.43\lib\net45\AWSSDK.S3.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="RestSharp, Version=106.3.1.0, Culture=neutral, PublicKeyToken=598062e77f915f75">
@@ -58,6 +58,9 @@
     <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263">
       <HintPath>..\..\..\..\packages\System.Reactive.Linq.4.0.0\lib\net46\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Minio">
+      <HintPath>..\..\..\..\packages\Minio.3.1.7\lib\net46\Minio.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows" />

--- a/Duplicati/Library/Backend/Idrivee2/packages.config
+++ b/Duplicati/Library/Backend/Idrivee2/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.103.37" targetFramework="net471" />
-  <package id="AWSSDK.S3" version="3.3.104.25" targetFramework="net471" />
+  <package id="AWSSDK.Core" version="3.3.103.71" targetFramework="net471" />
+  <package id="AWSSDK.S3" version="3.3.104.43" targetFramework="net471" />
   <package id="Minio" version="3.1.7" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
   <package id="System.Reactive" version="4.0.0" targetFramework="net471" />

--- a/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
+++ b/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
@@ -37,13 +37,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.37\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.71\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.IdentityManagement, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.26\lib\net45\AWSSDK.IdentityManagement.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.52\lib\net45\AWSSDK.IdentityManagement.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.25\lib\net45\AWSSDK.S3.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.43\lib\net45\AWSSDK.S3.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Minio, Version=3.1.7.0, Culture=neutral, PublicKeyToken=348239ebd7debb4c">
@@ -106,8 +106,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.26\analyzers\dotnet\cs\AWSSDK.IdentityManagement.CodeAnalysis.dll" />
-    <Analyzer Include="..\..\..\..\packages\AWSSDK.S3.3.3.104.25\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.52\analyzers\dotnet\cs\AWSSDK.IdentityManagement.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\..\..\packages\AWSSDK.S3.3.3.104.43\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Duplicati/Library/Backend/S3/packages.config
+++ b/Duplicati/Library/Backend/S3/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.103.37" targetFramework="net471" />
-  <package id="AWSSDK.IdentityManagement" version="3.3.103.26" targetFramework="net471" />
-  <package id="AWSSDK.S3" version="3.3.104.25" targetFramework="net471" />
+  <package id="AWSSDK.Core" version="3.3.103.71" targetFramework="net471" />
+  <package id="AWSSDK.IdentityManagement" version="3.3.103.52" targetFramework="net471" />
+  <package id="AWSSDK.S3" version="3.3.104.43" targetFramework="net471" />
   <package id="Minio" version="3.1.7" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
   <package id="System.Reactive" version="4.0.0" targetFramework="net471" />

--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -38,6 +38,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto">
+      <HintPath>..\..\..\..\packages\BouncyCastle.1.8.5\lib\BouncyCastle.Crypto.dll</HintPath>
+    </Reference>
     <Reference Include="MailKit, Version=2.3.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\MailKit.2.3.1.6\lib\net46\MailKit.dll</HintPath>
     </Reference>

--- a/Duplicati/Library/Modules/Builtin/packages.config
+++ b/Duplicati/Library/Modules/Builtin/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.8.5" targetFramework="net471" />
   <package id="MailKit" version="2.3.1.6" targetFramework="net471" />
   <package id="MimeKit" version="2.3.1" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />


### PR DESCRIPTION
This is a "Part 1" to fix the issues with newer versions of MacOS and Python.  This part enables us to get duplicati compiled on VS for Mac (and perhaps Xamarin Studio, etc.).  It primarily adds bouncycastle back in as a referenced packaged (as it's still being used in MailKit/MimeKit packages).  It also upgrades a few packages (a side effect of the process I was using to reinstall packages).

"Part 2" will come from @dgileadi, and include fixes to get the Duplicati.GUI.TrayIcon CocoaRunner class working, hopefully enabling us to deprecate the RumpsRunner class, and free us of the Python dependency. 