### PR TITLE
Simplify datafolder lookup

### DIFF
--- a/Duplicati/CommandLine/ServerUtil/Connection.cs
+++ b/Duplicati/CommandLine/ServerUtil/Connection.cs
@@ -135,10 +135,14 @@ public class Connection
         // If we can read the server database, try to create a signin token
         try
         {
-            if (!string.IsNullOrWhiteSpace(settings.ServerDatafolder) && File.Exists(Path.Combine(settings.ServerDatafolder, "Duplicati-server.sqlite")))
+            var opts = new Dictionary<string, string>();
+            if (!string.IsNullOrWhiteSpace(settings.ServerDatafolder))
+                opts.Add("server-datafolder", settings.ServerDatafolder);
+
+            if (File.Exists(Path.Combine(Server.Program.GetDataFolderPath(opts), Server.Program.SERVER_DATABASE_FILENAME)))
             {
                 string? cfg = null;
-                using (var connection = Duplicati.Server.Program.GetDatabaseConnection(new Dictionary<string, string> { { "server-datafolder", settings.ServerDatafolder } }))
+                using (var connection = Duplicati.Server.Program.GetDatabaseConnection(opts))
                     cfg = connection.ApplicationSettings.JWTConfig;
 
                 if (!string.IsNullOrWhiteSpace(cfg))

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using Duplicati.Library.Interface;
 using Duplicati.Server;
@@ -129,23 +130,26 @@ namespace Duplicati.GUI.TrayIcon
             }
             else if (Library.Utility.Utility.ParseBoolOption(options, READCONFIGFROMDB_OPTION))
             {
-                databaseConnection = Server.Program.GetDatabaseConnection(options);
-
-                if (databaseConnection != null)
+                if (File.Exists(Path.Combine(Server.Program.GetDataFolderPath(options), Server.Program.SERVER_DATABASE_FILENAME)))
                 {
-                    disableTrayIconLogin = databaseConnection.ApplicationSettings.DisableTrayIconLogin;
+                    databaseConnection = Server.Program.GetDatabaseConnection(options);
 
-                    var cert = databaseConnection.ApplicationSettings.ServerSSLCertificate;
-                    var scheme = "http";
-
-                    if (cert != null && cert.HasPrivateKey)
-                        scheme = "https";
-
-                    serverURL = new UriBuilder(serverURL)
+                    if (databaseConnection != null)
                     {
-                        Port = databaseConnection.ApplicationSettings.LastWebserverPort == -1 ? serverURL.Port : databaseConnection.ApplicationSettings.LastWebserverPort,
-                        Scheme = scheme
-                    }.Uri;
+                        disableTrayIconLogin = databaseConnection.ApplicationSettings.DisableTrayIconLogin;
+
+                        var cert = databaseConnection.ApplicationSettings.ServerSSLCertificate;
+                        var scheme = "http";
+
+                        if (cert != null && cert.HasPrivateKey)
+                            scheme = "https";
+
+                        serverURL = new UriBuilder(serverURL)
+                        {
+                            Port = databaseConnection.ApplicationSettings.LastWebserverPort == -1 ? serverURL.Port : databaseConnection.ApplicationSettings.LastWebserverPort,
+                            Scheme = scheme
+                        }.Uri;
+                    }
                 }
             }
 

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -66,7 +66,7 @@ namespace Duplicati.Server
         /// <summary>
         /// Name of the database file
         /// </summary>
-        private const string SERVER_DATABASE_FILENAME = "Duplicati-server.sqlite";
+        public const string SERVER_DATABASE_FILENAME = "Duplicati-server.sqlite";
 
         /// <summary>
         /// The environment variable prefix
@@ -655,7 +655,7 @@ namespace Duplicati.Server
             throw new Exception("Server invoked with --help");
         }
 
-        private static string GetDataFolderPath(Dictionary<string, string> commandlineOptions)
+        public static string GetDataFolderPath(Dictionary<string, string> commandlineOptions)
         {
             var serverDataFolder = Environment.GetEnvironmentVariable(DATAFOLDER_ENV_NAME);
             if (commandlineOptions.ContainsKey("server-datafolder"))

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -655,7 +655,7 @@ namespace Duplicati.Server
             throw new Exception("Server invoked with --help");
         }
 
-        public static Database.Connection GetDatabaseConnection(Dictionary<string, string> commandlineOptions)
+        private static string GetDataFolderPath(Dictionary<string, string> commandlineOptions)
         {
             var serverDataFolder = Environment.GetEnvironmentVariable(DATAFOLDER_ENV_NAME);
             if (commandlineOptions.ContainsKey("server-datafolder"))
@@ -670,23 +670,28 @@ namespace Duplicati.Server
                 if (DEBUG_MODE && portableMode)
                 {
                     //debug mode uses a lock file located in the app folder
-                    DataFolder = StartupPath;
+                    return StartupPath;
                 }
                 else if (portableMode)
                 {
                     //Portable mode uses a data folder in the application home dir
-                    DataFolder = System.IO.Path.Combine(StartupPath, "data");
                     System.IO.Directory.SetCurrentDirectory(StartupPath);
+                    return System.IO.Path.Combine(StartupPath, "data");
                 }
                 else
                 {
                     //Normal release mode uses the systems "(Local) Application Data" folder
                     // %LOCALAPPDATA% on Windows, ~/.config on Linux, ~/Library/Application\ Support on MacOS
-                    DataFolder = DatabaseLocator.GetDefaultStorageFolder(SERVER_DATABASE_FILENAME, Library.AutoUpdater.AutoUpdateSettings.AppName);
+                    return DatabaseLocator.GetDefaultStorageFolder(SERVER_DATABASE_FILENAME, Library.AutoUpdater.AutoUpdateSettings.AppName);
                 }
             }
             else
-                DataFolder = Util.AppendDirSeparator(Environment.ExpandEnvironmentVariables(serverDataFolder).Trim('"'));
+                return Util.AppendDirSeparator(Environment.ExpandEnvironmentVariables(serverDataFolder).Trim('"'));
+        }
+
+        public static Database.Connection GetDatabaseConnection(Dictionary<string, string> commandlineOptions)
+        {
+            DataFolder = GetDataFolderPath(commandlineOptions);
 
             var sqliteVersion = new Version(Duplicati.Library.SQLiteHelper.SQLiteLoader.SQLiteVersion);
             if (sqliteVersion < new Version(3, 6, 3))


### PR DESCRIPTION
This PR isolates the function that the server uses for finding the database.
With the function it is now possible for the Tray + ServerUtil to detect if the target database exists.
Before this change, they would create an empty database as part of the probing and then deal with an existing, but empty, database.