### PR TITLE
Check that the database exists before writing error logs

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -487,11 +487,14 @@ namespace Duplicati.Library.Main
                             {
                                 basicResults.OperationProgressUpdater.UpdatePhase(OperationPhase.Error);
                                 basicResults.Fatal = true;
-                                // Write logs to previous operation
-                                using (var db = new LocalDatabase(m_options.Dbpath, null, true))
+                                // Write logs to previous operation if database exists
+                                if (LocalDatabase.Exists(m_options.Dbpath))
                                 {
-                                    basicResults.SetDatabase(db);
-                                    db.WriteResults();
+                                    using (var db = new LocalDatabase(m_options.Dbpath, null, true))
+                                    {
+                                        basicResults.SetDatabase(db);
+                                        db.WriteResults();
+                                    }
                                 }
                             }
                         }

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -61,6 +61,11 @@ namespace Duplicati.Library.Main.Database
             return c;
         }
 
+        public static bool Exists(string path)
+        {
+            return File.Exists(path);
+        }
+
         /// <summary>
         /// Creates a new database instance and starts a new operation
         /// </summary>


### PR DESCRIPTION
Closes #5091

Fixes that any fatal error in test-filters created an INVALID! file in the current working dir.

I tested that a newly created backup still saves fatal errors for the first run (e.g. invalid destination drive letter).