### PR TITLE
Fixed issues with update detection.

### DIFF
--- a/Duplicati/Library/AutoUpdater/Program.cs
+++ b/Duplicati/Library/AutoUpdater/Program.cs
@@ -68,7 +68,7 @@ namespace Duplicati.Library.AutoUpdater
                         var update = UpdaterManager.CheckForUpdate();
                         if (update == null || update.Version == UpdaterManager.SelfVersion.Version)
                         {
-                            Console.WriteLine("You are running the latest version: {0} ({1})", UpdaterManager.SelfVersion.Displayname, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
+                            Console.WriteLine("You are running the latest version: {0} ({1})", UpdaterManager.SelfVersion.Displayname, UpdaterManager.SelfVersion.Version);
                             return 0;
                         }
 
@@ -117,7 +117,7 @@ namespace Duplicati.Library.AutoUpdater
             Console.WriteLine();
             Console.WriteLine("Updates are downloaded from: {0}", string.Join(";", AutoUpdateSettings.URLs));
             Console.WriteLine("Machine settings are installed in: {0}", UpdaterManager.UPDATEDIR);
-            Console.WriteLine("This version is \"{0}\" ({1}) and is installed in: {2}", UpdaterManager.SelfVersion.Displayname, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version, UpdaterManager.INSTALLATIONDIR);
+            Console.WriteLine("This version is \"{0}\" ({1}) and is installed in: {2}", UpdaterManager.SelfVersion.Displayname, UpdaterManager.SelfVersion.Version, UpdaterManager.INSTALLATIONDIR);
             Console.WriteLine();
         }
     }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -25,6 +25,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Crashlog;
 using Duplicati.Library.Encryption;
@@ -555,6 +556,23 @@ namespace Duplicati.Server
                 {
                     throw new UserInformationException(Strings.Program.InvalidTimezone(commandlineOptions[WebServerLoader.OPTION_WEBSERVICE_TIMEZONE]), "InvalidTimeZone", ex);
                 }
+
+            // The database has recorded a new version
+            if (DataConnection.ApplicationSettings.UpdatedVersion != null)
+            {
+                // Check if the running version is newer than the recorded version
+                if (UpdaterManager.TryParseVersion(DataConnection.ApplicationSettings.UpdatedVersion.Version) <= UpdaterManager.TryParseVersion(UpdaterManager.SelfVersion.Version))
+                {
+                    // Clean up lingering update notifications
+                    var updateNotifications = DataConnection.GetNotifications().Where(x => x.Action == "update:new").ToList();
+                    foreach (var n in updateNotifications)
+                        DataConnection.DismissNotification(n.ID);
+
+                    // Clear up the recorded version
+                    DataConnection.ApplicationSettings.UpdatedVersion = null;
+                }
+            }
+
         }
 
         private static void CreateApplicationInstance(bool writeToConsoleOnExceptionw)

--- a/Duplicati/Server/WebServerLoader.cs
+++ b/Duplicati/Server/WebServerLoader.cs
@@ -241,7 +241,7 @@ public static class WebServerLoader
             -1,
             listenInterface,
             connection.ApplicationSettings.UseHTTPS ? connection.ApplicationSettings.ServerSSLCertificate : null,
-            string.Format("{0} v{1}", Library.AutoUpdater.AutoUpdateSettings.AppName, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version),
+            string.Format("{0} v{1}", Library.AutoUpdater.AutoUpdateSettings.AppName, Library.AutoUpdater.UpdaterManager.SelfVersion.Version),
             (connection.ApplicationSettings.AllowedHostnames ?? string.Empty).Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries),
             Duplicati.Library.Utility.Utility.ParseBoolOption(options, OPTION_WEBSERVICE_API_ONLY),
             spaPathsString.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)

--- a/Duplicati/WebserverCore/Endpoints/V1/Changelog.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Changelog.cs
@@ -1,3 +1,4 @@
+using Duplicati.Library.AutoUpdater;
 using Duplicati.Server.Database;
 using Duplicati.WebserverCore.Abstractions;
 using Duplicati.WebserverCore.Exceptions;
@@ -32,7 +33,7 @@ public class Changelog : IEndpointV1
             var path = Path.Combine(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) ?? ".", "changelog.txt");
             return new Dto.ChangelogDto()
             {
-                Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(),
+                Version = UpdaterManager.SelfVersion.Version,
                 Changelog = System.IO.File.ReadAllText(path)
             };
         }

--- a/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
+++ b/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.RestAPI;
 using Duplicati.Server;
 using Duplicati.Server.Serialization.Interface;
@@ -190,7 +191,7 @@ public class SystemInfoProvider : ISystemInfoProvider
     {
         APIVersion = 1,
         PasswordPlaceholder = FIXMEGlobal.PASSWORD_PLACEHOLDER,
-        ServerVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(),
+        ServerVersion = UpdaterManager.SelfVersion.Version,
         ServerVersionName = License.VersionNumbers.Version,
         ServerVersionType = Library.AutoUpdater.UpdaterManager.SelfVersion.ReleaseType,
         RemoteControlRegistrationUrl = Duplicati.Library.RemoteControl.RegisterForRemote.DefaultRegisterationUrl,


### PR DESCRIPTION
This fixes a case where the update checker keeps an old reference to the previous updated version, despite running a newer version.

It also removes some use of `Assembly.GetExecutingAssembly().GetName().Version` with the information from `UpdaterManager.SelfVersion.Version` as that should follow the update info.

This fixes #5698
This fixes #5252