### PR TITLE
Added support for sending reports via HTTP(s) to multiple destinations

### DIFF
--- a/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
@@ -19,18 +19,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 using Duplicati.Library.Interface;
-using Duplicati.Library.Logging;
-using Duplicati.Library.Modules.Builtin.ResultSerialization;
-using Duplicati.Library.Utility;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
-using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
-namespace Duplicati.Library.Modules.Builtin {
+namespace Duplicati.Library.Modules.Builtin
+{
+    /// <summary>
+    /// Helper module to send HTTP report messages
+    /// </summary>
     public class SendHttpMessage : ReportHelper
     {
         /// <summary>
@@ -38,12 +39,28 @@ namespace Duplicati.Library.Modules.Builtin {
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<SendHttpMessage>();
 
+        /// <summary>
+        /// Entry describing a request to be sent
+        /// </summary>
+        /// <param name="Url">The url to send to</param>
+        /// <param name="Verb">The verb to use</param>
+        /// <param name="Format">The format to send</param>
+        private record SendRequestType(string Url, string Verb, ResultExportFormat Format);
+
         #region Option names
 
         /// <summary>
         /// Option used to specify server URL
         /// </summary>
         private const string OPTION_URL = "send-http-url";
+        /// <summary>
+        /// Option used to specify server URLs for sending text reports
+        /// </summary>
+        private const string OPTION_URL_FORM = "send-http-form-urls";
+        /// <summary>
+        /// Option used to specify server URLs for sending json reports
+        /// </summary>
+        private const string OPTION_URL_JSON = "send-http-json-urls";
         /// <summary>
         /// Option used to specify report body
         /// </summary>
@@ -104,9 +121,9 @@ namespace Duplicati.Library.Modules.Builtin {
 
         #region Private variables
         /// <summary>
-        /// The HTTP report URL
+        /// The HTTP text report URLs
         /// </summary>
-        private string m_url;
+        private List<SendRequestType> m_report_targets;
         /// <summary>
         /// The message parameter name
         /// </summary>
@@ -115,10 +132,6 @@ namespace Duplicati.Library.Modules.Builtin {
         /// The message parameter name
         /// </summary>
         private string m_extraParameters;
-        /// <summary>
-        /// The http verb
-        /// </summary>
-        private string m_verb;
 
         #endregion
 
@@ -133,7 +146,7 @@ namespace Duplicati.Library.Modules.Builtin {
         /// <summary>
         /// A localized string describing the module with a friendly name
         /// </summary>
-        public override string DisplayName { get { return Strings.SendHttpMessage.DisplayName;} }
+        public override string DisplayName { get { return Strings.SendHttpMessage.DisplayName; } }
 
         /// <summary>
         /// A localized description of the module
@@ -168,6 +181,9 @@ namespace Duplicati.Library.Modules.Builtin {
                     new CommandLineArgument(OPTION_MAX_LOG_LINES, CommandLineArgument.ArgumentType.Integer, Strings.ReportHelper.OptionmaxloglinesShort, Strings.ReportHelper.OptionmaxloglinesLong, DEFAULT_LOGLINES.ToString()),
 
                     new CommandLineArgument(OPTION_RESULT_FORMAT, CommandLineArgument.ArgumentType.Enumeration, Strings.ReportHelper.ResultFormatShort, Strings.ReportHelper.ResultFormatLong(Enum.GetNames(typeof(ResultExportFormat))), DEFAULT_EXPORT_FORMAT.ToString(), null, Enum.GetNames(typeof(ResultExportFormat))),
+
+                    new CommandLineArgument(OPTION_URL_FORM, CommandLineArgument.ArgumentType.String, Strings.SendHttpMessage.SendhttpurlsformShort, Strings.SendHttpMessage.SendhttpurlsformLong),
+                    new CommandLineArgument(OPTION_URL_JSON, CommandLineArgument.ArgumentType.String, Strings.SendHttpMessage.SendhttpurlsjsonShort, Strings.SendHttpMessage.SendhttpurlsjsonLong),
                 });
             }
         }
@@ -181,100 +197,142 @@ namespace Duplicati.Library.Modules.Builtin {
         protected override string LogLinesOptionName => OPTION_MAX_LOG_LINES;
         protected override string ResultFormatOptionName => OPTION_RESULT_FORMAT;
 
-		/// <summary>
-		/// This method is the interception where the module can interact with the execution environment and modify the settings.
-		/// </summary>
-		/// <param name="commandlineOptions">A set of commandline options passed to Duplicati</param>
-		protected override bool ConfigureModule(IDictionary<string, string> commandlineOptions)
+        /// <summary>
+        /// This method is the interception where the module can interact with the execution environment and modify the settings.
+        /// </summary>
+        /// <param name="commandlineOptions">A set of commandline options passed to Duplicati</param>
+        protected override bool ConfigureModule(IDictionary<string, string> commandlineOptions)
         {
-            //We need a URL to report to
-            commandlineOptions.TryGetValue(OPTION_URL, out m_url);
-            if (string.IsNullOrEmpty(m_url))
+            var reportTargets = new List<SendRequestType>();
+
+            // Grab the legacy URL option if it exists, and add it to the appropriate list
+            commandlineOptions.TryGetValue(OPTION_URL, out var legacy_urls);
+            if (!string.IsNullOrEmpty(legacy_urls))
+            {
+                if (!commandlineOptions.TryGetValue(OPTION_RESULT_FORMAT, out var format))
+                    format = ResultExportFormat.Duplicati.ToString();
+
+                if (!Enum.TryParse<ResultExportFormat>(format, out var exportFormat))
+                    exportFormat = ResultExportFormat.Duplicati;
+
+                commandlineOptions.TryGetValue(OPTION_VERB, out var verb);
+                if (string.IsNullOrEmpty(verb))
+                    verb = "POST";
+
+                reportTargets.AddRange(legacy_urls.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(url => new SendRequestType(url, verb, exportFormat)));
+            }
+
+            // Get the options as passed
+            commandlineOptions.TryGetValue(OPTION_URL_FORM, out var formurls);
+            if (!string.IsNullOrWhiteSpace(formurls))
+                reportTargets.AddRange(formurls.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(url => new SendRequestType(url, "POST", ResultExportFormat.Duplicati)));
+
+            commandlineOptions.TryGetValue(OPTION_URL_JSON, out var jsonurls);
+            if (!string.IsNullOrWhiteSpace(jsonurls))
+                reportTargets.AddRange(jsonurls.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(url => new SendRequestType(url, "POST", ResultExportFormat.Json)));
+
+            //We need at least one URL to report to
+            if (reportTargets.Count == 0)
                 return false;
+
+            m_report_targets = reportTargets;
 
             commandlineOptions.TryGetValue(OPTION_MESSAGE_PARAMETER_NAME, out m_messageParameterName);
             if (string.IsNullOrEmpty(m_messageParameterName))
                 m_messageParameterName = DEFAULT_MESSAGE_PARAMETER_NAME;
 
             commandlineOptions.TryGetValue(OPTION_EXTRA_PARAMETERS, out m_extraParameters);
-            commandlineOptions.TryGetValue(OPTION_VERB, out m_verb);
-            if (string.IsNullOrWhiteSpace(m_verb))
-                m_verb = "POST";
-
             return true;
         }
 
-		#endregion
+        #endregion
 
-		protected override string ReplaceTemplate(string input, object result, Exception exception, bool subjectline)
-		{
-            // No need to do the expansion as we throw away the result
-            if (subjectline)
-                return string.Empty;
-
-            return base.ReplaceTemplate(input, result, exception, subjectline);
-		}
-
-        protected override void SendMessage(string subject, string body) {
-            Exception ex = null;
-
+        private async Task<Exception?> SendMessage(HttpClient client, SendRequestType target, string subject, string body)
+        {
             byte[] data;
-            string contenttype;
+            MediaTypeHeaderValue contenttype;
 
-            if (ExportFormat == ResultExportFormat.Json)
+            if (target.Format == ResultExportFormat.Json)
             {
-                contenttype = "application/json";
+                contenttype = new MediaTypeHeaderValue("application/json");
                 data = Encoding.UTF8.GetBytes(body);
             }
             else
             {
-                contenttype = "application/x-www-form-urlencoded";
+                contenttype = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
                 var postData = $"{m_messageParameterName}={System.Uri.EscapeDataString(body)}";
                 if (!string.IsNullOrEmpty(m_extraParameters))
-                {
                     postData += $"&{System.Uri.EscapeUriString(m_extraParameters)}";
-                }
                 data = Encoding.UTF8.GetBytes(postData);
             }
 
-
-            var request = (HttpWebRequest)WebRequest.Create(m_url);
-            request.ContentType = contenttype;
-            request.Method = m_verb;
-            request.ContentLength = data.Length;
-
-            try 
+            var request = new HttpRequestMessage
             {
-                using (var stream = request.GetRequestStream()) 
-                {
-                    stream.Write(data, 0, data.Length);
-                }
+                RequestUri = new Uri(target.Url),
+                Method = new HttpMethod(target.Verb),
+                Content = new ByteArrayContent(data)
+            };
+            request.Content.Headers.ContentType = contenttype;
 
-                using (var response = (HttpWebResponse)request.GetResponse())
-                {
-                    Logging.Log.WriteVerboseMessage(LOGTAG, 
-                                                    "HttpResponseMessage", 
-                                                     "HTTP Response: {0} - {1}: {2}", 
-                                                     ((int)response.StatusCode).ToString(),
-                                                     response.StatusDescription,
-                                                     new StreamReader(response.GetResponseStream()).ReadToEnd()
-                                                    );
-                }
+            try
+            {
+                var response = await client.SendAsync(request);
+                var responseContent = await response.Content.ReadAsStringAsync();
+
+                Logging.Log.WriteVerboseMessage(LOGTAG, "HttpResponseMessage",
+                    "HTTP Response to {0}: {1} - {2}: {3}",
+                    target.Url,
+                    ((int)response.StatusCode).ToString(),
+                    response.ReasonPhrase,
+                    responseContent
+                );
             }
-            catch (Exception e) 
+            catch (Exception ex)
             {
-                ex = e;
-                if (ex is WebException exception && exception.Response is HttpWebResponse response)
-                {
-                    Logging.Log.WriteWarningMessage(LOGTAG,
-                                                    "HttpResponseError",
-                                                    exception,
-                                                     "HTTP Response: {0} - {1}: {2}",
-                                                     ((int)response.StatusCode).ToString(),
-                                                     response.StatusDescription,
-                                                     new StreamReader(response.GetResponseStream()).ReadToEnd()
-                                                    );
-                }
+                Logging.Log.WriteWarningMessage(LOGTAG, "HttpResponseError", ex, "HTTP Response request failed for: {0}", target.Url);
+                return ex;
+            }
+
+            return null;
+        }
+
+        private Dictionary<ResultExportFormat, string> m_cachedBodyResults;
+        private string m_form_body = string.Empty;
+
+        protected override string ReplaceTemplate(string input, object result, Exception exception, bool subjectline)
+        {
+            // No need to do the expansion as we throw away the result
+            if (subjectline)
+                return string.Empty;
+
+            if (m_report_targets == null)
+                return string.Empty;
+
+
+            m_cachedBodyResults = m_report_targets
+                .Select(x => x.Format)
+                .Distinct()
+                .ToDictionary(
+                    x => x,
+                    x => base.ReplaceTemplate(input, result, exception, false, x)
+                );
+
+            return string.Empty;
+        }
+
+        protected override void SendMessage(string subject, string body)
+        {
+            if (m_report_targets == null || m_cachedBodyResults == null)
+                return;
+
+            using var client = new HttpClient();
+
+            Exception ex = null;
+
+            foreach (var target in m_report_targets)
+            {
+                if (m_cachedBodyResults.TryGetValue(target.Format, out var result))
+                    ex ??= SendMessage(client, target, subject, body).ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
             if (ex != null)

--- a/Duplicati/Library/Modules/Builtin/Strings.cs
+++ b/Duplicati/Library/Modules/Builtin/Strings.cs
@@ -20,11 +20,12 @@
 // DEALINGS IN THE SOFTWARE.
 using Duplicati.Library.Localization.Short;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
-namespace Duplicati.Library.Modules.Builtin.Strings {
-    internal static class ConsolePasswordInput {
+namespace Duplicati.Library.Modules.Builtin.Strings
+{
+    internal static class ConsolePasswordInput
+    {
         public static string ConfirmPassphrasePrompt { get { return LC.L(@"Confirm encryption passphrase"); } }
         public static string Description { get { return LC.L(@"This module will ask the user for an encryption password on the command line unless encryption is disabled or the password is supplied by other means"); } }
         public static string Displayname { get { return LC.L(@"Password prompt"); } }
@@ -34,12 +35,14 @@ namespace Duplicati.Library.Modules.Builtin.Strings {
         public static string ForcepassphrasefromstdinShort { get { return LC.L(@"Read passphrase from STDIN"); } }
         public static string ForcepassphrasefromstdinLong { get { return LC.L(@"By default, the passphrase is attempted read from the TTY device directly, increasing the security by not copying the passphrase into a stream. In some setups, such as when running detached from a console, this does not work. Set this flag to prevent trying a TTY read and only read the passphrase from STDIN."); } }
     }
-    internal static class CheckMonoSSL {
+    internal static class CheckMonoSSL
+    {
         public static string Description { get { return LC.L(@"When running with Mono, this module will check if any certificates are installed and suggest installing them otherwise"); } }
         public static string Displayname { get { return LC.L(@"Check for SSL certificates"); } }
         public static string ErrorMessage { get { return LC.L(@"No certificates found, you can install some with one of these commands:{0}    cert-sync /etc/ssl/certs/ca-certificates.crt #for Debian based systems{0}    cert-sync /etc/pki/tls/certs/ca-bundle.crt #for RedHat derivatives{0}    curl -LO https://curl.se/ca/cacert.pem; cert-sync --user cacert.pem; rm cacert.pem #for MacOS{0}Read more: {1}", Environment.NewLine, "http://www.mono-project.com/docs/about-mono/releases/3.12.0/#cert-sync"); } }
     }
-    internal static class HttpOptions {
+    internal static class HttpOptions
+    {
         public static string Description { get { return LC.L(@"This module exposes a number of properties that can be used to change the way http requests are issued"); } }
         public static string DescriptionAcceptAnyCertificateLong { get { return LC.L(@"Use this option to accept any server certificate, regardless of what errors it may have. Please use --accept-specified-ssl-hash instead, whenever possible."); } }
         public static string DescriptionAcceptAnyCertificateShort { get { return LC.L(@"Accept any server certificate"); } }
@@ -61,7 +64,8 @@ namespace Duplicati.Library.Modules.Builtin.Strings {
         public static string BufferrequestsShort { get { return LC.L(@"Sets HTTP buffering"); } }
         public static string BufferrequestsLong { get { return LC.L(@"This option sets the HTTP buffering. Setting this to ""{0}"" can cause memory leaks, but can also improve performance in some cases.", "true"); } }
     }
-    internal static class HyperVOptions {
+    internal static class HyperVOptions
+    {
         public static string Description { get { return LC.L(@"This module works internaly to parse source parameters to backup Hyper-V virtual machines"); } }
         public static string DisplayName { get { return LC.L(@"Configure Hyper-V module"); } }
     }
@@ -70,7 +74,8 @@ namespace Duplicati.Library.Modules.Builtin.Strings {
         public static string Description { get { return LC.L(@"This module works internaly to parse source parameters to backup Microsoft SQL Server databases"); } }
         public static string DisplayName { get { return LC.L(@"Configure Microsoft SQL Server module"); } }
     }
-    internal static class RunScript {
+    internal static class RunScript
+    {
         public static string Description { get { return LC.L(@"Executes a script before starting an operation, and again on completion"); } }
         public static string DisplayName { get { return LC.L(@"Run script"); } }
         public static string FinishoptionLong { get { return LC.L(@"Executes a script after performing an operation. The script will receive the operation results written to stdout."); } }
@@ -89,7 +94,8 @@ namespace Duplicati.Library.Modules.Builtin.Strings {
         public static string TimeoutoptionLong { get { return LC.L(@"Sets the maximum time a script is allowed to execute. If the script has not completed within this time, it will continue to execute but the operation will continue too, and no script output will be processed."); } }
         public static string TimeoutoptionShort { get { return LC.L(@"Sets the script timeout"); } }
     }
-    internal static class SendMail {
+    internal static class SendMail
+    {
         public static string Description { get { return LC.L(@"This module can send email after an operation completes"); } }
         public static string Displayname { get { return LC.L(@"Send mail"); } }
         public static string FailedToLookupMXServer(string optionname) { return LC.L(@"Unable to find the destination mail server through MX lookup, please use the option {0} to specify what smtp server to use.", optionname); }
@@ -132,7 +138,8 @@ To enable SMTP over SSL, use the format smtps://example.com. To enable SMTP STAR
         public static string SendMailFailedRetryError(string failedserver, string message, string retryserver) { return LC.L(@"Failed to send email with server: {0}, message: {1}, retrying with {2}", failedserver, message, retryserver); }
         public static string SendMailSuccess(string server) { return LC.L(@"Email sent successfully using server: {0}", server); }
     }
-    internal static class SendJabberMessage {
+    internal static class SendJabberMessage
+    {
         public static string SendxmpptoShort { get { return LC.L(@"XMPP recipient email"); } }
         public static string SendxmpptoLong { get { return LC.L(@"The users who should have the messages sent, specify multiple users separated with commas"); } }
         public static string SendxmppmessageShort { get { return LC.L(@"The message template"); } }
@@ -159,7 +166,8 @@ You can supply multiple options with a comma separator, e.g. ""{0},{1}"". The sp
         public static string LoginTimeoutError { get { return LC.L(@"Timeout occurred while logging in to jabber server"); } }
     }
 
-    internal static class SendHttpMessage {
+    internal static class SendHttpMessage
+    {
         public static string DisplayName { get { return LC.L(@"HTTP report module"); } }
         public static string Description { get { return LC.L(@"This module provides support for sending status reports via HTTP messages"); } }
         public static string SendhttpurlShort { get { return LC.L(@"HTTP report url"); } }
@@ -185,9 +193,14 @@ You can supply multiple options with a comma separator, e.g. ""{0},{1}"". The sp
         public static string SendhttpanyoperationLong { get { return LC.L(@"By default, messages will only be sent after a Backup operation. Use this option to send messages for all operations"); } }
         public static string HttpverbShort { get { return LC.L(@"Sets the HTTP verb to use"); } }
         public static string HttpverbLong { get { return LC.L(@"Use this option to change the default HTTP verb used to submit a report"); } }
+        public static string SendhttpurlsformShort { get { return LC.L(@"HTTP report urls for sending form data"); } }
+        public static string SendhttpurlsformLong { get { return LC.L(@"HTTP report urls for sending form-encoded data. This property accepts multiple urls, seperated by a semi-colon. All urls will receive the same data. Note that this option ignores the format and verb settings"); } }
+        public static string SendhttpurlsjsonShort { get { return LC.L(@"HTTP report urls for sending JSON data"); } }
+        public static string SendhttpurlsjsonLong { get { return LC.L(@"HTTP report urls for sending JSON data. This property accepts multiple urls, seperated by a semi-colon. All urls will receive the same data. Note that this option ignores the format and verb settings"); } }
     }
 
-    internal static class ReportHelper {
+    internal static class ReportHelper
+    {
         public static string SendMessageFailedError(string message) { return LC.L(@"Failed to send message: {0}", message); }
         public static string OptionLoglevellShort { get { return LC.L("Defines a log level for messages"); } }
         public static string OptionLoglevelLong { get { return LC.L("Use this option to set the log level for messages to include in the report"); } }


### PR DESCRIPTION
This PR extends the HTTP reporting module to allow sending to multiple destinations.

The previous functionality is preserved, but two new options are added:
- `--send-http-form-urls` 
- `--send-http-json-urls`

These new options allows multiple urls to be set, and will ignore the verb and format parameters, but otherwise work the same.

Options passed via the regular `--send-http-url` option will retain its functionality and not be affected by the new options.

The motivation for this change is to better allow multiple destinations with different formats, which is not currently supported.