### PR TITLE
Make the libraries heading description translatable

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/about.html
+++ b/Duplicati/Server/webroot/ngax/templates/about.html
@@ -48,7 +48,7 @@
     </div>
 
     <div ng-show="Page == 'licenses'" class="licenses">
-        {{brandingService.appName}} is using the following third party libraries:
+        <span translate>{{brandingService.appName}} is using the following third party libraries:</span>
         <ul>
             <li ng-show="Licenses == null" translate>Loading …</li>
             <li ng-repeat="item in Licenses" class="licenseentry">


### PR DESCRIPTION
This PR intends to make the libraries heading description on http://localhost:8200/ngax/index.html#/about translatable.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>