### PR TITLE
Remove class `CheckMonoSSL`

### DIFF
--- a/Duplicati/Library/Modules/Builtin/Strings.cs
+++ b/Duplicati/Library/Modules/Builtin/Strings.cs
@@ -35,12 +35,6 @@ namespace Duplicati.Library.Modules.Builtin.Strings
         public static string ForcepassphrasefromstdinShort { get { return LC.L(@"Read passphrase from STDIN"); } }
         public static string ForcepassphrasefromstdinLong { get { return LC.L(@"By default, the passphrase is attempted read from the TTY device directly, increasing the security by not copying the passphrase into a stream. In some setups, such as when running detached from a console, this does not work. Set this flag to prevent trying a TTY read and only read the passphrase from STDIN."); } }
     }
-    internal static class CheckMonoSSL
-    {
-        public static string Description { get { return LC.L(@"When running with Mono, this module will check if any certificates are installed and suggest installing them otherwise"); } }
-        public static string Displayname { get { return LC.L(@"Check for SSL certificates"); } }
-        public static string ErrorMessage { get { return LC.L(@"No certificates found, you can install some with one of these commands:{0}    cert-sync /etc/ssl/certs/ca-certificates.crt #for Debian based systems{0}    cert-sync /etc/pki/tls/certs/ca-bundle.crt #for RedHat derivatives{0}    curl -LO https://curl.se/ca/cacert.pem; cert-sync --user cacert.pem; rm cacert.pem #for MacOS{0}Read more: {1}", Environment.NewLine, "http://www.mono-project.com/docs/about-mono/releases/3.12.0/#cert-sync"); } }
-    }
     internal static class HttpOptions
     {
         public static string Description { get { return LC.L(@"This module exposes a number of properties that can be used to change the way http requests are issued"); } }

--- a/Duplicati/Library/Utility/SslCertificateValidator.cs
+++ b/Duplicati/Library/Utility/SslCertificateValidator.cs
@@ -38,7 +38,7 @@ namespace Duplicati.Library.Utility
             public SslPolicyErrors SslError { get { return m_errors; } }
 
             public InvalidCertificateException(string certificate, SslPolicyErrors error)
-                : base(Strings.SslCertificateValidator.VerifyCertificateException(error, certificate) + (!OperatingSystem.IsWindows() ? Strings.SslCertificateValidator.MonoHelpSSL : ""))
+                : base(Strings.SslCertificateValidator.VerifyCertificateException(error, certificate))
             {
                 m_certificate = certificate;
                 m_errors = error;

--- a/Duplicati/Library/Utility/Strings.cs
+++ b/Duplicati/Library/Utility/Strings.cs
@@ -28,7 +28,6 @@ namespace Duplicati.Library.Utility.Strings {
     }
     internal static class SslCertificateValidator {
         public static string InvalidCallSequence { get { return LC.L(@"The SSL certificate validator was called in an incorrect order"); } }
-        public static string MonoHelpSSL { get { return LC.L(@"{0}You may want to import a set of trusted certificates into the Mono certificate store.{0}Use the command:{0}    cert-sync /etc/ssl/certs/ca-certificates.crt #for Debian based systems{0}    cert-sync /etc/pki/tls/certs/ca-bundle.crt #for RedHat derivatives{0}Read more: {1}", Environment.NewLine, "http://www.mono-project.com/docs/about-mono/releases/3.12.0/#cert-sync"); } }
         public static string VerifyCertificateException(System.Net.Security.SslPolicyErrors error, string hash) { return LC.L(@"The server certificate had the error {0} and the hash {1}{2}If you trust this certificate, use the commandline option --accept-specified-ssl-hash={1} to accept the server certificate anyway.{2}You can also attempt to import the server certificate into your operating systems trust pool.", error, hash, Environment.NewLine); }
         public static string VerifyCertificateHashError(System.Exception exception, System.Net.Security.SslPolicyErrors error) { return LC.L(@"Failed while validating certificate hash, error message: {0}, SSL error name: {1}", exception, error); }
     }


### PR DESCRIPTION
This PR intends to remove class `CheckMonoSSL` as Mono dependency has been deprecated.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>