### PR TITLE
Update stale action to v8

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v8
         with:
           days-before-issue-stale: 15
           days-before-issue-close: 15


### PR DESCRIPTION
The main reason to update this is because it closes issues as "not planned" instead of "completed", which makes it easier to spot compared to solved issues (has a different symbol in the list).