### PR TITLE
Made the number of open archives configurable

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -560,12 +560,14 @@ namespace Duplicati.CommandLine.RecoveryTool
             private readonly Dictionary<string, string> m_options;
             private readonly bool m_useWrappedZip;
 
-            private const int MAX_OPEN_ARCHIVES = 200;
+            private readonly int MAX_OPEN_ARCHIVES = 200;
 
             public CompressedFileMRUCache(Dictionary<string, string> options)
             {
                 m_options = options;
                 m_useWrappedZip = !Library.Utility.Utility.ParseBoolOption(options, "disable-wrapped-zip");
+                if (options.TryGetValue("max-open-archives", out var maxopenarchives))
+                    MAX_OPEN_ARCHIVES = int.Parse(maxopenarchives);
             }
 
             public Stream ReadBlock(string filename, string hash)

--- a/Duplicati/CommandLine/RecoveryTool/help.txt
+++ b/Duplicati/CommandLine/RecoveryTool/help.txt
@@ -72,7 +72,7 @@ Advanced performance options are:
   --reduce-memory-use: Disables keeping all hashes in memory; use if memory is limited on the restoring machine
   --disable-file-verify: Disables the initial hashing of the restored file
   --disable-wrapped-zip: Disable using the faster .NET native Zip archive in favor of the more resilient one in Duplicati
-
+  --max-open-archives: Sets the number of archives to keep open for faster access (uses some memory pr. archive); default 200
 
 List
 ----


### PR DESCRIPTION
The open archives keep the table of blocks inside the zip file in memory (filenames in the central directory) and this can consume some memory if the remote volumes are large.

This PR adds the `--max-open-archives` switch to toggle the number of archives to keep open, so memory use and speed can be better balanced to match the restoring machine.