### PR TITLE
Fix settings page when running as agent

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/settings.html
+++ b/Duplicati/Server/webroot/ngax/templates/settings.html
@@ -36,7 +36,7 @@
             <label translate>Status: {{getRemoteControlStatusText()}}</label>
         </div>
 
-        <div ng-show="remoteControlState != 'unknown'">
+        <div ng-show="remoteControlState != 'unknown' &amp;&amp; SystemInfo.StartedBy != 'Agent'">
 
             <div class="input mixed multiple" ng-show="remoteControlState == 'inactive'">
                 <label for="remoteControlRegisterUrl" translate>Registration URL</label>

--- a/Duplicati/WebserverCore/Endpoints/V1/RemoteControl.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/RemoteControl.cs
@@ -9,13 +9,13 @@ public class RemoteControl : IEndpointV1
 {
     public static void Map(RouteGroupBuilder group)
     {
-        // Don't allow these in agent-mode
-        if (FIXMEGlobal.Origin == "Agent")
-            return;
-
         group.MapGet("/remotecontrol/status", ([FromServices] IRemoteControllerRegistration registration, [FromServices] IRemoteController remoteController)
             => GetStatus(registration, remoteController))
             .RequireAuthorization();
+
+        // Don't allow these in agent-mode
+        if (FIXMEGlobal.Origin == "Agent")
+            return;
 
         group.MapPost("/remotecontrol/enable", ([FromServices] IRemoteControllerRegistration registration, [FromServices] IRemoteController remoteController)
             => EnableRemoteControl(registration, remoteController))


### PR DESCRIPTION
Made the status call available when running agent mode, and hiding the buttons.

This fixes #5674