### PR TITLE
Added encrypted fields to guarded input.

### DIFF
--- a/Duplicati/WebserverCore/Endpoints/V1/ServerSetting.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/ServerSetting.cs
@@ -35,6 +35,7 @@ public class ServerSetting : IEndpointV1
         Server.Database.ServerSettings.CONST.SERVER_PASSPHRASE_SALT,
         Server.Database.ServerSettings.CONST.SERVER_SSL_CERTIFICATE,
         Server.Database.ServerSettings.CONST.DISABLE_VISUAL_CAPTCHA,
+        Server.Database.ServerSettings.CONST.ENCRYPTED_FIELDS,
         "ServerSSLCertificate",
         "server-passphrase-trayicon-hash",
         "server-passphrase-trayicon-salt"


### PR DESCRIPTION
This prevents the API from setting the field, which would cause restarts to re-write the settings, but does not affect the encrypted/decrypted state.