### PR TITLE
Fix and sort entries on Duplicati.License.csproj to fix license tab on about page

### DIFF
--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -27,6 +27,10 @@
       <Link>licenses\alphavss\License.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\alphavss\licensedata.json">
+      <Link>licenses\alphavss\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">
       <Link>licenses\FluentFTP\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -111,10 +115,6 @@
     <Content Include="..\..\thirdparty\Json.NET\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>licenses\Json.NET\License.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\alphavss\licensedata.json">
-      <Link>licenses\alphavss\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\AWS SDK\licensedata.json">
       <Link>licenses\AWSSDK\licensedata.json</Link>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -79,6 +79,18 @@
       <Link>licenses\AWSSDK\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\CoCoL\download.txt">
+      <Link>licenses\CoCoL\download.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\CoCoL\license.txt">
+      <Link>licenses\CoCoL\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\CoCoL\licensedata.json">
+      <Link>licenses\CoCoL\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">
       <Link>licenses\FluentFTP\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -263,18 +275,6 @@
     </Content>
     <Content Include="..\..\thirdparty\jQuery\licensedata.json">
       <Link>licenses\jQuery\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\CoCoL\download.txt">
-      <Link>licenses\CoCoL\download.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\CoCoL\license.txt">
-      <Link>licenses\CoCoL\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\CoCoL\licensedata.json">
-      <Link>licenses\CoCoL\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -163,6 +163,18 @@
       <Link>licenses\MegaApi\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\MimeKit\Homepage.txt">
+      <Link>licenses\MimeKit\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\MimeKit\license.txt">
+      <Link>licenses\MimeKit\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\MimeKit\licensedata.json">
+      <Link>licenses\MimeKit\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -291,18 +303,6 @@
     </Content>
     <Content Include="..\..\thirdparty\SharpAESCrypt\licensedata.json">
       <Link>licenses\SharpAESCrypt\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MimeKit\Homepage.txt">
-      <Link>licenses\MimeKit\Homepage.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MimeKit\license.txt">
-      <Link>licenses\MimeKit\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MimeKit\licensedata.json">
-      <Link>licenses\MimeKit\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SharpCompress\licensedata.json">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -187,6 +187,18 @@
       <Link>licenses\Otp.NET\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\SharePointPnP-Sites-Core\download.txt">
+      <Link>licenses\SharePointPnP-Sites-Core\download.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\SharePointPnP-Sites-Core\license.txt">
+      <Link>licenses\SharePointPnP-Sites-Core\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\SharePointPnP-Sites-Core\licensedata.json">
+      <Link>licenses\SharePointPnP-Sites-Core\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\SharpCompress\download.txt">
       <Link>licenses\SharpCompress\download.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -276,18 +288,6 @@
     </Content>
     <Content Include="..\..\thirdparty\WindowsAzureStorage\licensedata.json">
       <Link>licenses\WindowsAzure\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SharePointPnP-Sites-Core\download.txt">
-      <Link>licenses\SharePointPnP-Sites-Core\download.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SharePointPnP-Sites-Core\license.txt">
-      <Link>licenses\SharePointPnP-Sites-Core\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SharePointPnP-Sites-Core\licensedata.json">
-      <Link>licenses\SharePointPnP-Sites-Core\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="acknowledgements.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -151,6 +151,18 @@
       <Link>licenses\ManagedLZMA\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\MegaApi\Homepage.txt">
+      <Link>licenses\MegaApi\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\MegaApi\license.txt">
+      <Link>licenses\MegaApi\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\MegaApi\licensedata.json">
+      <Link>licenses\MegaApi\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -279,18 +291,6 @@
     </Content>
     <Content Include="..\..\thirdparty\SharpAESCrypt\licensedata.json">
       <Link>licenses\SharpAESCrypt\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MegaApi\Homepage.txt">
-      <Link>licenses\MegaApi\Homepage.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MegaApi\licensedata.json">
-      <Link>licenses\MegaApi\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MegaApi\license.txt">
-      <Link>licenses\MegaApi\license.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\MimeKit\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -139,6 +139,18 @@
       <Link>licenses\MailKit\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\ManagedLZMA\download.txt">
+      <Link>licenses\ManagedLZMA\download.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\ManagedLZMA\license.txt">
+      <Link>licenses\ManagedLZMA\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\ManagedLZMA\licensedata.json">
+      <Link>licenses\ManagedLZMA\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -212,18 +224,6 @@
     </Content>
     <Content Include="..\..\thirdparty\SSH.NET\licensedata.json">
       <Link>licenses\SSH.NET\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\ManagedLZMA\licensedata.json">
-      <Link>licenses\ManagedLZMA\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\ManagedLZMA\download.txt">
-      <Link>licenses\ManagedLZMA\download.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\ManagedLZMA\license.txt">
-      <Link>licenses\ManagedLZMA\license.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SQLite\licensedata.json">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -235,6 +235,18 @@
       <Link>licenses\SQLite\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\SSH.NET\Homepage.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>licenses\SSH.NET\Homepage.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\SSH.NET\License.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>licenses\SSH.NET\License.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\SSH.NET\licensedata.json">
+      <Link>licenses\SSH.NET\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Tencentyun\download.txt">
       <Link>licenses\Tencentyun\download.txt</Link>
     </Content>
@@ -268,18 +280,6 @@
     </Content>
     <Content Include="duplicati-url.txt">
       <Link>licenses\duplicati-url.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SSH.NET\Homepage.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>licenses\SSH.NET\Homepage.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\SSH.NET\License.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>licenses\SSH.NET\License.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\SSH.NET\licensedata.json">
-      <Link>licenses\SSH.NET\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SshNet.Security.Cryptography\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -43,6 +43,18 @@
       <Link>licenses\AngularGettext\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\AngularJS\Homepage.txt">
+      <Link>licenses\AngularJS\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\AngularJS\License.txt">
+      <Link>licenses\AngularJS\License.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\AngularJS\licensedata.json">
+      <Link>licenses\AngularJS\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">
       <Link>licenses\FluentFTP\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -239,18 +251,6 @@
     </Content>
     <Content Include="..\..\thirdparty\MegaApi\license.txt">
       <Link>licenses\MegaApi\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\AngularJS\Homepage.txt">
-      <Link>licenses\AngularJS\Homepage.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\AngularJS\License.txt">
-      <Link>licenses\AngularJS\License.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\AngularJS\licensedata.json">
-      <Link>licenses\AngularJS\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\jQuery\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -231,6 +231,10 @@
       <Link>licenses\SQLite\License.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\SQLite\licensedata.json">
+      <Link>licenses\SQLite\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Tencentyun\download.txt">
       <Link>licenses\Tencentyun\download.txt</Link>
     </Content>
@@ -276,10 +280,6 @@
     </Content>
     <Content Include="..\..\thirdparty\SSH.NET\licensedata.json">
       <Link>licenses\SSH.NET\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SQLite\licensedata.json">
-      <Link>licenses\SQLite\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SshNet.Security.Cryptography\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -199,6 +199,18 @@
       <Link>licenses\SharePointPnP-Sites-Core\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\SharpAESCrypt\download.txt">
+      <Link>licenses\SharpAESCrypt\download.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\SharpAESCrypt\License.txt">
+      <Link>licenses\SharpAESCrypt\License.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\SharpAESCrypt\licensedata.json">
+      <Link>licenses\SharpAESCrypt\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\SharpCompress\download.txt">
       <Link>licenses\SharpCompress\download.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -291,18 +303,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="acknowledgements.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SharpAESCrypt\download.txt">
-      <Link>licenses\SharpAESCrypt\download.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SharpAESCrypt\License.txt">
-      <Link>licenses\SharpAESCrypt\License.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SharpAESCrypt\licensedata.json">
-      <Link>licenses\SharpAESCrypt\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SharpCompress\licensedata.json">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -265,6 +265,10 @@
     <Content Include="..\..\thirdparty\Tencentyun\LICENSE.txt">
       <Link>licenses\Tencentyun\LICENSE.txt</Link>
     </Content>
+    <Content Include="..\..\thirdparty\Tencentyun\licensedata.json">
+      <Link>licenses\Tencentyun\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\TLSharp\Homepage.txt">
       <Link>licenses\TLSharp\Homepage.txt</Link>
     </Content>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -127,6 +127,18 @@
       <Link>licenses\Json.NET\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\MailKit\Homepage.txt">
+      <Link>licenses\MailKit\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\MailKit\license.txt">
+      <Link>licenses\MailKit\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\MailKit\licensedata.json">
+      <Link>licenses\MailKit\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -279,18 +291,6 @@
     </Content>
     <Content Include="..\..\thirdparty\MegaApi\license.txt">
       <Link>licenses\MegaApi\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MailKit\Homepage.txt">
-      <Link>licenses\MailKit\Homepage.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MailKit\license.txt">
-      <Link>licenses\MailKit\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\MailKit\licensedata.json">
-      <Link>licenses\MailKit\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\MimeKit\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -99,6 +99,10 @@
       <Link>licenses\FluentFTP\License.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\FluentFTP\licensedata.json">
+      <Link>licenses\FluentFTP\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -275,18 +279,6 @@
     </Content>
     <Content Include="..\..\thirdparty\jQuery\licensedata.json">
       <Link>licenses\jQuery\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">
-      <Link>licenses\FluentFTP\Homepage.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\FluentFTP\License.txt">
-      <Link>licenses\FluentFTP\License.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\FluentFTP\licensedata.json">
-      <Link>licenses\FluentFTP\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\MailKit\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -31,6 +31,18 @@
       <Link>licenses\alphavss\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\angular-gettext\Homepage.txt">
+      <Link>licenses\AngularGettext\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\angular-gettext\License.txt">
+      <Link>licenses\AngularGettext\License.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\angular-gettext\licensedata.json">
+      <Link>licenses\AngularGettext\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">
       <Link>licenses\FluentFTP\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -84,9 +96,15 @@
     </Content>
     <Content Include="..\..\thirdparty\uplink.NET\Homepage.txt">
       <Link>licenses\uplink.NET\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\uplink.NET\license.txt">
       <Link>licenses\uplink.NET\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\uplink.NET\licensedata.json">
+      <Link>licenses\uplink.NET\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\LICENSE.txt">
       <Link>licenses\license.txt</Link>
@@ -293,18 +311,6 @@
     </Content>
     <Content Include="..\..\thirdparty\MimeKit\licensedata.json">
       <Link>licenses\MimeKit\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\angular-gettext\Homepage.txt">
-      <Link>licenses\AngularGettext\Homepage.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\angular-gettext\License.txt">
-      <Link>licenses\AngularGettext\License.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\angular-gettext\licensedata.json">
-      <Link>licenses\AngularGettext\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SharpCompress\licensedata.json">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -7,6 +7,18 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Content Include="..\..\thirdparty\aliyun-oss-csharp-sdk\download.txt">
+      <Link>licenses\aliyun-oss-csharp-sdk\README.md</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\aliyun-oss-csharp-sdk\LICENSE.txt">
+      <Link>licenses\aliyun-oss-csharp-sdk\LICENSE.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\aliyun-oss-csharp-sdk\licensedata.json">
+      <Link>licenses\aliyun-oss-csharp-sdk\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\alphavss\Homepage.txt">
       <Link>licenses\alphavss\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -299,18 +311,7 @@
       <Link>licenses\SharpCompress\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\thirdparty\aliyun-oss-csharp-sdk\licensedata.json">
-      <Link>licenses\aliyun-oss-csharp-sdk\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\aliyun-oss-csharp-sdk\LICENSE.txt">
-      <Link>licenses\aliyun-oss-csharp-sdk\LICENSE.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\aliyun-oss-csharp-sdk\download.txt">
-      <Link>licenses\aliyun-oss-csharp-sdk\README.md</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+
   </ItemGroup>
   
   <ItemGroup>
@@ -321,4 +322,3 @@
     <ProjectReference Include="..\Library\Utility\Duplicati.Library.Utility.csproj" />
   </ItemGroup>
 </Project>
-

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -219,6 +219,10 @@
       <Link>licenses\SharpCompress\License.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\SharpCompress\licensedata.json">
+      <Link>licenses\SharpCompress\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\SQLite\Homepage.txt">
       <Link>licenses\SQLite\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -305,10 +309,7 @@
     <Content Include="acknowledgements.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\thirdparty\SharpCompress\licensedata.json">
-      <Link>licenses\SharpCompress\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+
 
   </ItemGroup>
   

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -55,6 +55,18 @@
       <Link>licenses\AngularJS\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\Artalk.Xmpp\download.txt">
+      <Link>licenses\Artalk.Xmpp\download.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\Artalk.Xmpp\license.txt">
+      <Link>licenses\Artalk.Xmpp\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\Artalk.Xmpp\licensedata.json">
+      <Link>licenses\Artalk.Xmpp\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">
       <Link>licenses\FluentFTP\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -215,18 +227,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="acknowledgements.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\Artalk.Xmpp\download.txt">
-      <Link>licenses\Artalk.Xmpp\download.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\Artalk.Xmpp\license.txt">
-      <Link>licenses\Artalk.Xmpp\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\Artalk.Xmpp\licensedata.json">
-      <Link>licenses\Artalk.Xmpp\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\SharpAESCrypt\download.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -103,6 +103,18 @@
       <Link>licenses\FluentFTP\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\jQuery\Homepage.txt">
+      <Link>licenses\jQuery\Homepage.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\jQuery\License.txt">
+      <Link>licenses\jQuery\License.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\jQuery\licensedata.json">
+      <Link>licenses\jQuery\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -267,18 +279,6 @@
     </Content>
     <Content Include="..\..\thirdparty\MegaApi\license.txt">
       <Link>licenses\MegaApi\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\jQuery\Homepage.txt">
-      <Link>licenses\jQuery\Homepage.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\jQuery\License.txt">
-      <Link>licenses\jQuery\License.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\jQuery\licensedata.json">
-      <Link>licenses\jQuery\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\MailKit\Homepage.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -281,18 +281,6 @@
       <Link>licenses\uplink.NET\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\LICENSE.txt">
-      <Link>licenses\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="duplicati-url.txt">
-      <Link>licenses\duplicati-url.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\changelog.txt">
-      <Link>changelog.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="..\..\thirdparty\WindowsAzureStorage\download.txt">
       <Link>licenses\WindowsAzure\download.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -303,6 +291,18 @@
     </Content>
     <Content Include="..\..\thirdparty\WindowsAzureStorage\licensedata.json">
       <Link>licenses\WindowsAzure\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\LICENSE.txt">
+      <Link>licenses\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="duplicati-url.txt">
+      <Link>licenses\duplicati-url.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\changelog.txt">
+      <Link>changelog.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="acknowledgements.txt">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -7,6 +7,21 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Content Include="acknowledgements.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="duplicati-url.txt">
+      <Link>licenses\duplicati-url.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\changelog.txt">
+      <Link>changelog.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\LICENSE.txt">
+      <Link>licenses\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\aliyun-oss-csharp-sdk\download.txt">
       <Link>licenses\aliyun-oss-csharp-sdk\README.md</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -293,23 +308,6 @@
       <Link>licenses\WindowsAzure\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\LICENSE.txt">
-      <Link>licenses\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="duplicati-url.txt">
-      <Link>licenses\duplicati-url.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\changelog.txt">
-      <Link>changelog.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="acknowledgements.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-
-
   </ItemGroup>
   
   <ItemGroup>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -276,9 +276,11 @@
     </Content>
     <Content Include="..\..\thirdparty\Tencentyun\download.txt">
       <Link>licenses\Tencentyun\download.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\Tencentyun\LICENSE.txt">
       <Link>licenses\Tencentyun\LICENSE.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\Tencentyun\licensedata.json">
       <Link>licenses\Tencentyun\licensedata.json</Link>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -115,6 +115,18 @@
       <Link>licenses\jQuery\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\Json.NET\Homepage.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>licenses\Json.NET\Homepage.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\Json.NET\License.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>licenses\Json.NET\License.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\Json.NET\licensedata.json">
+      <Link>licenses\Json.NET\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Otp.NET\Homepage.txt">
       <Link>licenses\Otp.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -188,18 +200,6 @@
     </Content>
     <Content Include="..\..\thirdparty\SSH.NET\licensedata.json">
       <Link>licenses\SSH.NET\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\Json.NET\Homepage.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>licenses\Json.NET\Homepage.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\Json.NET\License.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>licenses\Json.NET\License.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\Json.NET\licensedata.json">
-      <Link>licenses\Json.NET\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\ManagedLZMA\licensedata.json">

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -269,15 +269,6 @@
       <Link>licenses\Tencentyun\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\thirdparty\TLSharp\Homepage.txt">
-      <Link>licenses\TLSharp\Homepage.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\TLSharp\License.txt">
-      <Link>licenses\TLSharp\License.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\TLSharp\licensedata.json">
-      <Link>licenses\TLSharp\licensedata.json</Link>
-    </Content>
     <Content Include="..\..\thirdparty\uplink.NET\Homepage.txt">
       <Link>licenses\uplink.NET\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -247,6 +247,18 @@
       <Link>licenses\SSH.NET\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\SshNet.Security.Cryptography\Homepage.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>licenses\SshNet.Security.Cryptography\Homepage.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\SshNet.Security.Cryptography\License.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>licenses\SshNet.Security.Cryptography\License.txt</Link>
+    </Content>
+    <Content Include="..\..\thirdparty\SshNet.Security.Cryptography\licensedata.json">
+      <Link>licenses\SshNet.Security.Cryptography\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\Tencentyun\download.txt">
       <Link>licenses\Tencentyun\download.txt</Link>
     </Content>
@@ -281,14 +293,6 @@
     <Content Include="duplicati-url.txt">
       <Link>licenses\duplicati-url.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\SshNet.Security.Cryptography\Homepage.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>licenses\SshNet.Security.Cryptography\Homepage.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\SshNet.Security.Cryptography\License.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>licenses\SshNet.Security.Cryptography\License.txt</Link>
     </Content>
     <Content Include="..\..\changelog.txt">
       <Link>changelog.txt</Link>

--- a/Duplicati/License/Duplicati.License.csproj
+++ b/Duplicati/License/Duplicati.License.csproj
@@ -67,6 +67,18 @@
       <Link>licenses\Artalk.Xmpp\licensedata.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\thirdparty\AWS SDK\download.txt">
+      <Link>licenses\AWSSDK\download.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\AWS SDK\license.txt">
+      <Link>licenses\AWSSDK\license.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\thirdparty\AWS SDK\licensedata.json">
+      <Link>licenses\AWSSDK\licensedata.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\thirdparty\FluentFTP\Homepage.txt">
       <Link>licenses\FluentFTP\Homepage.txt</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -157,18 +169,6 @@
     <Content Include="..\..\thirdparty\Json.NET\License.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>licenses\Json.NET\License.txt</Link>
-    </Content>
-    <Content Include="..\..\thirdparty\AWS SDK\licensedata.json">
-      <Link>licenses\AWSSDK\licensedata.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\AWS SDK\download.txt">
-      <Link>licenses\AWSSDK\download.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\thirdparty\AWS SDK\license.txt">
-      <Link>licenses\AWSSDK\license.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\thirdparty\Json.NET\licensedata.json">
       <Link>licenses\Json.NET\licensedata.json</Link>

--- a/Duplicati/Server/webroot/ngax/templates/about.html
+++ b/Duplicati/Server/webroot/ngax/templates/about.html
@@ -54,7 +54,7 @@
         <ul>
             <li ng-show="Licenses == null" translate>Loading …</li>
             <li ng-repeat="item in Licenses" class="licenseentry">
-                <external-link class="itemlink" link="item.link">{{item.name}}</external-link>: {{item.description}}. <external-link class="licenselink" link="item.licenselink">{{item.license}} licensed</external-link>
+                <external-link class="itemlink" link="item.link">{{item.name}}</external-link>: {{item.description}} <external-link class="licenselink" link="item.licenselink">{{item.license}} licensed</external-link>
             </li>
         </ul>
     </div>

--- a/thirdparty/AWS SDK/licensedata.json
+++ b/thirdparty/AWS SDK/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "AWS SDK for .NET",
-    "description": "An SDK to connect with Amazon Web Services",
+    "description": "An SDK to connect with Amazon Web Services.",
     "link": "http://aws.amazon.com/sdkfornet/",
     "license": "Apache 2.0",
     "notes": "Patched to support additional timeout properties"

--- a/thirdparty/AngularJS/licensedata.json
+++ b/thirdparty/AngularJS/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "AngularJS",
-    "description": "Superheroic JavaScript MVW Framework",
+    "description": "Superheroic JavaScript MVW Framework.",
     "link": "https://angularjs.org/",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/Artalk.Xmpp/licensedata.json
+++ b/thirdparty/Artalk.Xmpp/licensedata.json
@@ -1,6 +1,6 @@
 {
   "name": "Artalk.Xmpp",
-  "description": ".NET assembly for communicating with an XMPP server",
+  "description": ".NET assembly for communicating with an XMPP server.",
   "link": "https://github.com/araditc/Artalk.Xmpp",
   "license": "MIT",
   "notes": ""

--- a/thirdparty/CoCoL/licensedata.json
+++ b/thirdparty/CoCoL/licensedata.json
@@ -1,6 +1,6 @@
 {
   "name": "CoCoL",
-  "description": "Concurrent Communications Library",
+  "description": "Concurrent Communications Library.",
   "link": "https://github.com/kenkendk/cocol",
   "license": "MIT",
   "notes": ""

--- a/thirdparty/FluentFTP/licensedata.json
+++ b/thirdparty/FluentFTP/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "FluentFTP",
-    "description": "A .Net library for connecting with the FTP protocol",
+    "description": "A .Net library for connecting with the FTP protocol.",
     "link": "https://github.com/robinrodricks/FluentFTP",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/Json.NET/licensedata.json
+++ b/thirdparty/Json.NET/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "Json.NET",
-    "description": "A library for serializing and deserializing .Net and JSON objects",
+    "description": "A library for serializing and deserializing .Net and JSON objects.",
     "link": "https://github.com/JamesNK/Newtonsoft.Json/",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/MailKit/licensedata.json
+++ b/thirdparty/MailKit/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "MailKit",
-    "description": "A cross-platform .NET library for IMAP, POP3, and SMTP",
+    "description": "A cross-platform .NET library for IMAP, POP3, and SMTP.",
     "link": "https://github.com/jstedfast/MailKit/",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/ManagedLZMA/licensedata.json
+++ b/thirdparty/ManagedLZMA/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "ManagedLZMA",
-    "description": "An LZMA/7z compression library by Tobias Käs",
+    "description": "An LZMA/7z compression library by Tobias Käs.",
     "link": "https://github.com/weltkante/managed-lzma",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/MegaApi/licensedata.json
+++ b/thirdparty/MegaApi/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "MegaApi",
-    "description": "C# library to access http://mega.co.nz API",
+    "description": "C# library to access http://mega.co.nz API.",
     "link": "https://github.com/gpailler/MegaApiClient",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/SQLite/licensedata.json
+++ b/thirdparty/SQLite/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "SQLite for .Net",
-    "description": "A .Net library for working with SQLite databases",
+    "description": "A .Net library for working with SQLite databases.",
     "link": "https://system.data.sqlite.org",
     "license": "Public Domain",
     "notes": ""

--- a/thirdparty/SSH.NET/licensedata.json
+++ b/thirdparty/SSH.NET/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "SSH Client for .Net",
-    "description": "A .Net library for connecting with the SSH protocol",
+    "description": "A .Net library for connecting with the SSH protocol.",
     "link": "https://github.com/sshnet/SSH.NET",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/SharePointPnP-Sites-Core/licensedata.json
+++ b/thirdparty/SharePointPnP-Sites-Core/licensedata.json
@@ -1,7 +1,7 @@
 {
     "name": "SharePointPnP-Sites-Core",
-    "description": "Office 365 Dev PnP Core component (.NET) targeted for increasing developer productivity with CSOM based solutions. ",
+    "description": "Office 365 Dev PnP Core component (.NET) targeted for increasing developer productivity with CSOM based solutions.",
     "link": "https://github.com/SharePoint/PnP-Sites-Core",
-    "license": "license.txt",
+    "license": "MIT",
     "notes": ""
 }

--- a/thirdparty/SharpAESCrypt/licensedata.json
+++ b/thirdparty/SharpAESCrypt/licensedata.json
@@ -1,6 +1,6 @@
 {
   "name": "SharpAESCrypt",
-  "description": "A C# implementation of the AESCrypt file format ",
+  "description": "A C# implementation of the AESCrypt file format.",
   "link": "https://github.com/duplicati/sharpaescrypt",
   "license": "MIT",
   "notes": ""

--- a/thirdparty/SharpCompress/licensedata.json
+++ b/thirdparty/SharpCompress/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "SharpCompress",
-    "description": "A C# Library for RAR, Zip, 7z, Tar and BZ2 compression",
+    "description": "A C# Library for RAR, Zip, 7z, Tar and BZ2 compression.",
     "link": "https://github.com/adamhathcock/sharpcompress/",
     "license": "Microsoft Public",
     "notes": ""

--- a/thirdparty/SshNet.Security.Cryptography/licensedata.json
+++ b/thirdparty/SshNet.Security.Cryptography/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "SshNet.Security.Cryptography",
-    "description": "Crypto classes for SSH.NET",
+    "description": "Crypto classes for SSH.NET.",
     "link": "https://github.com/sshnet/Cryptography",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/WindowsAzureStorage/licensedata.json
+++ b/thirdparty/WindowsAzureStorage/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "WindowsAzure.Blob",
-    "description": "A .Net library for working with Azure Blobs",
+    "description": "A .Net library for working with Azure Blobs.",
     "link": "http://azure.microsoft.com/",
     "license": "Apache 2.0",
     "notes": ""

--- a/thirdparty/aliyun-oss-csharp-sdk/licensedata.json
+++ b/thirdparty/aliyun-oss-csharp-sdk/licensedata.json
@@ -1,6 +1,6 @@
 {
   "name": "aliyun-oss-csharp-sdk",
-  "description": "Alibaba Cloud Object Storage Service (OSS) library for C#",
+  "description": "Alibaba Cloud Object Storage Service (OSS) library for C#.",
   "link": "https://github.com/aliyun/aliyun-oss-csharp-sdk",
   "license": "MIT",
   "notes": ""

--- a/thirdparty/alphavss/licensedata.json
+++ b/thirdparty/alphavss/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "AlphaVSS",
-    "description": "A library for accessing Windows Shadow Copy service",
+    "description": "A library for accessing Windows Shadow Copy service.",
     "link": "https://github.com/alphaleonis/AlphaVSS/",
     "license": "Apache 2.0",
     "notes": ""

--- a/thirdparty/angular-gettext/licensedata.json
+++ b/thirdparty/angular-gettext/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-gettext",
-    "description": "Super-simple translation support for Angular.JS",
+    "description": "Super-simple translation support for Angular.JS.",
     "link": "https://angular-gettext.rocketeer.be/",
     "license": "MIT",
     "notes": ""

--- a/thirdparty/jQuery/licensedata.json
+++ b/thirdparty/jQuery/licensedata.json
@@ -1,6 +1,6 @@
 {
     "name": "jQuery",
-    "description": "The Write Less, Do More, JavaScript Library",
+    "description": "The Write Less, Do More, JavaScript Library.",
     "link": "https://jquery.com/",
     "license": "MIT",
     "notes": ""


### PR DESCRIPTION
This PR intends to fix the issue that some of the third party libraries are not listed on the license tab on about page.

Due to an error that licensedata.json for `SshNet.Security.Cryptography` was not included on `Duplicati.License.csproj`, these three libraries are not listed on the tab (on master branch):

- `SshNet.Security.Cryptography`
- `qcloud-sdk-dotnet`
- `uplink.NET`

This PR also should remove the hard-coded period from about.html for empty descriptions (please see `qcloud-sdk-dotnet`) and fix the license information for `SharePointPnP-Sites-Core` not being correctly specified. Duplicated periods are also going to be removed (please see `MimeKit` for example).

In order to tidy the list up, this PR also should sort entries.

Before:
![before](https://github.com/user-attachments/assets/a9d47c0a-451e-4969-9621-0014dbdca693)

After:
![after](https://github.com/user-attachments/assets/810c51e2-df51-4b72-b302-1cb1c91f0522)

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>