### PR TITLE
Improve result reporting

### DIFF
--- a/Duplicati/Library/Interface/ResultInterfaces.cs
+++ b/Duplicati/Library/Interface/ResultInterfaces.cs
@@ -39,6 +39,7 @@ namespace Duplicati.Library.Interface
         IEnumerable<string> Warnings { get; }
         IEnumerable<string> Messages { get; }
         ParsedResultType ParsedResult { get; }
+        bool Interrupted { get; }
     }
 
     public interface IBackendStatstics

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -190,6 +190,8 @@ namespace Duplicati.Library.Main
         {
             get
             {
+                if (Fatal)
+                    return ParsedResultType.Fatal;
                 if (Errors != null && Errors.Any())
                     return ParsedResultType.Error;
                 else if (Warnings != null && Warnings.Any())
@@ -198,6 +200,9 @@ namespace Duplicati.Library.Main
                     return ParsedResultType.Success;
             }
         }
+        public bool Interrupted { get; set; }
+        [JsonIgnore]
+        public bool Fatal { get; set; }
 
         // ReSharper disable once UnusedMember.Global
         // This is referenced in the logs.
@@ -593,7 +598,16 @@ namespace Duplicati.Library.Main
         {
             get
             {
-                if ((CompactResults != null && CompactResults.ParsedResult == ParsedResultType.Error) ||
+                if ((CompactResults != null && CompactResults.ParsedResult == ParsedResultType.Fatal) ||
+                    (VacuumResults != null && VacuumResults.ParsedResult == ParsedResultType.Fatal) ||
+                    (DeleteResults != null && DeleteResults.ParsedResult == ParsedResultType.Fatal) ||
+                    (RepairResults != null && RepairResults.ParsedResult == ParsedResultType.Fatal) ||
+                    (TestResults != null && TestResults.ParsedResult == ParsedResultType.Fatal) ||
+                    Fatal)
+                {
+                    return ParsedResultType.Fatal;
+                }
+                else if ((CompactResults != null && CompactResults.ParsedResult == ParsedResultType.Error) ||
                     (VacuumResults  != null && VacuumResults.ParsedResult  == ParsedResultType.Error) ||
                     (DeleteResults  != null && DeleteResults.ParsedResult  == ParsedResultType.Error) ||
                     (RepairResults  != null && RepairResults.ParsedResult  == ParsedResultType.Error) || 
@@ -638,7 +652,12 @@ namespace Duplicati.Library.Main
         {
             get
             {
-                if ((RecreateDatabaseResults != null && RecreateDatabaseResults.ParsedResult == ParsedResultType.Error) ||
+                if ((RecreateDatabaseResults != null && RecreateDatabaseResults.ParsedResult == ParsedResultType.Fatal) ||
+                    Fatal)
+                {
+                    return ParsedResultType.Fatal;
+                }
+                else if ((RecreateDatabaseResults != null && RecreateDatabaseResults.ParsedResult == ParsedResultType.Error) ||
                     (Errors != null && Errors.Any()))
                 {
                     return ParsedResultType.Error;
@@ -814,7 +833,12 @@ namespace Duplicati.Library.Main
         {
             get
             {
-                if ((RecreateDatabaseResults != null && RecreateDatabaseResults.ParsedResult == ParsedResultType.Error) ||
+                if ((RecreateDatabaseResults != null && RecreateDatabaseResults.ParsedResult == ParsedResultType.Fatal) ||
+                    Fatal)
+                {
+                    return ParsedResultType.Fatal;
+                }
+                else if ((RecreateDatabaseResults != null && RecreateDatabaseResults.ParsedResult == ParsedResultType.Error) ||
                     (Errors != null && Errors.Any()))
                 {
                     return ParsedResultType.Error;

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -754,18 +754,18 @@ namespace Duplicati.Server
                 backup.Metadata["LastRestoreFinished"] = Library.Utility.Utility.SerializeDateTime(result.EndTime.ToUniversalTime());
             }
 
-            if (result is IParsedBackendStatistics r2)
+            if (result is IParsedBackendStatistics r2 && !result.Interrupted)
             {
                 UpdateMetadata(backup, r2);
             }
 
-            if (result is IBackendStatsticsReporter r3)
+            if (result is IBackendStatsticsReporter r3 && !result.Interrupted)
             {
                 if (r3.BackendStatistics is IParsedBackendStatistics statistics)
                     UpdateMetadata(backup, statistics);
             }
 
-            if (result is ICompactResults r4)
+            if (result is ICompactResults r4 && !result.Interrupted)
             {
                 UpdateMetadataLastCompact(backup, r4);
 
@@ -773,25 +773,28 @@ namespace Duplicati.Server
                     UpdateMetadataLastVacuum(backup, r4.VacuumResults);
             }
 
-            if (result is IVacuumResults r5)
+            if (result is IVacuumResults r5 && !result.Interrupted)
             {
                 UpdateMetadataLastVacuum(backup, r5);
             }
 
             if (result is IBackupResults r)
             {
-                backup.Metadata["SourceFilesSize"] = r.SizeOfExaminedFiles.ToString();
-                backup.Metadata["SourceFilesCount"] = r.ExaminedFiles.ToString();
-                backup.Metadata["SourceSizeString"] = Duplicati.Library.Utility.Utility.FormatSizeString(r.SizeOfExaminedFiles);
-                backup.Metadata["LastBackupStarted"] = Library.Utility.Utility.SerializeDateTime(r.BeginTime.ToUniversalTime());
-                backup.Metadata["LastBackupFinished"] = Library.Utility.Utility.SerializeDateTime(r.EndTime.ToUniversalTime());
-                backup.Metadata["LastBackupDuration"] = r.Duration.ToString();
+                if (!result.Interrupted)
+                {
+                    backup.Metadata["SourceFilesSize"] = r.SizeOfExaminedFiles.ToString();
+                    backup.Metadata["SourceFilesCount"] = r.ExaminedFiles.ToString();
+                    backup.Metadata["SourceSizeString"] = Duplicati.Library.Utility.Utility.FormatSizeString(r.SizeOfExaminedFiles);
+                    backup.Metadata["LastBackupStarted"] = Library.Utility.Utility.SerializeDateTime(r.BeginTime.ToUniversalTime());
+                    backup.Metadata["LastBackupFinished"] = Library.Utility.Utility.SerializeDateTime(r.EndTime.ToUniversalTime());
+                    backup.Metadata["LastBackupDuration"] = r.Duration.ToString();
 
-                if (r.CompactResults != null)
-                    UpdateMetadataLastCompact(backup, r.CompactResults);
+                    if (r.CompactResults != null)
+                        UpdateMetadataLastCompact(backup, r.CompactResults);
 
-                if (r.VacuumResults != null)
-                    UpdateMetadataLastVacuum(backup, r.VacuumResults);
+                    if (r.VacuumResults != null)
+                        UpdateMetadataLastVacuum(backup, r.VacuumResults);
+                }
 
                 if (r.FilesWithError > 0 || r.Warnings.Any() || r.Errors.Any())
                 {
@@ -837,19 +840,19 @@ namespace Duplicati.Server
                     );
                 }
             }
-            else if (result.ParsedResult != Library.Interface.ParsedResultType.Success)
+            else if (result.ParsedResult != ParsedResultType.Success)
             {
-                var type = result.ParsedResult == Library.Interface.ParsedResultType.Warning
+                var type = result.ParsedResult != ParsedResultType.Warning
                             ? NotificationType.Warning
                             : NotificationType.Error;
 
-                var title = result.ParsedResult == Library.Interface.ParsedResultType.Warning
+                var title = result.ParsedResult != ParsedResultType.Warning
                                 ? (backup.IsTemporary ?
                                 "Warning" : string.Format("Warning while running {0}", backup.Name))
                             : (backup.IsTemporary ?
                                 "Error" : string.Format("Error while running {0}", backup.Name));
 
-                var message = result.ParsedResult == Library.Interface.ParsedResultType.Warning
+                var message = result.ParsedResult != ParsedResultType.Warning
                                     ? string.Format("Got {0} warning(s)", result.Warnings.Count())
                                     : string.Format("Got {0} error(s)", result.Errors.Count());
 

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/BackupLogController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/BackupLogController.js
@@ -64,6 +64,8 @@ backupApp.controller('BackupLogController', function($scope, $routeParams, AppUt
             return 'fa fa-exclamation-circle warning-color';
         } else if (parsedResult == 'Error') {
             return 'fa fa-times-circle error-color';
+        } else if (parsedResult == 'Fatal') {
+            return 'fa fa-times-circle error-color';
         } else {
             return 'fa fa-question-circle';
         }

--- a/Duplicati/Server/webroot/ngax/templates/backup-result/top-left-box.html
+++ b/Duplicati/Server/webroot/ngax/templates/backup-result/top-left-box.html
@@ -1,3 +1,7 @@
+<span class="item">
+    <span class="title" ng-show="item.Result && item.Result.Interrupted" tanslate>Interrupted</span>
+    <span class="title" ng-show="item.Result && item.Result.ParsedResult == 'Fatal'" translate>Fatal error</span>
+</span>
 <span class="title" translate>Time</span>
 <span class="item">
     <span class="key" translate>Start </span>


### PR DESCRIPTION
Closes #4829, closes #4344

Add a new 'Interrupted' field to `IBasicResult`. This is set to true if the operation was interrupted (e.g. by `run-script-before`).
Interrupted and failed backups are recorded in the job log (#4829).
When the backup is interrupted or fails (`Interrupted==true` or `ParsedResult=Fatal`), metadata for the server database is not updated (#4344).

If exceptions are caught from an operation this previously resulted in an error message in the server log. Now the error message is also recorded in the job log. This has to create a new Operation in the database for now, so the logs are not linked to the performed changes in the database yet.

There are two new translation needed (to display "Fatal error" or "Interrupted" in the job log). I put these messages above the time, please suggest other options:
![screenshot of log entry with fatal error](https://github.com/duplicati/duplicati/assets/33495614/f3f141df-5aec-475d-9e3b-0cb1912b8e67)

Also, maybe a darker shade of red and a different icon could be used for the icons of fatal errors, so they can be spotted easier. I don't have the tools installed to change the stylesheet.
