### PR TITLE
Add option to disable chunked encoding for AWS S3.

### DIFF
--- a/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
@@ -76,7 +76,7 @@ namespace Duplicati.Library.Backend
             string host= GetRegionEndpoint("https://api.idrivee2.com/api/service/get_region_end_point/" + accessKeyId);
 
 
-            m_s3Client = new S3AwsClient(accessKeyId, accessKeySecret, null, host, null, true, options);
+            m_s3Client = new S3AwsClient(accessKeyId, accessKeySecret, null, host, null, true, false, options);
 
         }
 

--- a/Duplicati/Library/Backend/S3/S3AwsClient.cs
+++ b/Duplicati/Library/Backend/S3/S3AwsClient.cs
@@ -42,11 +42,12 @@ namespace Duplicati.Library.Backend
         private readonly string m_locationConstraint;
         private readonly string m_storageClass;
         private AmazonS3Client m_client;
+        private readonly bool m_useChunkEncoding;
 
         private readonly string m_dnsHost;
 
         public S3AwsClient(string awsID, string awsKey, string locationConstraint, string servername,
-            string storageClass, bool useSSL, Dictionary<string, string> options)
+            string storageClass, bool useSSL, bool disableChunkEncoding, Dictionary<string, string> options)
         {
             var cfg = new AmazonS3Config
             {
@@ -82,6 +83,7 @@ namespace Duplicati.Library.Backend
             m_locationConstraint = locationConstraint;
             m_storageClass = storageClass;
             m_dnsHost = string.IsNullOrWhiteSpace(cfg.ServiceURL) ? null : new Uri(cfg.ServiceURL).Host;
+            m_useChunkEncoding = !disableChunkEncoding;
         }
 
         public void AddBucket(string bucketName)
@@ -133,7 +135,8 @@ namespace Duplicati.Library.Backend
             {
                 BucketName = bucketName,
                 Key = keyName,
-                InputStream = source
+                InputStream = source,
+                UseChunkEncoding = m_useChunkEncoding
             };
             if (!string.IsNullOrWhiteSpace(m_storageClass))
                 objectAddRequest.StorageClass = new S3StorageClass(m_storageClass);

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -41,6 +41,7 @@ namespace Duplicati.Library.Backend
         private const string LOCATION_OPTION = "s3-location-constraint";
         private const string SSL_OPTION = "use-ssl";
         private const string S3_CLIENT_OPTION = "s3-client";
+        private const string S3_DISABLE_CHUNK_ENCODING_OPTION = "s3-disable-chunk-encoding";
 
         public static readonly Dictionary<string, string> KNOWN_S3_PROVIDERS = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
             { "Amazon S3", "s3.amazonaws.com" },
@@ -300,12 +301,13 @@ namespace Duplicati.Library.Backend
             if (!hasForcePathStyle && !DEFAULT_S3_LOCATION_BASED_HOSTS.Any(x => string.Equals(x.Value, host, StringComparison.OrdinalIgnoreCase)) && !string.Equals(host, "s3.amazonaws.com", StringComparison.OrdinalIgnoreCase))
                 options["s3-ext-forcepathstyle"] = "true";
 
+            bool disableChunkEncoding = Utility.Utility.ParseBoolOption(options, S3_DISABLE_CHUNK_ENCODING_OPTION);
 
             options.TryGetValue(S3_CLIENT_OPTION, out var s3ClientOptionValue);
 
             if (s3ClientOptionValue == "aws" || s3ClientOptionValue == null)
             {
-                s3Client = new S3AwsClient(awsID, awsKey, locationConstraint, host, storageClass, useSSL, options);
+                s3Client = new S3AwsClient(awsID, awsKey, locationConstraint, host, storageClass, useSSL, disableChunkEncoding, options);
             }
             else
             {
@@ -415,6 +417,7 @@ namespace Duplicati.Library.Backend
                     new CommandLineArgument(LOCATION_OPTION, CommandLineArgument.ArgumentType.String, Strings.S3Backend.S3LocationDescriptionShort, Strings.S3Backend.S3LocationDescriptionLong(locations.ToString())),
                     new CommandLineArgument(SSL_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.S3Backend.DescriptionUseSSLShort, Strings.S3Backend.DescriptionUseSSLLong),
                     new CommandLineArgument(S3_CLIENT_OPTION, CommandLineArgument.ArgumentType.String, Strings.S3Backend.S3ClientDescriptionShort, Strings.S3Backend.DescriptionS3ClientLong),
+                    new CommandLineArgument(S3_DISABLE_CHUNK_ENCODING_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.S3Backend.DescriptionDisableChunkEncodingShort, Strings.S3Backend.DescriptionDisableChunkEncodingLong, "false"),
                     new CommandLineArgument("auth-password", CommandLineArgument.ArgumentType.Password, Strings.S3Backend.AuthPasswordDescriptionShort, Strings.S3Backend.AuthPasswordDescriptionLong),
                     new CommandLineArgument("auth-username", CommandLineArgument.ArgumentType.String, Strings.S3Backend.AuthUsernameDescriptionShort, Strings.S3Backend.AuthUsernameDescriptionLong),
                 };

--- a/Duplicati/Library/Backend/S3/Strings.cs
+++ b/Duplicati/Library/Backend/S3/Strings.cs
@@ -34,7 +34,8 @@ namespace Duplicati.Library.Backend.Strings {
         public static string DescriptionUseSSLLong { get { return LC.L(@"Use this flag to communicate using Secure Socket Layer (SSL) over http (https). Note that bucket names containing a period has problems with SSL connections."); } }
         public static string DescriptionS3ClientLong { get { return LC.L(@"Set either to aws or minio . Then either the AWS SDK or Minio SDK will used to communicate with S3 services."); } }
         public static string DescriptionUseSSLShort { get { return LC.L(@"Instructs Duplicati to use an SSL (https) connection"); } }
-
+        public static string DescriptionDisableChunkEncodingLong { get { return LC.L(@"This disables chunk encoding for the aws client, which is not supported by all S3 providers."); } }
+        public static string DescriptionDisableChunkEncodingShort { get { return LC.L(@"Disable chunk encoding (aws client only)"); } }
         public static string S3StorageclassDescriptionLong { get { return LC.L(@"Use this option to specify a storage class. If this option is not used, the server will choose a default storage class."); } }
         public static string S3StorageclassDescriptionShort { get { return LC.L(@"Specify storage class"); } }
         public static string S3RRSDeprecationDescription(string optionname, string optionvalue) { return LC.L(@"Please use --{0}={1} instead", optionname, optionvalue); }


### PR DESCRIPTION
Some S3 providers do not support MultiChunkedEncoding (#4994).

This adds an option for the S3 backend:
```
--s3-disable-chunk-encoding = false
  This disables chunk encoding for the aws client, which is not supported by
  all S3 providers.
```

It only affects the AWS client, because Minio either does not use this encoding, or does not allow to configure it.