### PR TITLE
Add SupportedOSPlatform attribute to Windows-specific classes

### DIFF
--- a/Duplicati/Library/Utility/Win32.cs
+++ b/Duplicati/Library/Utility/Win32.cs
@@ -23,11 +23,13 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Utility
 {
     //The signatures in this file are from http://pinvoke.net
 
+    [SupportedOSPlatform("windows")]
     /// <summary>
     /// Various Windows specific calls 
     /// </summary>

--- a/Duplicati/Library/Utility/WinTools.cs
+++ b/Duplicati/Library/Utility/WinTools.cs
@@ -19,10 +19,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+using System.Runtime.Versioning;
 using Duplicati.Library.Common;
 
 namespace Duplicati.Library.Utility
 {
+    [SupportedOSPlatform("windows")]
     public static class WinTools
     {
         public static string GetWindowsGpgExePath()


### PR DESCRIPTION
I hope this is correct, and that I understood the task at hand.
#5167 

Added the marker 
`[SupportedOSPlatform("windows")]`

On the Win32.cs and WinTools.cs classes.