### PR TITLE
Specify backup name on failures

### DIFF
--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -625,7 +625,7 @@ namespace Duplicati.Server
             }
             catch (Exception ex)
             {
-                Program.DataConnection.LogError(data.Backup.ID, string.Format("Failed while executing \"{0}\" with id: {1}", data.Operation, data.Backup.ID), ex);
+                Program.DataConnection.LogError(data.Backup.ID, string.Format("Failed while executing {0} \"{1}\" (id: {2})", data.Operation, data.Backup.Name, data.Backup.ID), ex);
                 UpdateMetadataError(data.Backup, ex);
                 Library.UsageReporter.Reporter.Report(ex);
 


### PR DESCRIPTION
After creating and deleting several backups, it's impossible to know which backup failed with the current message (id only).
Adding the name of the backup that failed.

![image](https://user-images.githubusercontent.com/77799839/199363677-3f5ccb3f-0dcb-4e9f-80bf-f05fd39bd9a0.png)

Closes #4828 (see more details there)