### PR TITLE
Suppress HyperV warning option

### DIFF
--- a/Duplicati/Library/Modules/Builtin/Strings.cs
+++ b/Duplicati/Library/Modules/Builtin/Strings.cs
@@ -62,6 +62,8 @@ namespace Duplicati.Library.Modules.Builtin.Strings
     {
         public static string Description { get { return LC.L(@"This module works internaly to parse source parameters to backup Hyper-V virtual machines"); } }
         public static string DisplayName { get { return LC.L(@"Configure Hyper-V module"); } }
+        public static string IgnoreConsistencyWarningShort { get { return LC.L(@"Ignore consistency warning"); } }
+        public static string IgnoreConsistencyWarningLong { get { return LC.L(@"This option will suppress the consistency warning that is normally issued when running on a client version of Windows. Enable this option if you are running on a client version of Windows and you are sure that crash-level consistency is acceptable for your use."); } }
     }
     internal static class MSSQLOptions
     {


### PR DESCRIPTION
This adds a new option to suppress the normal warning that is issues on client-version of Windows.

This fixes #5692