### PR TITLE
Make Xamarin-based CocoaRunner the default on Mac

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -115,7 +115,9 @@ namespace Duplicati.GUI.TrayIcon
                 var dp = new CGDataProvider(b, 0, b.Length);
                 var img2 = CGImage.FromPNG(dp, null, false, CGColorRenderingIntent.Default);
 
-                return new NSImage(img2, new CGSize(18, 18));
+                var nsImage = new NSImage(img2, new CGSize(18, 18));
+                nsImage.Template = true;
+                return nsImage;
             }
         }
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/CocoaRunner.cs
@@ -15,11 +15,10 @@
 //  License along with this library; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 using System;
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-using MonoMac.ObjCRuntime;
+using AppKit;
+using CoreGraphics;
+using Foundation;
 using System.Collections.Generic;
-using MonoMac.CoreGraphics;
 using System.IO;
 
 namespace Duplicati.GUI.TrayIcon
@@ -97,7 +96,7 @@ namespace Duplicati.GUI.TrayIcon
             m_app = NSApplication.SharedApplication;
             m_app.ActivateIgnoringOtherApps(true);
 
-            m_statusItem = NSStatusBar.SystemStatusBar.CreateStatusItem(32);
+            m_statusItem = NSStatusBar.SystemStatusBar.CreateStatusItem(NSStatusItemLength.Variable);
             m_statusItem.HighlightMode = true;
 
             base.Init(args);
@@ -116,7 +115,7 @@ namespace Duplicati.GUI.TrayIcon
                 var dp = new CGDataProvider(b, 0, b.Length);
                 var img2 = CGImage.FromPNG(dp, null, false, CGColorRenderingIntent.Default);
 
-                return new NSImage(img2, new System.Drawing.SizeF(18, 18));
+                return new NSImage(img2, new CGSize(18, 18));
             }
         }
 
@@ -197,7 +196,7 @@ namespace Duplicati.GUI.TrayIcon
                 m_app.Stop(m_app);
                 // Post an event to trigger the exit
                 m_app.PostEvent(NSEvent.OtherEvent(NSEventType.ApplicationDefined, 
-                    new System.Drawing.PointF(0,0),
+                    new CGPoint(0,0),
                     0, 0, 0, null, 0, 0, 0), true);
             }
         }
@@ -220,7 +219,7 @@ namespace Duplicati.GUI.TrayIcon
             var notification = new NSUserNotification();
             notification.Title = title;
             notification.InformativeText = message;
-            notification.DeliveryDate = DateTime.Now;
+            notification.DeliveryDate = NSDate.Now;
             notification.SoundName = NSUserNotification.NSUserNotificationDefaultSoundName;
  
             // We get the Default notification Center

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
@@ -32,6 +32,13 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
+  <PropertyGroup Condition="Exists('\Library\Frameworks\Xamarin.Mac.framework')">
+    <OutputType>Exe</OutputType>
+    <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <UseXamMacFullFramework>true</UseXamMacFullFramework>
+    <LinkMode>None</LinkMode>
+    <AOTMode>None</AOTMode>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>bin\Debug</OutputPath>
     <DebugType>full</DebugType>
@@ -105,8 +112,8 @@
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gtk-sharp-2.0</Package>
     </Reference>
-    <Reference Include="MonoMac">
-      <HintPath>..\..\..\thirdparty\MonoMac\MonoMac.dll</HintPath>
+    <Reference Include="Xamarin.Mac">
+      <HintPath>\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\64bits\full\Xamarin.Mac.dll</HintPath>
     </Reference>
     <Reference Include="notify-sharp">
       <HintPath>..\..\..\thirdparty\notify-sharp\notify-sharp.dll</HintPath>
@@ -167,6 +174,11 @@
     <EmbeddedResource Include="Resources\context_menu_pause.ico" />
     <EmbeddedResource Include="Resources\context_menu_play.ico" />
     <EmbeddedResource Include="Resources\context_menu_quit.ico" />
+    <None Include="\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\SDKs\Xamarin.macOS.sdk\lib\libxammac.dylib">
+      <Link>libxammac.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\CommandLine\ConfigurationImporter\Duplicati.CommandLine.ConfigurationImporter.csproj">

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
@@ -32,13 +32,6 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition="Exists('\Library\Frameworks\Xamarin.Mac.framework')">
-    <OutputType>Exe</OutputType>
-    <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
-    <UseXamMacFullFramework>true</UseXamMacFullFramework>
-    <LinkMode>None</LinkMode>
-    <AOTMode>None</AOTMode>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>bin\Debug</OutputPath>
     <DebugType>full</DebugType>
@@ -174,11 +167,10 @@
     <EmbeddedResource Include="Resources\context_menu_pause.ico" />
     <EmbeddedResource Include="Resources\context_menu_play.ico" />
     <EmbeddedResource Include="Resources\context_menu_quit.ico" />
-    <None Include="\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\SDKs\Xamarin.macOS.sdk\lib\libxammac.dylib">
+    <None Include="\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\SDKs\Xamarin.macOS.sdk\lib\libxammac.dylib" Condition="Exists('\Library\Frameworks\Xamarin.Mac.framework')">
       <Link>libxammac.dylib</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\CommandLine\ConfigurationImporter\Duplicati.CommandLine.ConfigurationImporter.csproj">

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
@@ -59,6 +59,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="Exists('\Library\Frameworks\Xamarin.Mac.framework')">
+    <DefineConstants>XAMARIN_MAC</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Duplicati.GUI.TrayIcon.Program</StartupObject>
   </PropertyGroup>
@@ -146,7 +149,7 @@
     <EmbeddedResource Include="Resources\TrayWorking.ico" />
     <Compile Include="ImageLoader.cs" />
     <Compile Include="GtkRunner.cs" />
-    <Compile Include="CocoaRunner.cs">
+    <Compile Include="CocoaRunner.cs" Condition="Exists('\Library\Frameworks\Xamarin.Mac.framework')">
       <DependentUpon>CocoaRunner.cs</DependentUpon>
     </Compile>
     <EmbeddedResource Include="OSX Icons\normal.png">

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using Duplicati.Library.Common;
@@ -43,9 +43,8 @@ namespace Duplicati.GUI.TrayIcon
 
         private static string GetDefaultToolKit()
         {
-            // No longer using Cocoa directly as it fails on 32bit as well            
             if (Platform.IsClientOSX)
-                return TOOLKIT_RUMPS;
+                return TOOLKIT_COCOA;
 
 #if __WindowsGTK__ || ENABLE_GTK
             if (Platform.IsClientPosix)
@@ -374,7 +373,7 @@ namespace Duplicati.GUI.TrayIcon
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static bool TryGetMonoMac()
         {
-            return !Environment.Is64BitProcess && typeof(MonoMac.AppKit.NSApplication) != null;
+            return typeof(AppKit.NSApplication) != null;
         }
   
         //The functions below here, simply wrap the call to the above functions,

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -380,9 +380,13 @@ namespace Duplicati.GUI.TrayIcon
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static bool TryGetXamarinMac()
         {
+#if XAMARIN_MAC
             return typeof(AppKit.NSApplication) != null;
+#else
+            return false;
+#endif
         }
-  
+
         //The functions below here, simply wrap the call to the above functions,
         // converting the exception to a simple boolean value, so the calling
         // code can be kept free of error handling

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -334,7 +334,14 @@ namespace Duplicati.GUI.TrayIcon
         private static TrayIconBase GetAppIndicatorInstance() { return new AppIndicatorRunner(); }
 #endif
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        private static TrayIconBase GetCocoaRunnerInstance() { return new CocoaRunner(); } 
+        private static TrayIconBase GetCocoaRunnerInstance()
+        {
+#if XAMARIN_MAC
+            return new CocoaRunner();
+#else
+            throw new UserInformationException("Xamarin.Mac framework not found", "TrayIconMissingXamarinMac");
+#endif
+        }
 
         private static TrayIconBase GetRumpsRunnerInstance() { return new RumpsRunner(); } 
 
@@ -371,7 +378,7 @@ namespace Duplicati.GUI.TrayIcon
         }
         
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        private static bool TryGetMonoMac()
+        private static bool TryGetXamarinMac()
         {
             return typeof(AppKit.NSApplication) != null;
         }
@@ -405,7 +412,7 @@ namespace Duplicati.GUI.TrayIcon
         {
             get 
             {
-                try { return TryGetMonoMac(); }
+                try { return TryGetXamarinMac(); }
                 catch {}
                 
                 return false;

--- a/Duplicati/Library/Backend/Idrivee2/Duplicati.Library.Backend.Idrivee2.csproj
+++ b/Duplicati/Library/Backend/Idrivee2/Duplicati.Library.Backend.Idrivee2.csproj
@@ -40,10 +40,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.37\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.71\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.25\lib\net45\AWSSDK.S3.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.43\lib\net45\AWSSDK.S3.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="RestSharp, Version=106.3.1.0, Culture=neutral, PublicKeyToken=598062e77f915f75">
@@ -59,6 +59,9 @@
       <HintPath>..\..\..\..\packages\System.Reactive.Linq.4.0.0\lib\net46\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+     <Reference Include="Minio">
+       <HintPath>..\..\..\..\packages\Minio.3.1.7\lib\net46\Minio.dll</HintPath>
+     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
@@ -101,7 +104,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Duplicati/Library/Backend/Idrivee2/packages.config
+++ b/Duplicati/Library/Backend/Idrivee2/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.103.37" targetFramework="net471" />
-  <package id="AWSSDK.S3" version="3.3.104.25" targetFramework="net471" />
+  <package id="AWSSDK.Core" version="3.3.103.71" targetFramework="net471" />
+  <package id="AWSSDK.S3" version="3.3.104.43" targetFramework="net471" />
   <package id="Minio" version="3.1.7" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
   <package id="System.Reactive" version="4.0.0" targetFramework="net471" />

--- a/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
+++ b/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
@@ -37,13 +37,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.37\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.Core.3.3.103.71\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.IdentityManagement, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.26\lib\net45\AWSSDK.IdentityManagement.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.52\lib\net45\AWSSDK.IdentityManagement.dll</HintPath>
     </Reference>
     <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.25\lib\net45\AWSSDK.S3.dll</HintPath>
+      <HintPath>..\..\..\..\packages\AWSSDK.S3.3.3.104.43\lib\net45\AWSSDK.S3.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Minio, Version=3.1.7.0, Culture=neutral, PublicKeyToken=348239ebd7debb4c">
@@ -106,11 +106,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.26\analyzers\dotnet\cs\AWSSDK.IdentityManagement.CodeAnalysis.dll" />
-    <Analyzer Include="..\..\..\..\packages\AWSSDK.S3.3.3.104.25\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\..\..\packages\AWSSDK.IdentityManagement.3.3.103.52\analyzers\dotnet\cs\AWSSDK.IdentityManagement.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\..\..\packages\AWSSDK.S3.3.3.104.43\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Duplicati/Library/Backend/S3/packages.config
+++ b/Duplicati/Library/Backend/S3/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.103.37" targetFramework="net471" />
-  <package id="AWSSDK.IdentityManagement" version="3.3.103.26" targetFramework="net471" />
-  <package id="AWSSDK.S3" version="3.3.104.25" targetFramework="net471" />
+  <package id="AWSSDK.Core" version="3.3.103.71" targetFramework="net471" />
+  <package id="AWSSDK.IdentityManagement" version="3.3.103.52" targetFramework="net471" />
+  <package id="AWSSDK.S3" version="3.3.104.43" targetFramework="net471" />
   <package id="Minio" version="3.1.7" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
   <package id="System.Reactive" version="4.0.0" targetFramework="net471" />

--- a/Duplicati/Library/DynamicLoader/DynamicLoader.cs
+++ b/Duplicati/Library/DynamicLoader/DynamicLoader.cs
@@ -19,6 +19,7 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 
 namespace Duplicati.Library.DynamicLoader
@@ -135,12 +136,14 @@ namespace Duplicati.Library.DynamicLoader
                             }
                             catch (Exception ex)
                             {
+                                ex = GetActualException(ex);
                                 Duplicati.Library.Logging.Log.WriteWarningMessage(LOGTAG, "SoftError", ex, Strings.DynamicLoader.DynamicTypeLoadError(t.FullName, s, ex.Message));
                             }
                     }
                 }
                 catch(Exception ex)
                 {   
+                    ex = GetActualException(ex);
                     // Since this is locating the assemblies that have the proper interface, it isn't an error to not.
                     // This was loading the log with errors about additional DLL's that are not plugins and do not have manifests.
                     Duplicati.Library.Logging.Log.WriteExplicitMessage(LOGTAG, "HardError", ex, Strings.DynamicLoader.DynamicAssemblyLoadError(s, ex.Message));
@@ -148,6 +151,13 @@ namespace Duplicati.Library.DynamicLoader
             }
 
             return interfaces;
+        }
+
+        private Exception GetActualException(Exception ex)
+        {
+            if (ex is TargetInvocationException)
+                ex = (ex as TargetInvocationException).InnerException;
+            return ex;
         }
 
         /// <summary>

--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -38,6 +38,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+     <Reference Include="BouncyCastle.Crypto">
+       <HintPath>..\..\..\..\packages\BouncyCastle.1.8.5\lib\BouncyCastle.Crypto.dll</HintPath>
+     </Reference>
     <Reference Include="MailKit, Version=2.3.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\MailKit.2.3.1.6\lib\net46\MailKit.dll</HintPath>
     </Reference>
@@ -124,7 +127,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Duplicati/Library/Modules/Builtin/packages.config
+++ b/Duplicati/Library/Modules/Builtin/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+   <package id="BouncyCastle" version="1.8.5" targetFramework="net471" />
   <package id="MailKit" version="2.3.1.6" targetFramework="net471" />
   <package id="MimeKit" version="2.3.1" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />


### PR DESCRIPTION
This gets the tray icon running for me on macOS 12.5 by changing CocoaRunner to use Xamarin.Mac and making it the default on Mac instead of RumpsRunner.

Huge thanks to @tgorgdotcom for the help with getting this to build. The dependency changes are all thanks to him.