### PR TITLE
address issue #4711 by fixing the length removed from the file name

### DIFF
--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -334,14 +334,12 @@ namespace Duplicati.Library.Backend
 
         public IEnumerable<IFileEntry> List()
         {
+            int lgt = m_prefix.Length;
+            if (m_prefix.StartsWith("/", StringComparison.Ordinal))
+                lgt = lgt - 1;
             foreach (IFileEntry file in Connection.ListBucket(m_bucket, m_prefix))
             {
-                ((FileEntry)file).Name = file.Name.Substring(m_prefix.Length);
-
-                //Fix for a bug in Duplicati 1.0 beta 3 and earlier, where filenames are incorrectly prefixed with a slash
-                if (file.Name.StartsWith("/", StringComparison.Ordinal) && !m_prefix.StartsWith("/", StringComparison.Ordinal))
-                    ((FileEntry)file).Name = file.Name.Substring(1);
-
+                ((FileEntry)file).Name = file.Name.Substring(lgt);
                 yield return file;
             }
         }


### PR DESCRIPTION
when the prefix has been erroneously prefixed by a slash Remove also a linked old fix that does not apply anymore, the file name is never prefixed by a slash