### PR TITLE
Added the missing crashlog feature.

### DIFF
--- a/Duplicati.sln
+++ b/Duplicati.sln
@@ -160,6 +160,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duplicati.CommandLine.Secre
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duplicati.CommandLine.SecretTool", "Executables\net8\Duplicati.CommandLine.SecretTool\Duplicati.CommandLine.SecretTool.csproj", "{E1D32EF7-368E-4148-9367-B328E78C871B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duplicati.Library.Crashlog", "Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj", "{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -454,6 +456,10 @@ Global
 		{E1D32EF7-368E-4148-9367-B328E78C871B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1D32EF7-368E-4148-9367-B328E78C871B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1D32EF7-368E-4148-9367-B328E78C871B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -511,6 +517,7 @@ Global
 		{A2957269-C11F-44CE-B355-CC9BA342295D} = {6B46F6B1-1898-49B8-ADA7-5CAF68EB77E3}
 		{D6417FD3-1645-4AB4-9F42-A1EC4A262B37} = {D19A38DD-68F1-4EF5-BF5F-8966CE0D9A5B}
 		{E1D32EF7-368E-4148-9367-B328E78C871B} = {6B46F6B1-1898-49B8-ADA7-5CAF68EB77E3}
+		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332} = {566EBBDA-19A4-4056-A615-D901D57D2439}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B40BAFE-D862-4397-9495-8F5EAF5CE80C}

--- a/Duplicati/Library/Crashlog/CrashlogHelper.cs
+++ b/Duplicati/Library/Crashlog/CrashlogHelper.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Duplicati.Library.Crashlog;
+#nullable enable
+
+/// <summary>
+/// Utility class to wrap a method in a try-catch block and log any exceptions to a file
+/// </summary>
+public static class CrashlogHelper
+{
+    /// <summary>
+    /// The system temp path
+    /// </summary>
+    private static readonly string SystemTempPath
+#if DEBUG
+        = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly()?.Location) ?? System.IO.Path.GetTempPath();
+#else
+        = System.IO.Path.GetTempPath();
+#endif
+
+    /// <summary>
+    /// The default directory to write crashlogs to
+    /// </summary>
+    public static string DefaultLogDir { get; set; } = SystemTempPath;
+
+    /// <summary>
+    /// Wraps a method in a try-catch block and logs any exceptions to a file
+    /// </summary>
+    /// <typeparam name="T">The return type of the method</typeparam>
+    /// <param name="method">The method to wrap</param>
+    /// <param name="logdir">The directory to write the crashlog to</param>
+    /// <param name="applicationName">The name of the application to write to the crashlog</param>
+    /// <returns>The result of the method</returns>
+    public static T WrapWithCrashLog<T>(Func<T> method, string? logdir = null, string? applicationName = null)
+        => WrapWithCrashLog(() => Task.Run(() => method()), logdir, applicationName).ConfigureAwait(false).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Wraps a method in a try-catch block and logs any exceptions to a file
+    /// </summary>
+    /// <typeparam name="T">The return type of the method</typeparam>
+    /// <param name="method">The method to wrap</param>
+    /// <param name="logdir">The directory to write the crashlog to</param>
+    /// <param name="applicationName">The name of the application to write to the crashlog</param>
+    /// <returns>The result of the method</returns>
+    public static async Task<T> WrapWithCrashLog<T>(Func<Task<T>> method, string? logdir = null, string? applicationName = null)
+    {
+        try
+        {
+            return await method().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                Console.WriteLine("Crash! {0}{1}", Environment.NewLine, ex);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                if (string.IsNullOrWhiteSpace(logdir))
+                {
+                    var def = DefaultLogDir;
+                    logdir = string.IsNullOrWhiteSpace(def)
+                        ? SystemTempPath
+                        : def;
+                }
+
+                applicationName = string.IsNullOrWhiteSpace(applicationName)
+                    ? System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? Guid.NewGuid().ToString()[..8]
+                    : applicationName;
+
+                var report_file = System.IO.Path.Combine(logdir, $"{applicationName}-crashlog.txt");
+                System.IO.File.WriteAllText(report_file, ex.ToString());
+            }
+            catch (Exception writeex)
+            {
+                try
+                {
+                    Console.WriteLine("Failed to write crashlog: {0}", writeex);
+                }
+                catch
+                {
+                }
+            }
+
+            throw;
+        }
+    }
+}

--- a/Duplicati/Library/Crashlog/Duplicati.Library.Crashlog.csproj
+++ b/Duplicati/Library/Crashlog/Duplicati.Library.Crashlog.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>    
+    <Description>Crashlog implementation</Description>
+	<RootNamespace>Duplicati.Library.Crashlog</RootNamespace>
+    <Copyright>Copyright © 2024 Team Duplicati, MIT license</Copyright>
+  </PropertyGroup>
+</Project>

--- a/Duplicati/Library/Snapshots/Program.cs
+++ b/Duplicati/Library/Snapshots/Program.cs
@@ -62,7 +62,7 @@ namespace Duplicati.Library.Snapshots
             return options;
         }
 
-        public static void Main(string[] _args)
+        public static int Main(string[] _args)
         {
             try
             {
@@ -78,7 +78,7 @@ namespace Duplicati.Library.Snapshots
 {PackageHelper.GetExecutableName(PackageHelper.NamedExecutable.Snapshots)} [test-folder]
 
 Where <test-folder> is the folder where files will be locked/created etc");
-                    return;
+                    return 1;
                 }
 
                 if (!System.IO.Directory.Exists(args[0]))
@@ -99,7 +99,7 @@ Where <test-folder> is the folder where files will be locked/created etc");
 
                         Console.WriteLine("Could open locked file {0}, cannot test", filename);
                         Console.WriteLine("* Test failed");
-                        return;
+                        return 1;
                     }
                     catch (Exception ex)
                     {
@@ -122,17 +122,19 @@ Where <test-folder> is the folder where files will be locked/created etc");
                         {
                             Console.WriteLine("The file {0} was locked even through snapshot, message: {1}", filename, ex);
                             Console.WriteLine("* Test failed");
-                            return;
+                            return 2;
                         }
                     }
                 }
 
                 Console.WriteLine("* Test passed");
+                return 0;
             }
             catch (Exception ex)
             {
                 Console.WriteLine("The snapshot tester failed: {0}", ex);
                 Console.WriteLine("* Test failed");
+                return 3;
             }
 
         }

--- a/Duplicati/Server/Duplicati.Server.csproj
+++ b/Duplicati/Server/Duplicati.Server.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\CommandLine\RecoveryTool\Duplicati.CommandLine.RecoveryTool.csproj" />
     <ProjectReference Include="..\Library\UsageReporter\Duplicati.Library.UsageReporter.csproj" />
     <ProjectReference Include="..\Tools\Duplicati.Tools.csproj" />
+    <ProjectReference Include="..\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Common.IO;
+using Duplicati.Library.Crashlog;
 using Duplicati.Library.Encryption;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
@@ -698,6 +699,7 @@ namespace Duplicati.Server
         public static Database.Connection GetDatabaseConnection(Dictionary<string, string> commandlineOptions, bool silentConsole)
         {
             DataFolder = GetDataFolderPath(commandlineOptions);
+            CrashlogHelper.DefaultLogDir = DataFolder;
 
             var sqliteVersion = new Version(Duplicati.Library.SQLiteHelper.SQLiteLoader.SQLiteVersion);
             if (sqliteVersion < new Version(3, 6, 3))

--- a/Executables/net8/Duplicati.Agent/Duplicati.Agent.csproj
+++ b/Executables/net8/Duplicati.Agent/Duplicati.Agent.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\Agent\Duplicati.Agent.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.Agent/Program.cs
+++ b/Executables/net8/Duplicati.Agent/Program.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Duplicati.Library.Crashlog;
 
 namespace Duplicati.Agent.Net8
 {
@@ -6,6 +7,6 @@ namespace Duplicati.Agent.Net8
     public static class Program
     {
         public static Task<int> Main(string[] args)
-            => Duplicati.Agent.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.Agent.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.AutoUpdater/Duplicati.CommandLine.AutoUpdater.csproj
+++ b/Executables/net8/Duplicati.CommandLine.AutoUpdater/Duplicati.CommandLine.AutoUpdater.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Duplicati\Library\AutoUpdater\Duplicati.Library.AutoUpdater.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.CommandLine.AutoUpdater/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.AutoUpdater/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.CommandLine.AutoUpdater.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.Library.AutoUpdater.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.Library.AutoUpdater.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.BackendTester/Duplicati.CommandLine.BackendTester.csproj
+++ b/Executables/net8/Duplicati.CommandLine.BackendTester/Duplicati.CommandLine.BackendTester.csproj
@@ -9,6 +9,7 @@
   
   <ItemGroup>	
 	  <ProjectReference Include="..\..\..\Duplicati\CommandLine\BackendTester\Duplicati.CommandLine.BackendTester.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.CommandLine.BackendTester/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.BackendTester/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.CommandLine.BackendTester.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.CommandLine.BackendTester.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.BackendTester.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.BackendTool/Duplicati.CommandLine.BackendTool.csproj
+++ b/Executables/net8/Duplicati.CommandLine.BackendTool/Duplicati.CommandLine.BackendTool.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\CommandLine\BackendTool\Duplicati.CommandLine.BackendTool.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.CommandLine.BackendTool/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.BackendTool/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.CommandLine.BackendTool.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.CommandLine.BackendTool.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.BackendTool.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
+++ b/Executables/net8/Duplicati.CommandLine.RecoveryTool/Duplicati.CommandLine.RecoveryTool.csproj
@@ -9,6 +9,7 @@
   
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\CommandLine\RecoveryTool\Duplicati.CommandLine.RecoveryTool.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.CommandLine.RecoveryTool/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.RecoveryTool/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.CommandLine.RecoveryTool.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.CommandLine.RecoveryTool.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.RecoveryTool.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.SecretTool/Duplicati.CommandLine.SecretTool.csproj
+++ b/Executables/net8/Duplicati.CommandLine.SecretTool/Duplicati.CommandLine.SecretTool.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\CommandLine\SecretTool\Duplicati.CommandLine.SecretTool.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.CommandLine.SecretTool/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.SecretTool/Program.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Duplicati.Library.Crashlog;
 
 namespace Duplicati.CommandLine.SecretTool.Net8
 {
@@ -6,6 +7,6 @@ namespace Duplicati.CommandLine.SecretTool.Net8
     public static class Program
     {
         public static Task<int> Main(string[] args)
-            => Duplicati.CommandLine.SecretTool.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.SecretTool.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.ServerUtil/Duplicati.CommandLine.ServerUtil.csproj
+++ b/Executables/net8/Duplicati.CommandLine.ServerUtil/Duplicati.CommandLine.ServerUtil.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\CommandLine\ServerUtil\Duplicati.CommandLine.ServerUtil.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.CommandLine.ServerUtil/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.ServerUtil/Program.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Duplicati.Library.Crashlog;
 
 namespace Duplicati.CommandLine.ServerUtil.Net8
 {
@@ -6,6 +7,6 @@ namespace Duplicati.CommandLine.ServerUtil.Net8
     public static class Program
     {
         public static Task<int> Main(string[] args)
-            => Duplicati.CommandLine.ServerUtil.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.ServerUtil.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.SharpAESCrypt/Duplicati.CommandLine.SharpAESCrypt.csproj
+++ b/Executables/net8/Duplicati.CommandLine.SharpAESCrypt/Duplicati.CommandLine.SharpAESCrypt.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Duplicati\Library\Encryption\Duplicati.Library.Encryption.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Executables/net8/Duplicati.CommandLine.SharpAESCrypt/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.SharpAESCrypt/Program.cs
@@ -1,9 +1,16 @@
+using System;
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.CommandLine.SharpAESCrypt.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
-        public static void Main(string[] args)
-            => global::SharpAESCrypt.Program.CommandLineMain(args);
+        public static int Main(string[] args)
+            => CrashlogHelper.WrapWithCrashLog(() =>
+            {
+                global::SharpAESCrypt.Program.CommandLineMain(args);
+                return Environment.ExitCode;
+            });
     }
 }

--- a/Executables/net8/Duplicati.CommandLine.Snapshots/Duplicati.CommandLine.Snapshots.csproj
+++ b/Executables/net8/Duplicati.CommandLine.Snapshots/Duplicati.CommandLine.Snapshots.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Duplicati\Library\Snapshots\Duplicati.Library.Snapshots.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Executables/net8/Duplicati.CommandLine.Snapshots/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine.Snapshots/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.CommandLine.Snapshots.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
-        public static void Main(string[] args)
-            => Duplicati.Library.Snapshots.Program.Main(args);
+        public static int Main(string[] args)
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.Library.Snapshots.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.CommandLine/Duplicati.CommandLine.csproj
+++ b/Executables/net8/Duplicati.CommandLine/Duplicati.CommandLine.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\CommandLine\CLI\Duplicati.CommandLine.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.CommandLine/Program.cs
+++ b/Executables/net8/Duplicati.CommandLine/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.CommandLine.CLI.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.CommandLine.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
+++ b/Executables/net8/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\GUI\Duplicati.GUI.TrayIcon\Duplicati.GUI.TrayIcon.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Executables/net8/Duplicati.GUI.TrayIcon/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.GUI.TrayIcon.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.GUI.TrayIcon.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.GUI.TrayIcon.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.Server/Duplicati.Server.csproj
+++ b/Executables/net8/Duplicati.Server/Duplicati.Server.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\Server\Duplicati.Server.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.Server/Program.cs
+++ b/Executables/net8/Duplicati.Server/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.Server.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.Server.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.Server.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.Service/Duplicati.Service.csproj
+++ b/Executables/net8/Duplicati.Service/Duplicati.Service.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>	
     <ProjectReference Include="..\..\..\Duplicati\Service\Duplicati.Service.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Executables/net8/Duplicati.Service/Program.cs
+++ b/Executables/net8/Duplicati.Service/Program.cs
@@ -1,9 +1,11 @@
+using Duplicati.Library.Crashlog;
+
 namespace Duplicati.Service.Net8
 {
     // Wrapper class to keep code independent
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.Service.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.Service.Program.Main(args));
     }
 }

--- a/Executables/net8/Duplicati.WindowsService/Duplicati.WindowsService.csproj
+++ b/Executables/net8/Duplicati.WindowsService/Duplicati.WindowsService.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../../Duplicati/WindowsService/Duplicati.WindowsService.csproj" />
+    <ProjectReference Include="..\..\..\Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Executables/net8/Duplicati.WindowsService/Program.cs
+++ b/Executables/net8/Duplicati.WindowsService/Program.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Versioning;
+using Duplicati.Library.Crashlog;
 
 namespace Duplicati.WindowsService.Net8
 {
@@ -6,6 +7,6 @@ namespace Duplicati.WindowsService.Net8
     public static class Program
     {
         public static int Main(string[] args)
-            => Duplicati.WindowsService.Program.Main(args);
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.WindowsService.Program.Main(args));
     }
 }


### PR DESCRIPTION
The crashlog feature was lost during the removal of the auto-updater. 
This PR adds it back, in a slightly different way.

If the process crashes, it will write a crashlog text file in the system temporary folder.
If the Server component is started, it will instead be placed next to the database.
