### PR TITLE
Fix runtime exceptions loading System.Net.Http

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/Duplicati.Library.Backend.OneDrive.csproj
+++ b/Duplicati/Library/Backend/OneDrive/Duplicati.Library.Backend.OneDrive.csproj
@@ -53,7 +53,9 @@
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http">
+      <HintPath>$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\net471\lib\System.Net.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The continuous integration tests have been failing for a long time, due to loading errors of the OneDrive backends.
I've also encountered the same runtime errors when building and running a fresh copy of Duplicati locally.
The failures seem to be rooted at version conflicts of System.Net.Http.

https://github.com/dotnet/runtime/issues/24382 seems to touch on the core issue, but it left me utterly confused.

I'm not an expert at this at all, tweaked removing/adding binding redirects, as well as any other solution I could find online, and nothing else solved the issue.

After a lot of tweaking, landed on the commit here - which fixed the Runtime errors locally and the continuous integration tests. I'm not sure this is the right approach, but it was the only one that fixed the issue (and therefore the tests) for me.

Fixes #4636 