### PR TITLE
Add copyright notices to files of AliyunOSS backend

### DIFF
--- a/Duplicati/Library/Backend/AliyunOSS/AliyunOSSBackend.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/AliyunOSSBackend.cs
@@ -1,3 +1,23 @@
+// Copyright (C) 2024, trueai-org
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
 ﻿using Aliyun.OSS;
 using Aliyun.OSS.Common;
 using Duplicati.Library.Common.IO;

--- a/Duplicati/Library/Backend/AliyunOSS/AliyunOSSOptions.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/AliyunOSSOptions.cs
@@ -1,4 +1,5 @@
 // Copyright (C) 2024, trueai-org
+// Copyright (C) 2024, Suguru Hirahara
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/Duplicati/Library/Backend/AliyunOSS/AliyunOSSOptions.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/AliyunOSSOptions.cs
@@ -1,3 +1,23 @@
+// Copyright (C) 2024, trueai-org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
 ﻿namespace Duplicati.Library.Backend.AliyunOSS
 {
     /// <summary>

--- a/Duplicati/Library/Backend/AliyunOSS/Extensions.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/Extensions.cs
@@ -1,3 +1,23 @@
+// Copyright (C) 2024, trueai-org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
 ﻿namespace Duplicati.Library.Backend.AliyunOSS
 {
     public static class Extensions

--- a/Duplicati/Library/Backend/AliyunOSS/Properties/AssemblyInfo.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/Properties/AssemblyInfo.cs
@@ -1,3 +1,23 @@
+// Copyright (C) 2024, trueai-org
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/Duplicati/Library/Backend/AliyunOSS/Strings.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/Strings.cs
@@ -1,4 +1,5 @@
 // Copyright (C) 2024, trueai-org
+// Copyright (C) 2024, Suguru Hirahara
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/Duplicati/Library/Backend/AliyunOSS/Strings.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/Strings.cs
@@ -1,3 +1,23 @@
+// Copyright (C) 2024, trueai-org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
 ﻿using Duplicati.Library.Localization.Short;
 
 namespace Duplicati.Library.Backend.Strings


### PR DESCRIPTION
This PR intends to add copyright notices to the files related to AliyunOSS backend, which was originally implemented by @trueai-org and partially modified by me thereafter. I believe copyright is granted to the original author unless the author provides the work to public domain, and https://github.com/duplicati/duplicati/pull/5106 does not mention it, so I think that this is the case where the author just forgot to add those notices.

Please forgive me if it is wrong understanding.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>