### PR TITLE
Added support for machine and backup ids in reports

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -357,6 +357,9 @@ namespace Duplicati.Library.Main
                     new CommandLineArgument("backup-name", CommandLineArgument.ArgumentType.String, Strings.Options.BackupnameShort, Strings.Options.BackupnameLong, DefaultBackupName),
                     new CommandLineArgument("compression-extension-file", CommandLineArgument.ArgumentType.Path, Strings.Options.CompressionextensionfileShort, Strings.Options.CompressionextensionfileLong(DEFAULT_COMPRESSED_EXTENSION_FILE), DEFAULT_COMPRESSED_EXTENSION_FILE),
 
+                    new CommandLineArgument("backup-id", CommandLineArgument.ArgumentType.String, Strings.Options.BackupidShort, Strings.Options.BackupidLong, ""),
+                    new CommandLineArgument("machine-id", CommandLineArgument.ArgumentType.String, Strings.Options.MachineidShort, Strings.Options.MachineidLong, Library.AutoUpdater.UpdaterManager.InstallID),
+
                     new CommandLineArgument("verbose", CommandLineArgument.ArgumentType.Boolean, Strings.Options.VerboseShort, Strings.Options.VerboseLong, "false", null, null, Strings.Options.VerboseDeprecated),
                     new CommandLineArgument("full-result", CommandLineArgument.ArgumentType.Boolean, Strings.Options.FullresultShort, Strings.Options.FullresultLong, "false"),
 
@@ -1284,6 +1287,30 @@ namespace Duplicati.Library.Main
             }
         }
 
+        /// <summary>
+        /// Gets the ID of the backup
+        /// </summary>
+        public string BackupId
+        {
+            get
+            {
+                m_options.TryGetValue("backup-id", out var tmp);
+                return tmp;
+            }
+        }
+
+        /// <summary>
+        /// Gets the ID of the machine
+        /// </summary>
+        public string MachineId
+        {
+            get
+            {
+                if (m_options.TryGetValue("machine-id", out var tmp))
+                    return tmp;
+                return Library.AutoUpdater.UpdaterManager.InstallID;
+            }
+        }
         /// <summary>
         /// Gets the path to the database
         /// </summary>

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -157,6 +157,10 @@ namespace Duplicati.Library.Main.Strings
         public static string VssusemappingShort { get { return LC.L(@"Map snapshots to a drive (Windows only)"); } }
         public static string BackupnameLong { get { return LC.L(@"A display name that is attached to this backup. Can be used to identify the backup when sending mail or running scripts."); } }
         public static string BackupnameShort { get { return LC.L(@"Name of the backup"); } }
+        public static string BackupidLong { get { return LC.L(@"A unique identification for this backup. Can be used to identify the backup when sending mail or running scripts."); } }
+        public static string BackupidShort { get { return LC.L(@"Backup ID"); } }
+        public static string MachineidLong { get { return LC.L(@"A unique identification of the machine running the backup. Can be used to identify the machine when sending mail or running scripts."); } }
+        public static string MachineidShort { get { return LC.L(@"Machine ID"); } }
         public static string CompressionextensionfileLong(string path) { return LC.L(@"This property can be used to point to a text file where each line contains a file extension that indicates a non-compressible file. Files that have an extension found in the file will not be compressed, but simply stored in the archive. The file format ignores any lines that do not start with a period, and considers a space to indicate the end of the extension. A default file is supplied, that also serves as an example. The default file is placed in {0}.", path); }
         public static string CompressionextensionfileShort { get { return LC.L(@"Manage non-compressible file extensions"); } }
         public static string BlocksizeLong { get { return LC.L(@"The block size determines how files are fragmented. Choosing a large value will cause a larger overhead on file changes, choosing a small value will cause a large overhead on storage of file lists. Note that the value cannot be changed after remote files are created."); } }

--- a/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
@@ -95,7 +95,7 @@ namespace Duplicati.Library.Modules.Builtin {
         /// <summary>
         /// The default message body
         /// </summary>
-        protected override string DEFAULT_BODY => string.Format("Duplicati %OPERATIONNAME% report for %backup-name%{0}{0}%RESULT%", Environment.NewLine);
+        protected override string DEFAULT_BODY => string.Format("Duplicati %OPERATIONNAME% report for %backup-name% (%machine-id%, %backup-id%){0}{0}%RESULT%", Environment.NewLine);
         /// <summary>
         /// Don't use the subject for HTTP
         /// </summary>

--- a/Duplicati/Server/Runner.cs
+++ b/Duplicati/Server/Runner.cs
@@ -905,6 +905,7 @@ namespace Duplicati.Server
         {
             options["backup-name"] = backup.Name;
             options["dbpath"] = backup.DBPath;
+            options["backup-id"] = $"DB-{backup.ID}";
 
             // Apply normal options
             foreach(var o in backup.Settings)
@@ -915,7 +916,6 @@ namespace Duplicati.Server
             foreach(var o in backup.Settings)
                 if (o.Name.StartsWith("--", StringComparison.Ordinal) && TestIfOptionApplies())
                     options[o.Name.Substring(2)] = o.Value;
-
 
             // The server hangs if the module is enabled as there is no console attached
             DisableModule("console-password-input", options);


### PR DESCRIPTION
This PR adds the fields `backup-id` and `machine-id` to the report fields.
The purpose of this is to allow using a single report url/method in global settings, but still being able to differentiate the backup reports.
Without this PR, each backup needs a unique url or template to differentiate the backups, or rely on the backup names being different.