### PR TITLE
Fix the placeholder for access grant input area of a backup task with Storj/Tardigrade 

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/backends/storj.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/storj.html
@@ -31,7 +31,7 @@
 </div>
 <div class="input text" ng-show="$parent.storj_auth_method == 'Access grant'">
     <label for="storj_shared_access" translate>Access grant</label>
-    <input type="text" name="storj_shared_access" id="storj_shared_access" ng-model="$parent.storj_shared_access" placeholder="{{'The access grant instead of the info above' | translate}}" />
+    <input type="text" name="storj_shared_access" id="storj_shared_access" ng-model="$parent.storj_shared_access" placeholder="{{'The access grant' | translate}}" />
 </div>
 <div class="input text">
     <label for="storj_bucket" translate>Bucket</label>

--- a/Duplicati/Server/webroot/ngax/templates/backends/tardigrade.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/tardigrade.html
@@ -31,7 +31,7 @@
 </div>
 <div class="input text" ng-show="$parent.tardigrade_auth_method == 'Access grant'">
     <label for="tardigrade_shared_access" translate>Access grant</label>
-    <input type="text" name="tardigrade_shared_access" id="tardigrade_shared_access" ng-model="$parent.tardigrade_shared_access" placeholder="{{'The access grant instead of the info above' | translate}}" />
+    <input type="text" name="tardigrade_shared_access" id="tardigrade_shared_access" ng-model="$parent.tardigrade_shared_access" placeholder="{{'The access grant' | translate}}" />
 </div>
 <div class="input text">
     <label for="tardigrade_bucket" translate>Bucket</label>


### PR DESCRIPTION
This PR intends to remove "instead of the info above" from the placeholder for access grant input area of a backup task with Storj/Tardigrade.

"The info above" here means the information provided for an access with API, but it does not make sense on the actual UI as the input area for API access is hidden if access grant is selected as the authentication method.

|Before|After|
|---------|------|
|![1](https://github.com/user-attachments/assets/b30d9cf1-bd84-43a7-90d8-5b39d31833eb)|![2](https://github.com/user-attachments/assets/b59bb01d-a7d1-4e2b-920f-df3008e79dc4)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>