### PR TITLE
Do not set advanced options with empty string to true

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/AppUtils.js
@@ -280,8 +280,6 @@ backupApp.service('AppUtils', function($rootScope, $timeout, $cookies, DialogSer
                 if (eqpos > 0) {
                     key = line.substr(0, eqpos).trim();
                     value = line.substr(eqpos + 1).trim();
-                    if (value == '')
-                        value = true;
                 }
 
                 if (validateCallback)


### PR DESCRIPTION
There are advanced options such as force-local that expect an empty string in some cases. While saving, these were replaced with `true` even though there was an equals sign. Now only options without an equals sign are set to true.

The options were not set to `true` when opening the configuration but already when saving, so the saved backup configuration was different than in the UI.

Closes #4757

> ## Steps to reproduce
> 1. Make a backup set in the GUI
> 2. set the `force-locale` option to blank string
> 3. save, close and re-open the config page of that backup
> 4. see that the blank field was filled with `true`
> 5. run the backup
> 6. warning that `true` is not a valid locale appears
> 
> * **Actual result**:
>   Option automatically set to `true`.
>   Backup throws warning
> * **Expected result**:
>   Option should remain blank.
>   Backup should complete without warning.

### Old behavior
Set flags and empty values to true before saving:
`--dry-run` => `--dry-run=true`
`--force-locale=` => `--force-locale=true`

### New behavior
Set flags to true (as before):
`--dry-run` => `--dry-run=true`

Keep empty options with empty value:
`--force-locale=` => `--force-locale=`
