### PR TITLE
Use 1MB default block as suggested by users.

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -36,9 +36,9 @@ namespace Duplicati.Library.Main
         private const string DEFAULT_FILE_HASH_ALGORITHM = "SHA256";
         
         /// <summary>
-        /// The default block size
+        /// The default block size, chose to minimize hash numbers but allow smaller upload sizes.
         /// </summary>
-        private const string DEFAULT_BLOCKSIZE = "100kb";
+        private const string DEFAULT_BLOCKSIZE = "1mb";
 
         /// <summary>
         /// The default threshold value


### PR DESCRIPTION
This still allows 50 blocks for the default upload size. It reduces the blocks to track by a factor of 10.
If you are using larger backups, you want a larger block size.

If you have small backups and it's a problem, recreating those will take less time.