### PR TITLE
Update options of a backup task with Sia Decentralized Cloud

### DIFF
--- a/Duplicati/Library/Backend/Sia/Strings.cs
+++ b/Duplicati/Library/Backend/Sia/Strings.cs
@@ -23,13 +23,13 @@ namespace Duplicati.Library.Backend.Strings
 {
     internal static class Sia
     {
-        public static string DisplayName { get { return LC.L(@"Sia Decentralized Cloud"); } }
         public static string Description { get { return LC.L(@"This backend can read and write data to Sia."); } }
-        public static string SiaPathDescriptionShort { get { return LC.L(@"Backup path"); } }
+        public static string DisplayName { get { return LC.L(@"Sia Decentralized Cloud"); } }
         public static string SiaPathDescriptionLong { get { return LC.L(@"Set the target path. Example: /backup"); } }
-        public static string SiaPasswordShort { get { return LC.L(@"Sia password"); } }
+        public static string SiaPathDescriptionShort { get { return LC.L(@"Backup path"); } }
         public static string SiaPasswordLong { get { return LC.L(@"Supply a password for Sia server."); } }
-        public static string SiaRedundancyDescriptionShort { get { return LC.L(@"Set the minimum redundancy"); } }
+        public static string SiaPasswordShort { get { return LC.L(@"Sia password"); } }
         public static string SiaRedundancyDescriptionLong { get { return LC.L(@"The minimum value for redundancy is 1.0."); } }
+        public static string SiaRedundancyDescriptionShort { get { return LC.L(@"Set the minimum redundancy"); } }
     }
 }

--- a/Duplicati/Library/Backend/Sia/Strings.cs
+++ b/Duplicati/Library/Backend/Sia/Strings.cs
@@ -26,7 +26,7 @@ namespace Duplicati.Library.Backend.Strings
         public static string DisplayName { get { return LC.L(@"Sia Decentralized Cloud"); } }
         public static string Description { get { return LC.L(@"This backend can read and write data to Sia."); } }
         public static string SiaPathDescriptionShort { get { return LC.L(@"Backup path"); } }
-        public static string SiaPathDescriptionLong { get { return LC.L(@"Target path, ie /backup"); } }
+        public static string SiaPathDescriptionLong { get { return LC.L(@"Set the target path. Example: /backup"); } }
         public static string SiaPasswordShort { get { return LC.L(@"Sia password"); } }
         public static string SiaPasswordLong { get { return LC.L(@"Sia password"); } }
         public static string SiaRedundancyDescriptionShort { get { return LC.L(@"3"); } }

--- a/Duplicati/Library/Backend/Sia/Strings.cs
+++ b/Duplicati/Library/Backend/Sia/Strings.cs
@@ -30,6 +30,6 @@ namespace Duplicati.Library.Backend.Strings
         public static string SiaPasswordShort { get { return LC.L(@"Sia password"); } }
         public static string SiaPasswordLong { get { return LC.L(@"Supply a password for Sia server."); } }
         public static string SiaRedundancyDescriptionShort { get { return LC.L(@"Set the minimum redundancy"); } }
-        public static string SiaRedundancyDescriptionLong { get { return LC.L(@"Minimum value is 3."); } }
+        public static string SiaRedundancyDescriptionLong { get { return LC.L(@"The minimum value for redundancy is 1.0."); } }
     }
 }

--- a/Duplicati/Library/Backend/Sia/Strings.cs
+++ b/Duplicati/Library/Backend/Sia/Strings.cs
@@ -28,7 +28,7 @@ namespace Duplicati.Library.Backend.Strings
         public static string SiaPathDescriptionShort { get { return LC.L(@"Backup path"); } }
         public static string SiaPathDescriptionLong { get { return LC.L(@"Set the target path. Example: /backup"); } }
         public static string SiaPasswordShort { get { return LC.L(@"Sia password"); } }
-        public static string SiaPasswordLong { get { return LC.L(@"Sia password"); } }
+        public static string SiaPasswordLong { get { return LC.L(@"Supply a password for Sia server."); } }
         public static string SiaRedundancyDescriptionShort { get { return LC.L(@"3"); } }
         public static string SiaRedundancyDescriptionLong { get { return LC.L(@"Minimum value is 3."); } }
     }

--- a/Duplicati/Library/Backend/Sia/Strings.cs
+++ b/Duplicati/Library/Backend/Sia/Strings.cs
@@ -29,7 +29,7 @@ namespace Duplicati.Library.Backend.Strings
         public static string SiaPathDescriptionLong { get { return LC.L(@"Set the target path. Example: /backup"); } }
         public static string SiaPasswordShort { get { return LC.L(@"Sia password"); } }
         public static string SiaPasswordLong { get { return LC.L(@"Supply a password for Sia server."); } }
-        public static string SiaRedundancyDescriptionShort { get { return LC.L(@"3"); } }
+        public static string SiaRedundancyDescriptionShort { get { return LC.L(@"Set the minimum redundancy"); } }
         public static string SiaRedundancyDescriptionLong { get { return LC.L(@"Minimum value is 3."); } }
     }
 }

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -1217,7 +1217,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         }
 
         if (res && (scope['sia_redundancy'] || '').trim().length == 0 || parseFloat(scope['sia_redundancy']) < 1.0)
-            res = EditUriBackendConfig.show_error_dialog(gettextCatalog.getString('Minimum redundancy is 1.0'));
+            res = EditUriBackendConfig.show_error_dialog(gettextCatalog.getString('Minimum redundancy is 1.0')); // Do not forget to update SiaRedundancyDescriptionLong as well if the value is changed
 
         if (res)
             continuation();

--- a/Duplicati/Server/webroot/ngax/templates/backends/sia.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/sia.html
@@ -4,7 +4,7 @@
 </div>
 <div class="input text">
     <label for="sia_path" translate>Folder path</label>
-    <input type="text" name="sia_targetpath" id="sia_targetpath" ng-model="$parent.sia_targetpath" placeholder="{{'Target path, ie /backup' | translate}}" />
+    <input type="text" name="sia_targetpath" id="sia_targetpath" ng-model="$parent.sia_targetpath" placeholder="{{'Set the target path. Example: /backup' | translate}}" />
 </div>
 <div class="input password">
     <label for="sia_password" translate>Server password</label>


### PR DESCRIPTION
This PR intends to update options of a backup task with Sia Decentralized Cloud:

- Replace the placeholder `Target path, ie /backup` with `Set the target path. Example: /backup` ("ie" means "that is"; here it indicates an example and 'eg' should have been used)
- Edit the long descriptions for each option to make them clearer
- Edit the short description for redundancy since it is not clear what the number "3" means
- Fix the description about the minimum redundancy based on https://github.com/duplicati/duplicati/commit/0988ba96002acea66b9f84cca427143829f51633.
- Order the strings `…Long` before `…Short` (for https://github.com/duplicati/duplicati/issues/5293)

|Before|After|
|---------|------|
|![3_1](https://github.com/user-attachments/assets/5d57b8b6-64fc-4808-9666-758af1f750d5)|![3](https://github.com/user-attachments/assets/b5ab45ae-cec6-4d58-aea4-64dce23427dc)|
|![2_1](https://github.com/user-attachments/assets/56a0deeb-fbcf-4ca0-b42b-6f32ffe8daf2)|![2](https://github.com/user-attachments/assets/f8e8cb0c-403b-4cf4-bcc8-e6588bc3cafc)|
|![1_1](https://github.com/user-attachments/assets/4c0a777d-1b5f-4faf-b5b8-a872a75b7846)|![1](https://github.com/user-attachments/assets/371ee94d-7610-4a3e-8d91-db3550706915)|

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>