### PR TITLE
Implement nested folder support and improve file operations on pCloud Backend

### DIFF
--- a/Duplicati/Library/Backend/pCloud/Model/pCloudFolderContent.cs
+++ b/Duplicati/Library/Backend/pCloud/Model/pCloudFolderContent.cs
@@ -85,7 +85,7 @@ internal record pCloudFolderContent
     /// <summary>
     /// Folder ID if the item is a folder (null otherwise)
     /// </summary>
-    public long? folderid { get; init; }
+    public ulong folderid { get; init; }
 
     /// <summary>
     /// File ID if the item is a file (null otherwise)


### PR DESCRIPTION
- Add support for subfolders
- Implement robust file selection using fileId for Download/Delete operations instead of concatenation of path + filename and folder selection using folderId rather than pathnames.


This is a fix for the issue raised on the forum: https://forum.duplicati.com/t/pcloud-and-duplicati/8546/16


