### PR TITLE
Fix filter UI

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/CommandlineController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/CommandlineController.js
@@ -54,11 +54,18 @@ backupApp.controller('CommandlineController', function($scope, $routeParams, $lo
 
         combined.unshift($scope.Command);
 
-        for(n in opts) {
-            if (opts[n] == null)
+        for (n in opts) {
+            var value = opts[n];
+            if (n == 'include' || n == 'exclude') {
+                // Handle filters that appear multiple times
+                for (var i = 0; i < value.length; ++i) {
+                    combined.push('--' + n + '=' + value[i]);
+                }
+            } else if (value == null) {
                 combined.push(n);
-            else
-                combined.push(n + '=' + opts[n]);
+            } else {
+                combined.push(n + '=' + value);
+            }
         }
 
         options = {

--- a/Duplicati/Server/webroot/ngax/scripts/directives/parseFilterType.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/parseFilterType.js
@@ -3,11 +3,13 @@ backupApp.directive('parseFilterType', function(AppUtils, SystemInfo) {
         restrict: 'A',
         require: ['ngModel'],
         link: function(scope, element, attr, ctrl) {
-            var body = null;
-
             ctrl[0].$parsers.push(function(txt) {
                 var dirsep = SystemInfo.state.DirectorySeparator || '/';
-                return AppUtils.buildFilter(txt, body, dirsep);
+                // Store type in scope for parseFilterContent directive
+                // This works because ng-repeat creates a child scope for each iteration
+                // It is still glitchy in some edge cases, but should be more consistent
+                scope.filterType = txt;
+                return AppUtils.buildFilter(txt, scope.filterBody, dirsep);
             });
 
             ctrl[0].$formatters.push(function(src) {
@@ -18,8 +20,7 @@ backupApp.directive('parseFilterType', function(AppUtils, SystemInfo) {
                     return null;
                 }
 
-                body = parts[1];
-
+                scope.filterType = parts[0];
                 return parts[0];
             });
         }
@@ -31,23 +32,23 @@ backupApp.directive('parseFilterContent', function(AppUtils, SystemInfo) {
         restrict: 'A',
         require: ['ngModel'],
         link: function(scope, element, attr, ctrl) {
-
-            var type = null;
-
             ctrl[0].$parsers.push(function(txt) {
                 var dirsep = SystemInfo.state.DirectorySeparator || '/';
-                return AppUtils.buildFilter(type, txt, dirsep);
+                // Store type in scope for parseFilterType directive
+                scope.filterBody = txt;
+                return AppUtils.buildFilter(scope.filterType, txt, dirsep);
             });
 
             ctrl[0].$formatters.push(function(src) {
                 var dirsep = SystemInfo.state.DirectorySeparator || '/';
+                // Remove double trailing slashes
                 var parts = AppUtils.splitFilterIntoTypeAndBody(src, dirsep);
                 if (parts == null) {
                     type = null;
                     return null;
                 }
 
-                type = parts[0];
+                scope.filterBody = parts[1];
                 return parts[1];
             });
         }

--- a/Duplicati/Server/webroot/ngax/scripts/directives/restoreFilePicker.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/restoreFilePicker.js
@@ -21,6 +21,7 @@ backupApp.directive('restoreFilePicker', function() {
 
             $scope.systeminfo = SystemInfo.watch($scope);
             $scope.treedata = [];
+            $scope.AppUtils = AppUtils;
 
             function compareablePath(path) {
                 return scope.systeminfo.CaseSensitiveFilesystem ? path : path.toLowerCase();

--- a/Duplicati/Server/webroot/ngax/scripts/directives/sourceFolderPicker.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/sourceFolderPicker.js
@@ -178,7 +178,9 @@ backupApp.directive('sourceFolderPicker', function() {
             for(var i = 0; i < (scope.ngFilters || []).length; i++) {
                 var f = AppUtils.splitFilterIntoTypeAndBody(scope.ngFilters[i], dirsep);
                 if (f != null) {
-                    if (f[0] == '-path')
+                    if (f[1].indexOf('?') != -1 || f[1].indexOf('*') != -1)
+                        anySpecials = true;
+                    else if (f[0] == '-path')
                         excludemap[compareablePath(f[1])] = true;
                     else if (f[0] == '-folder')
                         excludemap[compareablePath(f[1] + dirsep)] = true;

--- a/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
@@ -593,13 +593,25 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
             return [type, body];
         }
 
-        for(var i in this.filterClasses) {
+        var m = [];
+        for (var i in this.filterClasses) {
             var n = matches(src, this.filterClasses[i]);
             if (n != null)
-                return n;
+                m.push(n);
         }
-
-        return null;
+        if (m.length == 0) {
+            return null;
+        }
+        // Select match with shortest body, meaning longest prefix and suffix
+        var shortestIdx = 0;
+        var shortestLen = src.length;
+        for (i = 0; i < m.length; ++i) {
+            if (m[i][1].length < shortestLen) {
+                shortestIdx = i;
+                shortestLen = m[i][1].length;
+            }
+        }
+        return m[shortestIdx];
     };
 
     this.buildFilter = function(type, body, dirsep) {

--- a/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
@@ -138,11 +138,13 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
             key: '-folder',
             prefix: '-',
             suffix: '!',
+            stripSep: true,
             rx: '\\-(.*)\\!'
         }, {
             name: gettextCatalog.getString('Exclude file'),
             key: '-path',
             prefix: '-',
+            stripSep: true,
             exclude: ['*', '?', '{'],
             rx: '\\-([^\\[\\{\\*\\?]+)'
         }, {
@@ -597,7 +599,10 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
         if (pre.length >= 2 && pre[1] == '[') {
             //Regexp encode body ....
         }
-
+        if (f.stripSep == true && body[body.length - 1] == dirsep) {
+            // Remove trailing dirsep
+            body = body.slice(0, -1);
+        }
         return pre + body + suf;
     };
 

--- a/Duplicati/Server/webroot/ngax/templates/restorefilepicker.html
+++ b/Duplicati/Server/webroot/ngax/templates/restorefilepicker.html
@@ -5,7 +5,7 @@
         <a class="check" ng-click="toggleCheck(node)" ng-class="{include: node.include == '+', exclude: node.include == '-', partial: node.include == ' ', root: node.root}" alt="{{node.include == ' ' ? 'partially included' : (node.include == '-' ? 'excluded' : (node.include == '+' ? 'included' : 'not checked'))}}"></a>
           <a class="type {{node.iconCls}}" alt="{{loading ? 'loading' : node.entrytype}}" ng-class="{invisible: node.hidden, loading: node.loading}"></a>
 
-          <span ng-click="toggleSelected(node)" ng-bind-html="node.text | highlight:ngSearchFilter"></span>
+          <span ng-click="toggleSelected(node)" ng-bind-html="node.text | highlight:AppUtils.globToRegexp(ngSearchFilter)"></span>
     </div>
     <ul ng-class="{expanded: node.expanded}" dx-connect="node" alt="{{node.expanded ? 'expanded' : 'contracted'}}"/>
   </li>


### PR DESCRIPTION
Closes #2976, closes #3961, closes #3473, closes #2682.

Fixes bugs regarding filters in the web UI:
- The display of how filters with wildcards apply was bugged in the file selection list
- The input fields for filters could lead to inconsistent results in flags (e.g. double slash at end of directory filters, different data when switching types) (#3961)
- On the command line page, only the last exclude or include was applied (#2976)
- Regular expressions without wildcards were recognized as file excludes (#3473)
- Used regular expressions instead of globbing in restore picker (#2682)

All of these changes only impact the web UI, the backend is not affected.
The filters can still be inconsistent, but that would best be fixed by combining type select and input field in one component in a newer angular version. However, I did not find any with particularly unexpected behavior.
Example: enter `*.txt` in exclude filter, type changes to exclude extension but text still shows `*.txt` instead of `txt`, but internal flags are correct unless the text is changed again)