### PR TITLE
Fix minor details related to `Id` (`ID`) inside strings

### DIFF
--- a/Duplicati/Library/Backend/AliyunOSS/Strings.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/Strings.cs
@@ -6,9 +6,9 @@ namespace Duplicati.Library.Backend.Strings
     {
         public static string Description { get { return LC.L(@"This backend can read and write data to Aliyun OSS."); } }
         public static string DisplayName { get { return LC.L(@"Aliyun OSS (Object Storage Service)"); } }
-        public static string OSSAccessKeyIdDescriptionLong { get { return LC.L(@"AccessKeyID is used to identify the user."); } }
+        public static string OSSAccessKeyIdDescriptionLong { get { return LC.L(@"Access Key ID is used to identify the user."); } }
         public static string OSSAccessKeyIdDescriptionShort { get { return LC.L(@"Access Key ID"); } }
-        public static string OSSAccessKeySecretDescriptionLong { get { return LC.L(@"AccessKeySecret is the key used by the user to encrypt signature strings and by OSS to verify these signature strings"); } }
+        public static string OSSAccessKeySecretDescriptionLong { get { return LC.L(@"Access Key Secret is the key used by the user to encrypt signature strings and by OSS to verify these signature strings"); } }
         public static string OSSAccessKeySecretDescriptionShort { get { return LC.L(@"Access Key Secret"); } }
         public static string OSSBucketNameDescriptionLong { get { return LC.L(@"A storage space is a container used to store objects (Object), and all objects must belong to a specific storage space."); } }
         public static string OSSBucketNameDescriptionShort { get { return LC.L(@"Bucket Name"); } }

--- a/Duplicati/Library/Backend/AliyunOSS/Strings.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/Strings.cs
@@ -6,8 +6,8 @@ namespace Duplicati.Library.Backend.Strings
     {
         public static string Description { get { return LC.L(@"This backend can read and write data to Aliyun OSS."); } }
         public static string DisplayName { get { return LC.L(@"Aliyun OSS (Object Storage Service)"); } }
-        public static string OSSAccessKeyIdDescriptionLong { get { return LC.L(@"AccessKeyId is used to identify the user."); } }
-        public static string OSSAccessKeyIdDescriptionShort { get { return LC.L(@"Access Key Id"); } }
+        public static string OSSAccessKeyIdDescriptionLong { get { return LC.L(@"AccessKeyID is used to identify the user."); } }
+        public static string OSSAccessKeyIdDescriptionShort { get { return LC.L(@"Access Key ID"); } }
         public static string OSSAccessKeySecretDescriptionLong { get { return LC.L(@"AccessKeySecret is the key used by the user to encrypt signature strings and by OSS to verify these signature strings"); } }
         public static string OSSAccessKeySecretDescriptionShort { get { return LC.L(@"Access Key Secret"); } }
         public static string OSSBucketNameDescriptionLong { get { return LC.L(@"A storage space is a container used to store objects (Object), and all objects must belong to a specific storage space."); } }

--- a/Duplicati/Library/Backend/Backblaze/Strings.cs
+++ b/Duplicati/Library/Backend/Backblaze/Strings.cs
@@ -22,17 +22,17 @@
 using Duplicati.Library.Localization.Short;
 namespace Duplicati.Library.Backend.Strings {
     internal static class B2 {
-        public static string B2applicationkeyDescriptionLong { get { return LC.L(@"The ""B2 Cloud Storage Application Key"" can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-password"" property"); } }
-        public static string B2applicationkeyDescriptionShort { get { return LC.L(@"The ""B2 Cloud Storage Application Key"""); } }
-        public static string B2accountidDescriptionLong { get { return LC.L(@"The ""B2 Cloud Storage Account ID"" can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-username"" property"); } }
-        public static string B2accountidDescriptionShort { get { return LC.L(@"The ""B2 Cloud Storage Account ID"""); } }
+        public static string B2applicationkeyDescriptionLong { get { return LC.L(@"B2 Cloud Storage Application Key can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-password"" property"); } }
+        public static string B2applicationkeyDescriptionShort { get { return LC.L(@"B2 Cloud Storage Application Key"); } }
+        public static string B2accountidDescriptionLong { get { return LC.L(@"B2 Cloud Storage Account ID can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-username"" property"); } }
+        public static string B2accountidDescriptionShort { get { return LC.L(@"B2 Cloud Storage Account ID"); } }
         public static string DisplayName { get { return LC.L(@"B2 Cloud Storage"); } }
         public static string AuthPasswordDescriptionLong { get { return LC.L(@"The password used to connect to the server. This may also be supplied as the environment variable ""AUTH_PASSWORD""."); } }
         public static string AuthPasswordDescriptionShort { get { return LC.L(@"Supplies the password used to connect to the server"); } }
         public static string AuthUsernameDescriptionLong { get { return LC.L(@"The username used to connect to the server. This may also be supplied as the environment variable ""AUTH_USERNAME""."); } }
         public static string AuthUsernameDescriptionShort { get { return LC.L(@"Supplies the username used to connect to the server"); } }
-        public static string NoB2KeyError { get { return LC.L(@"No ""B2 Cloud Storage Application Key"" given"); } }
-        public static string NoB2UserIDError { get { return LC.L(@"No ""B2 Cloud Storage Account ID"" given"); } }
+        public static string NoB2KeyError { get { return LC.L(@"No B2 Cloud Storage Application Key given"); } }
+        public static string NoB2UserIDError { get { return LC.L(@"No B2 Cloud Storage Account ID given"); } }
         public static string Description { get { return LC.L(@"This backend can read and write data to the Backblaze B2 Cloud Storage. Allowed formats are: ""b2://bucketname/prefix"""); } }
         public static string B2createbuckettypeDescriptionLong { get { return LC.L(@"By default, a private bucket is created. Use this option to set the bucket type. Refer to the B2 documentation for allowed types "); } }
         public static string B2createbuckettypeDescriptionShort { get { return LC.L(@"The bucket type used when creating a bucket"); } }

--- a/Duplicati/Library/Backend/Backblaze/Strings.cs
+++ b/Duplicati/Library/Backend/Backblaze/Strings.cs
@@ -22,9 +22,9 @@
 using Duplicati.Library.Localization.Short;
 namespace Duplicati.Library.Backend.Strings {
     internal static class B2 {
-        public static string B2applicationkeyDescriptionLong { get { return LC.L(@"B2 Cloud Storage Application Key can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-password"" property"); } }
+        public static string B2applicationkeyDescriptionLong { get { return LC.L(@"B2 Cloud Storage Application Key can be obtained after logging into your Backblaze account. This can also be supplied through the ""auth-password"" property"); } }
         public static string B2applicationkeyDescriptionShort { get { return LC.L(@"B2 Cloud Storage Application Key"); } }
-        public static string B2accountidDescriptionLong { get { return LC.L(@"B2 Cloud Storage Account ID can be obtained after logging into your Backblaze account, this can also be supplied through the ""auth-username"" property"); } }
+        public static string B2accountidDescriptionLong { get { return LC.L(@"B2 Cloud Storage Account ID can be obtained after logging into your Backblaze account. This can also be supplied through the ""auth-username"" property"); } }
         public static string B2accountidDescriptionShort { get { return LC.L(@"B2 Cloud Storage Account ID"); } }
         public static string DisplayName { get { return LC.L(@"B2 Cloud Storage"); } }
         public static string AuthPasswordDescriptionLong { get { return LC.L(@"The password used to connect to the server. This may also be supplied as the environment variable ""AUTH_PASSWORD""."); } }

--- a/Duplicati/Library/Backend/Idrivee2/Strings.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Strings.cs
@@ -21,9 +21,9 @@
 using Duplicati.Library.Localization.Short;
 namespace Duplicati.Library.Backend.Strings {
     internal static class Idrivee2Backend {
-        public static string KeySecretDescriptionLong { get { return LC.L(@"Access Key Secret can be obtained after logging into your IDrive e2 account, this can also be supplied through the ""auth-password"" property."); } }
+        public static string KeySecretDescriptionLong { get { return LC.L(@"Access Key Secret can be obtained after logging into your IDrive e2 account. This can also be supplied through the ""auth-password"" property."); } }
         public static string KeySecretDescriptionShort { get { return LC.L(@"Access Key Secret"); } }
-        public static string KeyIDDescriptionLong { get { return LC.L(@"Access Key ID can be obtained after logging into your IDrive e2 account., this can also be supplied through the ""auth-username"" property."); } }
+        public static string KeyIDDescriptionLong { get { return LC.L(@"Access Key ID can be obtained after logging into your IDrive e2 account. This can also be supplied through the ""auth-username"" property."); } }
         public static string KeyIDDescriptionShort { get { return LC.L(@"Access Key ID"); } }
 
         public static string BucketNameOrPathDescriptionLong { get { return LC.L(@"The ""Bucket Name or Complete Path"" is name of target bucket or complete of a folder inside the bucket."); } }

--- a/Duplicati/Library/Backend/Idrivee2/Strings.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Strings.cs
@@ -21,10 +21,10 @@
 using Duplicati.Library.Localization.Short;
 namespace Duplicati.Library.Backend.Strings {
     internal static class Idrivee2Backend {
-        public static string KeySecretDescriptionLong { get { return LC.L(@"The ""Access Key Secret "" can be obtained after logging into your IDrive e2 account, this can also be supplied through the ""auth-password"" property."); } }
-        public static string KeySecretDescriptionShort { get { return LC.L(@"The ""Access Key Secret"""); } }
-        public static string KeyIDDescriptionLong { get { return LC.L(@"The ""Access Key ID"" can be obtained after logging into your IDrive e2 account., this can also be supplied through the ""auth-username"" property."); } }
-        public static string KeyIDDescriptionShort { get { return LC.L(@"The ""Access Key ID"""); } }
+        public static string KeySecretDescriptionLong { get { return LC.L(@"Access Key Secret can be obtained after logging into your IDrive e2 account, this can also be supplied through the ""auth-password"" property."); } }
+        public static string KeySecretDescriptionShort { get { return LC.L(@"Access Key Secret"); } }
+        public static string KeyIDDescriptionLong { get { return LC.L(@"Access Key ID can be obtained after logging into your IDrive e2 account., this can also be supplied through the ""auth-username"" property."); } }
+        public static string KeyIDDescriptionShort { get { return LC.L(@"Access Key ID"); } }
 
         public static string BucketNameOrPathDescriptionLong { get { return LC.L(@"The ""Bucket Name or Complete Path"" is name of target bucket or complete of a folder inside the bucket."); } }
         public static string BucketNameOrPathDescriptionShort { get { return LC.L(@"The ""Bucket Name or Complete Path"""); } }

--- a/Duplicati/Library/Backend/Idrivee2/Strings.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Strings.cs
@@ -31,7 +31,7 @@ namespace Duplicati.Library.Backend.Strings {
 
         public static string DisplayName { get { return LC.L(@"IDrive e2"); } }
         public static string NoKeySecretError { get { return LC.L(@"No Access key secret given"); } }
-        public static string NoKeyIdError { get { return LC.L(@"No Access key Id given"); } }
+        public static string NoKeyIdError { get { return LC.L(@"No Access key ID given"); } }
         public static string Description { get; set; }
     }
 }

--- a/Duplicati/Library/Backend/Idrivee2/Strings.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Strings.cs
@@ -30,8 +30,8 @@ namespace Duplicati.Library.Backend.Strings {
         public static string BucketNameOrPathDescriptionShort { get { return LC.L(@"The ""Bucket Name or Complete Path"""); } }
 
         public static string DisplayName { get { return LC.L(@"IDrive e2"); } }
-        public static string NoKeySecretError { get { return LC.L(@"No Access key secret given"); } }
-        public static string NoKeyIdError { get { return LC.L(@"No Access key ID given"); } }
+        public static string NoKeySecretError { get { return LC.L(@"No Access Key Secret given"); } }
+        public static string NoKeyIdError { get { return LC.L(@"No Access Key ID given"); } }
         public static string Description { get; set; }
     }
 }

--- a/Duplicati/Library/Backend/S3/Strings.cs
+++ b/Duplicati/Library/Backend/S3/Strings.cs
@@ -23,10 +23,10 @@ namespace Duplicati.Library.Backend.Strings
 {
     internal static class S3Backend
     {
-        public static string AMZKeyDescriptionLong { get { return LC.L(@"The AWS ""Secret Access Key"" can be obtained after logging into your AWS account, this can also be supplied through the ""auth-password"" property"); } }
-        public static string AMZKeyDescriptionShort { get { return LC.L(@"The AWS ""Secret Access Key"""); } }
-        public static string AMZUserIDDescriptionLong { get { return LC.L(@"The AWS ""Access Key ID"" can be obtained after logging into your AWS account, this can also be supplied through the ""auth-username"" property"); } }
-        public static string AMZUserIDDescriptionShort { get { return LC.L(@"The AWS ""Access Key ID"""); } }
+        public static string AMZKeyDescriptionLong { get { return LC.L(@"AWS Secret Access Key can be obtained after logging into your AWS account, this can also be supplied through the ""auth-password"" property"); } }
+        public static string AMZKeyDescriptionShort { get { return LC.L(@"AWS Secret Access Key"); } }
+        public static string AMZUserIDDescriptionLong { get { return LC.L(@"AWS Access Key ID can be obtained after logging into your AWS account, this can also be supplied through the ""auth-username"" property"); } }
+        public static string AMZUserIDDescriptionShort { get { return LC.L(@"AWS Access Key ID"); } }
         public static string DisplayName { get { return LC.L(@"S3 compatible"); } }
         public static string AuthPasswordDescriptionLong { get { return LC.L(@"The password used to connect to the server. This may also be supplied as the environment variable ""AUTH_PASSWORD""."); } }
         public static string AuthPasswordDescriptionShort { get { return LC.L(@"Supplies the password used to connect to the server"); } }

--- a/Duplicati/Library/Backend/S3/Strings.cs
+++ b/Duplicati/Library/Backend/S3/Strings.cs
@@ -23,9 +23,9 @@ namespace Duplicati.Library.Backend.Strings
 {
     internal static class S3Backend
     {
-        public static string AMZKeyDescriptionLong { get { return LC.L(@"AWS Secret Access Key can be obtained after logging into your AWS account, this can also be supplied through the ""auth-password"" property"); } }
+        public static string AMZKeyDescriptionLong { get { return LC.L(@"AWS Secret Access Key can be obtained after logging into your AWS account. This can also be supplied through the ""auth-password"" property"); } }
         public static string AMZKeyDescriptionShort { get { return LC.L(@"AWS Secret Access Key"); } }
-        public static string AMZUserIDDescriptionLong { get { return LC.L(@"AWS Access Key ID can be obtained after logging into your AWS account, this can also be supplied through the ""auth-username"" property"); } }
+        public static string AMZUserIDDescriptionLong { get { return LC.L(@"AWS Access Key ID can be obtained after logging into your AWS account. This can also be supplied through the ""auth-username"" property"); } }
         public static string AMZUserIDDescriptionShort { get { return LC.L(@"AWS Access Key ID"); } }
         public static string DisplayName { get { return LC.L(@"S3 compatible"); } }
         public static string AuthPasswordDescriptionLong { get { return LC.L(@"The password used to connect to the server. This may also be supplied as the environment variable ""AUTH_PASSWORD""."); } }

--- a/Duplicati/Library/Backend/TencentCOS/COSBackend.cs
+++ b/Duplicati/Library/Backend/TencentCOS/COSBackend.cs
@@ -82,7 +82,7 @@ namespace Duplicati.Library.Backend.TencentCOS
             /// </summary>
             public string Appid { get; set; }
             /// <summary>
-            /// Cloud API Secret Id
+            /// Cloud API Secret ID
             /// </summary>
             public string SecretId { get; set; }
             /// <summary>

--- a/Duplicati/Library/Backend/TencentCOS/Strings.cs
+++ b/Duplicati/Library/Backend/TencentCOS/Strings.cs
@@ -28,8 +28,8 @@ namespace Duplicati.Library.Backend.Strings
         public static string DisplayName { get { return LC.L(@"Tencent COS (Cloud Object Storage)"); } }
         public static string COSAccountDescriptionLong { get { return LC.L(@"Account ID of Tencent Cloud Account"); } }
         public static string COSAccountDescriptionShort { get { return LC.L(@"Account ID"); } }
-        public static string COSAPISecretIdDescriptionLong { get { return LC.L(@"Cloud API Secret Id"); } }
-        public static string COSAPISecretIdDescriptionShort { get { return LC.L(@"Secret Id"); } }
+        public static string COSAPISecretIdDescriptionLong { get { return LC.L(@"Cloud API Secret ID"); } }
+        public static string COSAPISecretIdDescriptionShort { get { return LC.L(@"Secret ID"); } }
         public static string COSAPISecretKeyDescriptionLong { get { return LC.L(@"Cloud API Secret Key"); } }
         public static string COSAPISecretKeyDescriptionShort { get { return LC.L(@"Secret Key"); } }
         public static string COSBucketDescriptionLong { get { return LC.L(@"Bucket, format: BucketName-APPID"); } }

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -1327,7 +1327,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
 
     EditUriBackendConfig.validaters['e2'] = function (scope, continuation) {
         var res =
-                EditUriBackendConfig.require_field(scope, 'Username', gettextCatalog.getString('Idrivee2 Access Key Id')) &&
+                EditUriBackendConfig.require_field(scope, 'Username', gettextCatalog.getString('Idrivee2 Access Key ID')) &&
             EditUriBackendConfig.require_field(scope, 'Password', gettextCatalog.getString('Idrivee2 Access Key Secret')) &&
             EditUriBackendConfig.require_field(scope, 'Server', gettextCatalog.getString('Bucket Name'));
 

--- a/Duplicati/Server/webroot/ngax/templates/backends/aliyunoss.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/aliyunoss.html
@@ -5,9 +5,9 @@
 </div>
 
 <div class="input text">
-    <label for="oss_access_key_id" translate>OSS Access Key Id</label>
+    <label for="oss_access_key_id" translate>OSS Access Key ID</label>
     <input type="text" name="oss_access_key_id" id="oss_access_key_id" ng-model="$parent.oss_access_key_id"
-           placeholder="{{'OSS Access Key Id' | translate}}"/>
+           placeholder="{{'OSS Access Key ID' | translate}}"/>
 </div>
 
 <div class="input password">

--- a/Duplicati/Server/webroot/ngax/templates/backends/cos.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/cos.html
@@ -1,13 +1,13 @@
 <div class="input text">
-    <label for="cos_app_id" translate>COS App Id</label>
+    <label for="cos_app_id" translate>COS App ID</label>
     <input type="text" name="cos_app_id" id="cos_app_id" ng-model="$parent.cos_app_id"
            placeholder="{{'Tencent Cloud Account APPID' | translate}}"/>
 </div>
 
 <div class="input text">
-    <label for="cos_secret_id" translate>COS Secret Id</label>
+    <label for="cos_secret_id" translate>COS Secret ID</label>
     <input type="text" name="cos_secret_id" id="cos_secret_id" ng-model="$parent.cos_secret_id"
-           placeholder="{{'Cloud API Secret Id' | translate}}"/>
+           placeholder="{{'Cloud API Secret ID' | translate}}"/>
 </div>
 
 <div class="input password">

--- a/Duplicati/Server/webroot/ngax/templates/backends/e2.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/e2.html
@@ -1,6 +1,6 @@
 <div class="input text">
-    <label for="e2_access_key" translate>Access Key Id</label>
-    <input type="text" name="e2_access_key" id="e2_access_key" ng-model="$parent.Username" placeholder="{{'Idrivee2 Access Id' | translate}}" />
+    <label for="e2_access_key" translate>Access Key ID</label>
+    <input type="text" name="e2_access_key" id="e2_access_key" ng-model="$parent.Username" placeholder="{{'Idrivee2 Access ID' | translate}}" />
 </div>
 <div class="input password">
     <label for="e2_access_secret" translate>Access Key Secret</label>


### PR DESCRIPTION
This PR intends to fix minor details related to `Id` inside strings.

1. Capitalize `Id` to `ID`
    - For localization.pot
        - `Access Key Id`
        - `Cloud API Secret Id`
        - `Secret Id`
        - `No Access key Id given`
    - For localization_webroot.pot:
        - `Access Key Id`
        - `COS App Id`
        - `COS Secret Id`
        - `Cloud API Secret Id`
        - `Idrivee2 Access Id`
        - `Idrivee2 Access Key Id`
        - `OSS Access Key Id`

3. Split 'AccessKeyID' and 'AccessKeySecret'

4. Remove irregular double quotation marks and "The" from the strings

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>