### PR TITLE
Setting the version number on files inside the MSI 

### DIFF
--- a/ReleaseBuilder/Build/Command.Compile.Post.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Post.cs
@@ -1,7 +1,4 @@
-using System.IO.Compression;
-using System.Net;
 using System.Text.RegularExpressions;
-using Duplicati.Library.Utility;
 
 namespace ReleaseBuilder.Build;
 

--- a/ReleaseBuilder/Build/Command.CreatePackage.cs
+++ b/ReleaseBuilder/Build/Command.CreatePackage.cs
@@ -258,7 +258,7 @@ public static partial class Command
             if (File.Exists(binFiles))
                 File.Delete(binFiles);
 
-            File.WriteAllText(binFiles, WixHeatBuilder.CreateWixFilelist(sourceFiles));
+            File.WriteAllText(binFiles, WixHeatBuilder.CreateWixFilelist(sourceFiles, version: rtcfg.ReleaseInfo.Version.ToString()));
 
             var msiArch = target.Arch switch
             {

--- a/ReleaseBuilder/Resources/Windows/Duplicati.wxs
+++ b/ReleaseBuilder/Resources/Windows/Duplicati.wxs
@@ -44,19 +44,19 @@
     <Feature Id="DuplicatiCore" Title="Duplicati core files" Level="1" Description="Installs the required files for Duplicati." AllowAdvertise="no" Absent="disallow" ConfigurableDirectory="INSTALLLOCATION" >
       <Feature Id="DuplicatiDesktopShortCutFeature" Title="Desktop Shortcut" Level="1" Description ="Installs a shortcut to Duplicati on the desktop" Absent="allow" AllowAdvertise="no">
         <ComponentRef Id="DuplicatiDesktopShortcutComponent"/>
-        <!-- <Condition Level="0">FORSERVICE = "true"</Condition> -->
+        <Condition Level="0">FORSERVICE = "true"</Condition>
       </Feature>
 
       <Feature Id="DuplicatiProgramMenuShortCutFeature" Title="Program Menu Shortcut" Level="1" Description ="Installs a shortcut to Duplicati in the Program menu" Absent="allow" AllowAdvertise="no">
         <ComponentRef Id="DuplicatiProgramMenuShortcutComponent"/>
-        <!-- <Condition Level="0">FORSERVICE = "true"</Condition> -->
+        <Condition Level="0">FORSERVICE = "true"</Condition>
       </Feature>
       <ComponentGroupRef Id="DUPLICATIBIN" />
     </Feature>
     
     <Feature Id="DuplicatiStartupShortCutFeature" Title="Launch Duplicati at startup" Level="1" Description ="Automatically launches Duplicati when you log on to the computer" Absent="allow" AllowAdvertise="no">
       <ComponentRef Id="StartupMenuItem"/>
-      <!-- <Condition Level="0">FORSERVICE = "true"</Condition> -->
+      <Condition Level="0">FORSERVICE = "true"</Condition>
     </Feature>
 
     <!-- Launch duplicati setup -->

--- a/ReleaseBuilder/Resources/Windows/Duplicati.wxs
+++ b/ReleaseBuilder/Resources/Windows/Duplicati.wxs
@@ -68,14 +68,9 @@
     <Property Id="ARPPRODUCTICON" Value="DuplicatiIcon.exe" />
 
     <!-- Remove old versions -->
-    <InstallExecuteSequence>
-      <RemoveExistingProducts Before="InstallInitialize" />
-    </InstallExecuteSequence>
-
-    <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />
-    <Upgrade Id="$(var.UpgradeCode)">
-      <UpgradeVersion Minimum="2.0.0.0" Property="PREVIOUSVERSIONSINSTALLED"  Maximum="99.0.0.0" IncludeMinimum="yes" IncludeMaximum="no" />
-    </Upgrade>
+  <MajorUpgrade
+      DowngradeErrorMessage="A later version of [ProductName] is already installed"
+      AllowSameVersionUpgrades="yes" />
 
     <Icon Id="DuplicatiIcon.exe" SourceFile="$(var.HarvestPath)Duplicati.GUI.TrayIcon.exe" />
 


### PR DESCRIPTION
With explicit versioning, it prevents broken upgrades.
Also changed the way upgrades are applied so they fully remove the previous versions before installing.
Also re-enabled the `FORSERVICE=true` setup with the help from [a wixl patch](https://gitlab.gnome.org/GNOME/msitools/-/issues/66)
This fixes #5233