### PR TITLE
Keep user-defined whitespace in description field

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/home.html
+++ b/Duplicati/Server/webroot/ngax/templates/home.html
@@ -15,9 +15,7 @@
                 <dl class="taskmenu" ng-show="$parent.TaskMenuID == item.Backup.ID">
                     <span ng-show="item.Backup.Description">
                         <dt translate>Description:</dt>
-                        <dd>
-                            {{item.Backup.Description}}
-                        </dd>
+                        <dd class="prewrapped-text">{{item.Backup.Description}}</dd>
                     </span>
 
                     <dt translate>Operations:</dt>


### PR DESCRIPTION
This allows users to use the description better, for example by making a list.
It uses the CSS property `white-space: pre-wrap`, which keeps all whitespace but inserts line breaks if necessary.

## Screenshot
![description with pre-wrap whitespace](https://github.com/duplicati/duplicati/assets/33495614/8bf3d498-f03d-4318-89c8-710424e74ebc)
