### PR TITLE
Implemented support for emitting intermediate certificates from pfx

### DIFF
--- a/Duplicati/CommandLine/ServerUtil/Connection.cs
+++ b/Duplicati/CommandLine/ServerUtil/Connection.cs
@@ -163,7 +163,11 @@ public class Connection
                 {
                     cfg = connection.ApplicationSettings.JWTConfig;
                     if (settings.HostUrl.Scheme == "https" && connection.ApplicationSettings.ServerSSLCertificate != null && trustedCertificateHashes.Count == 0)
-                        trustedCertificateHashes.Add(connection.ApplicationSettings.ServerSSLCertificate.GetCertHashString());
+                    {
+                        var selfSignedCertHash = connection.ApplicationSettings.ServerSSLCertificate?.FirstOrDefault(x => x.HasPrivateKey)?.GetCertHashString();
+                        if (!string.IsNullOrWhiteSpace(selfSignedCertHash))
+                            trustedCertificateHashes.Add(selfSignedCertHash);
+                    }
                 }
 
                 if (!string.IsNullOrWhiteSpace(cfg))

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using Duplicati.Library.Interface;
 using Duplicati.Library.RestAPI;
@@ -148,7 +149,7 @@ namespace Duplicati.GUI.TrayIcon
                 }.Uri;
 
                 if (Server.Program.DataConnection.ApplicationSettings.UseHTTPS && string.IsNullOrWhiteSpace(acceptedHostCertificate))
-                    acceptedHostCertificate = Server.Program.DataConnection.ApplicationSettings.ServerSSLCertificate.GetCertHashString();
+                    acceptedHostCertificate = Server.Program.DataConnection.ApplicationSettings.ServerSSLCertificate?.FirstOrDefault(x => x.HasPrivateKey)?.GetCertHashString();
 
             }
             else if (Library.Utility.Utility.ParseBoolOption(options, READCONFIGFROMDB_OPTION))
@@ -162,7 +163,7 @@ namespace Duplicati.GUI.TrayIcon
                     {
                         disableTrayIconLogin = databaseConnection.ApplicationSettings.DisableTrayIconLogin;
                         if (databaseConnection.ApplicationSettings.UseHTTPS && string.IsNullOrWhiteSpace(acceptedHostCertificate))
-                            acceptedHostCertificate = databaseConnection.ApplicationSettings.ServerSSLCertificate.GetCertHashString();
+                            acceptedHostCertificate = databaseConnection.ApplicationSettings.ServerSSLCertificate?.FirstOrDefault(x => x.HasPrivateKey)?.GetCertHashString();
 
                         var scheme = databaseConnection.ApplicationSettings.UseHTTPS ? "https" : "http";
                         serverURL = new UriBuilder(serverURL)

--- a/Duplicati/Library/RestAPI/Database/ServerSettings.cs
+++ b/Duplicati/Library/RestAPI/Database/ServerSettings.cs
@@ -644,7 +644,7 @@ namespace Duplicati.Server.Database
             }
         }
 
-        public X509Certificate2? ServerSSLCertificate
+        public X509Certificate2Collection? ServerSSLCertificate
         {
             get
             {

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, The Duplicati Team
+﻿// Copyright (C) 2024, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a 
@@ -1529,7 +1529,7 @@ namespace Duplicati.Library.Utility
         /// <param name="password">The password used to protect the PFX file</param>
         /// <param name="allowUnsafeCertificateLoad">A flag indicating if unsafe certificate loading is allowed</param>
         /// <returns>The loaded certificate</returns>
-        public static X509Certificate2 LoadPfxCertificate(ReadOnlySpan<byte> pfxcertificate, string? password, bool allowUnsafeCertificateLoad = false)
+        public static X509Certificate2Collection LoadPfxCertificate(ReadOnlySpan<byte> pfxcertificate, string? password, bool allowUnsafeCertificateLoad = false)
         {
             if (string.IsNullOrWhiteSpace(password) && !allowUnsafeCertificateLoad)
                 throw new ArgumentException("Refusing to write unencryped certificate to disk");
@@ -1545,7 +1545,7 @@ namespace Duplicati.Library.Utility
         /// <param name="pfxPath">The path to the file</param>
         /// <param name="password">The password used to protect the PFX file</param>
         /// <returns>The loaded certificate</returns>
-        public static X509Certificate2 LoadPfxCertificate(string pfxPath, string? password)
+        public static X509Certificate2Collection LoadPfxCertificate(string pfxPath, string? password)
         {
             if (string.IsNullOrEmpty(pfxPath))
                 throw new ArgumentNullException(nameof(pfxPath));
@@ -1553,7 +1553,9 @@ namespace Duplicati.Library.Utility
             if (!File.Exists(pfxPath))
                 throw new FileNotFoundException("The specified PFX file does not exist.", pfxPath);
 
-            return new X509Certificate2(pfxPath, password, X509KeyStorageFlags.Exportable);
+            var collection = new X509Certificate2Collection();
+            collection.Import(pfxPath, password, X509KeyStorageFlags.Exportable);
+            return collection;
         }
     }
 }

--- a/Duplicati/Server/WebServerLoader.cs
+++ b/Duplicati/Server/WebServerLoader.cs
@@ -151,7 +151,7 @@ public static class WebServerLoader
         string WebRoot,
         int Port,
         System.Net.IPAddress Interface,
-        X509Certificate2? Certificate,
+        X509Certificate2Collection? Certificate,
         string Servername,
         IEnumerable<string> AllowedHostnames,
         bool DisableStaticFiles,

--- a/Duplicati/WebserverCore/Endpoints/V1/UpdateCertificate.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/UpdateCertificate.cs
@@ -19,7 +19,7 @@ public class UpdateCertificate : IEndpointV1
 
     private static void ExecuteUpdate(Connection connection, Dto.UpdateCertificateInputDto input)
     {
-        X509Certificate2 certificate;
+        X509Certificate2Collection certificate;
         try
         {
             // Load certificate first, to give better error message if it is invalid


### PR DESCRIPTION
This PR adds support for emitting intermediate files, if present in a `.pfx`/`.p12` file.

The setup is fairly convoluted as .NET insists on stripping certificates that it does not like:
- https://github.com/dotnet/aspnetcore/issues/10971
- https://github.com/dotnet/aspnetcore/issues/21513

The logic for this is presumably to avoid issues where the clients (Android?) will reject the connection if it contains certain certificates. The logic in .NET is to remove any locally untrusted certificates. Since this happens on the setup of the SSL socket, it appears to be fixable only with reflection.

For backwards compatibility, the reflection code is only invoked if there is more than a single certificate in the `.pfx` file.

Need to test that this does not cause a regression with:
https://github.com/duplicati/duplicati/pull/5608