### PR TITLE
Fix restore search error in RestoreController

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -246,6 +246,10 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
                         if (cp.indexOf(compareablePath(sn.Path)) == 0) {
                             var curpath = sn.Path;
                             var parts = p.substr(sn.Path.length).split(dirsep);
+                            // Remove empty part if path had dirsep at end
+                            if (parts[parts.length - 1].length == 0) {
+                                parts.pop();
+                            }
                             var col = sn;
 
                             for(var k in parts) {

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/RestoreController.js
@@ -261,6 +261,7 @@ backupApp.controller('RestoreController', function ($rootScope, $scope, $routePa
                                     if (compareablePath(col.Children[m].Path) == compareablePath(curpath)) {
                                         found = true;
                                         col = col.Children[m];
+                                        break;
                                     }
                                 }
 


### PR DESCRIPTION
Closes #4997 

- Fix an error when searching for folder names
- Fix displaying duplicated, empty directory entries in restore view when the filter matches a folder

## Steps to reproduce
- Open restore page of a backup in web UI
- Search for a string that is part of one or more *Folder* names (that is not empty) and press enter/search

### Current behavior
- The list of files is not updated to match
- Console shows error:
```
TypeError: Cannot read Property 'Path' of undefined.
```
### New behavior
- The list of files is updated
- Folders which match the filter are expanded (because all child files also contain the string in their full path)

## Screenshots
**(Old) Empty entries:**
![screenshot of restore view with empty folder entries](https://github.com/duplicati/duplicati/assets/33495614/a39f69a5-0d04-4f38-9a59-259619762895)

**Fixed:**
![screenshot of restore view with folder](https://github.com/duplicati/duplicati/assets/33495614/80aaad69-7503-47eb-879d-28465c779f9f)


## Impact
This has only minimal changes to the web UI and does not affect the core duplicati code.