### PR TITLE
Fix missing auth-username and password in openstack

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -728,7 +728,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         if ((opts['openstack-version'] || '') == '')
             delete opts['openstack-version'];
 
-        EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
+        EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
 
         var url = AppUtils.format('{0}://{1}{2}',
             scope.Backend.Key,


### PR DESCRIPTION
Closes #5188

The changes in https://github.com/duplicati/duplicati/pull/4973 added an option to strip the username and password in backends where they are not shown to the user. The openstack backend needs these fields, but was incorrectly set to remove them. Because the removal happens after validation, the error is only noticed when testing the connection.