### PR TITLE
Fix "Index consistency check failed" when running repair

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1303,8 +1303,9 @@ ORDER BY
         {
             using (var cmd = m_connection.CreateCommand(transaction))
             {
+                // Group subquery by hash to ensure that each blocklist hash appears only once in the result
                 var sql = string.Format(@"SELECT ""A"".""Hash"", ""C"".""Hash"" FROM " +
-                    @"(SELECT ""BlocklistHash"".""BlocksetID"", ""Block"".""Hash"", * FROM  ""BlocklistHash"",""Block"" WHERE  ""BlocklistHash"".""Hash"" = ""Block"".""Hash"" AND ""Block"".""VolumeID"" = ?) A, " +
+                    @"(SELECT ""BlocklistHash"".""BlocksetID"", ""Block"".""Hash"", ""BlocklistHash"".""Index"" FROM  ""BlocklistHash"",""Block"" WHERE  ""BlocklistHash"".""Hash"" = ""Block"".""Hash"" AND ""Block"".""VolumeID"" = ? GROUP BY ""Block"".""Hash"") A, " +
                     @" ""BlocksetEntry"" B, ""Block"" C WHERE ""B"".""BlocksetID"" = ""A"".""BlocksetID"" AND " +
                     @" ""B"".""Index"" >= (""A"".""Index"" * {0}) AND ""B"".""Index"" < ((""A"".""Index"" + 1) * {0}) AND ""C"".""ID"" = ""B"".""BlockID"" " +
                     @" ORDER BY ""A"".""BlocksetID"", ""B"".""Index""",


### PR DESCRIPTION
Closes #3202 

[Forum discussion](https://forum.duplicati.com/t/any-way-to-recover-backup-repair-and-purge-broken-files-dont-help/17048/35?u=jojo-1000)

- Uses `GROUP BY Hash` to select any one of the possible blocklists in the database for each blocklist hash, so that re-use of blocks is ignored
- Add a test case to reproduce the bug
- Add a hash check when reading blocklists from index files, to prevent issues in recreate due to existing incorrect index files that might be caused by compact

## Steps to test recreate hash check
- Create unencrypted backup with at least one file larger than a block
- Make backup version
- Edit an index zip file on the destination, `list/[hash]` and duplicate the contents of the file (append to the back)
- Run database recreate

### Old behavior
- Recreate fails with error `Recreated database has missing blocks and 2 broken filelists. Consider using "list-broken-files" and "purge-broken-files" to purge broken data from the remote store and the database.`
- The database cannot be used to continue the backup

### New behavior
- Recreate finishes with warning `[file] had invalid blocklists which could not be used. Consider deleting this index file and run repair to recreate it.`
- The dblock file is used to get the correct blocklist
- The database can be used as normal

## Impact
This modifies a core SQL statement that will be used in repair, compact and to recreate missing index files. It should be tested that these work correctly for a backup with some data and a compact history.