### PR TITLE
Make strings for deprecated options consistent

### DIFF
--- a/Duplicati/Library/Compression/Strings.cs
+++ b/Duplicati/Library/Compression/Strings.cs
@@ -23,7 +23,7 @@ namespace Duplicati.Library.Compression.Strings {
     internal static class FileArchiveZip {
         public static string Description { get { return LC.L(@"This module provides the industry standard Zip compression. Files created with this module can be read by any standard-compliant zip application."); } }
         public static string DisplayName { get { return LC.L(@"Zip compression"); } }
-        public static string CompressionlevelDeprecated(string optionname) { return LC.L(@"Please use the {0} option instead.", optionname); }
+        public static string CompressionlevelDeprecated(string optionname) { return LC.L(@"Use the option --{0} instead.", optionname); }
         public static string CompressionlevelLong { get { return LC.L(@"This option controls the compression level used. A setting of zero gives no compression, and a setting of 9 gives maximum compression."); } }
         public static string CompressionlevelShort { get { return LC.L(@"Sets the Zip compression level"); } }
         public static string CompressionmethodLong(string optionname) { return LC.L(@"This option can be used to set an alternative compressor method, such as LZMA. Note that using another value than Deflate will cause the {0} option to be ignored.", optionname); }

--- a/Duplicati/Library/Encryption/Strings.cs
+++ b/Duplicati/Library/Encryption/Strings.cs
@@ -30,7 +30,7 @@ namespace Duplicati.Library.Encryption.Strings
         public static string EmptyKeyError { get { return LC.L(@"Empty passphrase not allowed"); } }
         public static string AessetthreadlevelLong { get { return LC.L(@"Use this option to set the thread level allowed for AES crypt operations."); } }
         public static string AessetthreadlevelShort { get { return LC.L(@"Set thread level utilized for crypting"); } }
-        public static string AessetthreadlevelDeprecated { get { return LC.L(@"This option has no effect and should not be used."); } }
+        public static string AessetthreadlevelDeprecated { get { return LC.L(@"The option --{0} is no longer used and has been deprecated.", "aes-set-threadlevel"); } }
     }
     internal static class EncryptionBase
     {

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -27,7 +27,7 @@ namespace Duplicati.Library.Main.Strings
     {
         public static string HashMismatchError(string filename, string recordedhash, string actualhash) { return LC.L(@"Hash mismatch on file ""{0}"", recorded hash: {1}, actual hash {2}", filename, recordedhash, actualhash); }
         public static string DownloadedFileSizeError(string filename, long actualsize, long expectedsize) { return LC.L(@"The file {0} was downloaded and had size {1} but the size was expected to be {2}", filename, actualsize, expectedsize); }
-        public static string DeprecatedOptionUsedWarning(string optionname, string message) { return LC.L(@"The option {0} is deprecated: {1}", optionname, message); }
+        public static string DeprecatedOptionUsedWarning(string optionname, string message) { return LC.L(@"The option --{0} has been deprecated: {1}", optionname, message); }
         public static string DuplicateOptionNameWarning(string optionname) { return LC.L(@"The option --{0} exists more than once. Please report this to the developers", optionname); }
         public static string NoSourceFoldersError { get { return LC.L(@"No source folders specified for backup"); } }
         public static string SourceIsMissingError(string foldername) { return LC.L(@"Backup aborted since the source path {0} does not exist. Please verify that the source path exists, or remove the source path from the backup configuration, or set the allow-missing-source option.", foldername); }

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -214,7 +214,7 @@ namespace Duplicati.Library.Main.Strings
         public static string OverwriteShort { get { return LC.L(@"Overwrite files when restoring"); } }
         public static string VerboseLong { get { return LC.L(@"Use this option to increase the amount of output generated when running an option. Generally this option will produce a line for each file processed."); } }
         public static string VerboseShort { get { return LC.L(@"Output more progress information"); } }
-        public static string VerboseDeprecated { get { return LC.L(@"Set a log-level for the desired output method instead."); } }
+        public static string VerboseDeprecated { get { return LC.L("Use the options --{0} and --{1} instead.", "log-file-log-level", "console-log-level"); } }
         public static string FullresultLong { get { return LC.L(@"Use this option to increase the amount of output generated as the result of the operation, including all filenames."); } }
         public static string FullresultShort { get { return LC.L(@"Output full results"); } }
         public static string UploadverificationfileLong { get { return LC.L(@"Use this option to upload a verification file after changing the remote storage. The file is not encrypted and contains the size and SHA256 hashes of all the remote files and can be used to verify the integrity of the files."); } }


### PR DESCRIPTION
This PR intends to make strings for deprecated options consistent.

Here is the list of strings for the deprecated options:
````
--aes-set-threadlevel=
--disable-filepath-cache=true
--disable-filepath-cache=true
--file-read-buffer-size=0kb
--log-level=Warning
--no-local-blocks=false
--patch-with-local-blocks=false
--verbose=false
--compression-level=BestCompression
````

Before:

![before](https://github.com/user-attachments/assets/5c74296b-2457-4a97-b135-66dae33aabc5)

After:

![after](https://github.com/user-attachments/assets/e96c14f7-bd0f-45fa-a3ff-09cdbbac09d3)

With this PR `VerboseDeprecated` will have the same message as `LogLevelDeprecated` about deprecation on the UI, as the option `--log-level` has also been deprecated.

Before:

![before](https://github.com/user-attachments/assets/9f05cb4d-2393-4331-bb50-579f0ea6c15e)

After:

![after](https://github.com/user-attachments/assets/558d6dd2-224f-4986-bac1-ff75c508e780)
