### PR TITLE
Feature/fix loading slowness

### DIFF
--- a/Duplicati/Library/Interface/IGenericServerModule.cs
+++ b/Duplicati/Library/Interface/IGenericServerModule.cs
@@ -19,11 +19,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 
 namespace Duplicati.Library.Interface
 {
+    // TODO: This interface has no implementers and should be removed
+
     /// <summary>
     /// A module that displays a set of options in the general setup area
     /// </summary>

--- a/Duplicati/Library/SecretProvider/AWSSecretProvider.cs
+++ b/Duplicati/Library/SecretProvider/AWSSecretProvider.cs
@@ -56,10 +56,30 @@ public class AWSSecretProvider : ISecretProvider
         public const string AWS_ENDPOINT_URL = "AWS_ENDPOINT_URL";
     }
 
+    /// <summary>
+    /// Properties that are present in the specfic configuration and the general configuration
+    /// </summary>
+    private static readonly HashSet<string> DuplicatedProperties = new[] {
+        nameof(AmazonSecretsManagerConfig.RegionEndpoint),
+        nameof(AmazonSecretsManagerConfig.ServiceURL)
+    }.ToHashSet();
+
+    /// <summary>
+    /// List of properties that slow down the loading of the AWS Secrets Manager client
+    /// </summary>
+    private static readonly HashSet<string> SlowLoadingProperties = new[] {
+        nameof(AmazonSecretsManagerConfig.RegionEndpoint),
+        nameof(AmazonSecretsManagerConfig.ServiceURL),
+        nameof(AmazonSecretsManagerConfig.MaxErrorRetry),
+        nameof(AmazonSecretsManagerConfig.DefaultConfigurationMode),
+        nameof(AmazonSecretsManagerConfig.Timeout),
+        nameof(AmazonSecretsManagerConfig.RetryMode),
+    }.ToHashSet();
+
     /// <inheritdoc/>
     public IList<ICommandLineArgument> SupportedCommands
         => CommandLineArgumentMapper.MapArguments(new AWSSettings())
-        .Concat(CommandLineArgumentMapper.MapArguments(new AmazonSecretsManagerConfig(), OPTION_PREFIX_EXTRA))
+        .Concat(CommandLineArgumentMapper.MapArguments(new AmazonSecretsManagerConfig(), OPTION_PREFIX_EXTRA, exclude: DuplicatedProperties, excludeDefaultValue: SlowLoadingProperties))
         .ToList();
 
     /// <summary>

--- a/Duplicati/WebserverCore/Abstractions/ISystemInfoProvider.cs
+++ b/Duplicati/WebserverCore/Abstractions/ISystemInfoProvider.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+
+namespace Duplicati.WebserverCore.Abstractions;
+
+/// <summary>
+/// Produces system information.
+/// </summary>
+public interface ISystemInfoProvider
+{
+    /// <summary>
+    /// Gets the system information.
+    /// </summary>
+    /// <param name="browserlanguage">The browser language.</param>
+    /// <returns>The system information.</returns>
+    Dto.SystemInfoDto GetSystemInfo(CultureInfo? browserlanguage);
+}

--- a/Duplicati/WebserverCore/DuplicatiWebserver.cs
+++ b/Duplicati/WebserverCore/DuplicatiWebserver.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, The Duplicati Team
+﻿// Copyright (C) 2024, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a 
@@ -266,6 +266,9 @@ public partial class DuplicatiWebserver
 
         if (connection.ApplicationSettings.RemoteControlEnabled)
             App.Services.GetRequiredService<IRemoteController>().Enable();
+
+        // Preload static system info, for better first-load experience
+        var _ = Task.Run(() => App.Services.GetRequiredService<ISystemInfoProvider>().GetSystemInfo(null));
     }
 
     public Task Start(InitSettings settings)

--- a/Duplicati/WebserverCore/Endpoints/V1/SystemInfo.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/SystemInfo.cs
@@ -1,6 +1,4 @@
 using System.Globalization;
-using Duplicati.Library.RestAPI;
-using Duplicati.Server;
 using Duplicati.WebserverCore.Abstractions;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,64 +8,12 @@ public class SystemInfo : IEndpointV1
 {
     public static void Map(RouteGroupBuilder group)
     {
-        group.MapGet("/systeminfo", ([FromServices] ILanguageService languageService) => Execute(languageService.GetLanguage())).RequireAuthorization();
+        group.MapGet("/systeminfo", ([FromServices] ILanguageService languageService, [FromServices] ISystemInfoProvider systemInfoProvider) => Execute(systemInfoProvider, languageService.GetLanguage())).RequireAuthorization();
         group.MapGet("/systeminfo/filtergroups", () => ExecuteFilterGroups()).RequireAuthorization();
     }
 
-    private static Dto.SystemInfoDto Execute(CultureInfo? browserlanguage)
-    {
-        browserlanguage ??= CultureInfo.InvariantCulture;
-
-        return new Dto.SystemInfoDto()
-        {
-            APIVersion = 1,
-            PasswordPlaceholder = FIXMEGlobal.PASSWORD_PLACEHOLDER,
-            ServerVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(),
-            ServerVersionName = License.VersionNumbers.Version,
-            ServerVersionType = Library.AutoUpdater.UpdaterManager.SelfVersion.ReleaseType,
-            RemoteControlRegistrationUrl = Duplicati.Library.RemoteControl.RegisterForRemote.DefaultRegisterationUrl,
-            StartedBy = FIXMEGlobal.Origin,
-            DefaultUpdateChannel = Library.AutoUpdater.AutoUpdateSettings.DefaultUpdateChannel.ToString(),
-            DefaultUsageReportLevel = Library.UsageReporter.Reporter.DefaultReportLevel,
-            ServerTime = DateTime.Now,
-            OSType = OperatingSystem.IsWindows() ? "Windows" : OperatingSystem.IsLinux() ? "Linux" : OperatingSystem.IsMacOS() ? "MacOS" : "Unknown",
-            OSVersion = Library.UsageReporter.OSInfoHelper.PlatformString,
-            DirectorySeparator = Path.DirectorySeparatorChar,
-            PathSeparator = Path.PathSeparator,
-            CaseSensitiveFilesystem = Library.Utility.Utility.IsFSCaseSensitive,
-            MachineName = Environment.MachineName,
-            PackageTypeId = Library.AutoUpdater.UpdaterManager.PackageTypeId,
-            UserName = OperatingSystem.IsWindows() ? System.Security.Principal.WindowsIdentity.GetCurrent().Name : Environment.UserName,
-            NewLine = Environment.NewLine,
-            CLRVersion = Environment.Version.ToString(),
-            Options = Server.Serializable.ServerSettings.Options,
-            CompressionModules = Server.Serializable.ServerSettings.CompressionModules,
-            EncryptionModules = Server.Serializable.ServerSettings.EncryptionModules,
-            BackendModules = Server.Serializable.ServerSettings.BackendModules,
-            GenericModules = Server.Serializable.ServerSettings.GenericModules,
-            WebModules = Server.Serializable.ServerSettings.WebModules,
-            ConnectionModules = Server.Serializable.ServerSettings.ConnectionModules,
-            ServerModules = Server.Serializable.ServerSettings.ServerModules,
-            SecretProviderModules = Server.Serializable.ServerSettings.SecretProviderModules,
-            UsingAlternateUpdateURLs = Library.AutoUpdater.AutoUpdateSettings.UsesAlternateURLs,
-            LogLevels = Enum.GetNames(typeof(Library.Logging.LogMessageType)),
-            SpecialFolders = SpecialFolders.Nodes.Select(n => new Dto.SystemInfoDto.SpecialFolderDto { ID = n.id, Path = n.resolvedpath }),
-            BrowserLocale = new Dto.SystemInfoDto.LocaleDto()
-            {
-                Code = browserlanguage.Name,
-                EnglishName = browserlanguage.EnglishName,
-                DisplayName = browserlanguage.NativeName
-            },
-            SupportedLocales = Library.Localization.LocalizationService.SupportedCultures
-                .Select(x => new Dto.SystemInfoDto.LocaleDto
-                {
-                    Code = x,
-                    EnglishName = new CultureInfo(x).EnglishName,
-                    DisplayName = new CultureInfo(x).NativeName
-                }),
-            BrowserLocaleSupported = Library.Localization.LocalizationService.isCultureSupported(browserlanguage)
-        };
-    }
+    private static Dto.SystemInfoDto Execute(ISystemInfoProvider systemInfoProvider, CultureInfo? browserlanguage)
+        => systemInfoProvider.GetSystemInfo(browserlanguage);
 
     private static object ExecuteFilterGroups()
         => new { FilterGroups = Library.Utility.FilterGroups.GetFilterStringMap() };

--- a/Duplicati/WebserverCore/Extensions/ServiceCollectionsExtensions.cs
+++ b/Duplicati/WebserverCore/Extensions/ServiceCollectionsExtensions.cs
@@ -47,7 +47,8 @@ public static class ServiceCollectionsExtensions
             .AddTransient<ITokenFamilyStore, TokenFamilyStore>()
             .AddTransient<ILoginProvider, LoginProvider>()
             .AddSingleton<IRemoteController, RemoteControllerService>()
-            .AddSingleton<IRemoteControllerRegistration, RemoteControllerRegistrationService>();
+            .AddSingleton<IRemoteControllerRegistration, RemoteControllerRegistrationService>()
+            .AddSingleton<ISystemInfoProvider, SystemInfoProvider>();
 
         return services;
     }

--- a/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
+++ b/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
@@ -1,0 +1,278 @@
+using System.Globalization;
+using Duplicati.Library.RestAPI;
+using Duplicati.Server;
+using Duplicati.Server.Serialization.Interface;
+using Duplicati.WebserverCore.Abstractions;
+using Duplicati.WebserverCore.Dto;
+
+namespace Duplicati.WebserverCore.Services;
+
+/// <summary>
+/// Produces system information.
+/// </summary>
+public class SystemInfoProvider : ISystemInfoProvider
+{
+    /// <summary>
+    /// System information that does not change during runtime.
+    /// </summary>
+    private sealed record StaticSystemInformation
+    {
+        /// <summary>
+        /// Gets or sets the API version.
+        /// </summary>
+        public required int APIVersion { get; init; }
+
+        /// <summary>
+        /// Gets or sets the password placeholder.
+        /// </summary>
+        public required string PasswordPlaceholder { get; init; }
+
+        /// <summary>
+        /// Gets or sets the server version.
+        /// </summary>
+        public required string? ServerVersion { get; init; }
+
+        /// <summary>
+        /// Gets or sets the server version name.
+        /// </summary>
+        public required string ServerVersionName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the server version type.
+        /// </summary>
+        public required string? ServerVersionType { get; init; }
+
+        /// <summary>
+        /// The default URL to present for remote control registration
+        /// </summary>
+        public required string RemoteControlRegistrationUrl { get; init; }
+
+        /// <summary>
+        /// Gets or sets the started by.
+        /// </summary>
+        public required string StartedBy { get; init; }
+
+        /// <summary>
+        /// Gets or sets the default update channel.
+        /// </summary>
+        public required string DefaultUpdateChannel { get; init; }
+
+        /// <summary>
+        /// Gets or sets the default usage report level.
+        /// </summary>
+        public required string DefaultUsageReportLevel { get; init; }
+
+        /// <summary>
+        /// Gets or sets the OS type.
+        /// </summary>
+        public required string OSType { get; init; }
+
+        /// <summary>
+        /// Gets or sets the OS version.
+        /// </summary>
+        public required string OSVersion { get; init; }
+
+        /// <summary>
+        /// Gets or sets the directory separator.
+        /// </summary>
+        public required char DirectorySeparator { get; init; }
+
+        /// <summary>
+        /// Gets or sets the path separator.
+        /// </summary>
+        public required char PathSeparator { get; init; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the filesystem is case sensitive.
+        /// </summary>
+        public required bool CaseSensitiveFilesystem { get; init; }
+
+        /// <summary>
+        /// Gets or sets the machine name.
+        /// </summary>
+        public required string MachineName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the package type ID.
+        /// </summary>
+        public required string PackageTypeId { get; init; }
+
+        /// <summary>
+        /// Gets or sets the user name.
+        /// </summary>
+        public required string UserName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the new line character.
+        /// </summary>
+        public required string NewLine { get; init; }
+
+        /// <summary>
+        /// Gets or sets the CLR version.
+        /// </summary>
+        public required string CLRVersion { get; init; }
+
+        /// <summary>
+        /// Gets or sets the options.
+        /// </summary>
+        public required Library.Interface.ICommandLineArgument[] Options { get; init; }
+
+        /// <summary>
+        /// Gets or sets the compression modules.
+        /// </summary>
+        public required IDynamicModule[] CompressionModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets the encryption modules.
+        /// </summary>
+        public required IDynamicModule[] EncryptionModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets the backend modules.
+        /// </summary>
+        public required IDynamicModule[] BackendModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets the generic modules.
+        /// </summary>
+        public required IDynamicModule[] GenericModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets the web modules.
+        /// </summary>
+        public required IDynamicModule[] WebModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets the connection modules.
+        /// </summary>
+        public required IDynamicModule[] ConnectionModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets the server modules.
+        /// </summary>
+        public required object[] ServerModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets the secret provider modules.
+        /// </summary>
+        public required IDynamicModule[] SecretProviderModules { get; init; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether alternate update URLs are being used.
+        /// </summary>
+        public required bool UsingAlternateUpdateURLs { get; init; }
+
+        /// <summary>
+        /// Gets or sets the log levels.
+        /// </summary>
+        public required string[] LogLevels { get; init; }
+
+        /// <summary>
+        /// Gets or sets the special folders.
+        /// </summary>
+        public required SystemInfoDto.SpecialFolderDto[] SpecialFolders { get; init; }
+
+        /// <summary>
+        /// Gets or sets the supported locales.
+        /// </summary>
+        public required SystemInfoDto.LocaleDto[] SupportedLocales { get; init; }
+    }
+
+    /// <summary>
+    /// Cached static system information.
+    /// </summary>
+    private Lazy<StaticSystemInformation> _systemInfoBase = new(() => new StaticSystemInformation
+    {
+        APIVersion = 1,
+        PasswordPlaceholder = FIXMEGlobal.PASSWORD_PLACEHOLDER,
+        ServerVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(),
+        ServerVersionName = License.VersionNumbers.Version,
+        ServerVersionType = Library.AutoUpdater.UpdaterManager.SelfVersion.ReleaseType,
+        RemoteControlRegistrationUrl = Duplicati.Library.RemoteControl.RegisterForRemote.DefaultRegisterationUrl,
+        StartedBy = FIXMEGlobal.Origin,
+        DefaultUpdateChannel = Library.AutoUpdater.AutoUpdateSettings.DefaultUpdateChannel.ToString(),
+        DefaultUsageReportLevel = Library.UsageReporter.Reporter.DefaultReportLevel,
+        OSType = OperatingSystem.IsWindows() ? "Windows" : OperatingSystem.IsLinux() ? "Linux" : OperatingSystem.IsMacOS() ? "MacOS" : "Unknown",
+        OSVersion = Library.UsageReporter.OSInfoHelper.PlatformString,
+        DirectorySeparator = Path.DirectorySeparatorChar,
+        PathSeparator = Path.PathSeparator,
+        CaseSensitiveFilesystem = Library.Utility.Utility.IsFSCaseSensitive,
+        MachineName = Environment.MachineName,
+        PackageTypeId = Library.AutoUpdater.UpdaterManager.PackageTypeId,
+        UserName = OperatingSystem.IsWindows() ? System.Security.Principal.WindowsIdentity.GetCurrent().Name : Environment.UserName,
+        NewLine = Environment.NewLine,
+        CLRVersion = Environment.Version.ToString(),
+        Options = Server.Serializable.ServerSettings.Options,
+        CompressionModules = Server.Serializable.ServerSettings.CompressionModules,
+        EncryptionModules = Server.Serializable.ServerSettings.EncryptionModules,
+        BackendModules = Server.Serializable.ServerSettings.BackendModules,
+        GenericModules = Server.Serializable.ServerSettings.GenericModules,
+        WebModules = Server.Serializable.ServerSettings.WebModules,
+        ConnectionModules = Server.Serializable.ServerSettings.ConnectionModules,
+        ServerModules = Server.Serializable.ServerSettings.ServerModules,
+        SecretProviderModules = Server.Serializable.ServerSettings.SecretProviderModules,
+        UsingAlternateUpdateURLs = Library.AutoUpdater.AutoUpdateSettings.UsesAlternateURLs,
+        LogLevels = Enum.GetNames(typeof(Library.Logging.LogMessageType)),
+        SpecialFolders = SpecialFolders.Nodes.Select(n => new Dto.SystemInfoDto.SpecialFolderDto { ID = n.id, Path = n.resolvedpath }).ToArray(),
+        SupportedLocales = Library.Localization.LocalizationService.SupportedCultures
+                .Select(x => new Dto.SystemInfoDto.LocaleDto
+                {
+                    Code = x,
+                    EnglishName = new CultureInfo(x).EnglishName,
+                    DisplayName = new CultureInfo(x).NativeName
+                }).ToArray()
+    });
+
+    /// <inheritdoc />
+    public SystemInfoDto GetSystemInfo(CultureInfo? browserlanguage)
+    {
+        browserlanguage ??= CultureInfo.InvariantCulture;
+        var systeminfo = _systemInfoBase.Value;
+
+        // Return the system information, patch in dynamic values
+        return new SystemInfoDto()
+        {
+            APIVersion = systeminfo.APIVersion,
+            PasswordPlaceholder = systeminfo.PasswordPlaceholder,
+            ServerVersion = systeminfo.ServerVersion,
+            ServerVersionName = systeminfo.ServerVersionName,
+            ServerVersionType = systeminfo.ServerVersionType,
+            RemoteControlRegistrationUrl = systeminfo.RemoteControlRegistrationUrl,
+            StartedBy = systeminfo.StartedBy,
+            DefaultUpdateChannel = systeminfo.DefaultUpdateChannel,
+            DefaultUsageReportLevel = systeminfo.DefaultUsageReportLevel,
+            ServerTime = DateTime.Now,
+            OSType = systeminfo.OSType,
+            OSVersion = systeminfo.OSVersion,
+            DirectorySeparator = systeminfo.DirectorySeparator,
+            PathSeparator = systeminfo.PathSeparator,
+            CaseSensitiveFilesystem = systeminfo.CaseSensitiveFilesystem,
+            MachineName = systeminfo.MachineName,
+            PackageTypeId = systeminfo.PackageTypeId,
+            UserName = systeminfo.UserName,
+            NewLine = systeminfo.NewLine,
+            CLRVersion = systeminfo.CLRVersion,
+            Options = systeminfo.Options,
+            CompressionModules = systeminfo.CompressionModules,
+            EncryptionModules = systeminfo.EncryptionModules,
+            BackendModules = systeminfo.BackendModules,
+            GenericModules = systeminfo.GenericModules,
+            WebModules = systeminfo.WebModules,
+            ConnectionModules = systeminfo.ConnectionModules,
+            ServerModules = systeminfo.ServerModules,
+            SecretProviderModules = systeminfo.SecretProviderModules,
+            UsingAlternateUpdateURLs = systeminfo.UsingAlternateUpdateURLs,
+            LogLevels = systeminfo.LogLevels,
+            SpecialFolders = systeminfo.SpecialFolders,
+            BrowserLocale = new SystemInfoDto.LocaleDto()
+            {
+                Code = browserlanguage.Name,
+                EnglishName = browserlanguage.EnglishName,
+                DisplayName = browserlanguage.NativeName
+            },
+            SupportedLocales = systeminfo.SupportedLocales,
+            BrowserLocaleSupported = Library.Localization.LocalizationService.isCultureSupported(browserlanguage)
+
+        };
+    }
+}


### PR DESCRIPTION
This PR fixes a slowness caused by the new AWS Secrets Manager provider options creating network requests when reading the default values.
It also adds a general cache mechanism to the system info, so it can be fetched faster and will mask such issues in the future.