### PR TITLE
Add custom hostname validation

### DIFF
--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -347,9 +347,6 @@ namespace Duplicati.Server
                     parsedOptions.Servername,
                     parsedOptions.AllowedHostnames);
 
-                if (mappedSettings.AllowedHostnames == null || !mappedSettings.AllowedHostnames.Any())
-                    mappedSettings = mappedSettings with { AllowedHostnames = ["localhost", "127.0.0.1", "::1"] };
-
                 var server = new DuplicatiWebserver();
 
                 server.InitWebServer(mappedSettings, connection);

--- a/Duplicati/Server/WebServerLoader.cs
+++ b/Duplicati/Server/WebServerLoader.cs
@@ -197,7 +197,7 @@ public static class WebServerLoader
             listenInterface,
             cert,
             string.Format("{0} v{1}", Library.AutoUpdater.AutoUpdateSettings.AppName, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version),
-            options.GetValueOrDefault(OPTION_WEBSERVICE_ALLOWEDHOSTNAMES, "").Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+            connection.ApplicationSettings.AllowedHostnames.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
         );
 
         // If we are in hosted mode with no specified port, 

--- a/Duplicati/Server/WebServerLoader.cs
+++ b/Duplicati/Server/WebServerLoader.cs
@@ -197,7 +197,7 @@ public static class WebServerLoader
             listenInterface,
             cert,
             string.Format("{0} v{1}", Library.AutoUpdater.AutoUpdateSettings.AppName, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version),
-            connection.ApplicationSettings.AllowedHostnames.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+            (connection.ApplicationSettings.AllowedHostnames ?? string.Empty).Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
         );
 
         // If we are in hosted mode with no specified port, 

--- a/Duplicati/WebserverCore/Abstractions/IHostnameValidator.cs
+++ b/Duplicati/WebserverCore/Abstractions/IHostnameValidator.cs
@@ -1,0 +1,14 @@
+namespace Duplicati.WebserverCore.Abstractions;
+
+/// <summary>
+/// Interface for hostname validation
+/// </summary>
+public interface IHostnameValidator
+{
+    /// <summary>
+    /// Validates a hostname
+    /// </summary>
+    /// <param name="hostname">The hostname to validate</param>
+    /// <returns>True if the hostname is valid, false otherwise</returns>
+    bool IsValidHostname(string hostname);
+}

--- a/Duplicati/WebserverCore/DuplicatiWebserver.cs
+++ b/Duplicati/WebserverCore/DuplicatiWebserver.cs
@@ -6,6 +6,7 @@ using Duplicati.WebserverCore.Abstractions;
 using Duplicati.WebserverCore.Exceptions;
 using Duplicati.WebserverCore.Extensions;
 using Duplicati.WebserverCore.Middlewares;
+using Duplicati.WebserverCore.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.Extensions.Configuration.Json;
@@ -96,11 +97,7 @@ public partial class DuplicatiWebserver
             .AddEndpointsApiExplorer()
             .AddSwaggerGen()
             .AddHttpContextAccessor()
-            .AddHostFiltering(options =>
-            {
-                if (!settings.AllowedHostnames.Any(x => x == "*"))
-                    options.AllowedHosts = settings.AllowedHostnames.ToArray();
-            })
+            .AddSingleton<IHostnameValidator>(new HostnameValidator(settings.AllowedHostnames))
             .AddSingleton(jwtConfig)
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
@@ -178,12 +175,8 @@ public partial class DuplicatiWebserver
 
     public Task Start(InitSettings settings)
     {
-        var allowedOrigins = settings.AllowedHostnames.Any(x => x == "*")
-            ? []
-            : settings.AllowedHostnames.Select(x => settings.Certificate == null ? $"http://{x}:{settings.Port}" : $"https://{x}:{settings.Port}");
-
         App.AddEndpoints()
-            .UseNotifications(allowedOrigins, "/notifications");
+            .UseNotifications("/notifications");
 
         return App.RunAsync();
     }

--- a/Duplicati/WebserverCore/Extensions/WebApplicationExtensions.cs
+++ b/Duplicati/WebserverCore/Extensions/WebApplicationExtensions.cs
@@ -26,7 +26,8 @@ public static class WebApplicationExtensions
         foreach (var endpoint in endpoints)
         {
             var group = application.MapGroup("/api/v1")
-                .AddEndpointFilter<LanguageFilter>();
+                .AddEndpointFilter<LanguageFilter>()
+                .AddEndpointFilter<HostnameFilter>();
 
             var methodMap = endpoint.GetMethod(nameof(IEndpointV1.Map), BindingFlags.Static | BindingFlags.Public);
             methodMap!.Invoke(null, [group]);

--- a/Duplicati/WebserverCore/Middlewares/HostnameFilter.cs
+++ b/Duplicati/WebserverCore/Middlewares/HostnameFilter.cs
@@ -1,0 +1,19 @@
+using Duplicati.WebserverCore.Abstractions;
+
+namespace Duplicati.WebserverCore.Middlewares;
+
+public class HostnameFilter(IHostnameValidator hostnameValidator) : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var hostname = context.HttpContext.Request.Host.Host;
+        if (!hostnameValidator.IsValidHostname(hostname))
+        {
+            context.HttpContext.Response.StatusCode = 403;
+            context.HttpContext.Response.Headers.Append("Content-Type", "text/plain");
+            await context.HttpContext.Response.WriteAsync("Invalid hostname");
+            return null;
+        }
+        return await next(context);
+    }
+}

--- a/Duplicati/WebserverCore/Middlewares/WebsocketExtensions.cs
+++ b/Duplicati/WebserverCore/Middlewares/WebsocketExtensions.cs
@@ -6,13 +6,9 @@ namespace Duplicati.WebserverCore.Middlewares;
 
 public static class WebsocketExtensions
 {
-    public static IApplicationBuilder UseNotifications(this IApplicationBuilder app, IEnumerable<string> allowedOrigins,
-        string notificationPath)
+    public static IApplicationBuilder UseNotifications(this IApplicationBuilder app, string notificationPath)
     {
         var opts = new WebSocketOptions();
-        if (allowedOrigins.Any())
-            foreach (var origin in allowedOrigins)
-                opts.AllowedOrigins.Add(origin);
 
         app.UseWebSockets(opts);
         return app.Use(async (context, next) =>

--- a/Duplicati/WebserverCore/Services/HostnameValidator.cs
+++ b/Duplicati/WebserverCore/Services/HostnameValidator.cs
@@ -11,7 +11,7 @@ public class HostnameValidator : IHostnameValidator
     /// <summary>
     /// Hostnames that are always allowed
     /// </summary>
-    private static readonly string[] DefaultAllowedHostnames = ["localhost", "127.0.0.1", "[::1]"];
+    private static readonly string[] DefaultAllowedHostnames = ["localhost", "127.0.0.1", "[::1]", "localhost.localdomain"];
     /// <summary>
     /// The list of allowed hostnames
     /// </summary>

--- a/Duplicati/WebserverCore/Services/HostnameValidator.cs
+++ b/Duplicati/WebserverCore/Services/HostnameValidator.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using Duplicati.WebserverCore.Abstractions;
+
+namespace Duplicati.WebserverCore.Services;
+
+/// <summary>
+/// Implementation of hostname validation
+/// </summary>
+public class HostnameValidator : IHostnameValidator
+{
+    /// <summary>
+    /// Hostnames that are always allowed
+    /// </summary>
+    private static readonly string[] DefaultAllowedHostnames = ["localhost", "127.0.0.1", "[::1]"];
+    /// <summary>
+    /// The list of allowed hostnames
+    /// </summary>
+    private readonly HashSet<string> m_allowedHostnames;
+    /// <summary>
+    /// A flag that indicates if any hostname is allowed
+    /// </summary>
+    private readonly bool m_allowAny;
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="HostnameValidator"/> class
+    /// </summary>
+    /// <param name="allowedHostnames">The list of allowed hostnames</param>
+    public HostnameValidator(IEnumerable<string> allowedHostnames)
+    {
+        m_allowedHostnames = (allowedHostnames ?? []).Concat(DefaultAllowedHostnames).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        m_allowAny = m_allowedHostnames.Contains("*");
+    }
+
+    /// <inheritdoc />
+    public bool IsValidHostname(string hostname)
+    {
+        if (m_allowAny)
+            return true;
+
+        if (string.IsNullOrWhiteSpace(hostname))
+            return false;
+
+        if (m_allowedHostnames.Contains(hostname))
+            return true;
+
+        if (IPAddress.TryParse(hostname, out _))
+            return true;
+
+        return false;
+    }
+}


### PR DESCRIPTION
This adds a manually implemented hostname check that is applied as an endpoint filter. 
With the implemented filter, the validation rules are similar to those before Kestrel was introduced. 
Additionally, it fixes a case where `--webservice-allowedhostnames` was not applied.
This fixes #5469