### PR TITLE
Performance/bumped the version of SharpAESCrypt

### DIFF
--- a/Duplicati/Library/Encryption/Duplicati.Library.Encryption.csproj
+++ b/Duplicati/Library/Encryption/Duplicati.Library.Encryption.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpAESCrypt" Version="2.0.2" />
+    <PackageReference Include="SharpAESCrypt" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This new version fixes the slow call to `GenerateHeaderIV()` which is a bottleneck when running with small block sizes. 