### PR TITLE
fix --all-versions=false being actually ignored

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -394,7 +394,7 @@ namespace Duplicati.CommandLine
                     (res.Files == null || !res.Files.Any()) &&
                     !compareFilter.Empty;
 
-                if (isRequestForFiles && !Library.Utility.Utility.ParseBoolOption(options, "all-versions"))
+                if (isRequestForFiles && !(options.ContainsKey("all-versions")))
                 {
                     outwriter.WriteLine("No files matching, looking in all versions");
                     options["all-versions"] = "true";


### PR DESCRIPTION
Small but irritating problem: asking for a list with '--version=0 --all-versions=false' while having no match on the request produces a 'not found, trying in all versions'. If I ask explicitly for NOT all-version, I expect the software to do what I asked for.