### PR TITLE
change error reporting for full backup remote verification

### DIFF
--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -189,6 +189,15 @@ namespace Duplicati.Library.Main.Operation
             }
 
             m_results.EndTime = DateTime.UtcNow;
+            var filtered = from n in m_results.Verifications where n.Value.Any() select n;
+            if (!filtered.Any())
+            {
+                Logging.Log.WriteInformationMessage(LOGTAG, "Test results", "Successfully verified {0} remote files", m_results.VerificationsActualLength);
+            }
+            else
+            {
+                Logging.Log.WriteErrorMessage(LOGTAG, "Test results", null,  "Verified {0} remote files with {1} problem(s)", m_results.VerificationsActualLength, filtered.Count());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Before the change, it could happen that when the postbackup test was finding problems in the backend, the job would be reported as having completed successfully, the found problems being displayed only in the complete log. After the change, an error is logged that cause the job to be failed.
To repro, the following procedure can be used in a test backup: change a hash for a block in the block table database and run a backup having set --full-remote-verification and --full-block-verification to true and --backup-test-percentage to 100.