### PR TITLE
Remove line breaks from addoredit.html which are not reflected on the actual UI

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -310,9 +310,7 @@
                     </select>
 
                     <div class="hint" translate>
-			The backups will be split up into multiple files called volumes. Here
-			you can set the maximum size of the individual volume files.
-                        <external-link link="'https://www.duplicati.com/articles/Choosing-Sizes/#remote-volume-size'">See this page for more information.</external-link>
+                        The backups will be split up into multiple files called volumes. Here you can set the maximum size of the individual volume files. <external-link link="'https://www.duplicati.com/articles/Choosing-Sizes/#remote-volume-size'">See this page for more information.</external-link>
                     </div>
 
                 </div>


### PR DESCRIPTION
This PR intends to remove line breaks from addoredit.html which are not reflected on the actual UI.

![1](https://github.com/user-attachments/assets/e6c8c0c3-c4ae-46ae-a347-84bf8108a397)

On the Transifex's UI, the string is displayed in this way:

![1](https://github.com/user-attachments/assets/4c537992-c93b-4e6e-a023-dc556f301d7a)

Here is the diff which should be created by extract.sh (not included in this PR):

![2](https://github.com/user-attachments/assets/c4220f19-0016-4766-9738-58731f39c481)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>