### PR TITLE
Fixed `%HOME%` to use `UserProfile`

### DIFF
--- a/Duplicati/Library/RestAPI/SpecialFolders.cs
+++ b/Duplicati/Library/RestAPI/SpecialFolders.cs
@@ -145,7 +145,7 @@ namespace Duplicati.Server
                 TryAdd(lst, Environment.SpecialFolder.MyPictures, "%MY_PICTURES%", "My Pictures");
                 TryAdd(lst, Environment.SpecialFolder.DesktopDirectory, "%DESKTOP%", "Desktop");
                 TryAdd(lst, Environment.GetEnvironmentVariable("HOME"), "%HOME%", "Home");
-                TryAdd(lst, Environment.SpecialFolder.Personal, "%HOME%", "Home");
+                TryAdd(lst, Environment.SpecialFolder.UserProfile, "%HOME%", "Home");
             }
 
             Nodes = lst.ToArray();


### PR DESCRIPTION
Previously the code would use `SpecialFolder.Personal` which is an alias for `SpecialFolder.MyDocuments` (makes sense only on Windows).

Under mono,`SpecialFolder.MyDocuments` would point to `~/`, but on .NET it correctly points to `~/Documents`.
For both mono and .NET, using `SpecialFolder.UserProfile` points to `~/` (and the logical equivalent on Windows).
This fixes #5491