### PR TITLE
Replace double slashes with single slashes and asterisks for vanilla CSS

### DIFF
--- a/Duplicati/Server/webroot/ngax/less/base.less
+++ b/Duplicati/Server/webroot/ngax/less/base.less
@@ -1,9 +1,9 @@
-// duplicati 2.0 less | Alex Franzelin 2015
+/* duplicati 2.0 less | Alex Franzelin 2015 */
 @import 'fonts.less';
 @import 'form.less';
 @import 'font-awesome/font-awesome.less';
 
-// https://css-tricks.com/snippets/css/a-guide-to-flexbox/
+/* https://css-tricks.com/snippets/css/a-guide-to-flexbox/ */
 .flexbox() {
     display: -webkit-box;
     display: -moz-box;
@@ -1298,8 +1298,8 @@ body {
 
                             dt.active,
                             dt:hover {
-                                //background: @lColor;
-                                //color: white;
+                                /* background: @lColor; */
+                                /* color: white; */
                             }
 
                             dd {
@@ -1942,7 +1942,7 @@ body {
     }
 }
 
-// Modal windows
+/* Modal windows */
 .remodal {
     padding: 30px;
     box-shadow: 0px 2px 7px rgba(0, 0, 0, 0.3);
@@ -2092,7 +2092,7 @@ div.modal-dialog {
         ul {
             float: right;
         }
-        // tooltipped css taken from: https://github.com/primer/primer-tooltips and https://sachinchoolur.github.io/ngclipboard/
+        /* tooltipped css taken from: https://github.com/primer/primer-tooltips and https://sachinchoolur.github.io/ngclipboard/ */
         .tooltipped {
             position: relative
         }
@@ -2790,7 +2790,7 @@ div.modal-dialog {
                             .input.overlayButton {
                                 padding-top: 8px;
                                 padding-bottom: 30px;
-                                //border-bottom: 1px #ddd solid;
+                                /* border-bottom: 1px #ddd solid; */
                                 margin-bottom: 10px;
 
                                 a.button {
@@ -2817,10 +2817,10 @@ div.modal-dialog {
                             }
 
                             .filters {
-                                //border-bottom: 1px #ddd solid;
+                                /* border-bottom: 1px #ddd solid; */
 
                                 .input.link {
-                                    //padding-bottom: 0;
+                                    /* padding-bottom: 0; */
                                 }
 
                                 .input.textarea {

--- a/Duplicati/Server/webroot/ngax/less/dark.less
+++ b/Duplicati/Server/webroot/ngax/less/dark.less
@@ -1,9 +1,9 @@
 @import 'variables.less';
 @import 'base.less';
 
-@tColor: #B0B0B0; // Text-color
-@hColor: #609301; // Heading-color
-@lColor: #2A89C0; // Link-color
+@tColor: #B0B0B0; /* Text-color */
+@hColor: #609301; /* Heading-color */
+@lColor: #2A89C0; /* Link-color */
 
 body {
     background-color: #1a1a1a !important;

--- a/Duplicati/Server/webroot/ngax/less/default.less
+++ b/Duplicati/Server/webroot/ngax/less/default.less
@@ -1,6 +1,6 @@
 @import 'variables.less';
 @import 'base.less';
 
-@tColor: #505050; // Text-color
-@hColor: #568301; // Heading-color
-@lColor: #277DB0; // Link-color
+@tColor: #505050; /* Text-color */
+@hColor: #568301; /* Heading-color */
+@lColor: #277DB0; /* Link-color */

--- a/Duplicati/Server/webroot/ngax/less/form.less
+++ b/Duplicati/Server/webroot/ngax/less/form.less
@@ -1,4 +1,4 @@
-// form.css for duplicati 2.0 | Alex Franzelin 2015
+/* form.css for duplicati 2.0 | Alex Franzelin 2015 */
 
 form.styled {
     div.leftflush {


### PR DESCRIPTION
For https://github.com/duplicati/duplicati/issues/5379

While a double slash may be used for [comments on Less](https://lesscss.org/#comments), double slash is not standard and not allowed on CSS (see: https://stackoverflow.com/questions/12298890/is-it-bad-practice-to-prefix-single-lines-of-css-with-as-a-personal-comment-s/20192639#20192639).

This PR intends to replace double slashes with the standard way of consuming comments, single slash and asterisk.

Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

