### PR TITLE
Include exception type and message in job log

### DIFF
--- a/Duplicati/Library/Logging/LogEntry.cs
+++ b/Duplicati/Library/Logging/LogEntry.cs
@@ -171,10 +171,15 @@ namespace Duplicati.Library.Logging
         /// <param name="withExceptionDetails">If set to <c>true</c> the result has expanded exception details.</param>
         public string AsString(bool withExceptionDetails)
         {
-            return this +
-                       ((withExceptionDetails && Exception != null)
-                        ? Environment.NewLine + Exception
-                        : string.Empty);
+            if (Exception == null)
+            {
+                return ToString();
+            }
+            else
+            {
+                return this + Environment.NewLine
+                    + (withExceptionDetails ? Exception.ToString() : (Exception.GetType().Name + ": " + Exception.Message));
+            }
         }
     }
 }

--- a/Duplicati/Server/webroot/ngax/templates/backup-result/message-list.html
+++ b/Duplicati/Server/webroot/ngax/templates/backup-result/message-list.html
@@ -6,8 +6,8 @@
         <i ng-if="data.length > 0" class="fa fa-angle-{{child_expanded ? 'up': 'down'}}"></i>
     </span>
 </span>
-<div ng-show="child_expanded && data.length > 0" class="expanded"">
+<div ng-show="child_expanded && data.length > 0" class="expanded">
     <ul>
-        <li ng-repeat="elem in data.messages track by $index">{{elem}}</li>
+        <li ng-repeat="elem in data.messages track by $index" class="prewrapped-text">{{elem}}</li>
     </ul>
 </div>


### PR DESCRIPTION
If an exception is provided for a log message, display the type and message (excluding stack trace) even if `withExceptionDetails=false`. This helps to diagnose bugs if the live log was not saved.

Closes #4843

> ## Steps to reproduce
> 1. Set something up that makes a Warning. In the case shown, I changed permissions on a source file, to refuse access.
> 2. Backup
> 3. Check job log
> 
> * **Actual result**:
>   Only the Duplicati message text is shown
> * **Expected result**:
>   Related exception summary is also shown

### Example job log message:
before:
```
2023-06-23 13:35:42 +02 - [Warning-Duplicati.Library.Main.Operation.Backup.FileBlockProcessor.FileEntry-PathProcessingFailed]: Failed to process path: C:\test\message.txt
```
after:
```
2023-06-23 15:32:20 +02 - [Warning-Duplicati.Library.Main.Operation.Backup.FileBlockProcessor.FileEntry-PathProcessingFailed]: Failed to process path: C:\test\message.txt
UnauthorizedAccessException: Access to the path '\\?\C:\test\message.txt' is denied.
```
