### PR TITLE
Fix hidden username and password options when changing backends

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
@@ -24,7 +24,7 @@ backupApp.service('EditUriBackendConfig', function(AppService, AppUtils, SystemI
     this.defaulttemplate = 'templates/backends/generic.html';
     this.defaultbuilder = function(scope) {
         var opts = {};
-        self.merge_in_advanced_options(scope, opts);
+        self.merge_in_advanced_options(scope, opts, true);
 
         var url = AppUtils.format('{0}{1}://{2}{3}/{4}{5}',
             scope.Backend.Key,
@@ -38,10 +38,17 @@ backupApp.service('EditUriBackendConfig', function(AppService, AppUtils, SystemI
         return url;
     };
 
-    this.merge_in_advanced_options = function(scope, dict) {
-        if (scope.Username != null && scope.Username != '')
+    this.merge_in_advanced_options = function (scope, dict, includeUserPassword) {
+        if (includeUserPassword == null) {
+            includeUserPassword = true;
+        }
+        // Some backends do not have input fields for Username and Password
+        // When changing backends, these variables are not cleared
+        // Only include them if the backend supports it and shows input fields for them
+        // Other options appear in the AdvancedOptions list and can be removed manually if not supported
+        if (includeUserPassword && scope.Username != null && scope.Username != '')
             dict['auth-username'] = scope.Username;
-        if (scope.Password != null && scope.Password != '')
+        if (includeUserPassword && scope.Password != null && scope.Password != '')
             dict['auth-password'] = scope.Password;
 
         if (!AppUtils.parse_extra_options(scope.AdvancedOptions, dict))

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -607,7 +607,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
 
         opts['s3-client']=scope.s3_client.name;
         
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
 
         var url = AppUtils.format('{0}{1}://{2}/{3}{4}',
             scope.Backend.Key,
@@ -623,7 +623,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
 
     EditUriBackendConfig.builders['file'] = function (scope) {
         var opts = {}
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
         var url = AppUtils.format('file://{0}{1}',
             scope.Path,
             AppUtils.encodeDictAsUrl(opts)
@@ -636,7 +636,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         var opts = {
             'authid': scope.AuthID
         }
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}{1}://{2}{3}',
             scope.Backend.Key,
@@ -679,7 +679,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         if ((opts['openstack-version'] || '') == '')
             delete opts['openstack-version'];
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://{1}{2}',
             scope.Backend.Key,
@@ -693,7 +693,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
     EditUriBackendConfig.builders['azure'] = function (scope) {
         var opts = {};
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
 
         // Slightly better error message
         scope.Folder = scope.Path;
@@ -716,7 +716,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         if ((opts['group-email'] || '') == '')
             delete opts['group-email'];
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://{1}{2}',
             scope.Backend.Key,
@@ -742,7 +742,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         if ((opts['gcs-project'] || '') == '')
             delete opts['gcs-project'];
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://{1}{2}',
             scope.Backend.Key,
@@ -756,7 +756,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
     EditUriBackendConfig.builders['b2'] = function (scope) {
         var opts = {};
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
 
         // Slightly better error message
         scope.Folder = scope.Server;
@@ -774,7 +774,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
     EditUriBackendConfig.builders['e2'] = function (scope) {
         var opts = {};
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
 
         // Slightly better error message
         scope.Folder = scope.Server;
@@ -792,7 +792,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
     EditUriBackendConfig.builders['mega'] = function (scope) {
         var opts = {};
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
 
         // Slightly better error message
         scope.Folder = scope.Path;
@@ -813,7 +813,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
             'sia-redundancy': scope.sia_redundancy
         };
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://{1}/{2}{3}',
             scope.Backend.Key,
@@ -836,7 +836,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
             'storj-folder': scope.storj_folder
         };
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://storj.io/config{1}',
             scope.Backend.Key,
@@ -857,7 +857,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
             'tardigrade-folder': scope.tardigrade_folder
         };
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://tardigrade.io/config{1}',
             scope.Backend.Key,
@@ -881,7 +881,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
             delete opts['rclone-option'];
 
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://{1}/{2}{3}',
             scope.Backend.Key,
@@ -905,7 +905,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
 			'cos-bucket': scope.cos_bucket
         };
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
         var url = AppUtils.format('{0}://{1}{2}',
             scope.Backend.Key,


### PR DESCRIPTION
Closes #3082, closes #4797

Remove username and password from target options if the backend does not show the input fields.

The username and password options are stored in different variables than the other backend options. Therefore, they are only visible if the backend supports them. This caused unintuitive warnings when changing backends.

## Steps to reproduce:
- Create backup with file target and specify username and password
- Save backup and open to edit
- Change backend to an OAuth backend, e.g. Dropbox and enter authid
- Save and run backup job or export target URI (... menu on Backup destination)

### Current behavior:
- Username and password are not visible on the OAuth backend page, nor in advanced options
- Backup shows warnings `The supplied option --auth-username is not supported and will be ignored`
- Exported target URI contains hidden parameters: `dropbox://path?authid=xxx&auth-password=123&auth-username=asdf`

### New behavior:
- Username and password are cleared when the backup is saved
- Changing to different backends without saving will keep username and password if supported
- Backups contain no warnings
- Exported target URI contains no hidden parameters: `dropbox://path?authid=xxx`