### PR TITLE
Remove a redundant word from a string on TencentCOS/Strings.cs

### DIFF
--- a/Duplicati/Library/Backend/TencentCOS/Strings.cs
+++ b/Duplicati/Library/Backend/TencentCOS/Strings.cs
@@ -34,7 +34,7 @@ namespace Duplicati.Library.Backend.Strings
         public static string COSAPISecretKeyDescriptionShort { get { return LC.L(@"Secret Key"); } }
         public static string COSBucketDescriptionLong { get { return LC.L(@"Bucket, format: BucketName-APPID"); } }
         public static string COSBucketDescriptionShort { get { return LC.L(@"Bucket"); } }
-        public static string COSLocationDescriptionLong { get { return LC.L(@"Region (Region) is the distribution area of ​​the Tencent cloud hosting machine room, the object storage COS data is stored in the storage buckets of these regions. https://intl.cloud.tencent.com/document/product/436/6224"); } }
+        public static string COSLocationDescriptionLong { get { return LC.L(@"Region is the distribution area of ​​the Tencent cloud hosting machine room, the object storage COS data is stored in the storage buckets of these regions. https://intl.cloud.tencent.com/document/product/436/6224"); } }
         public static string COSLocationDescriptionShort { get { return LC.L(@"Specifies COS location constraints"); } }
         public static string COSStorageClassDescriptionLong { get { return LC.L(@"Storage class of the object; check enumerated values at https://intl.cloud.tencent.com/document/product/436/30925"); } }
         public static string COSStorageClassDescriptionShort { get { return LC.L(@"Storage class of the object"); } }


### PR DESCRIPTION
This PR intends to remove a redundant word from a string on TencentCOS/Strings.cs.

`(Region)` was added by https://github.com/duplicati/duplicati/pull/4236/commits/603b2a3ccdd28b11bc133ef447701d66eada95d9 below the event at https://github.com/duplicati/duplicati/pull/4236#event-3488845860, but it is not clear what the intention of adding it was. It should be safe to be remove it.

Signed-off-by: Suguru Hirahara [luixxiul@users.noreply.github.com](mailto:luixxiul@users.noreply.github.com)