### PR TITLE
Replace Thread.abort with Thread.interrupt

### DIFF
--- a/Duplicati/CommandLine/Commands.cs
+++ b/Duplicati/CommandLine/Commands.cs
@@ -115,7 +115,7 @@ namespace Duplicati.CommandLine
 
                         if (m_thread != null && m_thread.IsAlive)
                         {
-                            m_thread.Abort();
+                            m_thread.Interrupt();
                             m_thread.Join(500);
                         }
                     }

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -211,11 +211,11 @@ namespace Duplicati.GUI.TrayIcon
         {
             m_shutdown = true;
             m_waitLock.Set();
-            m_pollThread.Abort();
+            m_pollThread.Interrupt();
             m_pollThread.Join(TimeSpan.FromSeconds(10));
             if (!m_requestThread.Join(TimeSpan.FromSeconds(10)))
             {
-                m_requestThread.Abort();
+                m_requestThread.Interrupt();
                 m_requestThread.Join(TimeSpan.FromSeconds(10));
             }
         }

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -401,7 +401,7 @@ namespace Duplicati.Library.Main
             if (m_taskControl != null)
                 m_taskControl.StateChangedEvent += (state) => {
                     if (state == TaskControlState.Abort)
-                        m_thread.Abort();
+                        m_thread.Interrupt();
                 };
             m_queue = new BlockingQueue<FileEntryItem>(options.SynchronousUpload ? 1 : (options.AsynchronousUploadLimit == 0 ? int.MaxValue : options.AsynchronousUploadLimit));
             m_thread = new System.Threading.Thread(this.ThreadRun);
@@ -1462,7 +1462,7 @@ namespace Duplicati.Library.Main
             {
                 if (!m_thread.Join(TimeSpan.FromSeconds(10)))
                 {
-                    m_thread.Abort();
+                    m_thread.Interrupt();
                     m_thread.Join(TimeSpan.FromSeconds(10));
                 }
 

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -496,7 +496,7 @@ namespace Duplicati.Library.Main
                 // If we are aborted, throw exception
                 if (m_controlState == TaskControlState.Abort)
                 {
-                    System.Threading.Thread.CurrentThread.Abort();
+                    System.Threading.Thread.CurrentThread.Interrupt();
 
                     // For some reason, aborting the current thread does not always throw an exception
                     throw new CancelException();

--- a/Duplicati/Library/Utility/WorkerThread.cs
+++ b/Duplicati/Library/Utility/WorkerThread.cs
@@ -232,7 +232,7 @@ namespace Duplicati.Library.Utility
             {
                 try
                 {
-                    m_thread.Abort();
+                    m_thread.Interrupt();
                     m_thread.Join(500);
                 }
                 catch


### PR DESCRIPTION
Thread.abort is defunt in modern .net versions.

We need to be good about not swallowing exceptions blindly, interupted exception needs to be rethrown.

I have not tested this on master, it is cherry picked from net5-split