### PR TITLE
Remove existing product before install for MSI

### DIFF
--- a/ReleaseBuilder/Resources/Windows/Duplicati.wxs
+++ b/ReleaseBuilder/Resources/Windows/Duplicati.wxs
@@ -68,9 +68,15 @@
     <Property Id="ARPPRODUCTICON" Value="DuplicatiIcon.exe" />
 
     <!-- Remove old versions -->
-  <MajorUpgrade
-      DowngradeErrorMessage="A later version of [ProductName] is already installed"
-      AllowSameVersionUpgrades="yes" />
+    <InstallExecuteSequence>
+      <!-- Note: This is suboptimal, but the ref counting is not working, so we use Early REP -->
+      <RemoveExistingProducts Before="CostInitialize" />
+    </InstallExecuteSequence>
+
+    <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />
+    <Upgrade Id="$(var.UpgradeCode)">
+      <UpgradeVersion Minimum="2.0.0.0" Property="PREVIOUSVERSIONSINSTALLED"  Maximum="99.0.0.0" IncludeMinimum="yes" IncludeMaximum="no" />
+    </Upgrade>
 
     <Icon Id="DuplicatiIcon.exe" SourceFile="$(var.HarvestPath)Duplicati.GUI.TrayIcon.exe" />
 


### PR DESCRIPTION
Fixed MSI install problems by removing existing product before installing new version.

This is based on the advice in an [MSI SO question](https://stackoverflow.com/a/52087185).

The problem is related to the fact that a large number of files are not changed between releases.
The logic should be that the MSI will leave the existing files in place to reduce the amount of copying.

But due to some key/id problem, it will instead remove the file and not replace it, causing a broken installation. The keypath and component ids seems to follow the WiX logic, so the proper fix is unknown at the time.

Unlike the recommendation, this moves the "remove existing products" all the way up before even calculating the installation costs, which may cause the upgrades to fail if the system is low on disk space even though the cost calculator approves the installation costs. Moving it down the sequence, did not improve the result.


This fixes #5233