### PR TITLE
Performance/speed up preliminary work in DoCompact()

### DIFF
--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -128,9 +128,16 @@ namespace Duplicati.Library.Main.Operation
                     var downloadedVolumes = new List<KeyValuePair<string, long>>();
 
                     //We start by deleting unused volumes to save space before uploading new stuff
-                    var fullyDeleteable = (from v in remoteList
-                                           where report.DeleteableVolumes.Contains(v.Name)
-                                           select (IRemoteVolume)v).ToList();
+                    List<IRemoteVolume> fullyDeleteable = [];
+                    if (report.DeleteableVolumes.Any())
+                    {
+                        var deleteableVolumesAsHashes = new HashSet<string>(report.DeleteableVolumes);
+                        fullyDeleteable =
+                            remoteList
+                                .Where(n => deleteableVolumesAsHashes.Contains(n.Name))
+                                .Cast<IRemoteVolume>()
+                                .ToList();
+                    }
                     deletedVolumes.AddRange(DoDelete(db, backend, fullyDeleteable, ref transaction));
 
                     // This list is used to pick up unused volumes,
@@ -141,9 +148,16 @@ namespace Duplicati.Library.Main.Operation
                     if (report.ShouldCompact)
                     {
                         newvolindex?.StartVolume(newvol.RemoteFilename);
-                        var volumesToDownload = (from v in remoteList
-                                                 where report.CompactableVolumes.Contains(v.Name)
-                                                 select (IRemoteVolume)v).ToList();
+                        List<IRemoteVolume> volumesToDownload = [];
+                        if (report.CompactableVolumes.Any())
+                        {
+                            var compactableVolumesAsHashSet = new HashSet<string>(report.CompactableVolumes);
+                            volumesToDownload =
+                                remoteList
+                                    .Where(n => compactableVolumesAsHashSet.Contains(n.Name))
+                                    .Cast<IRemoteVolume>()
+                                    .ToList();
+                        }
 
                         using (var q = db.CreateBlockQueryHelper(transaction))
                         {


### PR DESCRIPTION
During compacting, when the file lists become very large, the preliminary work of determining which files to download and compact took up a considerably amount of time (25 minutes out of the total 65 minutes). 

This pull request speeds up 
The first optimization was to add guards around the queries in case the second collection is empty (which it was when this slow path was found). 
The second optimization is to use a `HashSet` for the second collection, as this speeds up lookup, compared to using two `List` of `string`.

Attached to this pull request is also a micro benchmark of the original LINQ query compared to a few other approaches. The results on a laptop is shown here, where `HashSet` wins for the most part, only beaten by an equivalent PLINQ query when the number of elements becomes large, however, not by a whole lot (4958.76 µs vs 3851.81 µs ~= 1 ms). In the future, it should switch to the PLINQ for large samples, but that threshold requires more investigation. 

![results_mac](https://github.com/user-attachments/assets/1ef3f6fc-3879-4588-a479-582de2194dbf)

[do_compact_micro.zip](https://github.com/user-attachments/files/17463602/do_compact_micro.zip)