### PR TITLE
Improve recovery tool speed

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -83,6 +83,10 @@ namespace Duplicati.CommandLine.RecoveryTool
             options.TryGetValue("blocksize", out var blocksize_str);
             options.TryGetValue("block-hash-algorithm", out var blockhash_str);
             options.TryGetValue("block-hash-algorithm", out var filehash_str);
+            var offset = 0L;
+            if (options.TryGetValue("offset", out var offset_str))
+                offset = long.Parse(offset_str);
+
 
             long blocksize = string.IsNullOrWhiteSpace(blocksize_str) ? 0 : Library.Utility.Sizeparser.ParseSize(blocksize_str);
 
@@ -136,6 +140,13 @@ namespace Duplicati.CommandLine.RecoveryTool
                     var blocklistbuffer = new byte[blocksize];
                     foreach (var f in List.EnumerateFilesInDList(filelist, filter, options))
                     {
+                        if (i < offset)
+                        {
+                            Console.WriteLine($"Skipping {i}: {f.Path} ({Utility.FormatSizeString(f.Size)})");
+                            i++;
+                            continue;
+                        }
+
                         startedCount++;
                         try
                         {

--- a/Duplicati/CommandLine/RecoveryTool/help.txt
+++ b/Duplicati/CommandLine/RecoveryTool/help.txt
@@ -66,6 +66,7 @@ Version can be either a number, a filename or a date. If omitted the most recent
 
 The restore process can be memory intensive and requires appx. 4 GiB of memory pr. 1TiB of data.
 Use the option to --reduce-memory-use=true to toggle a slower low-memory restore.
+If the process is interrupted for any reason, note the file counter and use --offset=1 to start the restore after the first file.
 
 Advanced performance options are:
   --reduce-memory-use: Disables keeping all hashes in memory; use if memory is limited on the restoring machine

--- a/Duplicati/CommandLine/RecoveryTool/help.txt
+++ b/Duplicati/CommandLine/RecoveryTool/help.txt
@@ -64,7 +64,7 @@ Restores all files to their respective destinations. Use --targetpath to choose 
 Use the filters, --exclude, to perform a partial restore.
 Version can be either a number, a filename or a date. If omitted the most recent backup is used.
 
-The restore process can be memory intensive and requires appx. 4 GiB of memory pr. 1TiB of data.
+The restore process requires a fast lookup, which is optimal if all the hashes can be kept in memory.
 Use the option to --reduce-memory-use=true to toggle a slower low-memory restore.
 If the process is interrupted for any reason, note the file counter and use --offset=1 to start the restore after the first file.
 

--- a/Duplicati/CommandLine/RecoveryTool/help.txt
+++ b/Duplicati/CommandLine/RecoveryTool/help.txt
@@ -64,6 +64,13 @@ Restores all files to their respective destinations. Use --targetpath to choose 
 Use the filters, --exclude, to perform a partial restore.
 Version can be either a number, a filename or a date. If omitted the most recent backup is used.
 
+The restore process can be memory intensive and requires appx. 4 GiB of memory pr. 1TiB of data.
+Use the option to --reduce-memory-use=true to toggle a slower low-memory restore.
+
+Advanced performance options are:
+  --reduce-memory-use: Disables keeping all hashes in memory; use if memory is limited on the restoring machine
+  --disable-file-verify: Disables the initial hashing of the restored file
+  --disable-wrapped-zip: Disable using the faster .NET native Zip archive in favor of the more resilient one in Duplicati
 
 
 List

--- a/Duplicati/UnitTest/RecoveryToolTests.cs
+++ b/Duplicati/UnitTest/RecoveryToolTests.cs
@@ -206,9 +206,10 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("RecoveryTool")]
-        [TestCase("false")]
-        [TestCase("true")]
-        public void Recover(string buildIndexWithFiles)
+        [TestCase("false", "true")]
+        [TestCase("true", "false")]
+        [TestCase("false", "false")]
+        public void Recover(string buildIndexWithFiles, bool reducedMemoryUsage)
         {
             // Files to create in MB.
             int[] fileSizes = { 0, 10, 20, 30 };
@@ -244,17 +245,17 @@ namespace Duplicati.UnitTest
             // Download the backend files.
             string downloadFolder = Path.Combine(this.RESTOREFOLDER, "downloadedFiles");
             Directory.CreateDirectory(downloadFolder);
-            int status = CommandLine.RecoveryTool.Program.Main(new[] {"download", $"{backendURL}", $"{downloadFolder}", $"--passphrase={options["passphrase"]}"});
+            int status = CommandLine.RecoveryTool.Program.Main(new[] { "download", $"{backendURL}", $"{downloadFolder}", $"--passphrase={options["passphrase"]}" });
             Assert.AreEqual(0, status);
 
             // Create the index.
-            status = CommandLine.RecoveryTool.Program.Main(new[] {"index", $"{downloadFolder}", $"--build-index-with-files={buildIndexWithFiles}"});
+            status = CommandLine.RecoveryTool.Program.Main(new[] { "index", $"{downloadFolder}", $"--build-index-with-files={buildIndexWithFiles}" });
             Assert.AreEqual(0, status);
 
             // Restore to a different folder.
             string restoreFolder = Path.Combine(this.RESTOREFOLDER, "restoredFiles");
             Directory.CreateDirectory(restoreFolder);
-            status = CommandLine.RecoveryTool.Program.Main(new[] {"restore", $"{downloadFolder}", $"--targetpath={restoreFolder}"});
+            status = CommandLine.RecoveryTool.Program.Main(new[] { "restore", $"{downloadFolder}", $"--targetpath={restoreFolder}", $"--reduce-memory-use={reducedMemoryUsage}" });
             Assert.AreEqual(0, status);
 
             TestUtils.AssertDirectoryTreesAreEquivalent(this.DATAFOLDER, restoreFolder, false, "Verifying restore using RecoveryTool.");


### PR DESCRIPTION
This PR updates the speed of the recovery tool by keeping the entire lookup table in memory.
It also uses the .NET built-in support for Zip archives, in total giving at least a 60% speedup on 2GiB dataset.