### PR TITLE
Add note about concurrency setting to throttle-upload setting

### DIFF
--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -65,7 +65,7 @@ namespace Duplicati.Library.Main.Strings
         public static string AllowsleepLong { get { return LC.L(@"Allow system to enter sleep power modes for inactivity during backup/restore operations (Windows/OSX only)"); } }
         public static string ThrottledownloadLong { get { return LC.L(@"By setting this value you can limit how much bandwidth Duplicati consumes for downloads. Setting this limit can make the backups take longer, but will make Duplicati less intrusive."); } }
         public static string ThrottledownloadShort { get { return LC.L(@"Max number of kilobytes to download pr. second"); } }
-        public static string ThrottleuploadLong { get { return LC.L(@"By setting this value you can limit how much bandwidth Duplicati consumes for uploads. Setting this limit can make the backups take longer, but will make Duplicati less intrusive."); } }
+        public static string ThrottleuploadLong { get { return LC.L(@"By setting this value you can limit how much bandwidth Duplicati consumes for uploads. Setting this limit can make the backups take longer, but will make Duplicati less intrusive. Note that this setting applies to each concurrent upload, so try to set ""asynchronous-concurrent-upload-limit"" to ""1"" if your upstream exceeds the value configured here."); } }
         public static string ThrottleuploadShort { get { return LC.L(@"Max number of kilobytes to upload pr. second"); } }
         public static string NoencryptionLong { get { return LC.L(@"If you store the backups on a local disk, and prefer that they are kept unencrypted, you can turn of encryption completely by using this switch."); } }
         public static string NoencryptionShort { get { return LC.L(@"Disable encryption"); } }


### PR DESCRIPTION
I had trouble getting the upload throttle to work. The forum post https://forum.duplicati.com/t/upload-throttle-not-working/8955/7 helped me. So I thought that information could also go into the application's documentation.

If this is accepted / acceptable I can contribute this change to the documentation as well.