### PR TITLE
Added blacklisting of known invalid settings encryption keys

### DIFF
--- a/Duplicati/Library/RestAPI/Strings.cs
+++ b/Duplicati/Library/RestAPI/Strings.cs
@@ -61,6 +61,7 @@ Error message: {0}", error); }
         public static string RequiredbencryptionShort { get { return LC.L(@"Require database encryption"); } }
         public static string RequiredbencryptionLong { get { return LC.L(@"Use this option to require a custom provided key for database encryption of sensitive fields and not rely on the serial number"); } }
         public static string DatabaseEncryptionKeyRequired(string envkey, string disableoptionname) { return LC.L(@"Database encryption key is required. Supply an encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
+        public static string BlacklistedEncryptionKey(string envkey, string disableoptionname) { return LC.L(@"The encryption key is blacklisted and cannot be used. The database has been decrypted. Supply a new encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
     }
     internal static class Scheduler
     {

--- a/Duplicati/Library/Utility/DeviceIDHelper.cs
+++ b/Duplicati/Library/Utility/DeviceIDHelper.cs
@@ -18,30 +18,95 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
+#nullable enable
 
 using Duplicati.Library.Utility;
 using DeviceId;
+using System.Collections.Generic;
+using System.Linq;
 
 /// <summary>
 /// Helper class to get the device ID string and computed hash
 /// </summary>
 public static class DeviceIDHelper
 {
+    /// <summary>
+    /// Generates an empty ID
+    /// </summary>
+    /// <returns>An empty ID</returns>
+    private static string? GenerateEmptyId()
+    {
+        var builder = new DeviceIdBuilder();
+        builder.Components.Clear();
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// The empty ID produced by DeviceIdBuilder if no information is available
+    /// </summary>
+    private static readonly HashSet<string> EMPTY_DEVICE_IDS = new[] {
+        // Known empty Id
+        "WERC8GMRZGE196QVYK49JVXS4GKTWGF4CJDS6K54JPCHPY2JQ1AG",
+        // In case the library changes
+        GenerateEmptyId()
+    }
+    .Where(x => !string.IsNullOrWhiteSpace(x))
+    .Select(x => x!)
+    // Don't allow empty strings either
+    .Append(string.Empty)
+    .ToHashSet();
+
+    /// <summary>
+    /// Hashes a set of device IDs
+    /// </summary>
+    /// <param name="deviceIds">The deviceIds to hash</param>
+    /// <returns>The list of hashed ids</returns>
+    private static HashSet<string> HashDeviceIds(IEnumerable<string> deviceIds)
+    {
+        var hasher = HashFactory.CreateHasher("SHA256");
+        return deviceIds.Select(x => x.ComputeHashToHex(hasher)).ToHashSet();
+    }
+
+    /// <summary>
+    /// The empty deviceId hashes
+    /// </summary>
+    public static readonly HashSet<string> EMPTY_DEVICE_ID_HASHES = HashDeviceIds(EMPTY_DEVICE_IDS);
+
+    /// <summary>
+    /// Returns a configured builder
+    /// </summary>
+    /// <returns>The builder</returns>
+    private static DeviceIdBuilder GetBuilder()
+        => new DeviceIdBuilder()
+            .OnWindows(deviceid => deviceid
+                .AddMotherboardSerialNumber())
+            .OnLinux(deviceid => deviceid
+                .AddMotherboardSerialNumber())
+            .OnMac(deviceid => deviceid
+                .AddPlatformSerialNumber());
 
     /// <summary>
     /// Get the device ID string (motherboard serial number on Windows and Linux, platform serial number on Mac)
     /// </summary>
-    /// <returns>String</returns>
-    public static string GetDeviceID()
+    /// <returns>The device Id</returns>
+    public static string? GetDeviceID()
     {
-        return new DeviceIdBuilder()
-        .OnWindows(deviceid => deviceid
-            .AddMotherboardSerialNumber())
-        .OnLinux(deviceid => deviceid
-            .AddMotherboardSerialNumber())
-        .OnMac(deviceid => deviceid
-            .AddPlatformSerialNumber())
-        .ToString();
+        var id = GetBuilder().ToString();
+        if (string.IsNullOrWhiteSpace(id))
+            return EMPTY_DEVICE_IDS.First();
+
+        return id;
+    }
+
+    /// <summary>
+    /// Checks if the deviceId is a meaningful value
+    /// </summary>
+    /// <returns><c>true</c> if a deviceId can be obtained, <c>false</c> otherwise</returns>
+    public static bool CanGetDeviceId()
+    {
+        var builder = GetBuilder();
+        builder.UseFormatter(new DeviceId.Formatters.StringDeviceIdFormatter(new DeviceId.Encoders.PlainTextDeviceIdComponentEncoder()));
+        return !string.IsNullOrWhiteSpace(builder.ToString());
     }
 
     /// <summary>
@@ -50,6 +115,7 @@ public static class DeviceIDHelper
     /// <returns></returns>
     public static string GetDeviceIDHash()
     {
-        return GetDeviceID().ComputeHashToHex(HashFactory.CreateHasher("SHA256"));
+        using var hasher = HashFactory.CreateHasher("SHA256");
+        return (GetDeviceID() ?? "").ComputeHashToHex(hasher);
     }
 }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Duplicati.Library.Common.IO;
+using Duplicati.Library.Encryption;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using Duplicati.Library.Main.Database;
@@ -46,7 +47,7 @@ namespace Duplicati.Server
         private const string WINDOWS_EVENTLOG_OPTION = "windows-eventlog";
         private const string WINDOWS_EVENTLOG_LEVEL_OPTION = "windows-eventlog-level";
         private const string DISABLE_DB_ENCRYPTION_OPTION = "disable-db-encryption";
-        private const string REQUIRE_DB_ENCRYPTION_OPTION = "require-db-encryption-key";
+        private const string REQUIRE_DB_ENCRYPTION_KEY_OPTION = "require-db-encryption-key";
 
 #if DEBUG
         private const bool DEBUG_MODE = true;
@@ -259,6 +260,10 @@ namespace Duplicati.Server
             try
             {
                 DataConnection = GetDatabaseConnection(commandlineOptions);
+
+                // Replicate the check from within the database connection, to emit the message to the console as well
+                if (writeToConsole && EncryptedFieldHelper.IsCurrentKeyBlacklisted && !Library.Utility.Utility.ParseBoolOption(commandlineOptions, DISABLE_DB_ENCRYPTION_OPTION))
+                    Console.WriteLine(Strings.Program.BlacklistedEncryptionKey(Library.Encryption.EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME, DISABLE_DB_ENCRYPTION_OPTION));
 
                 if (!DataConnection.ApplicationSettings.FixedInvalidBackupId)
                     DataConnection.FixInvalidBackupId();
@@ -720,10 +725,18 @@ namespace Duplicati.Server
             }
 
             var disableDbEncryption = Library.Utility.Utility.ParseBoolOption(commandlineOptions, DISABLE_DB_ENCRYPTION_OPTION);
-            var requireDbEncryption = Library.Utility.Utility.ParseBoolOption(commandlineOptions, REQUIRE_DB_ENCRYPTION_OPTION);
+            var requireDbEncryptionKey = Library.Utility.Utility.ParseBoolOption(commandlineOptions, REQUIRE_DB_ENCRYPTION_KEY_OPTION);
             var hasEncryptionKey = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(Library.Encryption.EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME));
-            if (requireDbEncryption && !(hasEncryptionKey || disableDbEncryption))
+            var usingBlacklistedKey = Library.Encryption.EncryptedFieldHelper.IsCurrentKeyBlacklisted;
+
+            if (requireDbEncryptionKey && !(hasEncryptionKey || disableDbEncryption))
                 throw new UserInformationException(Strings.Program.DatabaseEncryptionKeyRequired(Library.Encryption.EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME, DISABLE_DB_ENCRYPTION_OPTION), "RequireDbEncryptionKey");
+
+            if (usingBlacklistedKey && !disableDbEncryption)
+            {
+                Duplicati.Library.Logging.Log.WriteErrorMessage(LOGTAG, "BlacklistedEncryptionKey", null, Strings.Program.BlacklistedEncryptionKey(Library.Encryption.EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME, DISABLE_DB_ENCRYPTION_OPTION));
+                disableDbEncryption = true;
+            }
 
             return new Database.Connection(con, disableDbEncryption);
         }
@@ -856,7 +869,7 @@ namespace Duplicati.Server
                 new Duplicati.Library.Interface.CommandLineArgument("log-retention", Duplicati.Library.Interface.CommandLineArgument.ArgumentType.Timespan, Strings.Program.LogretentionShort, Strings.Program.LogretentionLong, DEFAULT_LOG_RETENTION),
                 new Duplicati.Library.Interface.CommandLineArgument("server-datafolder", Duplicati.Library.Interface.CommandLineArgument.ArgumentType.Path, Strings.Program.ServerdatafolderShort, Strings.Program.ServerdatafolderLong(DATAFOLDER_ENV_NAME), System.IO.Path.Combine(System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Library.AutoUpdater.AutoUpdateSettings.AppName)),
                 new Duplicati.Library.Interface.CommandLineArgument(DISABLE_DB_ENCRYPTION_OPTION, Duplicati.Library.Interface.CommandLineArgument.ArgumentType.Boolean, Strings.Program.DisabledbencryptionShort, Strings.Program.DisabledbencryptionLong),
-                new Duplicati.Library.Interface.CommandLineArgument(REQUIRE_DB_ENCRYPTION_OPTION, Duplicati.Library.Interface.CommandLineArgument.ArgumentType.Boolean, Strings.Program.RequiredbencryptionShort, Strings.Program.RequiredbencryptionLong),
+                new Duplicati.Library.Interface.CommandLineArgument(REQUIRE_DB_ENCRYPTION_KEY_OPTION, Duplicati.Library.Interface.CommandLineArgument.ArgumentType.Boolean, Strings.Program.RequiredbencryptionShort, Strings.Program.RequiredbencryptionLong),
             ])
             .ToArray();
 


### PR DESCRIPTION
This PR adds a blacklisting mechanism to the settings keys to handle the case where the deviceId key is empty.
The logic will decrypt the database if a blacklisted key is used, because the security of using a known key vs not being encrypted is virtually the same.
The decryption also helps as the user can simply provide a valid key and the database will be re-encrypted with this new key.

This fixes #5510 