### PR TITLE
Change XMPP library to Artalk.Xmpp

### DIFF
--- a/Duplicati.Library.RestAPI/Duplicati.Library.RestAPI.csproj
+++ b/Duplicati.Library.RestAPI/Duplicati.Library.RestAPI.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -7,9 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Artalk.Xmpp" Version="1.0.5" />
     <PackageReference Include="DnsClient" Version="1.4.0" />
-    <PackageReference Include="ARSoft.Tools.Net" Version="1.8.1" />
-    <PackageReference Include="Sharp.Xmpp" Version="1.0.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="MailKit" Version="2.4.1" />
     <PackageReference Include="MimeKit" Version="2.4.1" />

--- a/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
@@ -25,7 +25,7 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Logging;
 using System.Net.NetworkInformation;
 using Duplicati.Library.Modules.Builtin.ResultSerialization;
-using Sharp.Xmpp.Client;
+using Artalk.Xmpp.Client;
 
 namespace Duplicati.Library.Modules.Builtin
 {
@@ -119,7 +119,7 @@ namespace Duplicati.Library.Modules.Builtin
         /// <summary>
         /// A localized string describing the module with a friendly name
         /// </summary>
-        public override string DisplayName { get { return Strings.SendJabberMessage.DisplayName;} }
+        public override string DisplayName { get { return Strings.SendJabberMessage.DisplayName; } }
 
         /// <summary>
         /// A localized description of the module
@@ -203,31 +203,32 @@ namespace Duplicati.Library.Modules.Builtin
 
             if (string.IsNullOrWhiteSpace(resource))
                 resource = "Duplicati";
-            using (XmppClient client = new XmppClient(uri.Host, uri.Username, string.IsNullOrWhiteSpace(m_password) ? uri.Password : m_password,  uri.Port == -1 ? (uri.Scheme == "https" ? 5223 :5222) : uri.Port))
+            using (ArtalkXmppClient client = new ArtalkXmppClient(uri.Host, uri.Username, string.IsNullOrWhiteSpace(m_password) ? uri.Password : m_password, uri.Port == -1 ? (uri.Scheme == "https" ? 5223 : 5222) : uri.Port))
             {
                 client.Connect(resource);
                 try
                 {
-                    foreach(var recipient in m_to.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries))
+                    foreach (var recipient in m_to.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries))
                     {
-		        client.SendMessage(recipient, new Dictionary<string, string>(){ {"en", body} });
+                        Artalk.Xmpp.Jid jid = new Artalk.Xmpp.Jid(recipient);
+                        client.SendMessage(jid, new Dictionary<string, string>() { { "en", body } });
                         // hack to work around a failure to send the second time
                         // (the xmpp server reports a read failure)
-			try 
-			{
-			    client.Ping(recipient);
-			}
-			catch {}
+                        try
+                        {
+                            client.Ping(jid);
+                        }
+                        catch { }
                     }
-		}
+                }
                 catch (Exception e)
                 {
                     Logging.Log.WriteWarningMessage(LOGTAG, "XMPPSendError", e, "Failed to send to XMPP messages: {0}", e.Message);
                 }
-		finally 
-		{
+                finally
+                {
                     client.Close();
-		}
+                }
             }
 
         }

--- a/Duplicati/Server/Duplicati.Server.csproj
+++ b/Duplicati/Server/Duplicati.Server.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The old library was not compatible with .NET 8. It was also required to update System.Drawing.Common and Microsoft.Win32.SystemEvents to 7.0.

I tested that sending XMPP messages works on both Windows and Linux.