### PR TITLE
Fix issues with extra blocks and files being recorded after an interrupted `Compact()`

### DIFF
--- a/Duplicati/Library/Main/Database/Database schema/13. Unique index on DuplicateBlock.sql
+++ b/Duplicati/Library/Main/Database/Database schema/13. Unique index on DuplicateBlock.sql
@@ -1,0 +1,16 @@
+CREATE TEMPORARY TABLE "UniqueReassignTable" AS
+SELECT "BlockID", "VolumeID"
+FROM "DuplicateBlock"
+GROUP BY "BlockID", "VolumeID";
+
+DELETE FROM "DuplicateBlock";
+
+INSERT INTO "DuplicateBlock"("BlockID", "VolumeID")
+SELECT "BlockID", "VolumeID" FROM "UniqueReassignTable";
+
+DROP TABLE "UniqueReassignTable";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "UniqueBlockVolumeDuplicateBlock"
+ON "DuplicateBlock" ("BlockID", "VolumeID");
+
+UPDATE "Version" SET "Version" = 13;

--- a/Duplicati/Library/Main/Database/Database schema/Schema.sql
+++ b/Duplicati/Library/Main/Database/Database schema/Schema.sql
@@ -217,6 +217,9 @@ CREATE TABLE "DuplicateBlock" (
     "VolumeID" INTEGER NOT NULL
 );
 
+CREATE UNIQUE INDEX "UniqueBlockVolumeDuplicateBlock"
+ON "DuplicateBlock" ("BlockID", "VolumeID");
+
 /*
 A metadata set, essentially a placeholder
 to easily extend metadatasets with new properties
@@ -287,4 +290,4 @@ CREATE TABLE "ChangeJournalData" (
     "ConfigHash" TEXT NOT NULL  
 );
 
-INSERT INTO "Version" ("Version") VALUES (12);
+INSERT INTO "Version" ("Version") VALUES (13);

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, The Duplicati Team
+﻿// Copyright (C) 2024, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a 
@@ -336,6 +336,20 @@ namespace Duplicati.Library.Main.Database
         {
             m_selectremotevolumeIdCommand.Transaction = transaction;
             return m_selectremotevolumeIdCommand.ExecuteScalarInt64(null, -1, file);
+        }
+
+        public IEnumerable<KeyValuePair<string, long>> GetRemoteVolumeIDs(IEnumerable<string> files, System.Data.IDbTransaction transaction = null)
+        {
+            using (var cmd = m_connection.CreateCommand(transaction))
+            {
+                cmd.CommandText = @"SELECT ""Name"", ""ID"" FROM ""RemoteVolume"" WHERE ""Name"" IN (?)";
+                cmd.AddParameters(1);
+                cmd.SetParameterValue(0, files);
+
+                using (var rd = cmd.ExecuteReader())
+                    while (rd.Read())
+                        yield return new KeyValuePair<string, long>(rd.GetString(0), rd.GetInt64(1));
+            }
         }
 
         public RemoteVolumeEntry GetRemoteVolume(string file, System.Data.IDbTransaction transaction = null)

--- a/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDeleteDatabase.cs
@@ -23,8 +23,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Text;
-using System.IO;
 using Duplicati.Library.Interface;
 
 namespace Duplicati.Library.Main.Database
@@ -36,26 +34,30 @@ namespace Duplicati.Library.Main.Database
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<LocalDeleteDatabase>();
 
-        private System.Data.IDbCommand m_moveBlockToNewVolumeCommand;
+        /// <summary>
+        /// Flag for toggling temporary tables; set to empty string if debugging
+        /// </summary>
+        private const string TEMPORARY = "TEMPORARY";
+
+        private System.Data.IDbCommand m_registerDuplicateBlockCommand;
 
         public LocalDeleteDatabase(string path, string operation)
             : base(path, operation, true)
         {
             InitializeCommands();
         }
-        
+
         public LocalDeleteDatabase(LocalDatabase db)
             : base(db)
         {
             InitializeCommands();
         }
-        
+
         private void InitializeCommands()
         {
-            m_moveBlockToNewVolumeCommand = m_connection.CreateCommand();
-            
-            m_moveBlockToNewVolumeCommand.CommandText = @"UPDATE ""Block"" SET ""VolumeID"" = ? WHERE ""Hash"" = ? AND ""Size"" = ?";
-            m_moveBlockToNewVolumeCommand.AddParameters(3);
+            m_registerDuplicateBlockCommand = m_connection.CreateCommand();
+            m_registerDuplicateBlockCommand.CommandText = @"INSERT OR IGNORE INTO ""DuplicateBlock"" (""BlockID"", ""VolumeID"") SELECT ""ID"", ? FROM ""Block"" WHERE ""Hash"" = ? AND ""Size"" = ? ";
+            m_registerDuplicateBlockCommand.AddParameters(3);
         }
 
         /// <summary>
@@ -66,7 +68,7 @@ namespace Duplicati.Library.Main.Database
         /// <returns>A list of filesets to delete</returns>
         public IEnumerable<KeyValuePair<string, long>> DropFilesetsFromTable(DateTime[] toDelete, System.Data.IDbTransaction transaction)
         {
-            using(var cmd = m_connection.CreateCommand())
+            using (var cmd = m_connection.CreateCommand())
             {
                 cmd.Transaction = transaction;
 
@@ -87,7 +89,7 @@ namespace Duplicati.Library.Main.Database
 
                 if (deleted != toDelete.Length)
                     throw new Exception(string.Format("Unexpected number of deleted filesets {0} vs {1}", deleted, toDelete.Length));
-    
+
                 //Then we delete anything that is no longer being referenced
                 cmd.ExecuteNonQuery(@"DELETE FROM ""FilesetEntry"" WHERE ""FilesetID"" NOT IN (SELECT DISTINCT ""ID"" FROM ""Fileset"")");
                 cmd.ExecuteNonQuery(@"DELETE FROM ""ChangeJournalData"" WHERE ""FilesetID"" NOT IN (SELECT DISTINCT ""ID"" FROM ""Fileset"")");
@@ -96,7 +98,7 @@ namespace Duplicati.Library.Main.Database
                 cmd.ExecuteNonQuery(@"DELETE FROM ""Blockset"" WHERE ""ID"" NOT IN (SELECT DISTINCT ""BlocksetID"" FROM ""FileLookup"" UNION SELECT DISTINCT ""BlocksetID"" FROM ""Metadataset"") ");
                 cmd.ExecuteNonQuery(@"DELETE FROM ""BlocksetEntry"" WHERE ""BlocksetID"" NOT IN (SELECT DISTINCT ""ID"" FROM ""Blockset"") ");
                 cmd.ExecuteNonQuery(@"DELETE FROM ""BlocklistHash"" WHERE ""BlocksetID"" NOT IN (SELECT DISTINCT ""ID"" FROM ""Blockset"") ");
-                
+
                 //We save the block info for the remote files, before we delete it
                 cmd.ExecuteNonQuery(@"INSERT INTO ""DeletedBlock"" (""Hash"", ""Size"", ""VolumeID"") SELECT ""Hash"", ""Size"", ""VolumeID"" FROM ""Block"" WHERE ""ID"" NOT IN (SELECT DISTINCT ""BlockID"" AS ""BlockID"" FROM ""BlocksetEntry"" UNION SELECT DISTINCT ""ID"" FROM ""Block"", ""BlocklistHash"" WHERE ""Block"".""Hash"" = ""BlocklistHash"".""Hash"") ");
                 cmd.ExecuteNonQuery(@"DELETE FROM ""Block"" WHERE ""ID"" NOT IN (SELECT DISTINCT ""BlockID"" FROM ""BlocksetEntry"" UNION SELECT DISTINCT ""ID"" FROM ""Block"", ""BlocklistHash"" WHERE ""Block"".""Hash"" = ""BlocklistHash"".""Hash"") ");
@@ -152,7 +154,7 @@ namespace Duplicati.Library.Main.Database
             public readonly long DataSize;
             public readonly long WastedSize;
             public readonly long CompressedSize;
-            
+
             public VolumeUsage(string name, long datasize, long wastedsize, long compressedsize)
             {
                 this.Name = name;
@@ -171,20 +173,20 @@ namespace Duplicati.Library.Main.Database
         private IEnumerable<VolumeUsage> GetWastedSpaceReport(System.Data.IDbTransaction transaction)
         {
             var tmptablename = "UsageReport-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
-            
+
             var usedBlocks = @"SELECT SUM(""Block"".""Size"") AS ""ActiveSize"", ""Block"".""VolumeID"" AS ""VolumeID"" FROM ""Block"", ""Remotevolume"" WHERE ""Block"".""VolumeID"" = ""Remotevolume"".""ID"" AND ""Block"".""ID"" NOT IN (SELECT ""Block"".""ID"" FROM ""Block"",""DeletedBlock"" WHERE ""Block"".""Hash"" = ""DeletedBlock"".""Hash"" AND ""Block"".""Size"" = ""DeletedBlock"".""Size"" AND ""Block"".""VolumeID"" = ""DeletedBlock"".""VolumeID"") GROUP BY ""Block"".""VolumeID"" ";
             var lastmodifiedFile = @"SELECT ""Block"".""VolumeID"" AS ""VolumeID"", ""Fileset"".""Timestamp"" AS ""Sorttime"" FROM ""Fileset"", ""FilesetEntry"", ""FileLookup"", ""BlocksetEntry"", ""Block"" WHERE ""FilesetEntry"".""FileID"" = ""FileLookup"".""ID"" AND ""FileLookup"".""BlocksetID"" = ""BlocksetEntry"".""BlocksetID"" AND ""BlocksetEntry"".""BlockID"" = ""Block"".""ID"" AND ""Fileset"".""ID"" = ""FilesetEntry"".""FilesetID"" ";
             var lastmodifiedMetadata = @"SELECT ""Block"".""VolumeID"" AS ""VolumeID"", ""Fileset"".""Timestamp"" AS ""Sorttime"" FROM ""Fileset"", ""FilesetEntry"", ""FileLookup"", ""BlocksetEntry"", ""Block"", ""Metadataset"" WHERE ""FilesetEntry"".""FileID"" = ""FileLookup"".""ID"" AND ""FileLookup"".""MetadataID"" = ""Metadataset"".""ID"" AND ""Metadataset"".""BlocksetID"" = ""BlocksetEntry"".""BlocksetID"" AND ""BlocksetEntry"".""BlockID"" = ""Block"".""ID"" AND ""Fileset"".""ID"" = ""FilesetEntry"".""FilesetID"" ";
             var scantime = @"SELECT ""VolumeID"" AS ""VolumeID"", MIN(""Sorttime"") AS ""Sorttime"" FROM (" + lastmodifiedFile + @" UNION " + lastmodifiedMetadata + @") GROUP BY ""VolumeID"" ";
             var active = @"SELECT ""A"".""ActiveSize"" AS ""ActiveSize"",  0 AS ""InactiveSize"", ""A"".""VolumeID"" AS ""VolumeID"", CASE WHEN ""B"".""Sorttime"" IS NULL THEN 0 ELSE ""B"".""Sorttime"" END AS ""Sorttime"" FROM (" + usedBlocks + @") A LEFT OUTER JOIN (" + scantime + @") B ON ""B"".""VolumeID"" = ""A"".""VolumeID"" ";
-            
+
             var inactive = @"SELECT 0 AS ""ActiveSize"", SUM(""Size"") AS ""InactiveSize"", ""VolumeID"" AS ""VolumeID"", 0 AS ""SortScantime"" FROM ""DeletedBlock"" GROUP BY ""VolumeID"" ";
             var empty = @"SELECT 0 AS ""ActiveSize"", 0 AS ""InactiveSize"", ""Remotevolume"".""ID"" AS ""VolumeID"", 0 AS ""SortScantime"" FROM ""Remotevolume"" WHERE ""Remotevolume"".""Type"" = ? AND ""Remotevolume"".""State"" IN (?, ?) AND ""Remotevolume"".""ID"" NOT IN (SELECT ""VolumeID"" FROM ""Block"") ";
-            
+
             var combined = active + " UNION " + inactive + " UNION " + empty;
             var collected = @"SELECT ""VolumeID"" AS ""VolumeID"", SUM(""ActiveSize"") AS ""ActiveSize"", SUM(""InactiveSize"") AS ""InactiveSize"", MAX(""Sorttime"") AS ""Sorttime"" FROM (" + combined + @") GROUP BY ""VolumeID"" ";
-            var createtable = @"CREATE TEMPORARY TABLE """ + tmptablename + @""" AS " + collected;
-                        
+            var createtable = @$"CREATE {TEMPORARY} TABLE ""{tmptablename}"" AS " + collected;
+
             using (var cmd = m_connection.CreateCommand())
             {
                 cmd.Transaction = transaction;
@@ -195,23 +197,23 @@ namespace Duplicati.Library.Main.Database
                         while (rd.Read())
                             yield return new VolumeUsage(rd.GetValue(0).ToString(), rd.ConvertValueToInt64(1, 0) + rd.ConvertValueToInt64(2, 0), rd.ConvertValueToInt64(2, 0), rd.ConvertValueToInt64(3, 0));
                 }
-                finally 
+                finally
                 {
                     try { cmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}"" ", tmptablename)); }
                     catch { }
                 }
             }
         }
-        
+
         public interface ICompactReport
         {
             IEnumerable<string> DeleteableVolumes { get; }
             IEnumerable<string> CompactableVolumes { get; }
             bool ShouldReclaim { get; }
             bool ShouldCompact { get; }
-            void ReportCompactData(); 
+            void ReportCompactData();
         }
-        
+
         private class CompactReport : ICompactReport
         {
             private readonly IEnumerable<VolumeUsage> m_report;
@@ -224,15 +226,15 @@ namespace Duplicati.Library.Main.Database
             private readonly long m_smallspace;
             private readonly long m_fullsize;
             private readonly long m_smallvolumecount;
-            
+
             private readonly long m_wastethreshold;
             private readonly long m_volsize;
             private readonly long m_maxsmallfilecount;
-            
+
             public CompactReport(long volsize, long wastethreshold, long smallfilesize, long maxsmallfilecount, IEnumerable<VolumeUsage> report)
             {
                 m_report = report;
-                
+
                 m_cleandelete = (from n in m_report where n.DataSize <= n.WastedSize select n).ToArray();
                 m_wastevolumes = from n in m_report where ((((n.WastedSize / (float)n.DataSize) * 100) >= wastethreshold) || (((n.WastedSize / (float)volsize) * 100) >= wastethreshold)) && !m_cleandelete.Contains(n) select n;
                 m_smallvolumes = from n in m_report where n.CompressedSize <= smallfilesize && !m_cleandelete.Contains(n) select n;
@@ -243,12 +245,12 @@ namespace Duplicati.Library.Main.Database
 
                 m_deletablevolumes = m_cleandelete.Count();
                 m_fullsize = report.Select(x => x.DataSize).Sum();
-                
+
                 m_wastedspace = m_wastevolumes.Select(x => x.WastedSize).Sum();
                 m_smallspace = m_smallvolumes.Select(x => x.CompressedSize).Sum();
                 m_smallvolumecount = m_smallvolumes.Count();
             }
-            
+
             public void ReportCompactData()
             {
                 var wastepercentage = ((m_wastedspace / (float)m_fullsize) * 100);
@@ -267,51 +269,51 @@ namespace Duplicati.Library.Main.Database
                 else
                     Logging.Log.WriteInformationMessage(LOGTAG, "CompactReason", "Compacting not required");
             }
-            
+
             public bool ShouldReclaim
             {
-                get 
+                get
                 {
                     return m_deletablevolumes > 0;
                 }
             }
-            
+
             public bool ShouldCompact
             {
-                get 
+                get
                 {
                     return (((m_wastedspace / (float)m_fullsize) * 100) >= m_wastethreshold && m_wastevolumes.Count() >= 2) || m_smallspace > m_volsize || m_smallvolumecount > m_maxsmallfilecount;
                 }
             }
 
-            public IEnumerable<string> DeleteableVolumes 
-            { 
-                get { return from n in m_cleandelete select n.Name; } 
+            public IEnumerable<string> DeleteableVolumes
+            {
+                get { return from n in m_cleandelete select n.Name; }
             }
-            
-            public IEnumerable<string> CompactableVolumes 
-            { 
-                get 
-                { 
+
+            public IEnumerable<string> CompactableVolumes
+            {
+                get
+                {
                     //The order matters, we compact old volumes together first,
                     // as we anticipate old data will stay around, where never data
                     // is more likely to be discarded again
                     return m_wastevolumes.Union(m_smallvolumes).Select(x => x.Name).Distinct();
-                } 
+                }
             }
         }
-        
+
         public ICompactReport GetCompactReport(long volsize, long wastethreshold, long smallfilesize, long maxsmallfilecount, System.Data.IDbTransaction transaction)
         {
             return new CompactReport(volsize, wastethreshold, smallfilesize, maxsmallfilecount, GetWastedSpaceReport(transaction).ToList());
         }
-        
-                
+
+
         public interface IBlockQuery : IDisposable
         {
             bool UseBlock(string hash, long size, System.Data.IDbTransaction transaction);
         }
-        
+
         private class BlockQuery : IBlockQuery
         {
             private System.Data.IDbCommand m_command;
@@ -325,16 +327,16 @@ namespace Duplicati.Library.Main.Database
                 m_command.CommandText = @"SELECT ""VolumeID"" FROM ""Block"" WHERE ""Hash"" = ? AND ""Size"" = ? ";
                 m_command.AddParameters(2);
             }
-            
+
             public bool UseBlock(string hash, long size, System.Data.IDbTransaction transaction)
-            {                
+            {
                 m_command.Transaction = transaction;
-                m_command.SetParameterValue(0, hash);    
+                m_command.SetParameterValue(0, hash);
                 m_command.SetParameterValue(1, size);
                 var r = m_command.ExecuteScalar();
                 return r != null && r != DBNull.Value;
             }
-            
+
             public void Dispose()
             {
                 if (m_command != null)
@@ -342,7 +344,7 @@ namespace Duplicati.Library.Main.Database
                     finally { m_command = null; }
             }
         }
-        
+
         /// <summary>
         /// Builds a lookup table to enable faster response to block queries
         /// </summary>
@@ -351,67 +353,112 @@ namespace Duplicati.Library.Main.Database
             return new BlockQuery(m_connection, transaction);
         }
 
-        public void MoveBlockToNewVolume(string hash, long size, long volumeID, System.Data.IDbTransaction tr)
+        /// <summary>
+        /// Registers a block as moved to a new volume
+        /// </summary>
+        /// <param name="hash">The hash of the block</param>
+        /// <param name="size">The size of the block</param>
+        /// <param name="volumeID">The new volume ID</param>
+        /// <param name="tr">The transaction to execute the command in</param>
+        public void RegisterDuplicatedBlock(string hash, long size, long volumeID, System.Data.IDbTransaction tr)
         {
-            m_moveBlockToNewVolumeCommand.SetParameterValue(0, volumeID);
-            m_moveBlockToNewVolumeCommand.SetParameterValue(1, hash);
-            m_moveBlockToNewVolumeCommand.SetParameterValue(2, size);
-            m_moveBlockToNewVolumeCommand.Transaction = tr;
-            var c = m_moveBlockToNewVolumeCommand.ExecuteNonQuery();
-            if (c != 1)
-                throw new Exception("Unexpected update result");
+            m_registerDuplicateBlockCommand.Transaction = tr;
+            m_registerDuplicateBlockCommand.SetParameterValue(0, volumeID);
+            m_registerDuplicateBlockCommand.SetParameterValue(1, hash);
+            m_registerDuplicateBlockCommand.SetParameterValue(2, size);
+            // Using INSERT OR IGNORE to avoid duplicate entries, result may be 1 or 0
+            m_registerDuplicateBlockCommand.ExecuteNonQuery();
         }
-        
+
+        /// <summary>
+        /// After new volumes are uploaded, this method will update the blocks from the old volumes to point to the new volumes
+        /// </summary>
+        /// <param name="filename">The file to remove</param>
+        /// <param name="volumeIdsToBeRemoved">The volume IDs that will be removed</param>
+        /// <param name="transaction">The transaction to execute the command in</param>
+        public void PrepareForDelete(string filename, IEnumerable<long> volumeIdsToBeRemoved, System.Data.IDbTransaction transaction)
+        {
+            var deletedVolume = GetRemoteVolume(filename, transaction);
+            if (deletedVolume.Type != RemoteVolumeType.Blocks)
+                return;
+
+            using (var cmd = m_connection.CreateCommand(transaction))
+            {
+                var updatedBlocks = "BlocksToUpdate-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
+                var replacementBlocks = "ReplacementBlocks-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
+                try
+                {
+                    cmd.ExecuteNonQuery(@$"CREATE {TEMPORARY} TABLE """ + updatedBlocks + @""" AS SELECT ""ID"" FROM ""Block"" WHERE ""VolumeID"" = ? ", deletedVolume.ID);
+                    cmd.ExecuteNonQuery(@$"CREATE {TEMPORARY} TABLE """ + replacementBlocks + @""" AS SELECT ""BlockID"", MAX(""VolumeID"") AS ""VolumeID"" FROM ""DuplicateBlock"" WHERE ""VolumeID"" NOT IN (?) AND ""BlockID"" IN (SELECT ""ID"" FROM """ + updatedBlocks + @""") GROUP BY ""BlockID"" ", volumeIdsToBeRemoved.ToArray());
+                    var targetCount = cmd.ExecuteScalarInt64(@"SELECT COUNT(*) FROM """ + updatedBlocks + @""" ");
+                    if (targetCount == 0)
+                        return;
+
+                    var replacementCount = cmd.ExecuteScalarInt64(@"SELECT COUNT(*) FROM """ + replacementBlocks + @""" ");
+                    var updateCount = cmd.ExecuteNonQuery(@$"UPDATE ""Block"" SET ""VolumeID"" = (SELECT ""VolumeID"" FROM ""{replacementBlocks}"" WHERE ""{replacementBlocks}"".""BlockID"" = ""Block"".""ID"" AND ""Block"".""VolumeID"" = ?) WHERE ""Block"".""VolumeID"" = ? ", deletedVolume.ID, deletedVolume.ID);
+                    var deleteCount = cmd.ExecuteNonQuery(@$"DELETE FROM ""DuplicateBlock"" WHERE (""DuplicateBlock"".""BlockID"" || ':' || ""DuplicateBlock"".""VolumeID"") IN (SELECT ""RB"".""BlockID"" || ':' || ""RB"".""VolumeID"" FROM ""{replacementBlocks}"" RB)");
+                    if (targetCount != updateCount || replacementCount != deleteCount || updateCount != deleteCount)
+                        throw new Exception(string.Format($"Unexpected number of rows updated. Expected {targetCount} but got updated {updateCount}, deleted {deleteCount}, and replaced {replacementCount}"));
+
+                    // Remove knowledge of any old blocks
+                    cmd.ExecuteNonQuery(@"DELETE FROM ""DuplicateBlock"" WHERE ""VolumeID"" = ?", deletedVolume.ID);
+                }
+                finally
+                {
+                    try { cmd.ExecuteNonQuery(@"DROP TABLE IF EXISTS """ + updatedBlocks + @""" "); }
+                    catch { }
+                    try { cmd.ExecuteNonQuery(@"DROP TABLE IF EXISTS """ + replacementBlocks + @""" "); }
+                    catch { }
+                }
+
+            }
+        }
+
         /// <summary>
         /// Calculates the sequence in which files should be deleted based on their relations.
         /// </summary>
-        /// <returns>The deletable volumes.</returns>
         /// <param name="deleteableVolumes">Block volumes slated for deletion.</param>
-        public IEnumerable<IRemoteVolume> GetDeletableVolumes(IEnumerable<IRemoteVolume> deleteableVolumes, System.Data.IDbTransaction transaction)
+        /// <param name="transaction">The transaction to execute the command in</param>
+        /// <returns>The deletable volumes.</returns>
+        public IEnumerable<IRemoteVolume> ReOrderDeleteableVolumes(IEnumerable<IRemoteVolume> deleteableVolumes, System.Data.IDbTransaction transaction)
         {
-            using(var cmd = m_connection.CreateCommand())
+            using (var cmd = m_connection.CreateCommand(transaction))
             {
                 // Although the generated index volumes are always in pairs,
                 // this code handles many-to-many relations between
                 // index files and block volumes, should this be added later
                 var lookupBlock = new Dictionary<string, List<IRemoteVolume>>();
                 var lookupIndexfiles = new Dictionary<string, List<string>>();
-                
-                cmd.Transaction = transaction;
-                
-                using(var rd = cmd.ExecuteReader(@"SELECT ""C"".""Name"", ""B"".""Name"", ""B"".""Hash"", ""B"".""Size"" FROM ""IndexBlockLink"" A, ""RemoteVolume"" B, ""RemoteVolume"" C WHERE ""A"".""IndexVolumeID"" = ""B"".""ID"" AND ""A"".""BlockVolumeID"" = ""C"".""ID"" AND ""B"".""Hash"" IS NOT NULL AND ""B"".""Size"" IS NOT NULL "))
-                    while(rd.Read())
+
+                using (var rd = cmd.ExecuteReader(@"SELECT ""C"".""Name"", ""B"".""Name"", ""B"".""Hash"", ""B"".""Size"" FROM ""IndexBlockLink"" A, ""RemoteVolume"" B, ""RemoteVolume"" C WHERE ""A"".""IndexVolumeID"" = ""B"".""ID"" AND ""A"".""BlockVolumeID"" = ""C"".""ID"" AND ""B"".""Hash"" IS NOT NULL AND ""B"".""Size"" IS NOT NULL "))
+                    while (rd.Read())
                     {
                         var name = rd.GetValue(0).ToString();
-                        List<IRemoteVolume> indexfileList;
-                        if (!lookupBlock.TryGetValue(name, out indexfileList))
-                        {    
+                        if (!lookupBlock.TryGetValue(name, out var indexfileList))
+                        {
                             indexfileList = new List<IRemoteVolume>();
                             lookupBlock.Add(name, indexfileList);
                         }
-                        
+
                         var v = new RemoteVolume(rd.GetString(1), rd.GetString(2), rd.GetInt64(3));
                         indexfileList.Add(v);
 
-                        List<string> blockList;
-                        if (!lookupIndexfiles.TryGetValue(v.Name, out blockList))
-                        {    
+                        if (!lookupIndexfiles.TryGetValue(v.Name, out var blockList))
+                        {
                             blockList = new List<string>();
                             lookupIndexfiles.Add(v.Name, blockList);
                         }
                         blockList.Add(name);
                     }
 
-                foreach(var r in deleteableVolumes.Distinct())
+                foreach (var r in deleteableVolumes.Distinct())
                 {
                     // Return the input
                     yield return r;
-                    List<IRemoteVolume> indexfileList;
-                    if (lookupBlock.TryGetValue(r.Name, out indexfileList))
-                        foreach(var sh in indexfileList)
+                    if (lookupBlock.TryGetValue(r.Name, out var indexfileList))
+                        foreach (var sh in indexfileList)
                         {
-                            List<string> backref;
-                            if (lookupIndexfiles.TryGetValue(sh.Name, out backref))
+                            if (lookupIndexfiles.TryGetValue(sh.Name, out var backref))
                             {
                                 //If this is the last reference, 
                                 // remove the index file as well

--- a/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRecreateDatabase.cs
@@ -192,7 +192,7 @@ namespace Duplicati.Library.Main.Database
             m_insertBlockCommand.CommandText = @"INSERT INTO ""Block"" (""Hash"", ""Size"", ""VolumeID"") VALUES (?,?,?)";
             m_insertBlockCommand.AddParameters(3);
 
-            m_insertDuplicateBlockCommand.CommandText = @"INSERT INTO ""DuplicateBlock"" (""BlockID"", ""VolumeID"") VALUES ((SELECT ""ID"" FROM ""Block"" WHERE ""Hash"" = ? AND ""Size"" = ?), ?)";
+            m_insertDuplicateBlockCommand.CommandText = @"INSERT OR IGNORE INTO ""DuplicateBlock"" (""BlockID"", ""VolumeID"") VALUES ((SELECT ""ID"" FROM ""Block"" WHERE ""Hash"" = ? AND ""Size"" = ?), ?)";
             m_insertDuplicateBlockCommand.AddParameters(3);
         }
 

--- a/Duplicati/Library/Main/Database/LocalTestDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalTestDatabase.cs
@@ -29,20 +29,20 @@ namespace Duplicati.Library.Main.Database
     {
         public LocalTestDatabase(string path)
             : base(path, "Test", true)
-        {        
+        {
         }
-        
+
         public LocalTestDatabase(LocalDatabase parent)
             : base(parent)
-        {        
+        {
         }
-        
+
         public void UpdateVerificationCount(string name)
         {
-            using(var cmd = m_connection.CreateCommand())
+            using (var cmd = m_connection.CreateCommand())
                 cmd.ExecuteNonQuery(@"UPDATE ""RemoteVolume"" SET ""VerificationCount"" = MAX(1, CASE WHEN ""VerificationCount"" <= 0 THEN (SELECT MAX(""VerificationCount"") FROM ""RemoteVolume"") ELSE ""VerificationCount"" + 1 END) WHERE ""Name"" = ?", name);
         }
-        
+
         private class RemoteVolume : IRemoteVolume
         {
             public long ID { get; private set; }
@@ -50,7 +50,7 @@ namespace Duplicati.Library.Main.Database
             public long Size { get; private set; }
             public string Hash { get; private set; }
             public long VerificationCount { get; private set; }
-            
+
             public RemoteVolume(System.Data.IDataReader rd)
             {
                 this.ID = rd.GetInt64(0);
@@ -60,7 +60,7 @@ namespace Duplicati.Library.Main.Database
                 this.VerificationCount = rd.ConvertValueToInt64(4);
             }
         }
-        
+
         private IEnumerable<RemoteVolume> FilterByVerificationCount(IEnumerable<RemoteVolume> volumes, long samples, long maxverification)
         {
             var rnd = new Random();
@@ -69,7 +69,7 @@ namespace Duplicati.Library.Main.Database
             var res = (from n in volumes where n.VerificationCount == 0 select n).ToList();
             while (res.Count > samples)
                 res.RemoveAt(rnd.Next(0, res.Count));
-            
+
             // Quick exit if we are done
             if (res.Count == samples)
                 return res;
@@ -81,8 +81,8 @@ namespace Duplicati.Library.Main.Database
             {
                 var max = starved.Select(x => x.VerificationCount).Max();
                 var min = starved.Select(x => x.VerificationCount).Min();
-            
-                for(var i = min; i <= max; i++)
+
+                for (var i = min; i <= max; i++)
                 {
                     var p = starved.Where(x => x.VerificationCount == i).ToList();
                     while (res.Count < samples && p.Count > 0)
@@ -92,12 +92,12 @@ namespace Duplicati.Library.Main.Database
                         p.RemoveAt(n);
                     }
                 }
-            
+
                 // Quick exit if we are done
                 if (res.Count == samples)
                     return res;
             }
-            
+
             if (maxverification > 0)
             {
                 // Last is the items that are verified mostly
@@ -109,16 +109,16 @@ namespace Duplicati.Library.Main.Database
                     remainder.RemoveAt(n);
                 }
             }
-             
+
             return res;
         }
-        
+
         public IEnumerable<IRemoteVolume> SelectTestTargets(long samples, Options options)
         {
             var tp = GetFilelistWhereClause(options.Time, options.Version);
-            
+
             samples = Math.Max(1, samples);
-            using(var cmd = m_connection.CreateCommand())
+            using (var cmd = m_connection.CreateCommand())
             {
                 // Select any broken items
                 using (var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""Name"", ""Size"", ""Hash"", ""VerificationCount"" FROM ""Remotevolume"" WHERE (""State"" = ? OR ""State"" = ?) AND (""Hash"" = '' OR ""Hash"" IS NULL OR ""Size"" <= 0) ", RemoteVolumeState.Verified.ToString(), RemoteVolumeState.Uploaded.ToString()))
@@ -127,70 +127,70 @@ namespace Duplicati.Library.Main.Database
 
                 //Grab the max value
                 var max = cmd.ExecuteScalarInt64(@"SELECT MAX(""VerificationCount"") FROM ""RemoteVolume""", 0);
-            
+
                 //First we select some filesets
                 var files = new List<RemoteVolume>();
                 var whereClause = string.IsNullOrEmpty(tp.Item1) ? " WHERE " : (" " + tp.Item1 + " AND ");
-                using(var rd = cmd.ExecuteReader(@"SELECT ""A"".""VolumeID"", ""A"".""Name"", ""A"".""Size"", ""A"".""Hash"", ""A"".""VerificationCount"" FROM (SELECT ""ID"" AS ""VolumeID"", ""Name"", ""Size"", ""Hash"", ""VerificationCount"" FROM ""Remotevolume"" WHERE ""State"" IN (?, ?)) A, ""Fileset"" " +  whereClause + @" ""A"".""VolumeID"" = ""Fileset"".""VolumeID"" ORDER BY ""Fileset"".""Timestamp"" ", RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString(), tp.Item2))
+                using (var rd = cmd.ExecuteReader(@"SELECT ""A"".""VolumeID"", ""A"".""Name"", ""A"".""Size"", ""A"".""Hash"", ""A"".""VerificationCount"" FROM (SELECT ""ID"" AS ""VolumeID"", ""Name"", ""Size"", ""Hash"", ""VerificationCount"" FROM ""Remotevolume"" WHERE ""State"" IN (?, ?)) A, ""Fileset"" " + whereClause + @" ""A"".""VolumeID"" = ""Fileset"".""VolumeID"" ORDER BY ""Fileset"".""Timestamp"" ", RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString(), tp.Item2))
                     while (rd.Read())
                         files.Add(new RemoteVolume(rd));
-                        
+
                 if (files.Count == 0)
                     yield break;
 
                 if (string.IsNullOrEmpty(tp.Item1))
                     files = FilterByVerificationCount(files, samples, max).ToList();
-                
-                foreach(var f in files)
+
+                foreach (var f in files)
                     yield return f;
-                
+
                 //Then we select some index files
                 files.Clear();
-                
-                using(var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""Name"", ""Size"", ""Hash"", ""VerificationCount"" FROM ""Remotevolume"" WHERE ""Type"" = ? AND ""State"" IN (?, ?)", RemoteVolumeType.Index.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString()))
+
+                using (var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""Name"", ""Size"", ""Hash"", ""VerificationCount"" FROM ""Remotevolume"" WHERE ""Type"" = ? AND ""State"" IN (?, ?)", RemoteVolumeType.Index.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString()))
                     while (rd.Read())
                         files.Add(new RemoteVolume(rd));
-                                            
-                foreach(var f in FilterByVerificationCount(files, samples, max))
+
+                foreach (var f in FilterByVerificationCount(files, samples, max))
                     yield return f;
 
                 if (options.FullRemoteVerification == Options.RemoteTestStrategy.ListAndIndexes)
-	            yield break;
+                    yield break;
 
                 //And finally some block files
                 files.Clear();
-                
-                using(var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""Name"", ""Size"", ""Hash"", ""VerificationCount"" FROM ""Remotevolume"" WHERE ""Type"" = ? AND ""State"" IN (?, ?)", RemoteVolumeType.Blocks.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString()))
+
+                using (var rd = cmd.ExecuteReader(@"SELECT ""ID"", ""Name"", ""Size"", ""Hash"", ""VerificationCount"" FROM ""Remotevolume"" WHERE ""Type"" = ? AND ""State"" IN (?, ?)", RemoteVolumeType.Blocks.ToString(), RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString()))
                     while (rd.Read())
                         files.Add(new RemoteVolume(rd));
-                        
-                foreach(var f in FilterByVerificationCount(files, samples, max))
+
+                foreach (var f in FilterByVerificationCount(files, samples, max))
                     yield return f;
             }
         }
-        
+
         private abstract class Basiclist : IDisposable
         {
-              protected readonly System.Data.IDbConnection m_connection;
-              protected readonly string m_volumename;
-              protected string m_tablename;
-              protected System.Data.IDbTransaction m_transaction;
-              protected System.Data.IDbCommand m_insertCommand;
+            protected readonly System.Data.IDbConnection m_connection;
+            protected readonly string m_volumename;
+            protected string m_tablename;
+            protected System.Data.IDbTransaction m_transaction;
+            protected System.Data.IDbCommand m_insertCommand;
 
-              protected Basiclist(System.Data.IDbConnection connection, string volumename, string tablePrefix, string tableFormat, string insertCommand, int insertArguments)
-              {
+            protected Basiclist(System.Data.IDbConnection connection, string volumename, string tablePrefix, string tableFormat, string insertCommand, int insertArguments)
+            {
                 m_connection = connection;
                 m_volumename = volumename;
                 m_transaction = m_connection.BeginTransaction();
                 var tablename = tablePrefix + "-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
 
-                using(var cmd = m_connection.CreateCommand())
+                using (var cmd = m_connection.CreateCommand())
                 {
                     cmd.Transaction = m_transaction;
                     cmd.ExecuteNonQuery(string.Format(@"CREATE TEMPORARY TABLE ""{0}"" {1}", tablename, tableFormat));
                     m_tablename = tablename;
                 }
-                
+
                 m_insertCommand = m_connection.CreateCommand();
                 m_insertCommand.Transaction = m_transaction;
                 m_insertCommand.CommandText = string.Format(@"INSERT INTO ""{0}"" {1}", m_tablename, insertCommand);
@@ -200,35 +200,35 @@ namespace Duplicati.Library.Main.Database
             public virtual void Dispose()
             {
                 if (m_tablename != null)
-                    try 
-                    { 
-                        using(var cmd = m_connection.CreateCommand())
+                    try
+                    {
+                        using (var cmd = m_connection.CreateCommand())
                         {
                             cmd.Transaction = m_transaction;
                             cmd.ExecuteNonQuery(string.Format(@"DROP TABLE IF EXISTS ""{0}""", m_tablename));
                         }
                     }
-                    catch {}
+                    catch { }
                     finally { m_tablename = null; }
-                    
+
                 if (m_insertCommand != null)
                     try { m_insertCommand.Dispose(); }
-                    catch {}
+                    catch { }
                     finally { m_insertCommand = null; }
-                    
+
                 if (m_transaction != null)
                     try { m_transaction.Rollback(); }
-                    catch {}
+                    catch { }
                     finally { m_transaction = null; }
             }
         }
-        
+
         public interface IFilelist : IDisposable
         {
             void Add(string path, long size, string hash, long metasize, string metahash, IEnumerable<string> blocklistHashes, FilelistEntryType type, DateTime time);
             IEnumerable<KeyValuePair<Library.Interface.TestEntryStatus, string>> Compare();
         }
-        
+
         private class Filelist : Basiclist, IFilelist
         {
             private const string TABLE_PREFIX = "Filelist";
@@ -238,68 +238,68 @@ namespace Duplicati.Library.Main.Database
 
             public Filelist(System.Data.IDbConnection connection, string volumename)
                 : base(connection, volumename, Filelist.TABLE_PREFIX, Filelist.TABLE_FORMAT, Filelist.INSERT_COMMAND, Filelist.INSERT_ARGUMENTS)
-            { 
+            {
             }
-            
+
             public void Add(string path, long size, string hash, long metasize, string metahash, IEnumerable<string> blocklistHashes, FilelistEntryType type, DateTime time)
             {
                 m_insertCommand.SetParameterValue(0, path);
-                m_insertCommand.SetParameterValue(1, hash == null ? - 1: size);
+                m_insertCommand.SetParameterValue(1, hash == null ? -1 : size);
                 m_insertCommand.SetParameterValue(2, hash);
                 m_insertCommand.SetParameterValue(3, metasize);
                 m_insertCommand.SetParameterValue(4, metahash);
                 m_insertCommand.ExecuteNonQuery();
             }
-            
+
             public IEnumerable<KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>> Compare()
             {
                 var cmpName = "CmpTable-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
-                
+
                 var create = @"CREATE TEMPORARY TABLE ""{1}"" AS SELECT ""A"".""Path"" AS ""Path"", CASE WHEN ""B"".""Fullhash"" IS NULL THEN -1 ELSE ""B"".""Length"" END AS ""Size"", ""B"".""Fullhash"" AS ""Hash"", ""C"".""Length"" AS ""Metasize"", ""C"".""Fullhash"" AS ""Metahash"" FROM (SELECT ""File"".""Path"", ""File"".""BlocksetID"" AS ""FileBlocksetID"", ""Metadataset"".""BlocksetID"" AS ""MetadataBlocksetID"" from ""Remotevolume"", ""Fileset"", ""FilesetEntry"", ""File"", ""Metadataset"" WHERE ""Remotevolume"".""Name"" = ? AND ""Fileset"".""VolumeID"" = ""Remotevolume"".""ID"" AND ""Fileset"".""ID"" = ""FilesetEntry"".""FilesetID"" AND ""File"".""ID"" = ""FilesetEntry"".""FileID"" AND ""File"".""MetadataID"" = ""Metadataset"".""ID"") A LEFT OUTER JOIN ""Blockset"" B ON ""B"".""ID"" = ""A"".""FileBlocksetID"" LEFT OUTER JOIN ""Blockset"" C ON ""C"".""ID""=""A"".""MetadataBlocksetID"" ";
                 var extra = @"SELECT ? AS ""Type"", ""{0}"".""Path"" AS ""Path"" FROM ""{0}"" WHERE ""{0}"".""Path"" NOT IN ( SELECT ""Path"" FROM ""{1}"" )";
                 var missing = @"SELECT ? AS ""Type"", ""Path"" AS ""Path"" FROM ""{1}"" WHERE ""Path"" NOT IN (SELECT ""Path"" FROM ""{0}"")";
                 var modified = @"SELECT ? AS ""Type"", ""E"".""Path"" AS ""Path"" FROM ""{0}"" E, ""{1}"" D WHERE ""D"".""Path"" = ""E"".""Path"" AND (""D"".""Size"" != ""E"".""Size"" OR ""D"".""Hash"" != ""E"".""Hash"" OR ""D"".""Metasize"" != ""E"".""Metasize"" OR ""D"".""Metahash"" != ""E"".""Metahash"")  ";
                 var drop = @"DROP TABLE IF EXISTS ""{1}"" ";
-                
-                using(var cmd = m_connection.CreateCommand())
+
+                using (var cmd = m_connection.CreateCommand())
                 {
                     cmd.Transaction = m_transaction;
-                    
+
                     try
                     {
                         cmd.ExecuteNonQuery(string.Format(create, m_tablename, cmpName), m_volumename);
-                        using(var rd = cmd.ExecuteReader(string.Format(extra + " UNION " + missing + " UNION " + modified, m_tablename, cmpName), (int)Library.Interface.TestEntryStatus.Extra, (int)Library.Interface.TestEntryStatus.Missing, (int)Library.Interface.TestEntryStatus.Modified))
-                            while(rd.Read())
+                        using (var rd = cmd.ExecuteReader(string.Format(extra + " UNION " + missing + " UNION " + modified, m_tablename, cmpName), (int)Library.Interface.TestEntryStatus.Extra, (int)Library.Interface.TestEntryStatus.Missing, (int)Library.Interface.TestEntryStatus.Modified))
+                            while (rd.Read())
                                 yield return new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>((Duplicati.Library.Interface.TestEntryStatus)rd.GetInt64(0), rd.GetString(1));
-                        
+
                     }
                     finally
                     {
                         try { cmd.ExecuteNonQuery(string.Format(drop, m_tablename, cmpName)); }
-                        catch {}
+                        catch { }
                     }
                 }
             }
         }
-        
-        public interface IIndexlist: IDisposable
+
+        public interface IIndexlist : IDisposable
         {
             void AddBlockLink(string filename, string hash, long length);
             IEnumerable<KeyValuePair<Library.Interface.TestEntryStatus, string>> Compare();
         }
-        
+
         private class Indexlist : Basiclist, IIndexlist
         {
             private const string TABLE_PREFIX = "Indexlist";
             private const string TABLE_FORMAT = @"(""Name"" TEXT NOT NULL, ""Hash"" TEXT NOT NULL, ""Size"" INTEGER NOT NULL)";
             private const string INSERT_COMMAND = @"(""Name"", ""Hash"", ""Size"") VALUES (?,?,?)";
             private const int INSERT_ARGUMENTS = 3;
-            
+
             public Indexlist(System.Data.IDbConnection connection, string volumename)
                 : base(connection, volumename, Indexlist.TABLE_PREFIX, Indexlist.TABLE_FORMAT, Indexlist.INSERT_COMMAND, Indexlist.INSERT_ARGUMENTS)
             {
             }
-                    
+
             public void AddBlockLink(string filename, string hash, long length)
             {
                 m_insertCommand.SetParameterValue(0, filename);
@@ -307,7 +307,7 @@ namespace Duplicati.Library.Main.Database
                 m_insertCommand.SetParameterValue(2, length);
                 m_insertCommand.ExecuteNonQuery();
             }
-            
+
             public IEnumerable<KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>> Compare()
             {
                 var cmpName = "CmpTable-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
@@ -316,84 +316,85 @@ namespace Duplicati.Library.Main.Database
                 var missing = @"SELECT ? AS ""Type"", ""Name"" AS ""Name"" FROM ""{1}"" WHERE ""Name"" NOT IN (SELECT ""Name"" FROM ""{0}"")";
                 var modified = @"SELECT ? AS ""Type"", ""E"".""Name"" AS ""Name"" FROM ""{0}"" E, ""{1}"" D WHERE ""D"".""Name"" = ""E"".""Name"" AND (""D"".""Hash"" != ""E"".""Hash"" OR ""D"".""Size"" != ""E"".""Size"") ";
                 var drop = @"DROP TABLE IF EXISTS ""{1}"" ";
-                
-                using(var cmd = m_connection.CreateCommand())
+
+                using (var cmd = m_connection.CreateCommand())
                 {
                     cmd.Transaction = m_transaction;
-                    
+
                     try
                     {
                         cmd.ExecuteNonQuery(string.Format(create, m_tablename, cmpName), m_volumename);
-                        using(var rd = cmd.ExecuteReader(string.Format(extra + " UNION " + missing + " UNION " + modified, m_tablename, cmpName), (int)Library.Interface.TestEntryStatus.Extra, (int)Library.Interface.TestEntryStatus.Missing, (int)Library.Interface.TestEntryStatus.Modified))
-                            while(rd.Read())
-                                yield return new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>((Duplicati.Library.Interface.TestEntryStatus)rd.GetInt64(0), rd.GetString(1) );
-                        
+                        using (var rd = cmd.ExecuteReader(string.Format(extra + " UNION " + missing + " UNION " + modified, m_tablename, cmpName), (int)Library.Interface.TestEntryStatus.Extra, (int)Library.Interface.TestEntryStatus.Missing, (int)Library.Interface.TestEntryStatus.Modified))
+                            while (rd.Read())
+                                yield return new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>((Duplicati.Library.Interface.TestEntryStatus)rd.GetInt64(0), rd.GetString(1));
+
                     }
                     finally
                     {
                         try { cmd.ExecuteNonQuery(string.Format(drop, m_tablename, cmpName)); }
-                        catch {}
+                        catch { }
                     }
                 }
             }
         }
-        
-        public interface IBlocklist: IDisposable
+
+        public interface IBlocklist : IDisposable
         {
             void AddBlock(string key, long value);
             IEnumerable<KeyValuePair<Library.Interface.TestEntryStatus, string>> Compare();
         }
 
-       private class Blocklist : Basiclist, IBlocklist
-       {
+        private class Blocklist : Basiclist, IBlocklist
+        {
             private const string TABLE_PREFIX = "Blocklist";
             private const string TABLE_FORMAT = @"(""Hash"" TEXT NOT NULL, ""Size"" INTEGER NOT NULL)";
             private const string INSERT_COMMAND = @"(""Hash"", ""Size"") VALUES (?,?)";
             private const int INSERT_ARGUMENTS = 2;
-            
+
             public Blocklist(System.Data.IDbConnection connection, string volumename)
                 : base(connection, volumename, Blocklist.TABLE_PREFIX, Blocklist.TABLE_FORMAT, Blocklist.INSERT_COMMAND, Blocklist.INSERT_ARGUMENTS)
-            { }            
-        
+            { }
+
             public void AddBlock(string hash, long size)
             {
                 m_insertCommand.SetParameterValue(0, hash);
                 m_insertCommand.SetParameterValue(1, size);
                 m_insertCommand.ExecuteNonQuery();
             }
-            
+
             public IEnumerable<KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>> Compare()
             {
                 var cmpName = "CmpTable-" + Library.Utility.Utility.ByteArrayAsHexString(Guid.NewGuid().ToByteArray());
                 var curBlocks = @"SELECT ""Block"".""Hash"" AS ""Hash"", ""Block"".""Size"" AS ""Size"" FROM ""Remotevolume"", ""Block"" WHERE ""Remotevolume"".""Name"" = ? AND ""Remotevolume"".""ID"" = ""Block"".""VolumeID""";
+                var duplBlocks = @"SELECT ""Block"".""Hash"" AS ""Hash"", ""Block"".""Size"" AS ""Size"" FROM ""DuplicateBlock"", ""Block"" WHERE ""DuplicateBlock"".""VolumeID"" = (SELECT ""ID"" FROM ""RemoteVolume"" WHERE ""Name"" = ?) AND ""Block"".""ID"" = ""DuplicateBlock"".""BlockID""";
                 var delBlocks = @"SELECT ""DeletedBlock"".""Hash"" AS ""Hash"", ""DeletedBlock"".""Size"" AS ""Size"" FROM ""DeletedBlock"", ""RemoteVolume"" WHERE ""RemoteVolume"".""Name"" = ? AND ""RemoteVolume"".""ID"" = ""DeletedBlock"".""VolumeID""";
-                var create = @"CREATE TEMPORARY TABLE ""{0}"" AS SELECT DISTINCT ""Hash"" AS ""Hash"", ""Size"" AS ""Size"" FROM ({1} UNION {2})";
+                var create = @"CREATE TEMPORARY TABLE ""{0}"" AS SELECT DISTINCT ""Hash"" AS ""Hash"", ""Size"" AS ""Size"" FROM ({1} UNION {2} UNION {3})";
                 var extra = @"SELECT ? AS ""Type"", ""{0}"".""Hash"" AS ""Hash"" FROM ""{0}"" WHERE ""{0}"".""Hash"" NOT IN ( SELECT ""Hash"" FROM ""{1}"" )";
                 var missing = @"SELECT ? AS ""Type"", ""Hash"" AS ""Hash"" FROM ""{1}"" WHERE ""Hash"" NOT IN (SELECT ""Hash"" FROM ""{0}"")";
                 var modified = @"SELECT ? AS ""Type"", ""E"".""Hash"" AS ""Hash"" FROM ""{0}"" E, ""{1}"" D WHERE ""D"".""Hash"" = ""E"".""Hash"" AND ""D"".""Size"" != ""E"".""Size""  ";
                 var drop = @"DROP TABLE IF EXISTS ""{1}"" ";
-                
-                using(var cmd = m_connection.CreateCommand())
+
+                using (var cmd = m_connection.CreateCommand())
                 {
                     cmd.Transaction = m_transaction;
-                    
+
                     try
                     {
-                        cmd.ExecuteNonQuery(string.Format(create, cmpName, curBlocks, delBlocks), m_volumename, m_volumename);
-                        using(var rd = cmd.ExecuteReader(string.Format(extra + " UNION " + missing + " UNION " + modified, m_tablename, cmpName), (int)Library.Interface.TestEntryStatus.Extra, (int)Library.Interface.TestEntryStatus.Missing, (int)Library.Interface.TestEntryStatus.Modified))
-                            while(rd.Read())
-                                yield return new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>((Duplicati.Library.Interface.TestEntryStatus)rd.GetInt64(0), rd.GetString(1) );
-                        
+                        cmd.ExecuteNonQuery(string.Format(create, cmpName, curBlocks, delBlocks, duplBlocks), m_volumename, m_volumename, m_volumename);
+                        using (var rd = cmd.ExecuteReader(string.Format(extra + " UNION " + missing + " UNION " + modified, m_tablename, cmpName), (int)Library.Interface.TestEntryStatus.Extra, (int)Library.Interface.TestEntryStatus.Missing, (int)Library.Interface.TestEntryStatus.Modified))
+                            while (rd.Read())
+                                yield return new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>((Duplicati.Library.Interface.TestEntryStatus)rd.GetInt64(0), rd.GetString(1));
+
                     }
                     finally
                     {
                         try { cmd.ExecuteNonQuery(string.Format(drop, m_tablename, cmpName)); }
-                        catch {}
+                        catch { }
                     }
                 }
             }
         }
-        
+
         public IFilelist CreateFilelist(string name)
         {
             return new Filelist(m_connection, name);

--- a/Duplicati/Library/Main/Duplicati.Library.Main.csproj
+++ b/Duplicati/Library/Main/Duplicati.Library.Main.csproj
@@ -34,6 +34,7 @@
     <EmbeddedResource Include="Database\Database schema\10. Add IsFullBackup to Fileset table.sql" />
     <EmbeddedResource Include="Database\Database schema\11. Add Block indices.sql" />
     <EmbeddedResource Include="Database\Database schema\12. Performance Indexes.sql" />
+    <EmbeddedResource Include="Database\Database schema\13. Unique index on DuplicateBlock.sql" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Duplicati/UnitTest/CompactDisruptionTests.cs
+++ b/Duplicati/UnitTest/CompactDisruptionTests.cs
@@ -1,11 +1,10 @@
-﻿using Duplicati.Library.Interface;
+using Duplicati.Library.Interface;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Duplicati.UnitTest
 {
@@ -28,9 +27,32 @@ namespace Duplicati.UnitTest
             return res.ToString();
         }
 
+        /// <summary>
+        /// Each backup run needs a unique timestamp to avoid the same backup being created.
+        /// During testing we often need to run backups in quick succession, so we need to
+        /// sleep until the next second to make sure the next backup timestamp is not the same.
+        /// </summary>
+        /// <param name="prevTimestamp">The timestamp of the previous backup</param>
+        private void SleepUntilNextSecond(DateTime prevTimestamp)
+        {
+            // Sleep until the next second to make sure the next backup is not the same
+            var nextSecond = prevTimestamp.AddMilliseconds(-prevTimestamp.Millisecond).AddSeconds(2);
+            var remainder = Math.Max(100, (nextSecond - DateTime.Now).TotalMilliseconds);
+            System.Threading.Thread.Sleep(TimeSpan.FromMilliseconds(remainder));
+        }
+
+        /// <summary>
+        /// Each backup run needs a unique timestamp to avoid the same backup being created.
+        /// During testing we often need to run backups in quick succession, so we need to
+        /// sleep until the next second to make sure the next backup timestamp is not the same.
+        /// </summary>
+        /// <param name="backupResults">The results of the previous backup</param>
+        private void SleepUntilNextSecond(IBackupResults backupResults)
+            => SleepUntilNextSecond(backupResults.BeginTime);
+
         [Test]
-        [Category("Disruption"), Category("Bug"), Explicit("Known bug")]
-        public void InterruptedCompact()
+        [Category("Disruption"), Category("Bug")]
+        public void InterruptedCompact5184()
         {
             // Reproduction steps from issue #4129 with smaller sizes
             var testopts = TestOptions;
@@ -61,18 +83,21 @@ namespace Duplicati.UnitTest
             {
                 IBackupResults backupResults = c.Backup(new[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
 
                 // Add files 3,4
                 TestUtils.WriteTestFile(file3, filesize);
                 TestUtils.WriteTestFile(file4, filesize);
                 backupResults = c.Backup(new[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
 
                 // Add files 5,6
                 TestUtils.WriteTestFile(file5, filesize);
                 TestUtils.WriteTestFile(file6, filesize);
                 backupResults = c.Backup(new[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
 
                 // Delete 1,3,5
                 File.Delete(file1);
@@ -100,7 +125,7 @@ namespace Duplicati.UnitTest
                 return false;
             };
             // Expect error from backend
-            Assert.Catch(() =>
+            Assert.Catch<DeterministicErrorBackend.DeterministicErrorBackendException>(() =>
             {
                 using (var c = new Library.Main.Controller(target, testopts, null))
                 {
@@ -111,6 +136,299 @@ namespace Duplicati.UnitTest
             DeterministicErrorBackend.ErrorGenerator = null;
             testopts["full-remote-verification"] = "true";
             testopts["full-block-verification"] = "true";
+            target = "file://" + TARGETFOLDER;
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+
+            // Remove the local database
+            File.Delete(DBFILE);
+
+            // Repair to recreate the local database
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                TestUtils.AssertResults(repairResults);
+            }
+
+            // Re-do the full verification
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+        }
+
+        [Test]
+        [Category("Disruption"), Category("Bug")]
+        public void InterruptedCompactPlusNormalCompact5184()
+        {
+            // Reproduction steps from issue #4129 with smaller sizes
+            var testopts = TestOptions;
+            testopts["backup-test-samples"] = "0";
+            testopts["number-of-retries"] = "0";
+            testopts["dblock-size"] = "20KB";
+            // Reduce blocksize, because with default blocksize too few blocks fit in a volume
+            testopts["blocksize"] = "1KB";
+            testopts["keep-versions"] = "1";
+            testopts["no-auto-compact"] = "true";
+            testopts["threshold"] = "5";
+
+            // This size seems to be appropriate to cause significant compacting
+            // in combination with dblock-size
+            const long filesize = 44971;
+
+            string target = "file://" + TARGETFOLDER;
+            string file1 = Path.Combine(DATAFOLDER, "f1");
+            string file2 = Path.Combine(DATAFOLDER, "f2");
+            string file3 = Path.Combine(DATAFOLDER, "f3");
+            string file4 = Path.Combine(DATAFOLDER, "f4");
+            string file5 = Path.Combine(DATAFOLDER, "f5");
+            string file6 = Path.Combine(DATAFOLDER, "f6");
+            // Add files 1,2
+            TestUtils.WriteTestFile(file1, filesize);
+            TestUtils.WriteTestFile(file2, filesize);
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Add files 3,4
+                TestUtils.WriteTestFile(file3, filesize);
+                TestUtils.WriteTestFile(file4, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Add files 5,6
+                TestUtils.WriteTestFile(file5, filesize);
+                TestUtils.WriteTestFile(file6, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Delete 1,3,5
+                File.Delete(file1);
+                File.Delete(file3);
+                File.Delete(file5);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+            }
+
+            // Deterministic error backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+            // Fail the compact after the first dblock put is completed
+            bool firstPutCompleted = false;
+            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            {
+                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                {
+                    return true;
+                }
+                if (action == "put_1" || action == "put_async")
+                {
+                    firstPutCompleted = true;
+                }
+                return false;
+            };
+            // Expect error from backend
+            Assert.Catch<DeterministicErrorBackend.DeterministicErrorBackendException>(() =>
+            {
+                using (var c = new Library.Main.Controller(target, testopts, null))
+                {
+                    ICompactResults compactResults = c.Compact();
+                    Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+                }
+            });
+            DeterministicErrorBackend.ErrorGenerator = null;
+            testopts["full-remote-verification"] = "true";
+            testopts["full-block-verification"] = "true";
+
+            target = "file://" + TARGETFOLDER;
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+
+            // Make sure we can compact after the interrupted compact
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ICompactResults compactResults = c.Compact();
+                Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+            }
+
+            // Make sure there are no errors after success compacting
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+
+            // Remove the local database
+            File.Delete(DBFILE);
+
+            // Repair to recreate the local database
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                TestUtils.AssertResults(repairResults);
+            }
+
+            // Re-do the full verification
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+        }
+
+        [Test]
+        [Category("Disruption"), Category("Bug")]
+        public void DoubleInterruptedCompact5184()
+        {
+            // Reproduction steps from issue #4129 with smaller sizes
+            var testopts = TestOptions;
+            testopts["backup-test-samples"] = "0";
+            testopts["number-of-retries"] = "0";
+            testopts["dblock-size"] = "20KB";
+            // Reduce blocksize, because with default blocksize too few blocks fit in a volume
+            testopts["blocksize"] = "1KB";
+            testopts["keep-versions"] = "1";
+            testopts["no-auto-compact"] = "true";
+            testopts["threshold"] = "5";
+
+            // This size seems to be appropriate to cause significant compacting
+            // in combination with dblock-size
+            const long filesize = 44971;
+
+            string target = "file://" + TARGETFOLDER;
+            string file1 = Path.Combine(DATAFOLDER, "f1");
+            string file2 = Path.Combine(DATAFOLDER, "f2");
+            string file3 = Path.Combine(DATAFOLDER, "f3");
+            string file4 = Path.Combine(DATAFOLDER, "f4");
+            string file5 = Path.Combine(DATAFOLDER, "f5");
+            string file6 = Path.Combine(DATAFOLDER, "f6");
+            // Add files 1,2
+            TestUtils.WriteTestFile(file1, filesize);
+            TestUtils.WriteTestFile(file2, filesize);
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Add files 3,4
+                TestUtils.WriteTestFile(file3, filesize);
+                TestUtils.WriteTestFile(file4, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Add files 5,6
+                TestUtils.WriteTestFile(file5, filesize);
+                TestUtils.WriteTestFile(file6, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Delete 1,3,5
+                File.Delete(file1);
+                File.Delete(file3);
+                File.Delete(file5);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+            }
+
+            // Deterministic error backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+            // Fail the compact after the first dblock put is completed
+            bool firstPutCompleted = false;
+            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            {
+                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                {
+                    return true;
+                }
+                if (action == "put_1" || action == "put_async")
+                {
+                    firstPutCompleted = true;
+                }
+                return false;
+            };
+            // Expect error from backend
+            Assert.Catch<DeterministicErrorBackend.DeterministicErrorBackendException>(() =>
+            {
+                using (var c = new Library.Main.Controller(target, testopts, null))
+                {
+                    ICompactResults compactResults = c.Compact();
+                    Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+                }
+            });
+
+            // Expect error from backend, again
+            Assert.Catch<DeterministicErrorBackend.DeterministicErrorBackendException>(() =>
+            {
+                using (var c = new Library.Main.Controller(target, testopts, null))
+                {
+                    ICompactResults compactResults = c.Compact();
+                    Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+                }
+            });
+
+            DeterministicErrorBackend.ErrorGenerator = null;
+            testopts["full-remote-verification"] = "true";
+            testopts["full-block-verification"] = "true";
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+
+            // Make sure we can compact after two interrupted compacts            
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ICompactResults compactResults = c.Compact();
+                Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+            }
+
+            // Make sure there are no errors after success compacting
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+
+            // Remove the local database
+            File.Delete(DBFILE);
+
+            // Repair to recreate the local database
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                TestUtils.AssertResults(repairResults);
+            }
+
+            // Re-do the full verification
             using (var c = new Library.Main.Controller(target, testopts, null))
             {
                 ITestResults testResults = c.Test(long.MaxValue);

--- a/Duplicati/UnitTest/CompactDisruptionTests.cs
+++ b/Duplicati/UnitTest/CompactDisruptionTests.cs
@@ -1,4 +1,4 @@
-using Duplicati.Library.Interface;
+﻿using Duplicati.Library.Interface;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -429,6 +429,149 @@ namespace Duplicati.UnitTest
             }
 
             // Re-do the full verification
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+        }
+
+        [Test]
+        [Category("Disruption"), Category("Bug")]
+        public void RestoreAfterDoubleInterruptedCompact5184()
+        {
+            // Reproduction steps from issue #4129 with smaller sizes
+            var testopts = TestOptions;
+            testopts["backup-test-samples"] = "0";
+            testopts["number-of-retries"] = "0";
+            testopts["dblock-size"] = "20KB";
+            // Reduce blocksize, because with default blocksize too few blocks fit in a volume
+            testopts["blocksize"] = "1KB";
+            testopts["keep-versions"] = "1";
+            testopts["no-auto-compact"] = "true";
+            testopts["threshold"] = "5";
+
+            // This size seems to be appropriate to cause significant compacting
+            // in combination with dblock-size
+            const long filesize = 44971;
+
+            string target = "file://" + TARGETFOLDER;
+            string file1 = Path.Combine(DATAFOLDER, "f1");
+            string file2 = Path.Combine(DATAFOLDER, "f2");
+            string file3 = Path.Combine(DATAFOLDER, "f3");
+            string file4 = Path.Combine(DATAFOLDER, "f4");
+            string file5 = Path.Combine(DATAFOLDER, "f5");
+            string file6 = Path.Combine(DATAFOLDER, "f6");
+            // Add files 1,2
+            TestUtils.WriteTestFile(file1, filesize);
+            TestUtils.WriteTestFile(file2, filesize);
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Add files 3,4
+                TestUtils.WriteTestFile(file3, filesize);
+                TestUtils.WriteTestFile(file4, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Add files 5,6
+                TestUtils.WriteTestFile(file5, filesize);
+                TestUtils.WriteTestFile(file6, filesize);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+                SleepUntilNextSecond(backupResults);
+
+                // Delete 1,3,5
+                File.Delete(file1);
+                File.Delete(file3);
+                File.Delete(file5);
+                backupResults = c.Backup(new[] { DATAFOLDER });
+                TestUtils.AssertResults(backupResults);
+            }
+
+            // Deterministic error backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+            // Fail the compact after the first dblock put is completed
+            bool firstPutCompleted = false;
+            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            {
+                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                {
+                    return true;
+                }
+                if (action == "put_1" || action == "put_async")
+                {
+                    firstPutCompleted = true;
+                }
+                return false;
+            };
+            // Expect error from backend
+            Assert.Catch<DeterministicErrorBackend.DeterministicErrorBackendException>(() =>
+            {
+                using (var c = new Library.Main.Controller(target, testopts, null))
+                {
+                    ICompactResults compactResults = c.Compact();
+                    Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+                }
+            });
+
+            // Expect error from backend, again
+            Assert.Catch<DeterministicErrorBackend.DeterministicErrorBackendException>(() =>
+            {
+                using (var c = new Library.Main.Controller(target, testopts, null))
+                {
+                    ICompactResults compactResults = c.Compact();
+                    Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+                }
+            });
+
+            DeterministicErrorBackend.ErrorGenerator = null;
+            testopts["full-remote-verification"] = "true";
+            testopts["full-block-verification"] = "true";
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+
+            // Remove the local database
+            File.Delete(DBFILE);
+
+            // Repair to recreate the local database
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                TestUtils.AssertResults(repairResults);
+            }
+
+            // Re-do the full verification
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ITestResults testResults = c.Test(long.MaxValue);
+                // Expect no verification errors
+                Assert.IsTrue(testResults.Verifications.All(v => !v.Value.Any()),
+                    "Test verification failed:\n {0}", VerificationToString(testResults.Verifications));
+            }
+
+            // Compact without issues on the repaired database
+            using (var c = new Library.Main.Controller(target, testopts, null))
+            {
+                ICompactResults compactResults = c.Compact();
+                // This currently fails, because the DeletedBlocks table is not populated after a repair
+                // Once PR #4982 is merged, this should work
+                // Assert.Greater(compactResults.DownloadedFileCount, 0, "No compact operation was performed");
+            }
+
+            // Make sure there are no errors after success compacting
             using (var c = new Library.Main.Controller(target, testopts, null))
             {
                 ITestResults testResults = c.Test(long.MaxValue);


### PR DESCRIPTION
As identified in #5184 if the compact process is interrupted, the local cache view of the remote storage gets slightly distorted.

The reason for this is that the blocks are moved from the old to the new volume in the database.
If the process completes, the old volume is deleted and all is fine.

But if the process is interrupted, the old file is recorded as having only the remaining blocks, but it has not been modified, so it actually has all the blocks still. If the verification process is started, the results here will show that the block file has "extra" data.

This PR changes the logic slightly, so each newly created volume will be assigned duplicated blocks, meaning the old volume stays the same through the process.
If the process is interrupted, the old volume is still fully registered in the database, and the verification works.
The new file has duplicate blocks, but these are also recognized and no errors happen.

When the compact is completed, the old volumes will be deleted. Before this step is performed, any blocks that are to be  lost from the old volume being deleted are selected from the duplicated blocks. These blocks now point to the new volume and the old volume is marked as deleted.

This fixes #5184 