### PR TITLE
Improve TrayIcon exit path

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/ProcessBasedActionDelay.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/ProcessBasedActionDelay.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using CoCoL;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.GUI.TrayIcon;
 
@@ -77,7 +78,7 @@ public class ProcessBasedActionDelay : IDisposable
     /// </summary>
     public void Dispose()
     {
-        m_inboundActionChannel.Retire();
-        m_initializedChannel.Retire();
+        m_inboundActionChannel.RetireAsync(true).Await();
+        m_initializedChannel.RetireAsync(true).Await();
     }
 }

--- a/Duplicati/Library/UsageReporter/Reporter.cs
+++ b/Duplicati/Library/UsageReporter/Reporter.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Threading.Tasks;
 using CoCoL;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.Library.UsageReporter
 {
@@ -34,7 +35,7 @@ namespace Duplicati.Library.UsageReporter
         /// The tag used for logging
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(Reporter));
-        
+
         /// <summary>
         /// The primary input channel for new report messages
         /// </summary>
@@ -126,7 +127,7 @@ namespace Duplicati.Library.UsageReporter
         public static void ShutDown()
         {
             if (_eventChannel != null && !_eventChannel.IsRetiredAsync.Result)
-                _eventChannel.Retire();
+                _eventChannel.RetireAsync().Await();
 
             if (ShutdownTask != null)
             {
@@ -194,7 +195,7 @@ namespace Duplicati.Library.UsageReporter
         /// <value><c>true</c> if is disabled; otherwise, <c>false</c>.</value>
         private static bool IsDisabled
         {
-            get 
+            get
             {
                 if (Forced_Disabled)
                     return true;


### PR DESCRIPTION
This adds a few safeguards to the exit.
Related to #5643, it should fix the hang and hopefully reveal the crash reason.