### PR TITLE
fix: Handle upload-error by raising exception

### DIFF
--- a/Duplicati/Library/Backend/Storj/StorjBackend.cs
+++ b/Duplicati/Library/Backend/Storj/StorjBackend.cs
@@ -319,6 +319,10 @@ namespace Duplicati.Library.Backend.Storj
             custom.Entries.Add(new CustomMetadataEntry { Key = StorjFile.STORJ_LAST_MODIFICATION, Value = DateTime.Now.ToUniversalTime().ToString("O") });
             var upload = await _objectService.UploadObjectAsync(bucket, GetBasePath() + remotename, new UploadOptions(), stream, custom, false);
             await upload.StartUploadAsync();
+            if(upload.Failed)
+            {
+                throw new Exception(upload.ErrorMessage);
+            }
         }
 
         public void Test()


### PR DESCRIPTION
Uploading to Storj DCS (Tardigrade) relied on list-verify-upload. If an upload fails, it was not reported to Duplicati immediately. So the user also did not get any info about e.g. StorageLimitExceeded or similar issues.

This PR adds a check for the "upload-Failed"-Property and raises an exception with the provided reason from uplink.NET.