### PR TITLE
Replace `B2applicationkeyDescriptionShort` with `B2applicationkeyDescriptionLong`

### DIFF
--- a/Duplicati/Library/Backend/Backblaze/Strings.cs
+++ b/Duplicati/Library/Backend/Backblaze/Strings.cs
@@ -22,8 +22,8 @@
 using Duplicati.Library.Localization.Short;
 namespace Duplicati.Library.Backend.Strings {
     internal static class B2 {
-        public static string B2applicationkeyDescriptionShort { get { return LC.L(@"The ""B2 Cloud Storage Application Key"" can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-password"" property"); } }
-        public static string B2applicationkeyDescriptionLong { get { return LC.L(@"The ""B2 Cloud Storage Application Key"""); } }
+        public static string B2applicationkeyDescriptionLong { get { return LC.L(@"The ""B2 Cloud Storage Application Key"" can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-password"" property"); } }
+        public static string B2applicationkeyDescriptionShort { get { return LC.L(@"The ""B2 Cloud Storage Application Key"""); } }
         public static string B2accountidDescriptionLong { get { return LC.L(@"The ""B2 Cloud Storage Account ID"" can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-username"" property"); } }
         public static string B2accountidDescriptionShort { get { return LC.L(@"The ""B2 Cloud Storage Account ID"""); } }
         public static string DisplayName { get { return LC.L(@"B2 Cloud Storage"); } }


### PR DESCRIPTION
This PR intends to fix the description for backup task with B2 Cloud Storage by switching `B2applicationkeyDescriptionShort` and `B2applicationkeyDescriptionLong`. I guess the bug has been introduced due to a small error.

Before:
![Screenshot from 2024-07-14 04-22-48](https://github.com/user-attachments/assets/371bd7e4-5d50-4cfb-b50d-35d0ec126224)

After:
![Screenshot from 2024-07-14 04-21-30](https://github.com/user-attachments/assets/62ce3e18-9077-464f-a665-a99ec5998d69)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>