### PR TITLE
Replace PGP keyserver with OpenPGP.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The latest version of Duplicati is a beta version for the Duplicati 2.0 release.
 The beta release will automatically notify you of updates and allows you to upgrade with a single click (or command in the terminal).
 For even more [bleeding edge access, check the latest releases](https://github.com/duplicati/duplicati/releases) or choose another update channel in the UI or on the commandline.
 
-All releases are GPG signed with the public key [3DAC703D](https://pgp.mit.edu/pks/lookup?op=get&search=0xC20E90473DAC703D). The latest signature file and latest ASCII signature file are also available from [the Duplicati download page](https://github.com/duplicati/duplicati/releases).
+All releases are GPG signed with the public key [3DAC703D](https://keys.openpgp.org/search?q=0xC20E90473DAC703D). The latest signature file and latest ASCII signature file are also available from [the Duplicati download page](https://github.com/duplicati/duplicati/releases).
 
 Support
 =======

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,7 @@ Duplicati 的最新版本是 Duplicati 2.0 发布的测试版。
 测试版将自动通知您更新，并允许您通过单击（或在终端中的命令）升级。
 要获取更多[前沿版本，查看最新发布](https://github.com/duplicati/duplicati/releases)或在 UI 或命令行中选择另一个更新渠道。
 
-所有发布版本都使用公钥 [3DAC703D](https://pgp.mit.edu/pks/lookup?op=get&search=0xC20E90473DAC703D) 进行 GPG 签名。最新的签名文件和最新的 ASCII 签名文件也可以在 [Duplicati 下载页面](https://github.com/duplicati/duplicati/releases) 获取。
+所有发布版本都使用公钥 [3DAC703D](https://keys.openpgp.org/search?q=0xC20E90473DAC703D) 进行 GPG 签名。最新的签名文件和最新的 ASCII 签名文件也可以在 [Duplicati 下载页面](https://github.com/duplicati/duplicati/releases) 获取。
 
 支持
 =======

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 Any security issues can be reported to the main author at kenneth@duplicati.com.
 
-If the issue is sensitive, the [PGP signing key](https://pgp.mit.edu/pks/lookup?op=get&search=0xC20E90473DAC703D) can be used for encryption.
+If the issue is sensitive, the [PGP signing key](https://keys.openpgp.org/search?q=0xC20E90473DAC703D) can be used for encryption.


### PR DESCRIPTION
This PR intends to replace PGP keyserver with OpenPGP.org.

This can be of just my preference; if we will stick to pgp.mit.edu, then it is fine and I am going to close this PR.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>
