### PR TITLE
Fix the issue that strings on the warning dialog of a backup task with Microsoft Office 365 Group are partially displayed in English

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
@@ -89,7 +89,7 @@ backupApp.service('EditUriBackendConfig', function(AppService, AppUtils, SystemI
 
     this.recommend_field = function (scope, field, label, reason, continuation) {
         if ((scope[field] || '').trim().length == 0)
-            return self.show_warning_dialog(gettextCatalog.getString('You should fill in {{field}}{{reason}}', { field: label || field, reason: reason }), continuation);
+            return self.show_warning_dialog(gettextCatalog.getString('You should fill in {{field}} {{reason}}', { field: label || field, reason: reason }), continuation);
         else
             continuation();
     };

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -1049,7 +1049,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
 
         EditUriBackendConfig.validaters['authid-base'](scope, function () {
             var res =
-                EditUriBackendConfig.recommend_field(scope, 'msgroup_group_email', gettextCatalog.getString('Group email'), gettextCatalog.getString(' unless you are explicitly specifying --group-id'), continuation);
+                EditUriBackendConfig.recommend_field(scope, 'msgroup_group_email', gettextCatalog.getString('Group email'), gettextCatalog.getString('unless you are explicitly specifying --group-id'), continuation);
 
             if (res)
                 continuation();
@@ -1060,7 +1060,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
 
         EditUriBackendConfig.validaters['authid-base'](scope, function () {
             var res =
-                EditUriBackendConfig.recommend_field(scope, 'msgroup_group_email', gettextCatalog.getString('Group email'), gettextCatalog.getString(' unless you are explicitly specifying --group-id'), continuation);
+                EditUriBackendConfig.recommend_field(scope, 'msgroup_group_email', gettextCatalog.getString('Group email'), gettextCatalog.getString('unless you are explicitly specifying --group-id'), continuation);
 
             if (res)
                 continuation();

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -1056,17 +1056,6 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         });
     };
 
-    EditUriBackendConfig.validaters['msgroup'] = function (scope, continuation) {
-
-        EditUriBackendConfig.validaters['authid-base'](scope, function () {
-            var res =
-                EditUriBackendConfig.recommend_field(scope, 'msgroup_group_email', gettextCatalog.getString('Group email'), gettextCatalog.getString('unless you are explicitly specifying --group-id'), continuation);
-
-            if (res)
-                continuation();
-        });
-    };
-
     EditUriBackendConfig.validaters['azure'] = function (scope, continuation) {
         var res =
             EditUriBackendConfig.require_field(scope, 'Username', gettextCatalog.getString('Account name')) &&


### PR DESCRIPTION
Fixes https://github.com/duplicati/duplicati/issues/5303

This PR intends to fix the issue that strings on the warning dialog of a backup task with Microsoft Office 365 Group are partially displayed in English.

The issue apparently is caused by Transifex's auto removal of a whitespace character added as a first character of a string, which therefore removes the whitespace character from PO files (see [here](https://github.com/duplicati/duplicati/blob/2569f94de8b3d1427554c8aeb381579560945603/Localizations/webroot/localization_webroot-nl_NL.po#L3301) for an example), causing the strings are not properly recognized. This PR should fix the issue by moving the whitespace character inside the string on EditUriBackendConfig.js. This also makes sense in that it lets translators decide how to handle the whitespace.

This PR also removes the duplicate block from EditUriBuiltins.js.

|Before|After|
|---------|------|
|![1](https://github.com/user-attachments/assets/8a13e4fd-3df8-4aca-b2b6-29f72b9de0b3)|![2](https://github.com/user-attachments/assets/dccee1ff-9d20-410f-ad35-ae4889c77e2d)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>