### PR TITLE
Use wss:// websocket protocol if current page is loaded over HTTPS

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
@@ -341,7 +341,8 @@ backupApp.service('ServerStatus', function ($rootScope, $timeout, AppService, Ap
 
     const reconnect_websocket = function () {
         window.clearInterval(websocketReconnectTimer);
-        const w = new WebSocket(`ws://${window.location.host}/notifications?token=${AppService.access_token}`)
+        const websocketProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const w = new WebSocket(`${websocketProtocol}//${window.location.host}/notifications?token=${AppService.access_token}`);
         w.addEventListener("message", (event) => {
             const status = JSON.parse(event.data);
             handleServerState({data: status});


### PR DESCRIPTION
Closes #5430
References https://forum.duplicati.com/t/release-2-0-9-102-canary-2024-08-02/18777/40

If Duplicati was being used in a HTTPS context the WebSocket requests would be blocked by the browser as the insecure ws:// cannot be used in the context of a HTTPS page.

This will check if the current page is HTTPS, and if so make the WebSocket connection using the wss:// protocol. Otherwise (if HTTP) it will fall back to the ws:// protocol.