### PR TITLE
Fix stale action permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      actions: write
     steps:
       - uses: actions/stale@v9
         with:
@@ -22,4 +23,4 @@ jobs:
           only-labels: "pending user feedback"
           exempt-issue-labels: "bug,enhancement,good first issue,backend enhancement,backend issue,backup corruption,bounty,bugreport attached,core logic,docker,filters,help wanted,linux,localization,MacOS,mono,performance issue,reproduced,server side,ssl/tls issue,Synology,tests,translation,UI,windows"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          operations-per-run: 60
+          operations-per-run: 500


### PR DESCRIPTION
Action write permissions is required to update the cache (see https://github.com/actions/stale/issues/1133).

Right now the action log has errors:
```
Warning: Error delete _state: [403] Resource not accessible by integration
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/duplicati/duplicati --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key _state, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: _state, Version: fa41d75081481069cfb6b92a5f83a94c6e06ef3ab2e6b762649ac5f86f46153f
```

Also, the operation limit is 5000 per hour, using 10% of that should be fine.