### PR TITLE
Changed logic for reporting exceptions

### DIFF
--- a/Duplicati/Library/Interface/IGenericCallbackModule.cs
+++ b/Duplicati/Library/Interface/IGenericCallbackModule.cs
@@ -38,6 +38,7 @@ namespace Duplicati.Library.Interface
         /// Called when the operation finishes
         /// </summary>
         /// <param name="result">The result object, if this derives from an exception, the operation failed</param>
-        void OnFinish(object result);
+        /// <param name="exception">The exception that stopped the backup, or null</param>
+        void OnFinish(object result, Exception exception);
     }
 }

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -441,7 +441,7 @@ namespace Duplicati.Library.Main
                         r.Interrupted = false;
                     }
 
-                    OnOperationComplete(result);
+                    OnOperationComplete(result, null);
 
                     Logging.Log.WriteInformationMessage(LOGTAG, "CompletedOperation", Strings.Controller.CompletedOperationMessage(m_options.MainAction));
 
@@ -469,23 +469,26 @@ namespace Duplicati.Library.Main
                                     db.WriteResults();
                                 }
 
-                                OnOperationComplete(result);
+                                // Do not propagate the cancel exception
+                                OnOperationComplete(result, null);
                             }
                             catch { }
                         }
                         else
                         {
                             // Perform the module shutdown
-                            OnOperationComplete(ex);
+                            OnOperationComplete(ex, ex);
                         }
 
                         return result;
                     }
                     else
                     {
-                        try
+                        Logging.Log.WriteErrorMessage(LOGTAG, "FailedOperation", ex, Strings.Controller.FailedOperationMessage(m_options.MainAction, ex.Message));
+
+                        if (result is BasicResults basicResults)
                         {
-                            if (result is BasicResults basicResults)
+                            try
                             {
                                 basicResults.OperationProgressUpdater.UpdatePhase(OperationPhase.Error);
                                 basicResults.Fatal = true;
@@ -498,13 +501,18 @@ namespace Duplicati.Library.Main
                                         db.WriteResults();
                                     }
                                 }
+
+                                // Report the result, and the failure
+                                OnOperationComplete(result, ex);
+
                             }
+                            catch { }
                         }
-                        catch { }
-
-                        OnOperationComplete(ex);
-
-                        Logging.Log.WriteErrorMessage(LOGTAG, "FailedOperation", ex, Strings.Controller.FailedOperationMessage(m_options.MainAction, ex.Message));
+                        else
+                        {
+                            // Perform the module shutdown
+                            OnOperationComplete(ex, ex);
+                        }
 
                         throw;
                     }
@@ -538,13 +546,13 @@ namespace Duplicati.Library.Main
             System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = uiLocale;
         }
 
-        private void OnOperationComplete(object result)
+        private void OnOperationComplete(object result, Exception exception)
         {
             if (m_options != null && m_options.LoadedModules != null)
             {
                 foreach (KeyValuePair<bool, Library.Interface.IGenericModule> mx in m_options.LoadedModules)
                     if (mx.Key && mx.Value is IGenericCallbackModule module)
-                        try { module.OnFinish(result); }
+                        try { module.OnFinish(result, exception); }
                         catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, $"OnFinishError{mx.Key}", ex, "OnFinish callback {0} failed: {1}", mx.Key, ex.Message); }
 
                 foreach (KeyValuePair<bool, Library.Interface.IGenericModule> mx in m_options.LoadedModules)

--- a/Duplicati/Library/Modules/Builtin/ResultSerialization/DuplicatiFormatSerializer.cs
+++ b/Duplicati/Library/Modules/Builtin/ResultSerialization/DuplicatiFormatSerializer.cs
@@ -37,11 +37,18 @@ namespace Duplicati.Library.Modules.Builtin.ResultSerialization
         /// </summary>
         /// <returns>The serialized result string.</returns>
         /// <param name="result">The result to serialize.</param>
+        /// <param name="failException">The exception, if any</param>
         /// <param name="loglines">The log lines to serialize.</param>
         /// <param name="additional">Additional parameters to include</param>
-        public string Serialize(object result, IEnumerable<string> loglines, Dictionary<string, string> additional)
+        public string Serialize(object result, Exception failException, IEnumerable<string> loglines, Dictionary<string, string> additional)
         {
             StringBuilder sb = new StringBuilder();
+
+            // Prepend the error message as the first two lines, to mimic previous behavior with only the exception text
+            if (failException != null && result != failException)
+            {
+                sb.AppendLine(Serialize(failException, null, null, null));
+            }
 
             if (result == null)
             {
@@ -105,7 +112,7 @@ namespace Duplicati.Library.Modules.Builtin.ResultSerialization
             }
             else
             {
-                var ignore = new string[] { 
+                var ignore = new string[] {
                     nameof(IBasicResults.Warnings),
                     nameof(IBasicResults.Errors),
                     nameof(IBasicResults.Messages)
@@ -115,7 +122,7 @@ namespace Duplicati.Library.Modules.Builtin.ResultSerialization
             }
 
             if (additional != null && additional.Count > 0)
-                sb.AppendLine(Serialize(additional, null, null));
+                sb.AppendLine(Serialize(additional, null, null, null));
 
             if (loglines != null && loglines.Any())
             {

--- a/Duplicati/Library/Modules/Builtin/ResultSerialization/IResultFormatSerializer.cs
+++ b/Duplicati/Library/Modules/Builtin/ResultSerialization/IResultFormatSerializer.cs
@@ -18,6 +18,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
+using System;
 using System.Collections.Generic;
 
 namespace Duplicati.Library.Modules.Builtin
@@ -32,9 +33,10 @@ namespace Duplicati.Library.Modules.Builtin
         /// </summary>
         /// <returns>The serialized result string.</returns>
         /// <param name="result">The result to serialize.</param>
+        /// <param name="exception">An optional failure exception, or null</param>
         /// <param name="loglines">The log lines to serialize.</param>
         /// <param name="additional">Additional parameters to include</param>
-        string Serialize(object result, IEnumerable<string> loglines, Dictionary<string, string> additional);
+        string Serialize(object result, Exception exception, IEnumerable<string> loglines, Dictionary<string, string> additional);
 
         /// <summary>
         /// Returns the format that the serializer represents

--- a/Duplicati/Library/Modules/Builtin/ResultSerialization/JsonFormatSerializer.cs
+++ b/Duplicati/Library/Modules/Builtin/ResultSerialization/JsonFormatSerializer.cs
@@ -76,16 +76,18 @@ namespace Duplicati.Library.Modules.Builtin.ResultSerialization
         /// </summary>
         /// <returns>The serialized result string.</returns>
         /// <param name="result">The result to serialize.</param>
+        /// <param name="exception">The exception, if any</param>
         /// <param name="loglines">The log lines to serialize.</param>
         /// <param name="additional">Additional parameters to include</param>
-        public string Serialize(object result, IEnumerable<string> loglines, Dictionary<string, string> additional)
+        public string Serialize(object result, Exception exception, IEnumerable<string> loglines, Dictionary<string, string> additional)
         {
             return JsonConvert.SerializeObject(
                 new
                 {
                     Data = result,
                     Extra = additional,
-                    LogLines = loglines
+                    LogLines = loglines,
+                    Exception = exception?.ToString()
                 }, 
                 
                 new JsonSerializerSettings()

--- a/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
@@ -206,13 +206,13 @@ namespace Duplicati.Library.Modules.Builtin {
 
 		#endregion
 
-		protected override string ReplaceTemplate(string input, object result, bool subjectline)
+		protected override string ReplaceTemplate(string input, object result, Exception exception, bool subjectline)
 		{
             // No need to do the expansion as we throw away the result
             if (subjectline)
                 return string.Empty;
 
-            return base.ReplaceTemplate(input, result, subjectline);
+            return base.ReplaceTemplate(input, result, exception, subjectline);
 		}
 
         protected override void SendMessage(string subject, string body) {

--- a/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
@@ -185,12 +185,12 @@ namespace Duplicati.Library.Modules.Builtin
 
         #endregion
 
-        protected override string ReplaceTemplate(string input, object result, bool subjectline)
+        protected override string ReplaceTemplate(string input, object result, Exception exception, bool subjectline)
         {
             // No need to do the expansion as we throw away the result
             if (subjectline)
                 return string.Empty;
-            return base.ReplaceTemplate(input, result, subjectline);
+            return base.ReplaceTemplate(input, result, exception, subjectline);
         }
 
         protected override void SendMessage(string subject, string body)


### PR DESCRIPTION
Previously, an exception happening mid-backup would report only the exception message, despite having additional data that may have helped diagnose the issue.

This PR adds the exception as an additional field to JSON output, and adds the additional reporting data to text messages, after the initial error.