### PR TITLE
Fix broken commandline page

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/commandline.html
+++ b/Duplicati/Server/webroot/ngax/templates/commandline.html
@@ -14,7 +14,7 @@
 
             <div class="input textarea linklabel">
                 <label for="target"><a href class="target" ng-click="EditUriState = true">Target URL &gt;</a></label>
-                <textarea name="target" id="target" ng-model="TargetURL" placeholder="{{'Enter a url, or click the \'Target URL &gt;\' link | translate}}"></textarea>
+                <textarea name="target" id="target" ng-model="TargetURL" placeholder="{{'Enter a url, or click the &quot;Target URL &gt;&quot; link' | translate}}"></textarea>
             </div>
 
             <div class="input textarea">


### PR DESCRIPTION
Fixes https://github.com/duplicati/duplicati/issues/5300

This PR, follow-up to https://github.com/duplicati/duplicati/pull/5274, intends to fix broken command line page. Since `placeholder` is a textarea attirbute and `\` does not have a special meaning in HTML, it did not escape the quotes.

After:
![after](https://github.com/user-attachments/assets/95ccb4db-1118-4aa7-89c4-75b55a95b21c)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>