### PR TITLE
Improve file backend list speed

### DIFF
--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -176,15 +176,7 @@ namespace Duplicati.Library.Backend
             if (!systemIO.DirectoryExists(m_path))
                 throw new FolderMissingException(Strings.FileBackend.FolderMissingError(m_path));
 
-            foreach (string s in systemIO.EnumerateFiles(m_path))
-            {
-                yield return systemIO.FileEntry(s);
-            }
-
-            foreach (string s in systemIO.EnumerateDirectories(m_path))
-            {
-                yield return systemIO.DirectoryEntry(s);
-            }
+            return systemIO.EnumerateFileEntries(m_path);
         }
 
 #if DEBUG_RETRY

--- a/Duplicati/Library/Common/IO/ISystemIO.cs
+++ b/Duplicati/Library/Common/IO/ISystemIO.cs
@@ -28,6 +28,7 @@ namespace Duplicati.Library.Common.IO
     public interface ISystemIO
     {
         IFileEntry DirectoryEntry(string path);
+        IFileEntry DirectoryEntry(DirectoryInfo dirInfo);
         void DirectoryCreate(string path);
         void DirectoryDelete(string path, bool recursive);
         bool DirectoryExists(string path);
@@ -36,6 +37,7 @@ namespace Duplicati.Library.Common.IO
         void DirectorySetCreationTimeUtc(string path, DateTime time);
 
         IFileEntry FileEntry(string path);
+        IFileEntry FileEntry(FileInfo fileInfo);
         void FileMove(string source, string target);
         void FileDelete(string path);
         void FileCopy(string source, string target, bool overwrite);
@@ -68,6 +70,10 @@ namespace Duplicati.Library.Common.IO
         IEnumerable<string> EnumerateFiles(string path);
         IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
         IEnumerable<string> EnumerateDirectories(string path);
+
+        // Enumerate FileEntries of files and directories
+        // This is more efficient than enumerating file names when metadata is needed
+        IEnumerable<IFileEntry> EnumerateFileEntries(string path);
 
         void SetMetadata(string path, Dictionary<string, string> metdata, bool restorePermissions);
         Dictionary<string, string> GetMetadata(string path, bool isSymlink, bool followSymlink);

--- a/Duplicati/Library/Common/IO/SystemIOLinux.cs
+++ b/Duplicati/Library/Common/IO/SystemIOLinux.cs
@@ -132,6 +132,22 @@ namespace Duplicati.Library.Common.IO
             return Directory.EnumerateFiles(path, searchPattern, searchOption);
         }
 
+        public IEnumerable<IFileEntry> EnumerateFileEntries(string path)
+        {
+            // For consistency with previous implementation, enumerate files first and directories after
+            DirectoryInfo dir = new DirectoryInfo(path);
+
+            foreach (FileInfo file in dir.EnumerateFiles())
+            {
+                yield return FileEntry(file);
+            }
+
+            foreach (DirectoryInfo d in dir.EnumerateDirectories())
+            {
+                yield return DirectoryEntry(d);
+            }
+        }
+
         public string PathGetFileName(string path)
         {
             return Path.GetFileName(path);
@@ -293,7 +309,10 @@ namespace Duplicati.Library.Common.IO
 
         public IFileEntry DirectoryEntry(string path)
         {
-            var dInfo = new DirectoryInfo(path);
+            return DirectoryEntry(new DirectoryInfo(path));
+        }
+        public IFileEntry DirectoryEntry(DirectoryInfo dInfo)
+        {
             return new FileEntry(dInfo.Name, 0, dInfo.LastAccessTime, dInfo.LastWriteTime)
             {
                 IsFolder = true
@@ -302,7 +321,10 @@ namespace Duplicati.Library.Common.IO
 
         public IFileEntry FileEntry(string path)
         {
-            var fileInfo = new FileInfo(path);
+            return FileEntry(new FileInfo(path));
+        }
+        public IFileEntry FileEntry(FileInfo fileInfo)
+        {
             return new FileEntry(fileInfo.Name, fileInfo.Length, fileInfo.LastAccessTime, fileInfo.LastWriteTime);
         }
     }


### PR DESCRIPTION
Directly list FileInfo instead of lookups by filename. This greatly speeds up backup verify on exFAT.

Closes #5061

## Steps to reproduce
See #5061 for steps to test.

### Current behavior
- `FileBackend.List` has to look up all file attributes by names
- Backup verify for directories with many files on exFAT target can take hours

### New behavior
- `FileBackend.List` uses `DirectoryInfo`/`FileInfo` to directly access file attributes
- Backup verify for directory with 100000 files takes less than a minute

## Impact
There should be no change about extended path prefixes on Windows, because `IFileEntry` only contains the filename without full paths.

I chose to only update the `FileBackend` list, not any other file accesses (such as during backup) to keep the changes minimal. It might be possible to improve the speed of other file accesses, but most of the interfaces use strings on many layers (also to apply filters first). However, those are probably on local drives with NTFS or ext4 partitions and should rarely have directories as large as some target folders can be.