### PR TITLE
Fix trailing whitespace characters being removed from strings

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
+++ b/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
@@ -40,8 +40,8 @@
 
         <a href ng-click="deleteItem(item)" title="{{'Remove option' | translate}}">x</a>
 
-        <div ng-if="getDeprecationMessage(item)" class="longdescription"><span translate>DEPRECATED: </span>{{getDeprecationMessage(item)}}</div>
-        <div class="longdescription">{{getLongDescription(item)}}<br>{{'Default value: ' | translate}}"{{getDefaultValue(item)}}"</div>
+        <div ng-if="getDeprecationMessage(item)" class="longdescription" translate>DEPRECATED: {{getDeprecationMessage(item)}}</div>
+        <div class="longdescription">{{getLongDescription(item)}}<div translate>Default value: "{{getDefaultValue(item)}}"</div></div>
     </li>
 
     <li>

--- a/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
+++ b/Duplicati/Server/webroot/ngax/templates/advancedoptionseditor.html
@@ -41,7 +41,7 @@
         <a href ng-click="deleteItem(item)" title="{{'Remove option' | translate}}">x</a>
 
         <div ng-if="getDeprecationMessage(item)" class="longdescription"><span translate>DEPRECATED: </span>{{getDeprecationMessage(item)}}</div>
-        <div class="longdescription">{{getLongDescription(item)}}<br>Default value: "{{getDefaultValue(item)}}"</div>
+        <div class="longdescription">{{getLongDescription(item)}}<br>{{'Default value: ' | translate}}"{{getDefaultValue(item)}}"</div>
     </li>
 
     <li>


### PR DESCRIPTION
This PR intends to fix the issue that trailing whitespace characters are removed from strings.

The current issue is that the trailing whitespace character is removed either by our script to generate pot files or by Transifex.  So basically `<span translate>DEPRECATED: </span>` is rendered as `<span translate>DEPRECATED:</span>` on the actual UI.

This causes the issue that a sentence comes directly after the span element, which means that this kind of sentence appears on the UI: `DEPRECATED:The option …` without a whitespace character after the colon.

With this PR the strings should be generated as below:

````diff
 #: templates/advancedoptionseditor.html:43
-msgid "DEPRECATED:"
+msgid "DEPRECATED: {{getDeprecationMessage(item)}}"
 msgstr ""
````

````diff
+#: templates/advancedoptionseditor.html:44
+msgid "Default value: \"{{getDefaultValue(item)}}\""
+msgstr ""
````

Before:

![before](https://github.com/user-attachments/assets/dcaa6a02-43de-4f26-ae5e-04fd3140e2ae)


After:

![after](https://github.com/user-attachments/assets/9dfc7ab0-d922-4724-9db4-8ca0e1b8e315)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>