### PR TITLE
Fixed saving settings with numbers

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -325,7 +325,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
 
             result.Backup.Settings.push({
                 Name: k,
-                Value: opts[k],
+                Value: opts[k]?.toString(),
                 Filter: origfilter,
                 Argument: origarg
             });
@@ -480,7 +480,7 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         } else {
 
             function putDb() {
-                AppService.put('/backup/' + $routeParams.backupid, result, {'headers': {'Content-Type': 'application/json'}}).then(function() {
+                AppService.put('/backup/' + $routeParams.backupid, result).then(function() {
                     $location.path('/');
                 }, AppUtils.connectionError);
             }

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Duplicati.Library.Encryption;
 using Duplicati.Library.Interface;
 using Duplicati.Library.RestAPI.Abstractions;
 using Duplicati.Server;

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Duplicati.Library.RestAPI.Abstractions;
 using Duplicati.Server;
 using Duplicati.Server.Database;

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPutDelete.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPutDelete.cs
@@ -1,7 +1,4 @@
 using System.Text.Json;
-using Duplicati.Library.Encryption;
-using Duplicati.Library.IO;
-using Duplicati.Library.RestAPI;
 using Duplicati.Library.RestAPI.Abstractions;
 using Duplicati.Server;
 using Duplicati.Server.Database;


### PR DESCRIPTION
Fixed a case where the FE would send a setting with a number in JSON instead of the expected string (with the number inside).

This fixes #5404 