### PR TITLE
allow for alternate oauth server to work - should fix #4714 and #2470

### DIFF
--- a/Duplicati/Server/WebServer/RESTMethods/RemoteOperation.cs
+++ b/Duplicati/Server/WebServer/RESTMethods/RemoteOperation.cs
@@ -36,7 +36,6 @@ namespace Duplicati.Server.WebServer.RESTMethods
         {
             using(var b = Duplicati.Library.DynamicLoader.BackendLoader.GetBackend(uri, new Dictionary<string, string>()))
                 b.CreateFolder();
-
             info.OutputOK();
         }
 
@@ -66,7 +65,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
         private void TestConnection(string url, RequestInfo info)
         {
-            
+            bool autoCreate = false;
             var modules = (from n in Library.DynamicLoader.GenericLoader.Modules
                 where n is Library.Interface.IConnectionModule
                 select n).ToArray();
@@ -84,13 +83,23 @@ namespace Duplicati.Server.WebServer.RESTMethods
                     n.Configure(opts);
 
                 using (var b = Duplicati.Library.DynamicLoader.BackendLoader.GetBackend(url, new Dictionary<string, string>()))
+                {
+                    if (opts.ContainsKey("autocreate"))
+                    {
+                        autoCreate = true;
+                        b.CreateFolder();
+                    }
                     b.Test();
-
-                info.OutputOK();
+                    info.OutputOK();
+                }
             }
             catch (Duplicati.Library.Interface.FolderMissingException)
             {
-                info.ReportServerError("missing-folder");
+                if (!autoCreate) {
+                    info.ReportServerError("missing-folder");
+                } else {
+                    info.ReportServerError("error-creating-folder");
+                }
             }
             catch (Duplicati.Library.Utility.SslCertificateValidator.InvalidCertificateException icex)
             {


### PR DESCRIPTION
This is a rather tentative PR, not very well tested. 

There is a lack of an actual alternate oauth server of course, I have one at 

https://duplicatipy3.ew.r.appspot.com

it's only for testing, I have a dev account for box.com only (other providers not available here, sorry).
This server is not a long term fact, don't expect it to last more than a few weeks, the migration of the production server is not really thought out yet. If you want to test the whole process, getting an account at box.com for 10 GB is free (only an email address is required).
As this serves me to test the python3 migration, it could even be broken from time to time in the following weeks.
Also, when connecting directly to it, the Box connection is displayed (it works), but a button is displayed for Jottacloud also. I don't know why since I don't have a Jottacloud dev account. There is something special going on there but I have no idea.
@albertony maybe ?

The previous code was relying on an advanced parameter specifying a server with a /refresh suffix, and had in the JS code the same server hard coded (but without a /refresh suffix). To keep the same scheme I have kept the /suffix idea even if can lead to some wretched code adding and removing the /refresh suffix.

This PR allows to set the alternate server in 2 ways:
- as a server parameter: in this case it will take precedence on the hard coded value (https://duplicati-oauth-handler.appspot.com/) for all backends using OAuth
- as a backend parameter: in this case it will take precedence for the job only on the hard coded value and on a server parameter (if any).
The alternate server can't be set reliably as an advanced parameter (tab 5 of the Web UI)
Don't ask why, I don't know.
