### PR TITLE
Update tests workflow - fix warnings that will soon break the tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
     - name: Add msbuild to PATH (Windows)
       if: matrix.os == 'windows-latest'
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Install NuGet
-      uses: nuget/setup-nuget@v1.0.5
+      uses: nuget/setup-nuget@v1
 
     - name: Checkout Source
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
 
     - name: Restore NuGet Packages
       run: nuget restore Duplicati.sln
@@ -61,10 +61,10 @@ jobs:
     # what we need (https://github.com/actions/runner/issues/646).
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
 
     - name: Install NuGet
-      uses: nuget/setup-nuget@v1.0.5
+      uses: nuget/setup-nuget@v1
 
     - name: Restore NuGet Packages
       run: nuget restore Duplicati.sln

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
       run: msbuild -p:Configuration=Release -p:DefineConstants=ENABLE_GTK Duplicati.sln
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
 


### PR DESCRIPTION
The tests workflow is using actions which use patterns that are currently deprecated. The commits here update the versions of the various actions used by the tests workflow, thus fixing all 17 warnings (about set-output, save-state, Node.js 12-->16 migration).

The soft deprecation (warnings) will become a hard deprecation (errors) and break the tests according to the documentation:
- June 1st 2023 - [set-output, save-state](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Summer 2023 - [node16](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

[e.g. test run before](https://github.com/taz-il/duplicati/actions/runs/4967727082):
![image](https://github.com/duplicati/duplicati/assets/77799839/2d395571-a780-4219-9145-c9d8a1ef5836)

[e.g. test run after](https://github.com/taz-il/duplicati/actions/runs/4969568960):
![image](https://github.com/duplicati/duplicati/assets/77799839/46ca57a7-4486-4949-a682-31a5472dc0a7)
