### PR TITLE
Fix to telegram notification

### DIFF
--- a/Duplicati/Library/Modules/Builtin/GenericModules.cs
+++ b/Duplicati/Library/Modules/Builtin/GenericModules.cs
@@ -36,8 +36,8 @@ public static class GenericModules
         new MSSQLOptions(),
         new RunScript(),
         new SendHttpMessage(),
-        new SendJabberMessage(),
-        // new SendTelegramMessage(),
+        new SendJabberMessage(), 
+        new SendTelegramMessage(),
         new SendMail(),
     ];
 }


### PR DESCRIPTION
Fixes the Telegram notification to use the correct API URL and to send the message in chunks if it is too long (which is often the case when an error occurs or there are warning messages).

Additionally, after the PR, the documentation will be rectified to include more details about configuration steps such as:

First create your telegram bot by messaging the @BotFather

For more information https://core.telegram.org/bots

Once you have created your bot you will have a bot token.

Now on the bot channel, send one message, “Hello”. This is important because the bot cannot initiate a conversation, it can only respond, so therefore that is the only way to obtain the chatId which needs to be configured on Duplicati.

Now on a browser or curl, access:

https://api.telegram.org/botYOURBOTTOKEN/getUpdates

Look for the property

"chat":{"id”:111122233,

Or get that with curl:

BOT_TOKEN="YOURBOTTOKEN" curl -s "https://api.telegram.org/bot$BOT_TOKEN/getUpdates" | grep -o '"id":[0-9]*' | head -1 | cut -d':' -f2
