### PR TITLE
Fixes connect to server not working when a password is used for the UI.

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/AppService.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/AppService.js
@@ -53,7 +53,6 @@ backupApp.service('AppService', function($http, $cookies, $q, $cookies, DialogSe
                 DialogService.accept('Not logged in', function () {
                     window.location = appConfig.login_url;
                 });
-                return;
             }
             deferred.reject(response);
         });

--- a/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
@@ -275,6 +275,9 @@ backupApp.service('ServerStatus', function($rootScope, $timeout, AppService, App
 
                     // Try again
                     longpoll(true);
+                } else if (response.status == 401) {
+                    // Change state to connected to hide the connecting message, which is on top of the login message from the AppService
+                    state.connectionState = 'connected';
                 } else {
 
                     state.connectionState = 'disconnected';


### PR DESCRIPTION
Fixes #3091 

This issue occurred when a password was set on the web UI, and the web client lost a connection to the server.  The web client would try to display a message to click to log in again, but it would not display for two reasons. First, the 401 unauthorized check in the appservice was not returning a promise so it was causing the Angular app to stop. Second, the connection message was appearing on top of the DialogController message, so when a 401 occurs my commit updates it to change the status to connected so it will then display the "Not Logged In" dialog.