### PR TITLE
Fix for the streaming error on BackendTester interaction

### DIFF
--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -250,7 +250,6 @@ public class pCloudBackend : IStreamingBackend
         using var requestResources =
             CreateRequest($"/uploadfile?folderid={_CachedFolderID}&filename={encodedPath}&nopartial=1",
                 HttpMethod.Post);
-        input.Position = 0;
         requestResources.RequestMessage.Content = new StreamContent(input);
         requestResources.RequestMessage.Content.Headers.ContentLength = input.Length;
         requestResources.RequestMessage.Content.Headers.ContentType =


### PR DESCRIPTION
This issue does not affect the pCloud backend per se and its functioning as expected.

The issue is related to a symptom the BackendTester revealed as discussed here:

https://github.com/duplicati/duplicati/pull/5709

It turns out the backends should assume the caller has set the input stream at the correct position and take it from there.

Therefore the fix is simply to remove the .Position = 0; which was well intended as a way to make sure the stream was at the beginning however thats not the pattern to follow when integrating backends.

A future blog post/tutorial on new backend integrations will mention these premises.

Even though this does not affect the actual backend usage, as soon as this is merged the CI PR can be incremented with the github actions and merged to have pCloud CI up and running.
