### PR TITLE
Fix string `DescriptionS3ClientLong`

### DIFF
--- a/Duplicati/Library/Backend/S3/Strings.cs
+++ b/Duplicati/Library/Backend/S3/Strings.cs
@@ -43,7 +43,7 @@ namespace Duplicati.Library.Backend.Strings
         public static string S3ServerNameDescriptionShort { get { return LC.L(@"Specifies an alternate S3 server name"); } }
         public static string S3ClientDescriptionShort { get { return LC.L(@"Specifies the S3 client library to use"); } }
         public static string DescriptionUseSSLLong { get { return LC.L(@"Use this flag to communicate using Secure Socket Layer (SSL) over http (https). Note that bucket names containing a period has problems with SSL connections."); } }
-        public static string DescriptionS3ClientLong { get { return LC.L(@"Set either to aws or minio . Then either the AWS SDK or Minio SDK will used to communicate with S3 services."); } }
+        public static string DescriptionS3ClientLong { get { return LC.L(@"Set either to aws or minio. Then either the AWS SDK or Minio SDK will be used to communicate with S3 services."); } }
         public static string DescriptionUseSSLShort { get { return LC.L(@"Instructs Duplicati to use an SSL (https) connection"); } }
         public static string DescriptionDisableChunkEncodingLong { get { return LC.L(@"This disables chunk encoding for the aws client, which is not supported by all S3 providers."); } }
         public static string DescriptionDisableChunkEncodingShort { get { return LC.L(@"Disable chunk encoding (aws client only)"); } }


### PR DESCRIPTION
This PR intends to fix string `DescriptionS3ClientLong` by removing a white space character and adding "be".

Signed-off-by: Suguru Hirahara luixxiul@users.noreply.github.com