### PR TITLE
Standardize build product names for releases

### DIFF
--- a/build-installers.sh
+++ b/build-installers.sh
@@ -36,8 +36,8 @@ BUILDTYPE=$(echo "${ZIPFILE}" | cut -d "-" -f 2 | cut -d "_" -f 2)
 BUILDTAG_RAW=$(echo "${ZIPFILE}" | cut -d "." -f 1-4 | cut -d "-" -f 2-4)
 BUILDTAG="${BUILDTAG_RAW//-}"
 
-RPMNAME="duplicati-${VERSION}-${BUILDTAG}.noarch.rpm"
-DEBNAME="duplicati_${VERSION}-1_all.deb"
+RPMNAME="duplicati-${BUILDTAG_RAW}.noarch.rpm"
+DEBNAME="duplicati-${BUILDTAG_RAW}-all.deb"
 MSI64NAME="duplicati-${BUILDTAG_RAW}-x64.msi"
 MSI32NAME="duplicati-${BUILDTAG_RAW}-x86.msi"
 DMGNAME="duplicati-${BUILDTAG_RAW}.dmg"


### PR DESCRIPTION
Currently, build products/installers on the GitHub Release tags aren't named in a standard way, and the `deb` release is missing the notice that it's a canary release:

![image](https://github.com/duplicati/duplicati/assets/11021263/5f9d990a-8151-46f9-964a-a94bd081af7a)

This update fixes this naming inconsistency. 

It's possible that there's a reason the `rpm` and `deb` package names were different than the rest, but I can't think of it, so I think this is a reasonable change.