### PR TITLE
Fix detached tray icon

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -279,7 +279,7 @@ namespace Duplicati.GUI.TrayIcon
 
         private T PerformRequest<T>(string method, string urlfragment, string body, TimeSpan? timeout)
         {
-            if (string.IsNullOrWhiteSpace(m_accesstoken))
+            if (string.IsNullOrWhiteSpace(m_accesstoken) && !urlfragment.StartsWith("/auth/"))
                 ObtainAccessToken();
 
             var hasTriedPassword = false;
@@ -373,7 +373,7 @@ namespace Duplicati.GUI.TrayIcon
             string signinjwt = null;
 
             // If we host the server, issue the token from the service
-            if (FIXMEGlobal.IsServerStarted || m_passwordSource == Program.PasswordSource.HostedServer)
+            if (FIXMEGlobal.IsServerStarted && m_passwordSource == Program.PasswordSource.HostedServer)
                 signinjwt = FIXMEGlobal.Provider.GetRequiredService<IJWTTokenProvider>().CreateSigninToken("trayicon");
 
             // If we have database access, grab the issuer key from the db and issue a token

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -161,6 +161,16 @@ namespace Duplicati.GUI.TrayIcon
             if (options.TryGetValue(HOSTURL_OPTION, out var url))
                 serverURL = new Uri(url);
 
+            if (string.IsNullOrWhiteSpace(password) && databaseConnection == null && hosted == null)
+            {
+                Console.WriteLine($@"
+When running the TrayIcon without a hosted server, you must provide the server password via the option --{WebServerLoader.OPTION_WEBSERVICE_PASSWORD}=<password>.
+If the TrayIcon instance has read access to the server database, you can also or use the option --{READCONFIGFROMDB_OPTION}, possibly with --server-datafolder=<path>.
+
+No password provided, unable to connect to server, exiting");
+                return 1;
+            }
+
             StartTray(_args, options, hosted, password);
 
             return 0;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -154,6 +154,10 @@ namespace Duplicati.GUI.TrayIcon
             if (options.TryGetValue(WebServerLoader.OPTION_WEBSERVICE_PASSWORD, out pwd))
                 password = pwd;
 
+            // Let the user specify the port, if they are not providing a hosturl
+            if (!options.ContainsKey(HOSTURL_OPTION) && options.TryGetValue(WebServerLoader.OPTION_PORT, out var portString) && int.TryParse(portString, out var port))
+                serverURL = new UriBuilder(serverURL) { Port = port }.Uri;
+
             if (options.TryGetValue(HOSTURL_OPTION, out var url))
                 serverURL = new Uri(url);
 

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -702,7 +702,7 @@ namespace Duplicati.Server
                 if (ex is System.Reflection.TargetInvocationException && ex.InnerException != null)
                     ex = ex.InnerException;
 
-                throw new Exception(Strings.Program.DatabaseOpenError(ex.Message));
+                throw new Exception(Strings.Program.DatabaseOpenError(ex.Message), ex);
             }
 
             return new Database.Connection(con);


### PR DESCRIPTION
This fixes a logic issue that prevents a detached tray-icon from obtaining a connection to a non-hosted server.
Added help message if an invalid detached configuration is provided.
This fixes https://github.com/duplicati/duplicati/issues/5468