### PR TITLE
Update 'Command' select element on command line page

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/commandline.html
+++ b/Duplicati/Server/webroot/ngax/templates/commandline.html
@@ -4,13 +4,10 @@
 
         <div ng-hide="EditUriState">
 
-            <div class="input mixed">
+            <div class="input select">
                 <label for="command" translate>Command</label>
-                <select name="command" id="command" ng-model="Command" ng-options="item for item in SupportedCommands">
-                </select>
-                <div style="float: left">{{CommandHelp[Command]}}</div>
+                <select name="command" id="command" ng-model="Command" ng-options="item for item in SupportedCommands"></select>
             </div>
-
 
             <div class="input textarea linklabel">
                 <label for="target"><a href class="target" ng-click="EditUriState = true" translate>Target URL &gt;</a></label>


### PR DESCRIPTION
This PR intends to update 'Command' select element on command line page.

Before:
![before](https://github.com/user-attachments/assets/70a14157-2206-44fb-9216-021d62793d40)

After:
![after](https://github.com/user-attachments/assets/2e4f6322-a6a7-4692-803c-23b1bf4f9948)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>