### PR TITLE
Further progress on removal of build warnings.

### DIFF
--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -208,9 +208,11 @@ namespace Duplicati.Library.Backend
             }
             else
             {
+#pragma warning disable DE0001
                 System.Security.SecureString securePwd = new System.Security.SecureString();
+#pragma warning restore DE0001
                 usePassword.ToList().ForEach(c => securePwd.AppendChar(c));
-                m_userInfo = new Microsoft.SharePoint.Client.SharePointOnlineCredentials(useUsername, securePwd);
+                m_userInfo = new SharePointOnlineCredentials(useUsername, securePwd);
                 // Other options (also ADAL, see class remarks) might be supported on request.
                 // Maybe go in deep then and also look at:
                 // - Microsoft.SharePoint.Client.AppPrincipalCredential.CreateFromKeyGroup()

--- a/Duplicati/Library/Common/IO/PosixFile.cs
+++ b/Duplicati/Library/Common/IO/PosixFile.cs
@@ -41,7 +41,7 @@ namespace Duplicati.Library.Common.IO
                 Mono.Unix.Native.Syscall.llistxattr("/", out v);
                 works = true;
             }
-            catch (EntryPointNotFoundException e)
+            catch (EntryPointNotFoundException)
             {
             }
             catch

--- a/Duplicati/Library/Common/IO/SystemIO.cs
+++ b/Duplicati/Library/Common/IO/SystemIO.cs
@@ -42,8 +42,13 @@ namespace Duplicati.Library.Common.IO
         {
             // TODO: These interfaces cannot be properly guarded by the supported platform attribute in this form.
             // They are used in static methods of USNJournal on all platforms.
+            
+            // Since that is the case, the warnings will be suppressed with pragma.
+            
+#pragma warning disable CA1416
             IO_WIN = new SystemIOWindows();
             IO_SYS = new SystemIOLinux();
+#pragma warning restore CA1416
             if (OperatingSystem.IsWindows())
             {
                 IO_OS = IO_WIN;

--- a/Duplicati/Library/Interface/IQuotaEnabledBackend.cs
+++ b/Duplicati/Library/Interface/IQuotaEnabledBackend.cs
@@ -22,6 +22,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Duplicati.Library.Interface
 {
     /// <summary>

--- a/Duplicati/Library/Snapshots/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/UsnJournalService.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Common.IO;
@@ -421,6 +422,7 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="sources">List of sources</param>
         /// <returns>Dictionary of volumes, with list of sources as values</returns>
+        [SupportedOSPlatform("windows")]
         private static Dictionary<string, List<string>> SortByVolume(IEnumerable<string> sources)
         {
             var sourcesByVolume = new Dictionary<string, List<string>>();
@@ -446,6 +448,7 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
+        [SupportedOSPlatform("windows")]
         public bool IsPathEnumerated(string path)
         {
             // get NTFS volume root

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -19,6 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Duplicati/Library/Utility/WorkerThread.cs
+++ b/Duplicati/Library/Utility/WorkerThread.cs
@@ -333,18 +333,17 @@ namespace Duplicati.Library.Utility
                 }
                 catch (Exception ex)
                 {
-                    try { System.Threading.Thread.ResetAbort(); }
-                    catch { }
-
+                    //TODO: Here where Thread.ResetAbort() was called we shall integrate the CancelationToken pattern.
                     if (OnError != null)
                         try { OnError(this, m_currentTask, ex); }
-                        catch { }
+                        catch
+                        {
+                            // ignored
+                        }
                 }
                 finally
                 {
-                    try { System.Threading.Thread.ResetAbort(); }
-                    catch { }
-
+                    //TODO: Here where Thread.ResetAbort() was called we shall integrate the CancelationToken pattern.
                     m_active = false;
                 }
 
@@ -356,7 +355,10 @@ namespace Duplicati.Library.Utility
                     catch (Exception ex)
                     {
                         try { OnError(this, task, ex); }
-                        catch { }
+                        catch
+                        {
+                            // ignored
+                        }
                     }
             }
         }


### PR DESCRIPTION
None of these changes have impact on code execution, they are mainly part of the effort to remove all build warnings.

The removal of Thread.ResetAbort leaves a TODO for us to integrate CancelationToken when it gets propagated down here on future changes.
