### PR TITLE
Fix compare on linux showing 0 bytes when exclude filters are used

### DIFF
--- a/Duplicati/Library/Main/Database/LocalListChangesDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListChangesDatabase.cs
@@ -164,8 +164,19 @@ namespace Duplicati.Library.Main.Database
                             cmd.SetParameterValue(0, s);
                             cmd.ExecuteNonQuery();
                         }
-                    
-                        cmd.ExecuteNonQuery(string.Format(@"INSERT INTO ""{0}"" (""Path"", ""FileHash"", ""MetaHash"", ""Size"", ""Type"") SELECT ""Path"", ""FileHash"", ""MetaHash"", ""Size"", ""Type"" FROM {1} A WHERE ""A"".""FilesetID"" = ? AND ""A"".""Path"" IN (SELECT DISTINCT ""Path"" FROM ""{2}"") ", tablename, combined, filenamestable), filesetId);
+
+                        string whereClause;
+                        if (expression.Result)
+                        {
+                            // Include filter
+                            whereClause = string.Format(@"""A"".""FilesetID"" = ? AND ""A"".""Path"" IN (SELECT DISTINCT ""Path"" FROM ""{0}"")", filenamestable);
+                        }
+                        else
+                        {
+                            // Exclude filter
+                            whereClause = string.Format(@"""A"".""FilesetID"" = ? AND ""A"".""Path"" NOT IN (SELECT DISTINCT ""Path"" FROM ""{0}"")", filenamestable);
+                        }
+                        cmd.ExecuteNonQuery(string.Format(@"INSERT INTO ""{0}"" (""Path"", ""FileHash"", ""MetaHash"", ""Size"", ""Type"") SELECT ""Path"", ""FileHash"", ""MetaHash"", ""Size"", ""Type"" FROM {1} A WHERE {2} ", tablename, combined, whereClause), filesetId);
                         cmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}"" ", filenamestable));
                     }
                     else


### PR DESCRIPTION
Closes #5229

The SQL statement that is used when the filters are simple on a case sensitive filesystem assumed that the filter is an include filter. I added a proper distinction between include and exclude filters.