### PR TITLE
Make a div on throttle.html translatable

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/throttle.html
+++ b/Duplicati/Server/webroot/ngax/templates/throttle.html
@@ -19,7 +19,7 @@
             </select>
         </div>
 
-        <div>
+        <div translate>
         Note that speeds are entered in bytes, and line speeds are typically reported in bits. Use a factor of 8 to convert, such that an 8 mbit/s line is equivalent to 1 MByte/s.
         <div>
 	</form>


### PR DESCRIPTION
This PR intends to make a div on `throttle.html` translatable.

![throttle](https://github.com/user-attachments/assets/f08b3aae-40d0-44e3-a6e4-1fc8285c336e)


Since I am not quite sure if adding `translate` to the element would be sufficient, please let me know what I should do additionally if any.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>
