### PR TITLE
Top level log stats

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/backuplog.html
+++ b/Duplicati/Server/webroot/ngax/templates/backuplog.html
@@ -14,6 +14,9 @@
                 <div ng-click="expanded = !expanded" class="entryline clickable">
                     <i class="{{ResultIcon(item.Result ? item.Result.ParsedResult : 'None')}}"></i>
                     {{item.Timestamp | parsetimestamp}} - {{"Operation" | translate}}: {{item.Result ? item.Result.MainOperation : item.Type | translate}}
+                    <span ng-show="item.Result" translate>(took {{ formatDuration(item.Result.Duration) }},
+                    uploaded {{ formatSize(item.Result.BackendStatistics.BytesUploaded) }},
+                    backup size {{ formatSize(item.Result.BackendStatistics.KnownFileSize) }})</span>
                     <i style="float: right" class="fa fa-angle-{{expanded ? 'up': 'down'}}"></i>
                     <div style="clear: both;"></div>
                 </div>

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -216,5 +217,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.4.2.1\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
 </Project>

--- a/Duplicati/UnitTest/packages.config
+++ b/Duplicati/UnitTest/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.12.0" targetFramework="net471" />
+  <package id="NUnit3TestAdapter" version="4.2.1" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
Added top-level stats (duration, size uploaded, backup size) to the job-specific log page.

While one can expand each row and dig-up these stats, this change will make it easy to glance over multiple runs, and see that things are ok (e.g. durations are stable / proportional to upload size, backup size not exploding, etc).

![image](https://user-images.githubusercontent.com/77799839/199324969-169f4311-d32f-4b76-996b-f29c1a58f6c8.png)

Closes #4830 

(also - added NUnit 3 nuget test adapter, VSIX test adapters are deprecated)