### PR TITLE
Remove a redundant line break on s3.html

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/backends/s3.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/s3.html
@@ -86,6 +86,5 @@
 </div>
 
 <div class="buttons">
-    <a href ng-click="s3_createIAMPolicy()" ng-show="$parent.s3_server == 's3.amazonaws.com'" translate>Generate IAM
-        access policy</a>
+    <a href ng-click="s3_createIAMPolicy()" ng-show="$parent.s3_server == 's3.amazonaws.com'" translate>Generate IAM access policy</a>
 </div>


### PR DESCRIPTION
This PR intends to remove a redundant line break from s3.html.

On Transifex, the line break is applied to the source area and has translators wonder if there would be a meaning of it, while on the UI the line break is in fact ignored since it is inside a HTML tag. Removing the line break prevents them from taking it into consideration.

On http://localhost:8200/ngax/index.html#/add:
![1](https://github.com/user-attachments/assets/99a55835-389c-4ab0-a71f-75246d42d491)

On Transifex:
![2](https://github.com/user-attachments/assets/8d73dca2-0529-4c29-a031-78ceefd0f7b4)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>