### PR TITLE
Follow-up to recent strings updates

### DIFF
--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -277,7 +277,7 @@ namespace Duplicati.Library.Main.Strings
         public static string DisablefilescannerShort { get { return LC.L(@"Disable the read-ahead scanner"); } }
         public static string DisablefilelistconsistencychecksLong { get { return LC.L(@"In backups with a large number of filesets, the verification can take up a large part of the backup time. If you disable the checks, make sure you run regular check commands to ensure that everything is working as expected."); } }
         public static string DisablefilelistconsistencychecksShort { get { return LC.L(@"Disable filelist consistency checks"); } }
-        public static string DisableOnBatteryLong { get { return LC.L("Use this option to run a scheduled backup if the system is detected to be running on battery power (manual or command line backups will still be run). If the detected power source is mains (e.g., AC) or unknown, then scheduled backups will proceed as normal."); } }
+        public static string DisableOnBatteryLong { get { return LC.L("Use this option to disable a scheduled backup if the system is detected to be running on battery power (manual or command line backups will still be run). If the detected power source is mains (e.g., AC) or unknown, then scheduled backups will proceed as normal."); } }
         public static string DisableOnBatteryShort { get { return LC.L("Disable the backup when on battery power"); } }
 
         public static string LogfileloglevelLong { get { return LC.L(@"Specifies the amount of log information to write into the file specified by the option --{0}.", "log-file"); } }

--- a/Duplicati/Library/Modules/Builtin/Strings.cs
+++ b/Duplicati/Library/Modules/Builtin/Strings.cs
@@ -94,7 +94,7 @@ namespace Duplicati.Library.Modules.Builtin.Strings
     {
         public static string Description { get { return LC.L(@"This module can send email after an operation completes"); } }
         public static string Displayname { get { return LC.L(@"Send mail"); } }
-        public static string FailedToLookupMXServer(string optionname) { return LC.L(@"Unable to find the destination mail server through MX lookup. Please use the option {0} to specify what smtp server to use.", optionname); }
+        public static string FailedToLookupMXServer(string optionname) { return LC.L(@"Unable to find the destination mail server through MX lookup. Please use the option --{0} to specify what SMTP server to use.", optionname); }
         public static string OptionBodyLong { get { return LC.L(@"This value can be a filename. If the file exists, the file contents will be used as the message body.
 
 In the message body, certain tokens are replaced:

--- a/Duplicati/Server/webroot/ngax/templates/settings.html
+++ b/Duplicati/Server/webroot/ngax/templates/settings.html
@@ -122,7 +122,7 @@
                 <option value="crash" translate>Crashes only</option>
                 <option value="none" translate>None / disabled</option>
             </select>
-            <div class="sublabel"><p translate>Usage reports help us improve the user experience and evaluate impact of new features. We use them to generate <external-link link="'https://usage-reporter.duplicati.com/'">{{'public usage statistics' | translate}}</external-link>.</p>
+            <div class="sublabel"><p translate>Usage reports help us improve the user experience and evaluate impact of new features. We use them to generate <external-link link="'https://usage-reporter.duplicati.com/'">public usage statistics</external-link>.</p>
 
             <p translate>All usage reports are sent anonymously and do not contain any personal information. They contain information about hardware and operating system, the type of backend, backup duration, overall size of source data and similar data. They do not contain paths, filenames, usernames, passwords or similar sensitive information.</p></div>
         </div>


### PR DESCRIPTION
This PR intends to be a follow-up to recent strings updates:

- Fix a regression of `DisableOnBatteryLong` introduced by https://github.com/duplicati/duplicati/pull/5361
- Update `FailedToLookupMXServer`
- Remove a wrapped `translate` function from templates/settings.html

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>