### PR TITLE
Fix supported platform warnings (except Captcha)

### DIFF
--- a/Duplicati.Library.RestAPI/Database/ServerSettings.cs
+++ b/Duplicati.Library.RestAPI/Database/ServerSettings.cs
@@ -493,7 +493,7 @@ namespace Duplicati.Server.Database
                 if (String.IsNullOrEmpty(settings[CONST.SERVER_SSL_CERTIFICATE]))
                     return null;
 
-                if (Platform.IsClientWindows)
+                if (OperatingSystem.IsWindows())
                     return new X509Certificate2(Convert.FromBase64String(settings[CONST.SERVER_SSL_CERTIFICATE]));
                 else
                     return new X509Certificate2(Convert.FromBase64String(settings[CONST.SERVER_SSL_CERTIFICATE]), "");
@@ -507,7 +507,7 @@ namespace Duplicati.Server.Database
                 }
                 else
                 {
-                    if (Platform.IsClientWindows)
+                    if (OperatingSystem.IsWindows())
                         lock (databaseConnection.m_lock)
                             settings[CONST.SERVER_SSL_CERTIFICATE] = Convert.ToBase64String(value.Export(X509ContentType.Pkcs12));
                     else

--- a/Duplicati.Library.RestAPI/LiveControls.cs
+++ b/Duplicati.Library.RestAPI/LiveControls.cs
@@ -213,7 +213,7 @@ namespace Duplicati.Server
 
             try
             {
-                if (!Platform.IsClientPosix)
+                if (OperatingSystem.IsWindows())
                     RegisterHibernateMonitor();
             }
             catch { }

--- a/Duplicati.Library.RestAPI/LiveControls.cs
+++ b/Duplicati.Library.RestAPI/LiveControls.cs
@@ -19,6 +19,7 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using System.Text;
 using Duplicati.Library.Common;
 using Duplicati.Library.RestAPI;
@@ -337,6 +338,7 @@ namespace Duplicati.Server
         /// <summary>
         /// Method for calling a Win32 API
         /// </summary>
+        [SupportedOSPlatform("windows")]
         private void RegisterHibernateMonitor()
         {
             Microsoft.Win32.SystemEvents.PowerModeChanged += new Microsoft.Win32.PowerModeChangedEventHandler(SystemEvents_PowerModeChanged);
@@ -347,6 +349,7 @@ namespace Duplicati.Server
         /// </summary>
         /// <param name="sender">Unused sender parameter</param>
         /// <param name="_e">The event information</param>
+        [SupportedOSPlatform("windows")]
         private void SystemEvents_PowerModeChanged(object sender, object _e)
         {
             Microsoft.Win32.PowerModeChangedEventArgs e = _e as Microsoft.Win32.PowerModeChangedEventArgs;

--- a/Duplicati.Library.RestAPI/RESTMethods/Filesystem.cs
+++ b/Duplicati.Library.RestAPI/RESTMethods/Filesystem.cs
@@ -72,7 +72,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
             path = SpecialFolders.ExpandEnvironmentVariables(path);
 
-            if (Platform.IsClientPosix && !path.StartsWith("/", StringComparison.Ordinal))
+            if ((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) && !path.StartsWith("/", StringComparison.Ordinal))
             {
                 info.ReportClientError("The path parameter must start with a forward-slash", System.Net.HttpStatusCode.BadRequest);
                 return;
@@ -111,7 +111,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
 
                 IEnumerable<Serializable.TreeNode> res;
 
-                if (!Platform.IsClientPosix && (path.Equals("/") || path.Equals("")))
+                if (!(OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) && (path.Equals("/") || path.Equals("")))
                 {
                     res = DriveInfo.GetDrives()
                             .Where(di =>

--- a/Duplicati.Library.RestAPI/RESTMethods/HyperV.cs
+++ b/Duplicati.Library.RestAPI/RESTMethods/HyperV.cs
@@ -34,7 +34,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         public void GET(string key, RequestInfo info)
         {
             // Early exit in case we are non-windows to prevent attempting to load Windows-only components
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
                 RealGET(key, info);
             else
                 info.OutputOK(new string[0]);

--- a/Duplicati.Library.RestAPI/RESTMethods/HyperV.cs
+++ b/Duplicati.Library.RestAPI/RESTMethods/HyperV.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Security.Principal;
 using Duplicati.Library.Snapshots;
 using Duplicati.Library.Common;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
@@ -42,6 +43,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         // Make sure the JIT does not attempt to inline this call and thus load
         // referenced types from System.Management here
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         private void RealGET(string key, RequestInfo info)
         {
             var hypervUtility = new HyperVUtility();

--- a/Duplicati.Library.RestAPI/RESTMethods/Licenses.cs
+++ b/Duplicati.Library.RestAPI/RESTMethods/Licenses.cs
@@ -29,7 +29,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         {
             var exefolder = System.IO.Path.GetDirectoryName(Duplicati.Library.Utility.Utility.getEntryAssembly().Location);
             var path = System.IO.Path.Combine(exefolder, "licenses");
-            if (Duplicati.Library.Common.Platform.IsClientOSX && !Directory.Exists(path))
+            if (OperatingSystem.IsMacOS() && !Directory.Exists(path))
             {
                 // Go up one, as the licenses cannot be in the binary folder in MacOS Packages
                 exefolder = Path.GetDirectoryName(exefolder);

--- a/Duplicati.Library.RestAPI/RESTMethods/MSSQL.cs
+++ b/Duplicati.Library.RestAPI/RESTMethods/MSSQL.cs
@@ -25,15 +25,17 @@ using System.Linq;
 using System.Security.Principal;
 using Duplicati.Library.Snapshots;
 using Duplicati.Library.Common;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Server.WebServer.RESTMethods
 {
+
     public class MSSQL : IRESTMethodGET, IRESTMethodDocumented
     {
         public void GET(string key, RequestInfo info)
         {
             // Early exit in case we are non-windows to prevent attempting to load Windows-only components
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
                 RealGET(key, info);
             else
                 info.OutputOK(new string[0]);
@@ -42,6 +44,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
         // Make sure the JIT does not attempt to inline this call and thus load
         // referenced types from System.Management here
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         private void RealGET(string key, RequestInfo info)
         {
             var mssqlUtility = new MSSQLUtility();

--- a/Duplicati.Library.RestAPI/RESTMethods/SystemInfo.cs
+++ b/Duplicati.Library.RestAPI/RESTMethods/SystemInfo.cs
@@ -71,7 +71,7 @@ namespace Duplicati.Server.WebServer.RESTMethods
                 DefaultUpdateChannel = Duplicati.Library.AutoUpdater.AutoUpdateSettings.DefaultUpdateChannel,
                 DefaultUsageReportLevel = Duplicati.Library.UsageReporter.Reporter.DefaultReportLevel,
                 ServerTime = DateTime.Now,
-                OSType = Platform.IsClientPosix ? (Platform.IsClientOSX ? "OSX" : "Linux") : "Windows",
+                OSType = OperatingSystem.IsWindows() ? "Windows" : (OperatingSystem.IsMacOS() ? "OSX" : "Linux"),
                 DirectorySeparator = System.IO.Path.DirectorySeparatorChar,
                 PathSeparator = System.IO.Path.PathSeparator,
                 CaseSensitiveFilesystem = Duplicati.Library.Utility.Utility.IsFSCaseSensitive,

--- a/Duplicati.Library.RestAPI/SpecialFolders.cs
+++ b/Duplicati.Library.RestAPI/SpecialFolders.cs
@@ -114,7 +114,7 @@ namespace Duplicati.Server
         {
             var lst = new List<Serializable.TreeNode>();
             
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 TryAdd(lst, Environment.SpecialFolder.MyDocuments, "%MY_DOCUMENTS%", "My Documents");
                 TryAdd(lst, Environment.SpecialFolder.MyMusic, "%MY_MUSIC%", "My Music");

--- a/Duplicati/CommandLine/CLI/Help.cs
+++ b/Duplicati/CommandLine/CLI/Help.cs
@@ -120,9 +120,9 @@ namespace Duplicati.CommandLine
                 tp = tp.Replace("%BACKENDS%", string.Join(", ", Library.DynamicLoader.BackendLoader.Keys));
                 tp = tp.Replace("%APP_PATH%", Path.Combine(UpdaterManager.INSTALLATIONDIR, PackageHelper.GetExecutableName(PackageHelper.NamedExecutable.CommandLine)));
                 tp = tp.Replace("%PATH_SEPARATOR%", System.IO.Path.PathSeparator.ToString());
-                tp = tp.Replace("%EXAMPLE_SOURCE_PATH%", Platform.IsClientPosix ? "/source" : @"D:\source");
-                tp = tp.Replace("%EXAMPLE_SOURCE_FILE%", Platform.IsClientPosix ? "/source/myfile.txt" : @"D:\source\file.txt");
-                tp = tp.Replace("%EXAMPLE_RESTORE_PATH%", Platform.IsClientPosix ? "/restore" : @"D:\restore");
+                tp = tp.Replace("%EXAMPLE_SOURCE_PATH%", !OperatingSystem.IsWindows() ? "/source" : @"D:\source");
+                tp = tp.Replace("%EXAMPLE_SOURCE_FILE%", !OperatingSystem.IsWindows() ? "/source/myfile.txt" : @"D:\source\file.txt");
+                tp = tp.Replace("%EXAMPLE_RESTORE_PATH%", !OperatingSystem.IsWindows() ? "/restore" : @"D:\restore");
                 tp = tp.Replace("%ENCRYPTIONMODULES%", string.Join(", ", Library.DynamicLoader.EncryptionLoader.Keys));
                 tp = tp.Replace("%COMPRESSIONMODULES%", string.Join(", ", Library.DynamicLoader.CompressionLoader.Keys));
                 tp = tp.Replace("%DEFAULTENCRYPTIONMODULE%", opts.EncryptionModule);

--- a/Duplicati/CommandLine/CLI/Help.cs
+++ b/Duplicati/CommandLine/CLI/Help.cs
@@ -132,7 +132,7 @@ namespace Duplicati.CommandLine
                 tp = tp.Replace("%FILTER_GROUPS_SHORT%", string.Join(Environment.NewLine + "  ", metaGroupNames.Concat(Enum.GetNames(typeof(FilterGroup)).Except(metaGroupNames, StringComparer.OrdinalIgnoreCase).OrderBy(x => x, StringComparer.OrdinalIgnoreCase)).Select(group => "{" + group + "}")));
                 tp = tp.Replace("%FILTER_GROUPS_LONG%", Library.Utility.FilterGroups.GetOptionDescriptions(4, true));
 
-                if (Platform.IsClientWindows)
+                if (OperatingSystem.IsWindows())
                 {
                     // These properties are only valid for Windows
                     tp = tp.Replace("%EXAMPLE_WILDCARD_DRIVE_SOURCE_PATH%", @"*:\source");

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -64,7 +64,7 @@ namespace Duplicati.GUI.TrayIcon
             List<string> args = new List<string>(_args);
             Dictionary<string, string> options = Duplicati.Library.Utility.CommandLineParser.ExtractOptions(args);
 
-            if (Platform.IsClientWindows && !Duplicati.Library.Utility.Utility.ParseBoolOption(options, DETACHED_PROCESS))
+            if (OperatingSystem.IsWindows() && !Duplicati.Library.Utility.Utility.ParseBoolOption(options, DETACHED_PROCESS))
                 Duplicati.Library.Utility.Win32.AttachConsole(Duplicati.Library.Utility.Win32.ATTACH_PARENT_PROCESS);
 
             foreach (string s in args)
@@ -265,7 +265,7 @@ namespace Duplicati.GUI.TrayIcon
                     new Duplicati.Library.Interface.CommandLineArgument(BROWSER_COMMAND_OPTION, CommandLineArgument.ArgumentType.String, "Sets the browser command", "Set this option to override the default browser detection"),
                 };
 
-                if (Platform.IsClientWindows)
+                if (OperatingSystem.IsWindows())
                 {
                     args.Add(new Duplicati.Library.Interface.CommandLineArgument(DETACHED_PROCESS, CommandLineArgument.ArgumentType.String, "Runs the tray-icon detached", "This option runs the tray-icon in detached mode, meaning that the process will exit immediately and not send output to the console of the caller"));
                 }

--- a/Duplicati/Library/AutoUpdater/PackageHelper.cs
+++ b/Duplicati/Library/AutoUpdater/PackageHelper.cs
@@ -73,17 +73,17 @@ namespace Duplicati.Library.AutoUpdater
         public static string GetExecutableName(NamedExecutable exe)
             => exe switch
             {
-                NamedExecutable.TrayIcon => Platform.IsClientWindows ? "Duplicati.GUI.TrayIcon.exe" : "duplicati",
-                NamedExecutable.CommandLine => Platform.IsClientWindows ? "Duplicati.CommandLine.exe" : "duplicati-cli",
-                NamedExecutable.AutoUpdater => Platform.IsClientWindows ? "Duplicati.CommandLine.AutoUpdater.exe" : "duplicati-autoupdater",
-                NamedExecutable.Server => Platform.IsClientWindows ? "Duplicati.Server.exe" : "duplicati-server",
+                NamedExecutable.TrayIcon => OperatingSystem.IsWindows() ? "Duplicati.GUI.TrayIcon.exe" : "duplicati",
+                NamedExecutable.CommandLine => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.exe" : "duplicati-cli",
+                NamedExecutable.AutoUpdater => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.AutoUpdater.exe" : "duplicati-autoupdater",
+                NamedExecutable.Server => OperatingSystem.IsWindows() ? "Duplicati.Server.exe" : "duplicati-server",
                 NamedExecutable.WindowsService => "Duplicati.WindowsServer.exe",
-                NamedExecutable.BackendTool => Platform.IsClientWindows ? "Duplicati.CommandLine.BackendTool.exe" : "duplicati-backend-tool",
-                NamedExecutable.RecoveryTool => Platform.IsClientWindows ? "Duplicati.CommandLine.RecoveryTool.exe" : "duplicati-recovery-tool",
-                NamedExecutable.BackendTester => Platform.IsClientWindows ? "Duplicati.CommandLine.BackendTester.exe" : "duplicati-backend-tester",
-                NamedExecutable.SharpAESCrypt => Platform.IsClientWindows ? "Duplicati.CommandLine.SharpAESCrypt.exe" : "duplicati-aescrypt",
-                NamedExecutable.Snapshots => Platform.IsClientWindows ? "Duplicati.CommandLine.Snapshots.exe" : "duplicati-snapshots",
-                NamedExecutable.ConfigurationImporter => Platform.IsClientWindows ? "Duplicati.CommandLine.ConfigurationImporter.exe" : "duplicati-configuration-importer",
+                NamedExecutable.BackendTool => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.BackendTool.exe" : "duplicati-backend-tool",
+                NamedExecutable.RecoveryTool => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.RecoveryTool.exe" : "duplicati-recovery-tool",
+                NamedExecutable.BackendTester => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.BackendTester.exe" : "duplicati-backend-tester",
+                NamedExecutable.SharpAESCrypt => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.SharpAESCrypt.exe" : "duplicati-aescrypt",
+                NamedExecutable.Snapshots => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.Snapshots.exe" : "duplicati-snapshots",
+                NamedExecutable.ConfigurationImporter => OperatingSystem.IsWindows() ? "Duplicati.CommandLine.ConfigurationImporter.exe" : "duplicati-configuration-importer",
                 _ => throw new ArgumentException($"Named executable not known: {exe}", nameof(exe))
             };
 

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -118,7 +118,7 @@ namespace Duplicati.Library.AutoUpdater
             {
                 // OS specific folders for probing
                 var candidates = new List<string>();
-                if (Platform.IsClientWindows)
+                if (OperatingSystem.IsWindows())
                 {
                     candidates.Add(System.IO.Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), APPNAME));
                     candidates.Add(System.IO.Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), APPNAME));
@@ -128,7 +128,7 @@ namespace Duplicati.Library.AutoUpdater
                     candidates.Add(System.IO.Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), APPNAME));
                 }
 
-                if (Platform.IsClientOSX)
+                if (OperatingSystem.IsMacOS())
                     candidates.Add(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Application Support", APPNAME));
 
                 // Find the first writeable directory in the list

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -83,7 +84,7 @@ namespace Duplicati.Library.Backend
                 paths.AddRange(options[OPTION_ALTERNATE_PATHS].Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries));
 
                 //On windows we expand the drive letter * to all drives
-                if (!Platform.IsClientPosix)
+                if (!OperatingSystem.IsWindows())
                 {
                     System.IO.DriveInfo[] drives = System.IO.DriveInfo.GetDrives();
 
@@ -300,7 +301,7 @@ namespace Duplicati.Library.Backend
         private System.IO.DriveInfo GetDrive()
         {
             string root;
-            if (Platform.IsClientPosix)
+            if (OperatingSystem.IsWindows())
             {
                 string path = Util.AppendDirSeparator(systemIO.PathGetFullPath(m_path));
                 root = "/";
@@ -319,7 +320,7 @@ namespace Duplicati.Library.Backend
 
             // On Windows, DriveInfo is only valid for lettered drives. (e.g., not for UNC paths and shares)
             // So only attempt to get it if we aren't on Windows or if the root starts with a letter.
-            if (!Platform.IsClientWindows || (root.Length > 0 && char.IsLetter(root[0])))
+            if (!OperatingSystem.IsWindows() || (root.Length > 0 && char.IsLetter(root[0])))
             {
                 try
                 {
@@ -349,7 +350,7 @@ namespace Duplicati.Library.Backend
                     }
                 }
 
-                if (Platform.IsClientWindows)
+                if (OperatingSystem.IsWindows())
                 {
                     // If we can't get the DriveInfo on Windows, fallback to GetFreeDiskSpaceEx
                     // https://stackoverflow.com/questions/2050343/programmatically-determining-space-available-from-unc-path
@@ -380,6 +381,7 @@ namespace Duplicati.Library.Backend
         /// <param name="directory">Directory</param>
         /// <returns>Quota info</returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         public static QuotaInfo GetDiskFreeSpace(string directory)
         {
             ulong available;
@@ -394,6 +396,7 @@ namespace Duplicati.Library.Backend
             }
         }
 
+        [SupportedOSPlatform("windows")]
         private static class WindowsDriveHelper
         {
             [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]

--- a/Duplicati/Library/Common/IO/PosixFile.cs
+++ b/Duplicati/Library/Common/IO/PosixFile.cs
@@ -20,10 +20,13 @@
 // DEALINGS IN THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Mono.Unix.Native;
 
 namespace Duplicati.Library.Common.IO
 {
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macOS")]
     public static class PosixFile
     {
     

--- a/Duplicati/Library/Common/IO/SystemIO.cs
+++ b/Duplicati/Library/Common/IO/SystemIO.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Runtime.Versioning;
 namespace Duplicati.Library.Common.IO
 {
     public static class SystemIO
@@ -28,17 +29,27 @@ namespace Duplicati.Library.Common.IO
         /// <summary>
         /// A cached lookup for windows methods for dealing with long filenames
         /// </summary>
+        [SupportedOSPlatform("windows")]
         public static readonly ISystemIO IO_WIN;
 
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
         public static readonly ISystemIO IO_SYS;
 
         public static readonly ISystemIO IO_OS;
 
         static SystemIO()
         {
-            IO_WIN = new SystemIOWindows();
-            IO_SYS = new SystemIOLinux();
-            IO_OS = Platform.IsClientWindows ? IO_WIN : IO_SYS;
+            if (OperatingSystem.IsWindows())
+            {
+                IO_WIN = new SystemIOWindows();
+                IO_OS = IO_WIN;
+            }
+            else if (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
+            {
+                IO_SYS = new SystemIOLinux();
+                IO_OS = IO_SYS;
+            }
         }
     }
 }

--- a/Duplicati/Library/Common/IO/SystemIO.cs
+++ b/Duplicati/Library/Common/IO/SystemIO.cs
@@ -40,14 +40,16 @@ namespace Duplicati.Library.Common.IO
 
         static SystemIO()
         {
+            // TODO: These interfaces cannot be properly guarded by the supported platform attribute in this form.
+            // They are used in static methods of USNJournal on all platforms.
+            IO_WIN = new SystemIOWindows();
+            IO_SYS = new SystemIOLinux();
             if (OperatingSystem.IsWindows())
             {
-                IO_WIN = new SystemIOWindows();
                 IO_OS = IO_WIN;
             }
             else if (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
             {
-                IO_SYS = new SystemIOLinux();
                 IO_OS = IO_SYS;
             }
         }

--- a/Duplicati/Library/Common/IO/SystemIOLinux.cs
+++ b/Duplicati/Library/Common/IO/SystemIOLinux.cs
@@ -24,9 +24,12 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using Duplicati.Library.Interface;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Common.IO
 {
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macOS")]
     public struct SystemIOLinux : ISystemIO
     {
         #region ISystemIO implementation

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -32,7 +32,6 @@ using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Common.IO
 {
-    [SupportedOSPlatform("windows")]
     public struct SystemIOWindows : ISystemIO
     {
         // Based on the constant names used in
@@ -158,6 +157,8 @@ namespace Duplicati.Library.Common.IO
             return path.Replace("/", Util.DirectorySeparatorString);
         }
 
+
+        [SupportedOSPlatform("windows")]
         private class FileSystemAccess
         {
             // Use JsonProperty Attribute to allow readonly fields to be set by deserializer
@@ -237,21 +238,29 @@ namespace Duplicati.Library.Common.IO
             }
         }
 
+
+        [SupportedOSPlatform("windows")]
         private System.Security.AccessControl.FileSystemSecurity GetAccessControlDir(string path)
         {
             return new DirectoryInfo(AddExtendedDevicePathPrefix(path)).GetAccessControl();
         }
 
+
+        [SupportedOSPlatform("windows")]
         private System.Security.AccessControl.FileSystemSecurity GetAccessControlFile(string path)
         {
             return new FileInfo(AddExtendedDevicePathPrefix(path)).GetAccessControl();
         }
 
+
+        [SupportedOSPlatform("windows")]
         private void SetAccessControlFile(string path, FileSecurity rules)
         {
             new FileInfo(AddExtendedDevicePathPrefix(path)).SetAccessControl(rules);
         }
 
+
+        [SupportedOSPlatform("windows")]
         private void SetAccessControlDir(string path, DirectorySecurity rules)
         {
             new DirectoryInfo(AddExtendedDevicePathPrefix(path)).SetAccessControl(rules);
@@ -559,6 +568,7 @@ namespace Duplicati.Library.Common.IO
             return new FileEntry(fileInfo.Name, fileInfo.Length, lastAccess, fileInfo.LastWriteTime);
         }
 
+        [SupportedOSPlatform("windows")]
         public Dictionary<string, string> GetMetadata(string path, bool isSymlink, bool followSymlink)
         {
             var isDirTarget = path.EndsWith(DIRSEP, StringComparison.Ordinal);
@@ -584,6 +594,7 @@ namespace Duplicati.Library.Common.IO
             return dict;
         }
 
+        [SupportedOSPlatform("windows")]
         public void SetMetadata(string path, Dictionary<string, string> data, bool restorePermissions)
         {
             var isDirTarget = path.EndsWith(DIRSEP, StringComparison.Ordinal);

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -28,9 +28,11 @@ using System.Linq;
 using AlphaFS = Alphaleonis.Win32.Filesystem;
 using Duplicati.Library.Interface;
 using Newtonsoft.Json;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Common.IO
 {
+    [SupportedOSPlatform("windows")]
     public struct SystemIOWindows : ISystemIO
     {
         // Based on the constant names used in

--- a/Duplicati/Library/Common/IO/VssBackupComponents.cs
+++ b/Duplicati/Library/Common/IO/VssBackupComponents.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using Alphaleonis.Win32.Vss;
 
 namespace Duplicati.Library.Common.IO
@@ -35,6 +36,7 @@ namespace Duplicati.Library.Common.IO
         public List<string> Paths { get; set; }
     }
 
+    [SupportedOSPlatform("windows")]
     public class VssBackupComponents : IDisposable
     {
         /// <summary>

--- a/Duplicati/Library/Common/Platform/Platform.cs
+++ b/Duplicati/Library/Common/Platform/Platform.cs
@@ -27,25 +27,30 @@ namespace Duplicati.Library.Common
         /// <value>
         /// Gets or sets a value indicating if the client is Linux/Unix based
         /// </value>
+        [Obsolete("Use OperatingSystem.IsXXX instead")]
         public static readonly bool IsClientPosix;
 
 
         /// <summary>
         /// Gets a value indicating if the client is Windows based
         /// </summary>
+        [Obsolete("Use OperatingSystem.IsXXX instead")]
         public static readonly bool IsClientWindows;
 
 
         /// <value>
         /// Gets or sets a value indicating if the client is running OSX
         /// </value>
+        [Obsolete("Use OperatingSystem.IsXXX instead")]
         public static readonly bool IsClientOSX;
 
         static Platform()
         {
+#pragma warning disable CS0618 // Obsolete
             IsClientPosix = Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX;
             IsClientWindows = !IsClientPosix;
             IsClientOSX = IsClientPosix && "Darwin".Equals(_RetrieveUname(false));
+#pragma warning restore CS0618 // Obsolete
         }
 
         /// <value>
@@ -55,8 +60,10 @@ namespace Duplicati.Library.Common
         {
             get
             {
+#pragma warning disable CS0618 // Obsolete
                 if (!IsClientPosix)
                     return null;
+#pragma warning restore CS0618 // Obsolete
 
                 return _RetrieveUname(true);
 

--- a/Duplicati/Library/Encryption/GPGEncryption.cs
+++ b/Duplicati/Library/Encryption/GPGEncryption.cs
@@ -283,9 +283,9 @@ namespace Duplicati.Library.Encryption
         /// </summary>
         public static string GetGpgProgramPath()
         {
-            Log.WriteInformationMessage("GetGpgProgramPath", "gpg", Platform.IsClientWindows ? WinTools.GetWindowsGpgExePath() : "gpg");
+            Log.WriteInformationMessage("GetGpgProgramPath", "gpg", OperatingSystem.IsWindows() ? WinTools.GetWindowsGpgExePath() : "gpg");
             // for Windows return the full path, otherwise just return "gpg"
-            return Platform.IsClientWindows ? WinTools.GetWindowsGpgExePath() : "gpg";
+            return OperatingSystem.IsWindows() ? WinTools.GetWindowsGpgExePath() : "gpg";
         }
     }
 }

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -886,7 +886,7 @@ namespace Duplicati.Library.Main
             {
                 List<string> expandedSources = new List<string>();
 
-                if (Platform.IsClientWindows && (inputsource.StartsWith("*:", StringComparison.Ordinal) || inputsource.StartsWith("?:", StringComparison.Ordinal)))
+                if (OperatingSystem.IsWindows() && (inputsource.StartsWith("*:", StringComparison.Ordinal) || inputsource.StartsWith("?:", StringComparison.Ordinal)))
                 {
                     // *: drive paths are only supported on Windows clients
                     // Lazily load the drive info
@@ -901,7 +901,7 @@ namespace Duplicati.Library.Main
                         expandedSources.Add(expandedSource);
                     }
                 }
-                else if (Platform.IsClientWindows && inputsource.StartsWith(@"\\?\Volume{", StringComparison.OrdinalIgnoreCase))
+                else if (OperatingSystem.IsWindows() && inputsource.StartsWith(@"\\?\Volume{", StringComparison.OrdinalIgnoreCase))
                 {
                     // In order to specify a drive by it's volume name, adopt the volume guid path syntax:
                     //   \\?\Volume{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}

--- a/Duplicati/Library/Main/Database/LocalBugReportDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBugReportDatabase.cs
@@ -54,7 +54,7 @@ namespace Duplicati.Library.Main.Database
                     upcmd.Transaction = tr;
                     upcmd.ExecuteNonQuery(string.Format(@"CREATE TEMPORARY TABLE ""{0}"" (""ID"" INTEGER PRIMARY KEY, ""RealPath"" TEXT NOT NULL, ""Obfuscated"" TEXT NULL)", tablename));
                     upcmd.ExecuteNonQuery(string.Format(@"INSERT INTO ""{0}"" (""RealPath"") SELECT DISTINCT ""Path"" FROM ""File"" ORDER BY ""Path"" ", tablename));
-                    upcmd.ExecuteNonQuery(string.Format(@"UPDATE ""{0}"" SET ""Obfuscated"" = ? || length(""RealPath"") || ? || ""ID"" || (CASE WHEN substr(""RealPath"", length(""RealPath"")) = ? THEN ? ELSE ? END) ", tablename), Platform.IsClientPosix ? "/" : "X:\\", Util.DirectorySeparatorString, Util.DirectorySeparatorString, Util.DirectorySeparatorString, ".bin");
+                    upcmd.ExecuteNonQuery(string.Format(@"UPDATE ""{0}"" SET ""Obfuscated"" = ? || length(""RealPath"") || ? || ""ID"" || (CASE WHEN substr(""RealPath"", length(""RealPath"")) = ? THEN ? ELSE ? END) ", tablename), !OperatingSystem.IsWindows() ? "/" : "X:\\", Util.DirectorySeparatorString, Util.DirectorySeparatorString, Util.DirectorySeparatorString, ".bin");
                     
                     /*long id = 1;
                     using(var rd = cmd.ExecuteReader(string.Format(@"SELECT ""RealPath"", ""Obfuscated"" FROM ""{0}"" ", tablename)))

--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -413,14 +413,14 @@ namespace Duplicati.Library.Main.Database
                     // defaults when restoring cross OS, e.g. backup on Linux, restore on Windows
                     //This is mostly meaningless, and the user really should use --restore-path
 
-                    if (Platform.IsClientPosix && dirsep == "\\")
+                    if ((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) && dirsep == "\\")
                     {
                         // For Win -> Linux, we remove the colon from the drive letter, and use the drive letter as root folder
                         cmd.ExecuteNonQuery(string.Format(@"UPDATE ""{0}"" SET ""Targetpath"" = CASE WHEN SUBSTR(""Path"", 2, 1) == ':' THEN '\\' || SUBSTR(""Path"", 1, 1) || SUBSTR(""Path"", 3) ELSE ""Path"" END", m_tempfiletable));
                         cmd.ExecuteNonQuery(string.Format(@"UPDATE ""{0}"" SET ""Targetpath"" = CASE WHEN SUBSTR(""Path"", 1, 2) == '\\' THEN '\\' || SUBSTR(""Path"", 2) ELSE ""Path"" END", m_tempfiletable));
 
                     }
-                    else if (Platform.IsClientWindows && dirsep == "/")
+                    else if (OperatingSystem.IsWindows() && dirsep == "/")
                     {
                         // For Linux -> Win, we use the temporary folder's drive as the root path
                         cmd.ExecuteNonQuery(string.Format(@"UPDATE ""{0}"" SET ""Targetpath"" = CASE WHEN SUBSTR(""Path"", 1, 1) == '/' THEN ? || SUBSTR(""Path"", 2) ELSE ""Path"" END", m_tempfiletable), Util.AppendDirSeparator(System.IO.Path.GetPathRoot(Library.Utility.TempFolder.SystemTempPath)).Replace("\\", "/"));
@@ -451,10 +451,10 @@ namespace Duplicati.Library.Main.Database
                 }
 
                 // Cross-os path remapping support
-                if (Platform.IsClientPosix && dirsep == "\\")
+                if ((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) && dirsep == "\\")
                     // For Win paths on Linux
                     cmd.ExecuteNonQuery(string.Format(@"UPDATE ""{0}"" SET ""TargetPath"" = REPLACE(""TargetPath"", '\', '/')", m_tempfiletable));
-                else if (Platform.IsClientWindows && dirsep == "/")
+                else if (OperatingSystem.IsWindows() && dirsep == "/")
                     // For Linux paths on Windows
                     cmd.ExecuteNonQuery(string.Format(@"UPDATE ""{0}"" SET ""TargetPath"" = REPLACE(REPLACE(""TargetPath"", '\', '_'), '/', '\')", m_tempfiletable));
 

--- a/Duplicati/Library/Main/DatabaseLocator.cs
+++ b/Duplicati/Library/Main/DatabaseLocator.cs
@@ -63,7 +63,7 @@ namespace Duplicati.Library.Main
 
 			var folder = System.IO.Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Duplicati");
 
-			if (Platform.IsClientWindows)
+			if (OperatingSystem.IsWindows())
 			{
 				var newlocation = System.IO.Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Duplicati");
 

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -88,10 +88,18 @@ namespace Duplicati.Library.Main.Operation
                     Logging.Log.WriteInformationMessage(LOGTAG, "SnapshotFailed", Strings.Common.SnapshotFailedError(ex.Message));
             }
 
-            return Platform.IsClientPosix ?
-                (Library.Snapshots.ISnapshotService)new Duplicati.Library.Snapshots.NoSnapshotLinux()
-                    :
-                new Duplicati.Library.Snapshots.NoSnapshotWindows();
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
+            {
+                return new NoSnapshotLinux();
+            }
+            else if (OperatingSystem.IsWindows())
+            {
+                return new NoSnapshotWindows();
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported Operating System");
+            }
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -233,6 +233,7 @@ namespace Duplicati.Library.Main.Operation
                     // append files from previous fileset, unless part of modifiedSources, which we've just scanned
                     await database.AppendFilesFromPreviousSetWithPredicateAsync((path, fileSize) =>
                     {
+                        // TODO: This is technically unsupported, but the method itself works cross-platform
                         if (journalService.IsPathEnumerated(path))
                             return true;
 

--- a/Duplicati/Library/Main/ProcessController.cs
+++ b/Duplicati/Library/Main/ProcessController.cs
@@ -104,7 +104,7 @@ namespace Duplicati.Library.Main
         /// </summary>
         private void StartSleepPrevention()
         {
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 try
                 {
@@ -116,7 +116,7 @@ namespace Duplicati.Library.Main
                     Logging.Log.WriteWarningMessage(LOGTAG, "SleepPrevetionError", ex, "Failed to set sleep prevention");
                 }
             }
-            else if (Platform.IsClientOSX)
+            else if (OperatingSystem.IsMacOS())
             {
                 try
                 {
@@ -150,7 +150,7 @@ namespace Duplicati.Library.Main
         {
             var pid = System.Diagnostics.Process.GetCurrentProcess().Id;
 
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 var handle = System.Diagnostics.Process.GetCurrentProcess().Handle;
 
@@ -187,7 +187,7 @@ namespace Duplicati.Library.Main
             }
             else
             {
-                if (Platform.IsClientOSX)
+                if (OperatingSystem.IsMacOS())
                 {
                     var data = RunProcessAndGetResult("ps", $"-onice -p {pid}");
                     if (data.Item1 != 0)
@@ -253,7 +253,7 @@ namespace Duplicati.Library.Main
             //
             // See https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-rtlqueryprocessplaceholdercompatibilitymode
 
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 try
                 {
@@ -286,7 +286,7 @@ namespace Duplicati.Library.Main
         /// </summary>
         private void StopSleepPrevention()
         {
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 try
                 {
@@ -301,7 +301,7 @@ namespace Duplicati.Library.Main
                     Logging.Log.WriteWarningMessage(LOGTAG, "SleepPrevetionError", ex, "Failed to set sleep prevention");
                 }
             }
-            else if (Platform.IsClientOSX)
+            else if (OperatingSystem.IsMacOS())
             {
                 try
                 {
@@ -334,7 +334,7 @@ namespace Duplicati.Library.Main
         /// </summary>
         private void DeactivateBackgroundIOPriority()
         {
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 try
                 {
@@ -377,7 +377,7 @@ namespace Duplicati.Library.Main
                     var pid = System.Diagnostics.Process.GetCurrentProcess().Id;
                     Tuple<int, string, string> data;
 
-                    if (Platform.IsClientOSX)
+                    if (OperatingSystem.IsMacOS())
                     {
                         // TODO: We can only give lower priority, thus not reset it ...
                         data = RunProcessAndGetResult($"renice", $"{m_originalNiceLevel} -p {pid}");

--- a/Duplicati/Library/Modules/Builtin/ConsolePasswordInput.cs
+++ b/Duplicati/Library/Modules/Builtin/ConsolePasswordInput.cs
@@ -85,7 +85,7 @@ namespace Duplicati.Library.Modules.Builtin
                     catch (InvalidOperationException)
                     {
                         // Handle redirect issues on Windows only
-                        if (!Platform.IsClientWindows)
+                        if (!OperatingSystem.IsWindows())
                             throw;
 
                         commandlineOptions["passphrase"] = ReadPassphraseFromStdin(confirm);

--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -57,7 +57,7 @@ namespace Duplicati.Library.Modules.Builtin
 
         public bool LoadAsDefault
         {
-            get { return Platform.IsClientWindows; }
+            get { return OperatingSystem.IsWindows(); }
         }
 
         public IList<Interface.ICommandLineArgument> SupportedCommands
@@ -218,7 +218,7 @@ namespace Duplicati.Library.Modules.Builtin
         
         public bool ContainFilesForBackup(string[] paths)
         {
-            if (paths == null || !Platform.IsClientWindows)
+            if (paths == null || !OperatingSystem.IsWindows())
                 return false;
 
             return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Any(x => x.Equals(m_HyperVPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_HyperVPathGuidRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));

--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -76,7 +76,7 @@ namespace Duplicati.Library.Modules.Builtin
         public Dictionary<string, string> ParseSourcePaths(ref string[] paths, ref string filter, Dictionary<string, string> commandlineOptions)
         {
             // Early exit in case we are non-windows to prevent attempting to load Windows-only components
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 Logging.Log.WriteWarningMessage(LOGTAG, "HyperVWindowsOnly", null, "Hyper-V backup works only on Windows OS");
 

--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using Duplicati.Library.Common;
 using Duplicati.Library.Snapshots;
@@ -99,6 +100,7 @@ namespace Duplicati.Library.Modules.Builtin
         // Make sure the JIT does not attempt to inline this call and thus load
         // referenced types from System.Management here
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         private Dictionary<string, string> RealParseSourcePaths(ref string[] paths, ref string filter, Dictionary<string, string> commandlineOptions)
         {
             var changedOptions = new Dictionary<string, string>();

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -58,7 +58,7 @@ namespace Duplicati.Library.Modules.Builtin
 
         public bool LoadAsDefault
         {
-            get { return Platform.IsClientWindows; }
+            get { return OperatingSystem.IsWindows(); }
         }
 
         public IList<Interface.ICommandLineArgument> SupportedCommands
@@ -216,7 +216,7 @@ namespace Duplicati.Library.Modules.Builtin
         
         public bool ContainFilesForBackup(string[] paths)
         {
-            if (paths == null || !Platform.IsClientWindows)
+            if (paths == null || !OperatingSystem.IsWindows())
                 return false;
 
             return paths.Where(x => !string.IsNullOrWhiteSpace(x)).Any(x => x.Equals(m_MSSQLPathAllRegExp, StringComparison.OrdinalIgnoreCase) || Regex.IsMatch(x, m_MSSQLPathDBRegExp, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using Duplicati.Library.Common;
 using Duplicati.Library.Snapshots;
@@ -100,6 +101,7 @@ namespace Duplicati.Library.Modules.Builtin
         // Make sure the JIT does not attempt to inline this call and thus load
         // referenced types from System.Management here
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         private Dictionary<string, string> RealParseSourcePaths(ref string[] paths, ref string filter, Dictionary<string, string> commandlineOptions)
         {
             var changedOptions = new Dictionary<string, string>();

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -77,7 +77,7 @@ namespace Duplicati.Library.Modules.Builtin
         public Dictionary<string, string> ParseSourcePaths(ref string[] paths, ref string filter, Dictionary<string, string> commandlineOptions)
         {
             // Early exit in case we are non-windows to prevent attempting to load Windows-only components
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 Logging.Log.WriteWarningMessage(LOGTAG, "MSSqlWindowsOnly", null, "Microsoft SQL Server databases backup works only on Windows OS");
 

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Interface;
@@ -234,6 +235,8 @@ namespace Duplicati.Library.SQLiteHelper
         /// <param name="path">The file to set permissions on.</param>
         /// <remarks> Make sure we do not inline this, as we might eventually load Mono.Posix, which is not present on Windows</remarks>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
         private static void SetUnixPermissionUserRWOnly(string path)
         {
             var fi = PosixFile.GetUserGroupAndPermissions(path);

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -218,14 +218,14 @@ namespace Duplicati.Library.SQLiteHelper
             // Check if SQLite database exists before opening a connection to it.
             // This information is used to 'fix' permissions on a newly created file.
             var fileExists = false;
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
                 fileExists = File.Exists(path);
 
             con.ConnectionString = "Data Source=" + path;
             con.Open();
 
             // If we are non-Windows, make the file only accessible by the current user
-            if (!Platform.IsClientWindows && !fileExists)
+            if ((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) && !fileExists)
                 SetUnixPermissionUserRWOnly(path);
         }
 

--- a/Duplicati/Library/Snapshots/HyperVUtility.cs
+++ b/Duplicati/Library/Snapshots/HyperVUtility.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management;
+using System.Runtime.Versioning;
 using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 
@@ -81,6 +82,7 @@ namespace Duplicati.Library.Snapshots
         }
     }
 
+    [SupportedOSPlatform("windows")]
     public class HyperVUtility
     {
         /// <summary>

--- a/Duplicati/Library/Snapshots/HyperVUtility.cs
+++ b/Duplicati/Library/Snapshots/HyperVUtility.cs
@@ -116,13 +116,14 @@ namespace Duplicati.Library.Snapshots
         {
             Guests = new List<HyperVGuest>();
 
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 IsHyperVInstalled = false;
                 IsVSSWriterSupported = false;
                 return;
             }
 
+            // TODO: Replace with OperatingSystem.IsWindowsVersionAtLeast(6,2) if that is correct
             //Set the namespace depending off host OS
             _wmiv2Namespace = Environment.OSVersion.Version.Major > 6 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor >= 2);
 

--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Text;
 using Duplicati.Library.Common.IO;
 
@@ -35,12 +36,14 @@ namespace Duplicati.Library.Snapshots
     /// The class presents all files and folders with their regular filenames to the caller,
     /// and internally handles the conversion to the snapshot path.
     /// </summary>
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macOS")]
     public sealed class LinuxSnapshot : SnapshotBase
     {
 		/// <summary>
         /// The tag used for logging messages
         /// </summary>
-        public static readonly string LOGTAG = Logging.Log.LogTagFromType<WindowsSnapshot>();
+        public static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(WindowsSnapshot));
 
         /// <summary>
         /// This is a lookup, mapping each source folder to the corresponding snapshot

--- a/Duplicati/Library/Snapshots/MSSQLUtility.cs
+++ b/Duplicati/Library/Snapshots/MSSQLUtility.cs
@@ -23,6 +23,7 @@ using Duplicati.Library.Common.IO;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Snapshots
 {
@@ -81,6 +82,7 @@ namespace Duplicati.Library.Snapshots
         }
     }
 
+    [SupportedOSPlatform("windows")]
     public class MSSQLUtility
     {
         /// <summary>

--- a/Duplicati/Library/Snapshots/MSSQLUtility.cs
+++ b/Duplicati/Library/Snapshots/MSSQLUtility.cs
@@ -107,7 +107,7 @@ namespace Duplicati.Library.Snapshots
         {
             m_DBs = new List<MSSQLDB>();
 
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 IsMSSQLInstalled = false;
                 return;

--- a/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Snapshots
@@ -27,6 +28,8 @@ namespace Duplicati.Library.Snapshots
     /// <summary>
     /// Handler for providing a snapshot like access to files and folders
     /// </summary>
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macOS")]
     public sealed class NoSnapshotLinux : SnapshotBase
     {
         /// <summary>

--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Snapshots
@@ -29,6 +30,7 @@ namespace Duplicati.Library.Snapshots
     /// <summary>
     /// Handler for providing a snapshot like access to files and folders
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public sealed class NoSnapshotWindows : SnapshotBase
     {
         /// <summary>

--- a/Duplicati/Library/Snapshots/Program.cs
+++ b/Duplicati/Library/Snapshots/Program.cs
@@ -107,7 +107,7 @@ Where <test-folder> is the folder where files will be locked/created etc");
                     }
 
                     Console.WriteLine("Creating snapshot for folder: {0}", args[0]);
-                    Console.WriteLine("If this fails, try to run as " + (Platform.IsClientPosix ? "root" : "Administrator"));
+                    Console.WriteLine("If this fails, try to run as " + ((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) ? "root" : "Administrator"));
                     using (ISnapshotService snapshot = SnapshotUtility.CreateSnapshot(new[] { args[0] }, options))
                     {
                         Console.WriteLine("Attempting to read locked file via snapshot");

--- a/Duplicati/Library/Snapshots/SnapshotUtility.cs
+++ b/Duplicati/Library/Snapshots/SnapshotUtility.cs
@@ -20,8 +20,10 @@
 // DEALINGS IN THE SOFTWARE.
 
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Versioning;
 using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 
@@ -57,6 +59,8 @@ namespace Duplicati.Library.Snapshots
         /// <param name="folders">The list of folders to create snapshots of</param>
         /// <returns>The ISnapshotService implementation</returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
         private static ISnapshotService CreateLinuxSnapshot(IEnumerable<string> folders)
         {
             return new LinuxSnapshot(folders);
@@ -69,6 +73,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="options">A set of commandline options</param>
         /// <returns>The ISnapshotService implementation</returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         private static ISnapshotService CreateWindowsSnapshot(IEnumerable<string> folders, Dictionary<string, string> options)
         {
             return new WindowsSnapshot(folders, options);

--- a/Duplicati/Library/Snapshots/SnapshotUtility.cs
+++ b/Duplicati/Library/Snapshots/SnapshotUtility.cs
@@ -42,10 +42,18 @@ namespace Duplicati.Library.Snapshots
         /// <returns>The ISnapshotService implementation</returns>
         public static ISnapshotService CreateSnapshot(IEnumerable<string> folders, Dictionary<string, string> options)
         {
-            return
-                Platform.IsClientPosix
-                       ? CreateLinuxSnapshot(folders)
-                       : CreateWindowsSnapshot(folders, options);
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
+            {
+                return CreateLinuxSnapshot(folders);
+            }
+            else if (OperatingSystem.IsWindows())
+            {
+                return CreateWindowsSnapshot(folders, options);
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported Operating System");
+            }
             
         }
 

--- a/Duplicati/Library/Snapshots/USNJournal.cs
+++ b/Duplicati/Library/Snapshots/USNJournal.cs
@@ -28,6 +28,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 using Microsoft.Win32.SafeHandles;
@@ -37,6 +38,7 @@ namespace Duplicati.Library.Snapshots
     /// <summary>
     /// Class that encapsulates USN journal access to a single volume
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public sealed class USNJournal : IDisposable
     {
         /// <summary>

--- a/Duplicati/Library/Snapshots/USNJournal.cs
+++ b/Duplicati/Library/Snapshots/USNJournal.cs
@@ -102,9 +102,6 @@ namespace Duplicati.Library.Snapshots
         /// <param name="volumeRoot">The root volume where the USN lookup is performed</param>
         internal USNJournal(string volumeRoot)
         {
-            if (Platform.IsClientPosix)
-                throw new Interface.UserInformationException(Strings.USNHelper.LinuxNotSupportedError, "UsnOnLinuxNotSupported");
-
             m_volume = Util.AppendDirSeparator(volumeRoot);
 
             try

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -28,6 +28,7 @@ using System.Threading;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Utility;
+using Duplicati.Library.Common;
 
 namespace Duplicati.Library.Snapshots
 {
@@ -110,6 +111,9 @@ namespace Duplicati.Library.Snapshots
                 try
                 {
                     // prepare journal data entry to store with current fileset
+                    if (!OperatingSystem.IsWindows())
+                        throw new Interface.UserInformationException(Strings.USNHelper.LinuxNotSupportedError, "UsnOnLinuxNotSupported");
+
                     var journal = new USNJournal(volume);
                     var nextData = new USNJournalDataEntry
                     {

--- a/Duplicati/Library/Snapshots/Win32USN.cs
+++ b/Duplicati/Library/Snapshots/Win32USN.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
 namespace Duplicati.Library.Snapshots
@@ -30,6 +31,7 @@ namespace Duplicati.Library.Snapshots
     /// <summary>
     /// Various Windows specific calls to support USN
     /// </summary>
+    [SupportedOSPlatform("windows")]
     internal static class Win32USN
     {
         public const int ERROR_HANDLE_EOF = 38;

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -24,7 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using System.Runtime.Versioning;
 using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Snapshots
@@ -36,6 +36,7 @@ namespace Duplicati.Library.Snapshots
     /// The class presents all files and folders with their regular filenames to the caller,
     /// and internally handles the conversion to the shadow path.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public sealed class WindowsSnapshot : SnapshotBase
     {
         /// <summary>

--- a/Duplicati/Library/UsageReporter/OSInfoHelper.cs
+++ b/Duplicati/Library/UsageReporter/OSInfoHelper.cs
@@ -77,11 +77,11 @@ namespace Duplicati.Library.UsageReporter
         {
             get
             {
-                if (!Platform.IsClientPosix)
+                if (!(OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()))
                 {
                     return Environment.OSVersion.ToString();
                 }
-                else if (Platform.IsClientOSX)
+                else if (OperatingSystem.IsMacOS())
                 {
                     var m = RunProgramAndReadOutput("sw_vers", null);
                     if (m != null)

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Xml.Linq;
 using Duplicati.Library.Common;
 
@@ -719,6 +720,7 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>The list of paths to exclude.</returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         private static string[] GetWindowsRegistryFiltersInternal()
         {
             var rk = Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Default);

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -699,7 +699,7 @@ namespace Duplicati.Library.Utility
         /// <returns>The list of paths to exclude.</returns>
         private static string[] GetWindowsRegistryFilters()
         {
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 // One Windows, filters may also be stored in the registry
                 try

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -237,11 +237,11 @@ namespace Duplicati.Library.Utility
         {
             IEnumerable<string> osFilters;
 
-            if (Platform.IsClientOSX)
+            if (OperatingSystem.IsMacOS())
                 osFilters = CreateOSXFilters(group);
-            else if (Platform.IsClientPosix)
+            else if (OperatingSystem.IsLinux())
                 osFilters = CreateLinuxFilters(group);
-            else if (Platform.IsClientWindows)
+            else if (OperatingSystem.IsWindows())
                 osFilters = CreateWindowsFilters(group);
             else
                 throw new ArgumentException("Unknown operating system?");
@@ -641,7 +641,7 @@ namespace Duplicati.Library.Utility
         private static IEnumerable<string> GetOSXExcludeFiles()
         {
             var res = new List<string>();
-            if (Platform.IsClientOSX)
+            if (OperatingSystem.IsMacOS())
             {
                 try
                 {

--- a/Duplicati/Library/Utility/Power/LinuxPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/LinuxPowerSupplyState.cs
@@ -22,9 +22,11 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Utility.Power
 {
+    [SupportedOSPlatform("linux")]
     public class LinuxPowerSupplyState : IPowerSupplyState
     {
         private readonly string sysfsPath = Path.Combine("/", "sys", "class", "power_supply");

--- a/Duplicati/Library/Utility/Power/MacOSPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/MacOSPowerSupplyState.cs
@@ -21,9 +21,11 @@
 
 using System;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Utility.Power
 {
+    [SupportedOSPlatform("macOS")]
     public class MacOSPowerSupplyState : IPowerSupplyState
     {
         public PowerSupply.Source GetSource()

--- a/Duplicati/Library/Utility/Power/PowerSupply.cs
+++ b/Duplicati/Library/Utility/Power/PowerSupply.cs
@@ -37,15 +37,15 @@ namespace Duplicati.Library.Utility.Power
             IPowerSupplyState state;
 
             // Since IsClientLinux returns true when on Mac OS X, we need to check IsClientOSX first.
-            if (Platform.IsClientOSX)
+            if (System.OperatingSystem.IsMacOS())
             {
                 state = new MacOSPowerSupplyState();
             }
-            else if (Platform.IsClientPosix)
+            else if (System.OperatingSystem.IsLinux())
             {
                 state = new LinuxPowerSupplyState();
             }
-            else if (Platform.IsClientWindows)
+            else if (System.OperatingSystem.IsWindows())
             {
                 state = new WindowsPowerSupplyState();
             }

--- a/Duplicati/Library/Utility/Power/WindowsPowerSupplyState.cs
+++ b/Duplicati/Library/Utility/Power/WindowsPowerSupplyState.cs
@@ -20,9 +20,11 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Utility.Power
 {
+    [SupportedOSPlatform("windows")]
     public class WindowsPowerSupplyState : IPowerSupplyState
     {
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]

--- a/Duplicati/Library/Utility/RegistryUtility.cs
+++ b/Duplicati/Library/Utility/RegistryUtility.cs
@@ -20,9 +20,11 @@
 // DEALINGS IN THE SOFTWARE.
 
 using Microsoft.Win32;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Utility
 {
+    [SupportedOSPlatform("windows")]
     public static class RegistryUtility
     {
         public static string GetDataByValueName(string parentKeyName, string name)

--- a/Duplicati/Library/Utility/SslCertificateValidator.cs
+++ b/Duplicati/Library/Utility/SslCertificateValidator.cs
@@ -38,7 +38,7 @@ namespace Duplicati.Library.Utility
             public SslPolicyErrors SslError { get { return m_errors; } }
 
             public InvalidCertificateException(string certificate, SslPolicyErrors error)
-                : base(Strings.SslCertificateValidator.VerifyCertificateException(error, certificate) + (Platform.IsClientPosix ? Strings.SslCertificateValidator.MonoHelpSSL : ""))
+                : base(Strings.SslCertificateValidator.VerifyCertificateException(error, certificate) + (!OperatingSystem.IsWindows() ? Strings.SslCertificateValidator.MonoHelpSSL : ""))
             {
                 m_certificate = certificate;
                 m_errors = error;

--- a/Duplicati/Library/Utility/UrlUtility.cs
+++ b/Duplicati/Library/Utility/UrlUtility.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using System.Text;
 using Duplicati.Library.Common;
 
@@ -57,7 +58,7 @@ namespace Duplicati.Library.Utility
                 browserprogram = SystemBrowser;
 
             //Fallback is to just show the window in a browser
-            if (Platform.IsClientOSX)
+            if (OperatingSystem.IsMacOS())
             {
                 try
                 {
@@ -70,7 +71,7 @@ namespace Duplicati.Library.Utility
                         ErrorHandler(string.Format("Unable to open a browser window, please manually visit: \r\n{0}", url));
                 }
             }
-            else if (Platform.IsClientPosix)
+            else if (OperatingSystem.IsLinux())
             {
                 try
                 {
@@ -93,9 +94,13 @@ namespace Duplicati.Library.Utility
                         ErrorHandler(string.Format("Unable to open a browser window, please manually visit: \r\n{0}", url));
                 }
             }
-            else
+            else if (OperatingSystem.IsWindows())
             {
                 OpenUrlWindows(url, browserprogram);
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported Operating System");
             }
         }
 
@@ -103,6 +108,7 @@ namespace Duplicati.Library.Utility
         /// Opens the given URL in a browser
         /// </summary>
         /// <param name="url">The url to open, must start with http:// or https://</param>
+        [SupportedOSPlatform("windows")]
         private static void OpenUrlWindows(string url, string browserprogram)
         {
             if (string.IsNullOrWhiteSpace(browserprogram))

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -460,13 +460,13 @@ namespace Duplicati.Library.Utility
             if (last == -1 || last == 0 && len == 0)
                 return null;
             
-            if (last == 0 && !Platform.IsClientWindows)
+            if (last == 0 && !OperatingSystem.IsWindows())
                 return Util.DirectorySeparatorString;
 
             var parent = path.Substring(0, last);
 
             if (forceTrailingDirectorySeparator ||
-                Platform.IsClientWindows && parent.Length == 2 && parent[1] == ':' && char.IsLetter(parent[0]))
+                OperatingSystem.IsWindows() && parent.Length == 2 && parent[1] == ':' && char.IsLetter(parent[0]))
             {
                 parent += Path.DirectorySeparatorChar;
             }
@@ -874,7 +874,7 @@ namespace Duplicati.Library.Utility
 
                     // TODO: This should probably be determined by filesystem rather than OS,
                     // OSX can actually have the disks formatted as Case Sensitive, but insensitive is default
-                    CachedIsFSCaseSensitive = ParseBool(str, () => Platform.IsClientPosix && !Platform.IsClientOSX);
+                    CachedIsFSCaseSensitive = ParseBool(str, () => OperatingSystem.IsLinux());
                 }
 
                 return CachedIsFSCaseSensitive.Value;
@@ -894,7 +894,7 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// The path to the users home directory
         /// </summary>
-        public static readonly string HOME_PATH = Environment.GetFolderPath(Platform.IsClientPosix ? Environment.SpecialFolder.Personal : Environment.SpecialFolder.UserProfile);
+        public static readonly string HOME_PATH = Environment.GetFolderPath(!OperatingSystem.IsWindows() ? Environment.SpecialFolder.Personal : Environment.SpecialFolder.UserProfile);
 
         /// <summary>
         /// Regexp for matching environment variables on Windows (%VAR%)
@@ -1392,7 +1392,7 @@ namespace Duplicati.Library.Utility
             if (string.IsNullOrWhiteSpace(arg))
                 return arg;
 
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 // We could consider using single quotes that prevents all expansions
                 //if (!allowEnvExpansion)

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -31,6 +31,7 @@ using Duplicati.Library.Common.IO;
 using Duplicati.Library.Common;
 using System.Globalization;
 using System.Security.Cryptography;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Utility
 {
@@ -1314,6 +1315,7 @@ namespace Duplicati.Library.Utility
         /// <param name="volumeGuid">Volume guid</param>
         /// <returns>Drive letter, as a single character, or null if the volume wasn't found</returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         public static string GetDriveLetterFromVolumeGuid(Guid volumeGuid)
         {
             // Based on this answer:
@@ -1348,6 +1350,7 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>Pairs of drive letter to volume guids</returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [SupportedOSPlatform("windows")]
         public static IEnumerable<KeyValuePair<string, string>> GetVolumeGuidsAndDriveLetters()
         {
             using (var searcher = new System.Management.ManagementObjectSearcher("Select * from Win32_Volume"))

--- a/Duplicati/Library/Utility/WinTools.cs
+++ b/Duplicati/Library/Utility/WinTools.cs
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Runtime.Versioning;
 using Duplicati.Library.Common;
 
@@ -29,7 +30,7 @@ namespace Duplicati.Library.Utility
     {
         public static string GetWindowsGpgExePath()
         {
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 return null;
             }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -222,7 +222,7 @@ namespace Duplicati.Server
         {
             //If we are on Windows, append the bundled "win-tools" programs to the search path
             //We add it last, to allow the user to override with other versions
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 Environment.SetEnvironmentVariable("PATH",
                     Environment.GetEnvironmentVariable("PATH") +
@@ -800,7 +800,7 @@ namespace Duplicati.Server
 
                 });
 
-                if (!Platform.IsClientPosix)
+                if (!(OperatingSystem.IsMacOS()|| OperatingSystem.IsLinux()))
                     lst.Add(new Duplicati.Library.Interface.CommandLineArgument("server-encryption-key", Duplicati.Library.Interface.CommandLineArgument.ArgumentType.Password, Strings.Program.ServerencryptionkeyShort, Strings.Program.ServerencryptionkeyLong(DB_KEY_ENV_NAME, "unencrypted-database"), Library.AutoUpdater.AutoUpdateSettings.AppName + "_Key_42", null, null, "Database encryption is no longer supported, this setting can only be used to decrypt the database"));
 
                 return lst.ToArray();

--- a/Duplicati/Server/SingleInstance.cs
+++ b/Duplicati/Server/SingleInstance.cs
@@ -191,7 +191,7 @@ namespace Duplicati.Server
 
                 //HACK: the unix file lock does not allow us to read the file length when the file is locked
                 if (new System.IO.FileInfo(m_lockfilename).Length == 0)
-                    if (!Platform.IsClientPosix)
+                    if (!(OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()))
                         throw new Exception("The file was locked, but had no data");
 
                 //Notify the other process that we have started
@@ -241,7 +241,7 @@ namespace Duplicati.Server
             // needs a little time to create+lock the file. This is not really a fix, but an
             // ugly workaround. This functionality is only used to allow a new instance to signal
             // the running instance, so errors here would only affect that functionality
-            if (Platform.IsClientPosix)
+            if ((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()))
                 System.Threading.Thread.Sleep(1000);
 
             do

--- a/Duplicati/Server/SingleInstance.cs
+++ b/Duplicati/Server/SingleInstance.cs
@@ -143,7 +143,7 @@ namespace Duplicati.Server
 
             try
             {
-                if (Platform.IsClientPosix)
+                if (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
                     temp_fs = PosixFile.OpenExclusive(m_lockfilename, System.IO.FileAccess.Write);
                 else
                     temp_fs = System.IO.File.Open(m_lockfilename, System.IO.FileMode.Create, System.IO.FileAccess.Write, System.IO.FileShare.None);
@@ -199,7 +199,8 @@ namespace Duplicati.Server
 
                 //Write out the commandline arguments
                 string[] cmdargs = System.Environment.GetCommandLineArgs();
-                using (System.IO.StreamWriter sw = new System.IO.StreamWriter(Platform.IsClientPosix ? PosixFile.OpenExclusive(filename, System.IO.FileAccess.Write) : new System.IO.FileStream(filename, System.IO.FileMode.CreateNew, System.IO.FileAccess.Write, System.IO.FileShare.None)))
+                using (System.IO.StreamWriter sw = new System.IO.StreamWriter((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) ? PosixFile.OpenExclusive(filename, System.IO.FileAccess.Write)
+                    : new System.IO.FileStream(filename, System.IO.FileMode.CreateNew, System.IO.FileAccess.Write, System.IO.FileShare.None)))
                     for (int i = 1; i < cmdargs.Length; i++) //Skip the first, as that is the filename
                         sw.WriteLine(cmdargs[i]);
 
@@ -252,7 +253,8 @@ namespace Duplicati.Server
                         return;
 
                     List<string> args = new List<string>();
-                    using (System.IO.StreamReader sr = new System.IO.StreamReader(Platform.IsClientPosix ? PosixFile.OpenExclusive(e.FullPath, System.IO.FileAccess.ReadWrite) : new System.IO.FileStream(e.FullPath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.None)))
+                    using (System.IO.StreamReader sr = new System.IO.StreamReader((OperatingSystem.IsMacOS() || OperatingSystem.IsLinux()) ? PosixFile.OpenExclusive(e.FullPath, System.IO.FileAccess.ReadWrite)
+                        : new System.IO.FileStream(e.FullPath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.None)))
                     {
                         while (!sr.EndOfStream)
                         {

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -203,7 +203,7 @@ namespace Duplicati.UnitTest
         /// </summary>
         protected static void ZipFileExtractToDirectory(string sourceArchiveFileName, string destinationDirectoryName)
         {
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 // Handle long paths under Windows by extracting to a
                 // temporary file and moving the resulting file to the

--- a/Duplicati/UnitTest/IOTests.cs
+++ b/Duplicati/UnitTest/IOTests.cs
@@ -51,7 +51,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestUncBehaviourOfGetPathRoot()
         {
-            if (!Platform.IsClientWindows)
+            if (!System.OperatingSystem.IsWindows())
             {
                 return;
             }
@@ -104,7 +104,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestAddExtendedDevicePathPrefixInWindowsClient()
         {
-            if (!Platform.IsClientWindows)
+            if (!System.OperatingSystem.IsWindows())
             {
                 return;
             }
@@ -212,7 +212,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestPathGetFullPathInWindowsClient()
         {
-            if (!Platform.IsClientWindows)
+            if (!System.OperatingSystem.IsWindows())
             {
                 return;
             }

--- a/Duplicati/UnitTest/IOTests.cs
+++ b/Duplicati/UnitTest/IOTests.cs
@@ -26,6 +26,7 @@ using Duplicati.Library.Common.IO;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Common;
 using System.Collections.Generic;
+using System;
 
 namespace Duplicati.UnitTest
 {
@@ -42,7 +43,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestGetPathRootWithLongPath()
         {
-            var pathRoot =  Platform.IsClientWindows ? "C:\\" : "/";
+            var pathRoot = OperatingSystem.IsWindows() ? "C:\\" : "/";
             var root = SystemIO.IO_OS.GetPathRoot(LongPath(pathRoot));
 
             Assert.AreEqual(pathRoot, root);
@@ -51,7 +52,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestUncBehaviourOfGetPathRoot()
         {
-            if (!System.OperatingSystem.IsWindows())
+            if (!OperatingSystem.IsWindows())
             {
                 return;
             }
@@ -74,7 +75,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestGetFilesWhenDirectoryDoesNotExist()
         {
-            var pathRoot = Platform.IsClientWindows ? "C:\\" : "/";
+            var pathRoot = OperatingSystem.IsWindows() ? "C:\\" : "/";
 
             var longPath = LongPath(pathRoot);
             if (SystemIO.IO_OS.DirectoryExists(longPath))
@@ -89,7 +90,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestGetDirectoriesWhenDirectoryDoesNotExist()
         {
-            var pathRoot = Platform.IsClientWindows ? "C:\\" : "/";
+            var pathRoot = OperatingSystem.IsWindows() ? "C:\\" : "/";
 
             var longPath = LongPath(pathRoot);
             if (SystemIO.IO_OS.DirectoryExists(longPath))
@@ -104,7 +105,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestAddExtendedDevicePathPrefixInWindowsClient()
         {
-            if (!System.OperatingSystem.IsWindows())
+            if (!OperatingSystem.IsWindows())
             {
                 return;
             }
@@ -212,7 +213,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TestPathGetFullPathInWindowsClient()
         {
-            if (!System.OperatingSystem.IsWindows())
+            if (!OperatingSystem.IsWindows())
             {
                 return;
             }

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -18,6 +18,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -50,7 +51,7 @@ namespace Duplicati.UnitTest
             const string asterisk = "*";
             string dirWithAsterisk = Path.Combine(this.DATAFOLDER, asterisk);
             // Windows does not support literal asterisks in paths.
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 SystemIO.IO_OS.DirectoryCreate(dirWithAsterisk);
                 TestUtils.WriteFile(SystemIO.IO_OS.PathCombine(dirWithAsterisk, file), new byte[] {0});
@@ -62,7 +63,7 @@ namespace Duplicati.UnitTest
             const string questionMark = "?";
             string dirWithQuestionMark = Path.Combine(this.DATAFOLDER, questionMark);
             // Windows does not support literal question marks in paths.
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 SystemIO.IO_OS.DirectoryCreate(dirWithQuestionMark);
                 TestUtils.WriteFile(SystemIO.IO_OS.PathCombine(dirWithQuestionMark, file), new byte[] { 1 });
@@ -280,7 +281,7 @@ namespace Duplicati.UnitTest
         [TestCase("ends_with_newline\n", true)]
         public void ProblematicSuffixes(string pathComponent, bool skipOnWindows)
         {
-            if (Platform.IsClientWindows && skipOnWindows)
+            if (OperatingSystem.IsWindows() && skipOnWindows)
             {
                 return;
             }

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -18,6 +18,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -65,7 +66,7 @@ namespace Duplicati.UnitTest
             // if it's determined to be an absolute path.
             string rootString = SystemIO.IO_OS.GetPathRoot(filePath);
             string newPathPart = filePath.Substring(rootString.Length);
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 // On Windows, the drive letter is included in the path when the dont-compress-restore-paths option is used.
                 // The drive letter is assumed to be the first character of the path root (e.g., C:\).
@@ -80,7 +81,7 @@ namespace Duplicati.UnitTest
         [Category("RestoreHandler")]
         public void RestoreInheritanceBreaks()
         {
-            if (!Platform.IsClientWindows)
+            if (!OperatingSystem.IsWindows())
             {
                 return;
             }

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -222,7 +222,7 @@ namespace Duplicati.UnitTest
         {
             string parsedResultFile = Path.Combine(this.RESTOREFOLDER, "result.txt");
             List<string> customCommands = new List<string>();
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 customCommands.Add($"echo %DUPLICATI__PARSED_RESULT%>\"{parsedResultFile}\"");
             }
@@ -335,7 +335,7 @@ namespace Duplicati.UnitTest
         private string CreateScript(int exitcode, string stderr = null, string stdout = null, int sleeptime = 0, List<string> customCommands = null)
         {
             var id = Guid.NewGuid().ToString("N").Substring(0, 6);
-            if (Platform.IsClientWindows)
+            if (OperatingSystem.IsWindows())
             {
                 var commands = customCommands ?? new List<string>();
                 if (!string.IsNullOrWhiteSpace(stdout))

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -253,7 +253,7 @@ namespace Duplicati.UnitTest
                 // macOS seem to like to actually set the time to some value different than what you set by hundreds of milliseconds.
                 // Reading the time right after it is set gives the expected value but when read later it is slightly different.
                 // Maybe a bug in .net?
-                int granularity = Platform.IsClientOSX ? 2999 : 1;
+                int granularity = OperatingSystem.IsMacOS() ? 2999 : 1;
                 Assert.That(
                     SystemIO.IO_OS.GetLastWriteTimeUtc(actualFile),
                     Is.EqualTo(SystemIO.IO_OS.GetLastWriteTimeUtc(expectedFile)).Within(granularity).Milliseconds,

--- a/Duplicati/WindowsService/Program.cs
+++ b/Duplicati/WindowsService/Program.cs
@@ -31,6 +31,10 @@ namespace Duplicati.WindowsService
         [STAThread]
         public static int Main(string[] args)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new NotSupportedException("Unsupported Operating System");
+            }
             var install = args != null && args.Any(x => string.Equals("install", x, StringComparison.OrdinalIgnoreCase));
             var uninstall = args != null && args.Any(x => string.Equals("uninstall", x, StringComparison.OrdinalIgnoreCase));
             var help = args != null && args.Any(x => string.Equals("help", x, StringComparison.OrdinalIgnoreCase));

--- a/Duplicati/WindowsService/ServiceInstaller.cs
+++ b/Duplicati/WindowsService/ServiceInstaller.cs
@@ -21,10 +21,12 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 
 namespace Duplicati.WindowsService
 {
+    [SupportedOSPlatform("windows")]
     public class ServiceInstaller
     {
         [DllImport("advapi32.dll", EntryPoint = "OpenSCManagerW", ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]

--- a/Duplicati/WindowsService/WindowsService.csproj
+++ b/Duplicati/WindowsService/WindowsService.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Duplicati.WindowsService.Implementation</AssemblyName>
-    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Duplicati/WindowsService/WindowsService.csproj
+++ b/Duplicati/WindowsService/WindowsService.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <AssemblyName>Duplicati.WindowsService.Implementation</AssemblyName>
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.WindowsService/Duplicati.WindowsService.csproj
+++ b/Executables/net8/Duplicati.WindowsService/Duplicati.WindowsService.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <Description>WindowsService for Duplicati</Description>
     <AssemblyName>Duplicati.WindowsService</AssemblyName>
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.WindowsService/Duplicati.WindowsService.csproj
+++ b/Executables/net8/Duplicati.WindowsService/Duplicati.WindowsService.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>WindowsService for Duplicati</Description>
     <AssemblyName>Duplicati.WindowsService</AssemblyName>
-    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.WindowsService/Program.cs
+++ b/Executables/net8/Duplicati.WindowsService/Program.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Versioning;
+
 namespace Duplicati.WindowsService.Net8
 {
     // Wrapper class to keep code independent


### PR DESCRIPTION
Partially completes #5167 

This fixes most of the platform warnings and adds attributes to more platform-specific classes. There are two things still remaining:
- Refactor the `SystemIO` concept, because it currently needs platform-specific classes on all platforms
- Replace the Captcha (System.Drawing library or completely)

The windows server projects were changed to only target windows plaforms.