### PR TITLE
Update placeholders without 'translate'

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/backends/openstack.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/openstack.html
@@ -37,15 +37,15 @@
 
 <div class="input text">
     <label for="openstack_tenantname" translate>Tenant Name</label>
-    <input type="text" name="openstack_tenantname" id="openstack_tenantname" ng-model="$parent.openstack_tenantname" placeholder="optional tenant name" title="{{'If you do not enter an API Key, the tenant name is required' | translate}}"/>
+    <input type="text" name="openstack_tenantname" id="openstack_tenantname" ng-model="$parent.openstack_tenantname" placeholder="{{'Optional tenant name' | translate}}" title="{{'If you do not enter an API Key, the tenant name is required' | translate}}"/>
 </div>
 
 <div class="input text">
     <label for="openstack_apikey" translate>API Key</label>
-    <input type="text" name="openstack_apikey" id="openstack_apikey" ng-model="$parent.openstack_apikey" placeholder="optional api key" title="{{'Some OpenStack providers allow an API key instead of a password and tenant name' | translate}}" />
+    <input type="text" name="openstack_apikey" id="openstack_apikey" ng-model="$parent.openstack_apikey" placeholder="{{'Optional api key' | translate}}" title="{{'Some OpenStack providers allow an API key instead of a password and tenant name' | translate}}" />
 </div>
 
 <div class="input text">
     <label for="openstack_region" translate>Container region</label>
-    <input type="text" name="openstack_region" id="openstack_region" ng-model="$parent.openstack_region" placeholder="optional region" title="{{'The region parameter is only used when creating a bucket' | translate}}"/>
+    <input type="text" name="openstack_region" id="openstack_region" ng-model="$parent.openstack_region" placeholder="{{'Optional region' | translate}}" title="{{'The region parameter is only used when creating a bucket' | translate}}"/>
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/rclone.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/rclone.html
@@ -1,13 +1,13 @@
 <div class="input text">
     <label for="rclone_local_repository" translate>Local repository</label>
-    <input type="text" name="rclone_local_repository" id="rclone_local_repository" ng-model="$parent.rclone_local_repository" placeholder="{{'local repository, eg local'}}" />
+    <input type="text" name="rclone_local_repository" id="rclone_local_repository" ng-model="$parent.rclone_local_repository" placeholder="{{'local repository, eg local' | translate}}" />
 </div>
 <div class="input text">
     <label for="rclone_remote_repository" translate>Remote repository</label>
-    <input type="text" name="rclone_remote_repository" id="rclone_remote-repository" ng-model="$parent.Server" placeholder="{{'remote repository, eg. remote'}}" />
+    <input type="text" name="rclone_remote_repository" id="rclone_remote-repository" ng-model="$parent.Server" placeholder="{{'remote repository, eg. remote' | translate}}" />
 </div>
 <div class="input text">
     <label for="rclone_remote_path" translate>Remote path</label>
-    <input type="text" name="rclone_remote_path" id="rclone_remote_path" ng-model="$parent.Path" placeholder="{{'remote path, eg backup'}}" />
+    <input type="text" name="rclone_remote_path" id="rclone_remote_path" ng-model="$parent.Path" placeholder="{{'remote path, eg backup' | translate}}" />
 </div>
 <div>Make sure that rclone is in your path, or add the location to rclone via the advanced options.</div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/s3.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/s3.html
@@ -53,7 +53,7 @@
     </select>
 
     <input ng-hide="contains_value(s3_storageclasses, s3_storageclass)" type="text" id="s3_storageclass_custom"
-           ng-model="$parent.s3_storageclass_custom" placeholder="Custom bucket storage class"/>
+           ng-model="$parent.s3_storageclass_custom" placeholder="{{'Custom bucket storage class' | translate}}"/>
 
 </div>
 

--- a/Duplicati/Server/webroot/ngax/templates/backends/storj.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/storj.html
@@ -31,13 +31,13 @@
 </div>
 <div class="input text" ng-show="$parent.storj_auth_method == 'Access grant'">
     <label for="storj_shared_access" translate>Access grant</label>
-    <input type="text" name="storj_shared_access" id="storj_shared_access" ng-model="$parent.storj_shared_access" placeholder="{{'The access grant instead of the info above'}}" />
+    <input type="text" name="storj_shared_access" id="storj_shared_access" ng-model="$parent.storj_shared_access" placeholder="{{'The access grant instead of the info above' | translate}}" />
 </div>
 <div class="input text">
     <label for="storj_bucket" translate>Bucket</label>
-    <input type="text" name="storj_bucket" id="storj_bucket" ng-model="$parent.storj_bucket" placeholder="{{'The bucket for storing the backup'}}" />
+    <input type="text" name="storj_bucket" id="storj_bucket" ng-model="$parent.storj_bucket" placeholder="{{'The bucket for storing the backup' | translate}}" />
 </div>
 <div class="input text">
     <label for="storj_folder" translate>Folder path</label>
-    <input type="text" name="storj_folder" id="storj_folder" ng-model="$parent.storj_folder" placeholder="{{'The folder within the bucket for storing the backup'}}" />
+    <input type="text" name="storj_folder" id="storj_folder" ng-model="$parent.storj_folder" placeholder="{{'The folder within the bucket for storing the backup' | translate}}" />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/backends/tardigrade.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/tardigrade.html
@@ -31,13 +31,13 @@
 </div>
 <div class="input text" ng-show="$parent.tardigrade_auth_method == 'Access grant'">
     <label for="tardigrade_shared_access" translate>Access grant</label>
-    <input type="text" name="tardigrade_shared_access" id="tardigrade_shared_access" ng-model="$parent.tardigrade_shared_access" placeholder="{{'The access grant instead of the info above'}}" />
+    <input type="text" name="tardigrade_shared_access" id="tardigrade_shared_access" ng-model="$parent.tardigrade_shared_access" placeholder="{{'The access grant instead of the info above' | translate}}" />
 </div>
 <div class="input text">
     <label for="tardigrade_bucket" translate>Bucket</label>
-    <input type="text" name="tardigrade_bucket" id="tardigrade_bucket" ng-model="$parent.tardigrade_bucket" placeholder="{{'The bucket for storing the backup'}}" />
+    <input type="text" name="tardigrade_bucket" id="tardigrade_bucket" ng-model="$parent.tardigrade_bucket" placeholder="{{'The bucket for storing the backup' | translate}}" />
 </div>
 <div class="input text">
     <label for="tardigrade_folder" translate>Folder path</label>
-    <input type="text" name="tardigrade_folder" id="tardigrade_folder" ng-model="$parent.tardigrade_folder" placeholder="{{'The folder within the bucket for storing the backup'}}" />
+    <input type="text" name="tardigrade_folder" id="tardigrade_folder" ng-model="$parent.tardigrade_folder" placeholder="{{'The folder within the bucket for storing the backup' | translate}}" />
 </div>

--- a/Duplicati/Server/webroot/ngax/templates/commandline.html
+++ b/Duplicati/Server/webroot/ngax/templates/commandline.html
@@ -14,22 +14,22 @@
 
             <div class="input textarea linklabel">
                 <label for="target"><a href class="target" ng-click="EditUriState = true">Target URL &gt;</a></label>
-                <textarea name="target" id="target" ng-model="TargetURL" placeholder="Enter a url, or click the 'Target URL &gt;' link"></textarea>
+                <textarea name="target" id="target" ng-model="TargetURL" placeholder="{{'Enter a url, or click the \'Target URL &gt;\' link | translate}}"></textarea>
             </div>
 
             <div class="input textarea">
                 <label for="arguments">Commandline arguments</label>
-                <textarea id="arguments" ng-model="Arguments" string-array-as-text placeholder="Enter one argument per line without quotes, e.g. *.txt"></textarea>
+                <textarea id="arguments" ng-model="Arguments" string-array-as-text placeholder="{{'Enter one argument per line without quotes, e.g. *.txt' | translate}}"></textarea>
             </div>
 
             <div class="input textarea" ng-show="ShowAdvancedTextArea">
                 <label for="backupOptions">Advanced options</label>
                 <div>
                     <a href ng-click="ShowAdvancedTextArea = false" class="advanced-toggle"><i class="fa fa-check"></i> Edit as text</a>
-                    <textarea id="backupOptions" ng-model="ExtendedOptions" string-array-as-text placeholder="Enter one option per line in command-line format, eg. --dblock-size=100MB"></textarea>
+                    <textarea id="backupOptions" ng-model="ExtendedOptions" string-array-as-text placeholder="{{'Enter one option per line in command-line format, eg. --dblock-size=100MB' | translate}}"></textarea>
                 </div>
             </div>
-            
+
             <div class="input" ng-hide="ShowAdvancedTextArea">
                 <label for="backupOptions">Advanced options</label>
                 <a href ng-click="ShowAdvancedTextArea = true" class="advanced-toggle"><i class="fa"></i> Edit as text</a>


### PR DESCRIPTION
This PR intends to update placeholders without `translate` to make them translatable on Transifex. Please note that it is required to pull the changes to Transifex manually.

If these strings have been intentionally made untranslatable due to any reasons, please let me know, so that I would close the PR.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>