### PR TITLE
Fix missing file error caused by interrupted compact

### DIFF
--- a/Duplicati/UnitTest/CompactDisruptionTests.cs
+++ b/Duplicati/UnitTest/CompactDisruptionTests.cs
@@ -1,0 +1,134 @@
+﻿using Duplicati.Library.Interface;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Duplicati.UnitTest
+{
+    public class CompactDisruptionTests : BasicSetupHelper
+    {
+
+        private void WriteTestFile(string name, long size)
+        {
+            var data = new byte[size];
+            new Random(name.GetHashCode()).NextBytes(data);
+            File.WriteAllBytes(name, data);
+        }
+
+        private string VerificationToString(IEnumerable<KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>>> verifications)
+        {
+            StringBuilder res = new StringBuilder();
+            foreach (var file in verifications)
+            {
+                if (file.Value.Any())
+                {
+                    res.AppendLine($"{file.Key}: {file.Value.Count()} errors");
+                    foreach (var c in file.Value)
+                    {
+                        res.AppendLine($"\t{c.Key}: {c.Value}");
+                    }
+                }
+            }
+            return res.ToString();
+        }
+
+        [Test]
+        [Category("Disruption")]
+        public void InterruptedCompact()
+        {
+            // Reproduction steps from issue #4129 with smaller sizes
+            var testopts = TestOptions;
+            testopts["backup-test-samples"] = "0";
+            testopts["number-of-retries"] = "0";
+            testopts["dblock-size"] = "20KB";
+            // Reduce blocksize, because with default blocksize too few blocks fit in a volume
+            testopts["blocksize"] = "1KB";
+            testopts["keep-versions"] = "1";
+            testopts["no-auto-compact"] = "true";
+            testopts["threshold"] = "5";
+
+            // This size seems to be appropriate to cause significant compacting
+            // in combination with dblock-size
+            const long filesize = 44971;
+
+            string target = "file://" + TARGETFOLDER;
+            string file1 = Path.Combine(DATAFOLDER, "f1");
+            string file2 = Path.Combine(DATAFOLDER, "f2");
+            string file3 = Path.Combine(DATAFOLDER, "f3");
+            string file4 = Path.Combine(DATAFOLDER, "f4");
+            string file5 = Path.Combine(DATAFOLDER, "f5");
+            string file6 = Path.Combine(DATAFOLDER, "f6");
+            // Add files 1,2
+            WriteTestFile(file1, filesize);
+            WriteTestFile(file2, filesize);
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+
+                // Add files 3,4
+                WriteTestFile(file3, filesize);
+                WriteTestFile(file4, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+
+                // Add files 5,6
+                WriteTestFile(file5, filesize);
+                WriteTestFile(file6, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+
+                // Delete 1,3,5
+                File.Delete(file1);
+                File.Delete(file3);
+                File.Delete(file5);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Deterministic error backend
+            target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+            // Fail the compact after the first dblock put is completed
+            bool firstPutCompleted = false;
+            DeterministicErrorBackend.ErrorGenerator = (string action) =>
+            {
+                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                {
+                    return true;
+                }
+                if (action == "put_1" || action == "put_async")
+                {
+                    firstPutCompleted = true;
+                }
+                return false;
+            };
+            // Expect error from backend
+            Assert.Catch(() =>
+            {
+                using (var c = new Library.Main.Controller(target, testopts, null))
+                {
+                    ICompactResults compactResults = c.Compact();
+                    Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+                }
+            });
+            DeterministicErrorBackend.ErrorGenerator = null;
+            testopts["full-remote-verification"] = "true";
+            testopts["full-block-verification"] = "true";
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+        }
+    }
+}

--- a/Duplicati/UnitTest/DeterministicErrorBackend.cs
+++ b/Duplicati/UnitTest/DeterministicErrorBackend.cs
@@ -1,0 +1,153 @@
+﻿//  Copyright (C) 2015, The Duplicati Team
+//  http://www.duplicati.com, info@duplicati.com
+//
+//  This library is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as
+//  published by the Free Software Foundation; either version 2.1 of the
+//  License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+using Duplicati.Library.Interface;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Duplicati.UnitTest
+{
+    public class DeterministicErrorBackend : IBackend, IStreamingBackend
+    {
+        static DeterministicErrorBackend() { WrappedBackend = "file"; }
+
+        private static readonly Random random = new Random(42);
+
+        public static Func<string, bool> ErrorGenerator = null;
+
+        public static string WrappedBackend { get; set; }
+
+        private IStreamingBackend m_backend;
+        public DeterministicErrorBackend()
+        {
+        }
+
+        // ReSharper disable once UnusedMember.Global
+        public DeterministicErrorBackend(string url, Dictionary<string, string> options)
+        {
+            var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();
+            m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(u, options);
+        }
+
+        private void ThrowError(string action)
+        {
+            if (ErrorGenerator != null && ErrorGenerator(action))
+            {
+                throw new Exception("Backend error");
+            }
+        }
+        #region IStreamingBackend implementation
+        public async Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken)
+        {
+            var uploadError = random.NextDouble() > 0.9;
+
+            using (var f = new Library.Utility.ProgressReportingStream(stream, x => { if (uploadError && stream.Position > stream.Length / 2) throw new Exception("Random upload failure"); }))
+                await m_backend.PutAsync(remotename, f, cancelToken);
+            ThrowError("put_async");
+        }
+        public void Get(string remotename, Stream stream)
+        {
+            ThrowError("get_0");
+            m_backend.Get(remotename, stream);
+            ThrowError("get_1");
+        }
+        #endregion
+
+        #region IBackend implementation
+        public IEnumerable<IFileEntry> List()
+        {
+            return m_backend.List();
+        }
+        public async Task PutAsync(string remotename, string filename, CancellationToken cancelToken)
+        {
+            ThrowError("put_0");
+            await m_backend.PutAsync(remotename, filename, cancelToken);
+            ThrowError("put_1");
+        }
+        public void Get(string remotename, string filename)
+        {
+            ThrowError("get_0");
+            m_backend.Get(remotename, filename);
+            ThrowError("get_1");
+        }
+        public void Delete(string remotename)
+        {
+            ThrowError("delete_0");
+            m_backend.Delete(remotename);
+            ThrowError("delete_1");
+        }
+        public void Test()
+        {
+            m_backend.Test();
+        }
+        public void CreateFolder()
+        {
+            m_backend.CreateFolder();
+        }
+        public string[] DNSName
+        {
+            get
+            {
+                return m_backend.DNSName;
+            }
+        }
+        public string DisplayName
+        {
+            get
+            {
+                return "Deterministic Error Backend";
+            }
+        }
+        public string ProtocolKey
+        {
+            get
+            {
+                return "deterror";
+            }
+        }
+        public IList<ICommandLineArgument> SupportedCommands
+        {
+            get
+            {
+                if (m_backend == null)
+                    try { return Duplicati.Library.DynamicLoader.BackendLoader.GetSupportedCommands(WrappedBackend + "://"); }
+                    catch { }
+
+                return m_backend.SupportedCommands;
+            }
+        }
+        public string Description
+        {
+            get
+            {
+                return "A testing backend that randomly fails";
+            }
+        }
+        #endregion
+        #region IDisposable implementation
+        public void Dispose()
+        {
+            if (m_backend != null)
+                try { m_backend.Dispose(); }
+                finally { m_backend = null; }
+        }
+        #endregion
+    }
+}
+

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -47,6 +47,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BackendToolTests.cs" />
+    <Compile Include="CompactDisruptionTests.cs" />
+    <Compile Include="DeterministicErrorBackend.cs" />
     <Compile Include="SymLinkTests.cs" />
     <Compile Include="ControllerTests.cs" />
     <Compile Include="DeleteHandlerTests.cs" />


### PR DESCRIPTION
Before the dindex files are deleted on the remote, update the state in the database to Deleting. Previously, only dblock files were handled this way. Patch by warwickmm

Closes #4129