### PR TITLE
Updated rclone backend to handle empty options 

### DIFF
--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -60,26 +60,23 @@ namespace Duplicati.Library.Backend
         public Rclone(string url, Dictionary<string, string> options)
         {
             var uri = new Utility.Uri(url);
-
-            remote_repo = uri.Host;
-            remote_path = uri.Path;
-
-
-            local_repo = "local";
-            opt_rclone = "";
-            rclone_executable = "rclone";
             /*should check here if program is installed */
 
-            if (options.ContainsKey(OPTION_LOCAL_REPO))
-                local_repo = options[OPTION_LOCAL_REPO];
-            if (options.ContainsKey(OPTION_REMOTE_REPO))
-                remote_repo = options[OPTION_REMOTE_REPO];
-            if (options.ContainsKey(OPTION_REMOTE_PATH))
-                remote_path = options[OPTION_REMOTE_PATH];
-            if (options.ContainsKey(OPTION_RCLONE))
-                opt_rclone = options[OPTION_RCLONE];
-            if (options.ContainsKey(OPTION_RCLONE_EXECUTABLE))
-                rclone_executable = options[OPTION_RCLONE_EXECUTABLE];
+            local_repo = options.GetValueOrDefault(OPTION_LOCAL_REPO, local_repo);
+            remote_repo = options.GetValueOrDefault(OPTION_REMOTE_REPO, remote_repo);
+            remote_path = options.GetValueOrDefault(OPTION_REMOTE_PATH, remote_path);
+            opt_rclone = options.GetValueOrDefault(OPTION_RCLONE, opt_rclone) ?? "";
+            rclone_executable = options.GetValueOrDefault(OPTION_RCLONE_EXECUTABLE, rclone_executable);
+
+            if (string.IsNullOrWhiteSpace(local_repo))
+                local_repo = "local";
+            if (string.IsNullOrWhiteSpace(remote_repo))
+                remote_repo = uri.Host;
+            if (string.IsNullOrWhiteSpace(remote_path))
+                remote_path = uri.Path;
+            if (string.IsNullOrWhiteSpace(rclone_executable))
+                rclone_executable = "rclone";
+
 #if DEBUG
             Console.WriteLine("Constructor {0}: {1}:{2} {3}", local_repo, remote_repo, remote_path, opt_rclone);
 #endif

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -1188,7 +1188,6 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
     EditUriBackendConfig.validaters['rclone'] = function (scope, continuation) {
         var res =
             EditUriBackendConfig.require_field(scope, 'Server', gettextCatalog.getString('Remote Repository')) &&
-            EditUriBackendConfig.require_field(scope, 'rclone_local_repository', gettextCatalog.getString('Local Repository')) &&
             EditUriBackendConfig.require_field(scope, 'Path', gettextCatalog.getString('Remote Path'));
 
         if (res)

--- a/Duplicati/Server/webroot/ngax/templates/backends/rclone.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/rclone.html
@@ -1,6 +1,6 @@
 <div class="input text">
     <label for="rclone_local_repository" translate>Local repository</label>
-    <input type="text" name="rclone_local_repository" id="rclone_local_repository" ng-model="$parent.rclone_local_repository" placeholder="{{'local repository, e.g. local' | translate}}" />
+    <input type="text" name="rclone_local_repository" id="rclone_local_repository" ng-model="$parent.rclone_local_repository" placeholder="{{'local repository, leave empty for local' | translate}}" />
 </div>
 <div class="input text">
     <label for="rclone_remote_repository" translate>Remote repository</label>


### PR DESCRIPTION
Empty option values are now treated the same as missing options (apply default values).
Made the local repo optional in the UI because it has a default value.