### PR TITLE
Specify correct string to OPTION_DISABLE_LENGTH_VERIFICATION

### DIFF
--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -258,7 +258,7 @@ namespace Duplicati.Library.Backend
                     new CommandLineArgument(OPTION_ALTERNATE_PATHS, CommandLineArgument.ArgumentType.Path, Strings.FileBackend.AlternateTargetPathsShort, Strings.FileBackend.AlternateTargetPathsLong(OPTION_DESTINATION_MARKER, System.IO.Path.PathSeparator)),
                     new CommandLineArgument(OPTION_MOVE_FILE, CommandLineArgument.ArgumentType.Boolean, Strings.FileBackend.UseMoveForPutShort, Strings.FileBackend.UseMoveForPutLong),
                     new CommandLineArgument(OPTION_FORCE_REAUTH, CommandLineArgument.ArgumentType.Boolean, Strings.FileBackend.ForceReauthShort, Strings.FileBackend.ForceReauthLong),
-                    new CommandLineArgument(OPTION_DISABLE_LENGTH_VERIFICATION, CommandLineArgument.ArgumentType.Boolean, Strings.FileBackend.DisableLengthVerificationShort, Strings.FileBackend.DisableLengthVerificationShort),
+                    new CommandLineArgument(OPTION_DISABLE_LENGTH_VERIFICATION, CommandLineArgument.ArgumentType.Boolean, Strings.FileBackend.DisableLengthVerificationShort, Strings.FileBackend.DisableLengthVerificationLong),
 
                 });
 


### PR DESCRIPTION
This PR intends to fix the issue that the string is incorrectly specified to `OPTION_DISABLE_LENGTH_VERIFICATION` on FileBackend.cs:

![1](https://github.com/user-attachments/assets/b4c1c76b-78cb-468b-8503-eb91aaa129c0)

This is the string to be applied:

https://github.com/duplicati/duplicati/blob/64ac0c5a86cc8fb1ac2209c0834bce9f62027bce/Duplicati/Library/Backend/File/Strings.cs#L41

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>
