### PR TITLE
Fix SQL string quotes

### DIFF
--- a/Duplicati/Library/Main/Database/LocalBugReportDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBugReportDatabase.cs
@@ -66,10 +66,10 @@ namespace Duplicati.Library.Main.Database
                         */
                 }
 
-                cmd.ExecuteNonQuery(@"UPDATE ""LogData"" SET ""Message"" = ""ERASED!"" WHERE ""Message"" LIKE ""%/%"" OR ""Message"" LIKE ""%:\%"" ");                
-                cmd.ExecuteNonQuery(@"UPDATE ""LogData"" SET ""Exception"" = ""ERASED!"" WHERE ""Exception"" LIKE ""%/%"" OR ""Exception"" LIKE ""%:\%"" ");                
+                cmd.ExecuteNonQuery(@"UPDATE ""LogData"" SET ""Message"" = 'ERASED!' WHERE ""Message"" LIKE '%/%' OR ""Message"" LIKE '%:\%' ");                
+                cmd.ExecuteNonQuery(@"UPDATE ""LogData"" SET ""Exception"" = 'ERASED!' WHERE ""Exception"" LIKE '%/%' OR ""Exception"" LIKE '%:\%' ");                
 
-                cmd.ExecuteNonQuery(@"UPDATE ""Configuration"" SET ""Value"" = ""ERASED!"" WHERE ""Key"" = ""passphrase"" ");
+                cmd.ExecuteNonQuery(@"UPDATE ""Configuration"" SET ""Value"" = 'ERASED!' WHERE ""Key"" = 'passphrase' ");
 
                 cmd.ExecuteNonQuery(string.Format(@"CREATE TABLE ""FixedFile"" AS SELECT ""B"".""ID"" AS ""ID"", ""A"".""Obfuscated"" AS ""Path"", ""B"".""BlocksetID"" AS ""BlocksetID"", ""B"".""MetadataID"" AS ""MetadataID"" FROM ""{0}"" ""A"", ""File"" ""B"" WHERE ""A"".""RealPath"" = ""B"".""Path"" ", tablename));
                 cmd.ExecuteNonQuery(@"DROP VIEW ""File"" ");

--- a/Duplicati/Library/Main/Database/LocalListBrokenFilesDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListBrokenFilesDatabase.cs
@@ -27,7 +27,7 @@ namespace Duplicati.Library.Main.Database
 {
     internal class LocalListBrokenFilesDatabase : LocalDatabase
     {
-        private const string BLOCK_VOLUME_IDS = @"SELECT ""ID"" FROM ""RemoteVolume"" WHERE ""Type"" = ""{2}""";
+        private const string BLOCK_VOLUME_IDS = @"SELECT ""ID"" FROM ""RemoteVolume"" WHERE ""Type"" = '{2}'";
 
         // Invalid blocksets include those that:
         // - Have BlocksetEntries with unknown/invalid blocks (meaning the data to rebuild the blockset isn't available)

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -222,6 +222,12 @@ namespace Duplicati.Library.SQLiteHelper
 
             con.ConnectionString = "Data Source=" + path;
             con.Open();
+            if (con is System.Data.SQLite.SQLiteConnection sqlitecon)
+            {
+                sqlitecon.SetConfigurationOption(System.Data.SQLite.SQLiteConfigDbOpsEnum.SQLITE_DBCONFIG_DQS_DDL, false);
+                sqlitecon.SetConfigurationOption(System.Data.SQLite.SQLiteConfigDbOpsEnum.SQLITE_DBCONFIG_DQS_DML, false);
+            }
+
 
             // If we are non-Windows, make the file only accessible by the current user
             if (!Platform.IsClientWindows && !fileExists)

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -222,8 +222,9 @@ namespace Duplicati.Library.SQLiteHelper
 
             con.ConnectionString = "Data Source=" + path;
             con.Open();
-            if (con is System.Data.SQLite.SQLiteConnection sqlitecon)
+            if (con is System.Data.SQLite.SQLiteConnection sqlitecon && !OperatingSystem.IsMacOS())
             {
+                // These configuration options crash on MacOS (arm64), but the other platforms should be enough to detect incorrect SQL
                 sqlitecon.SetConfigurationOption(System.Data.SQLite.SQLiteConfigDbOpsEnum.SQLITE_DBCONFIG_DQS_DDL, false);
                 sqlitecon.SetConfigurationOption(System.Data.SQLite.SQLiteConfigDbOpsEnum.SQLITE_DBCONFIG_DQS_DML, false);
             }


### PR DESCRIPTION
Closes #5202 

Changed all occurrences of double-quoted strings to single quotes.

Also, the compatibility options to allow these strings are disabled in SQLite to make incorrect statements easier to detect in the future. If that is not desired, we could alternatively change the options to always enable the compatibility mode on all systems, even if disabled by default. I am not sure why the SQLiteLoader only accesses the connection with reflection (is that still relevant with the .NET build?), so please check whether my method introduces some undesired effects.