### PR TITLE
Updated launchagent installs on MacOS.

### DIFF
--- a/ReleaseBuilder/Resources/MacOS/Agent/daemon-scripts/postinstall
+++ b/ReleaseBuilder/Resources/MacOS/Agent/daemon-scripts/postinstall
@@ -1,5 +1,11 @@
 #!/bin/sh
 
 set -e
-/bin/launchctl unload -w "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist"
-/bin/launchctl load -w "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist"
+
+# Identify the user installing the package
+USER=$(stat -f%Su /dev/console)
+
+# Load the LaunchAgent for the user
+launchctl bootstrap gui/$(id -u "$USER") "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist"
+launchctl enable gui/$(id -u "$USER")/com.duplicati.agent.launchagent
+exit 0

--- a/ReleaseBuilder/Resources/MacOS/Agent/daemon-scripts/preinstall
+++ b/ReleaseBuilder/Resources/MacOS/Agent/daemon-scripts/preinstall
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -e
-if /bin/launchctl list "com.duplicati.agent.launchagent" &> /dev/null; then
+# Identify the user installing the package
+USER=$(stat -f%Su /dev/console)
+
+if [ -f "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist" ]; then
+    /bin/launchctl bootout gui/$(id -u "$USER")/com.duplicati.agent.launchagent
     /bin/launchctl unload "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist"
 fi

--- a/ReleaseBuilder/Resources/MacOS/Agent/uninstall.sh
+++ b/ReleaseBuilder/Resources/MacOS/Agent/uninstall.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
-if /bin/launchctl list "com.duplicati.agent.launchagent" &> /dev/null; then
-    /bin/launchctl unload "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist"
-fi
+LAUNCHAGENT_LABEL="com.duplicati.agent.launchagent"
+LAUNCHAGENT_PLIST="/Library/LaunchAgents/$LAUNCHAGENT_LABEL.plist"
 
-if [ -f "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist" ]; then
-	rm "/Library/LaunchAgents/com.duplicati.agent.launchagent.plist"
+ANY_ULOAD_FAILURES=""
+
+if [ -f "$LAUNCHAGENT_PLIST" ]; then
+
+    # Loop through all logged-in users
+    for USER_ID in $(ps aux | awk '/loginwindow/ && !/awk/ {print $1}' | uniq | xargs id -u); do
+
+        # Check if the LaunchAgent is loaded for the user
+        launchctl print gui/$USER_ID/$LAUNCHAGENT_LABEL > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            # Unload the LaunchAgent for the user
+            launchctl bootout gui/$USER_ID "$LAUNCHAGENT_PLIST"
+            if [ $? -eq 0 ]; then
+                echo "Successfully unloaded LaunchAgent for user with UID: $USER_ID."
+            else
+                echo "Failed to unload LaunchAgent for user with UID: $USER_ID."
+                ANY_ULOAD_FAILURES="1"
+            fi
+        fi
+    done
+
+    # Legacy unload, don't care about the result
+    /bin/launchctl unload "$LAUNCHAGENT_PLIST" > /dev/null 2>&1
+
+	rm "$LAUNCHAGENT_PLIST"
+
+    if ! [ -z "$ANY_UNLOAD_FAILURES"  ]; then
+        echo "Failed to unload LaunchAgent for one or more users. A machine restart may be required to fully remove the LaunchAgent."
+    fi
 fi
 
 if [ -d /usr/local/duplicati-agent ]; then
     rm -rf /usr/local/duplicati-agent
+    echo "Removed /usr/local/duplicati-agent"
 fi
 
 pkgutil --forget "com.duplicati.agent"

--- a/ReleaseBuilder/Resources/MacOS/AppBundle/app-scripts/postinstall
+++ b/ReleaseBuilder/Resources/MacOS/AppBundle/app-scripts/postinstall
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/open /Applications/Duplicati.app
+exit 0

--- a/ReleaseBuilder/Resources/MacOS/AppBundle/daemon-scripts/postinstall
+++ b/ReleaseBuilder/Resources/MacOS/AppBundle/daemon-scripts/postinstall
@@ -1,5 +1,11 @@
 #!/bin/sh
 
 set -e
-/bin/launchctl unload -w "/Library/LaunchAgents/com.duplicati.app.launchagent.plist"
-/bin/launchctl load -w "/Library/LaunchAgents/com.duplicati.app.launchagent.plist"
+
+# Identify the user installing the package
+USER=$(stat -f%Su /dev/console)
+
+# Load the LaunchAgent for the user
+launchctl bootstrap gui/$(id -u "$USER") "/Library/LaunchAgents/com.duplicati.app.launchagent.plist"
+launchctl enable gui/$(id -u "$USER")/com.duplicati.app.launchagent
+exit 0

--- a/ReleaseBuilder/Resources/MacOS/AppBundle/daemon-scripts/preinstall
+++ b/ReleaseBuilder/Resources/MacOS/AppBundle/daemon-scripts/preinstall
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-set -e
-if /bin/launchctl list "com.duplicati.app.launchagent" &> /dev/null; then
+set +e
+
+# Identify the user installing the package
+USER=$(stat -f%Su /dev/console)
+
+if [ -f "/Library/LaunchAgents/com.duplicati.app.launchagent.plist" ]; then
+    /bin/launchctl bootout gui/$(id -u "$USER")/com.duplicati.app.launchagent
     /bin/launchctl unload "/Library/LaunchAgents/com.duplicati.app.launchagent.plist"
 fi
+

--- a/ReleaseBuilder/Resources/MacOS/AppBundle/daemon/com.duplicati.app.launchagent.plist
+++ b/ReleaseBuilder/Resources/MacOS/AppBundle/daemon/com.duplicati.app.launchagent.plist
@@ -6,8 +6,7 @@
 	<string>com.duplicati.app.launchagent</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/bin/open</string>
-		<string>/Applications/Duplicati.app</string>
+		<string>/Applications/Duplicati.app/Contents/MacOS/duplicati</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>

--- a/ReleaseBuilder/Resources/MacOS/AppBundle/uninstall.sh
+++ b/ReleaseBuilder/Resources/MacOS/AppBundle/uninstall.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
+LAUNCHAGENT_LABEL="com.duplicati.app.launchagent"
+LAUNCHAGENT_PLIST="/Library/LaunchAgents/$LAUNCHAGENT_LABEL.plist"
+
+ANY_ULOAD_FAILURES=""
+
+if [ -f "$LAUNCHAGENT_PLIST" ]; then
+
+    # Loop through all logged-in users
+    for USER_ID in $(ps aux | awk '/loginwindow/ && !/awk/ {print $1}' | uniq | xargs id -u); do
+
+        # Check if the LaunchAgent is loaded for the user
+        launchctl print gui/$USER_ID/$LAUNCHAGENT_LABEL > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            # Unload the LaunchAgent for the user
+            launchctl bootout gui/$USER_ID "$LAUNCHAGENT_PLIST"
+            if [ $? -eq 0 ]; then
+                echo "Successfully unloaded LaunchAgent for user with UID: $USER_ID."
+            else
+                echo "Failed to unload LaunchAgent for user with UID: $USER_ID."
+                ANY_ULOAD_FAILURES="1"
+            fi
+        fi
+    done
+
+    # Legacy unload, don't care about the result
+    /bin/launchctl unload "$LAUNCHAGENT_PLIST" > /dev/null 2>&1
+
+	rm "$LAUNCHAGENT_PLIST"
+
+    if ! [ -z "$ANY_UNLOAD_FAILURES"  ]; then
+        echo "Failed to unload LaunchAgent for one or more users. A machine restart may be required to fully remove the LaunchAgent."
+    fi
+fi
+
 if [ -d /Applications/Duplicati.app ]; then
     rm -rf /Applications/Duplicati.app
-fi
-
-if /bin/launchctl list "com.duplicati.app.launchagent" &> /dev/null; then
-    /bin/launchctl unload "/Library/LaunchAgents/com.duplicati.app.launchagent.plist"
-fi
-
-if [ -f "/Library/LaunchAgents/com.duplicati.app.launchagent.plist" ]; then
-	rm "/Library/LaunchAgents/com.duplicati.app.launchagent.plist"
+    echo "Removed /Applications/Duplicati.app"
 fi
 
 pkgutil --forget "com.duplicati.app"

--- a/ReleaseBuilder/Resources/MacOS/CLI/daemon-scripts/postinstall
+++ b/ReleaseBuilder/Resources/MacOS/CLI/daemon-scripts/postinstall
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 set -e
+
+# Identify the user installing the package
+USER=$(stat -f%Su /dev/console)
+
 # Package is CLI, so we do not install the server launch agent automatically
-#/bin/launchctl unload -w "/Library/LaunchAgents/com.duplicati.server.launchagent.plist"
-#/bin/launchctl load -w "/Library/LaunchAgents/com.duplicati.server.launchagent.plist"
+# launchctl bootstrap gui/$(id -u "$USER") "/Library/LaunchAgents/com.duplicati.server.launchagent.plist"
+# launchctl enable gui/$(id -u "$USER")/com.duplicati.server.launchagent
+exit 0

--- a/ReleaseBuilder/Resources/MacOS/CLI/daemon-scripts/preinstall
+++ b/ReleaseBuilder/Resources/MacOS/CLI/daemon-scripts/preinstall
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -e
-if /bin/launchctl list "com.duplicati.server.launchagent" &> /dev/null; then
+# Identify the user installing the package
+USER=$(stat -f%Su /dev/console)
+
+if [ -f "/Library/LaunchAgents/com.duplicati.server.launchagent.plist" ]; then
+    /bin/launchctl bootout gui/$(id -u "$USER")/com.duplicati.server.launchagent
     /bin/launchctl unload "/Library/LaunchAgents/com.duplicati.server.launchagent.plist"
 fi

--- a/ReleaseBuilder/Resources/MacOS/CLI/uninstall.sh
+++ b/ReleaseBuilder/Resources/MacOS/CLI/uninstall.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
-if /bin/launchctl list "com.duplicati.server.launchagent" &> /dev/null; then
-    /bin/launchctl unload "/Library/LaunchAgents/com.duplicati.server.launchagent.plist"
-fi
+LAUNCHAGENT_LABEL="com.duplicati.server.launchagent"
+LAUNCHAGENT_PLIST="/Library/LaunchAgents/$LAUNCHAGENT_LABEL.plist"
 
-if [ -f "/Library/LaunchAgents/com.duplicati.server.launchagent.plist" ]; then
-	rm "/Library/LaunchAgents/com.duplicati.server.launchagent.plist"
+ANY_ULOAD_FAILURES=""
+
+if [ -f "$LAUNCHAGENT_PLIST" ]; then
+
+    # Loop through all logged-in users
+    for USER_ID in $(ps aux | awk '/loginwindow/ && !/awk/ {print $1}' | uniq | xargs id -u); do
+
+        # Check if the LaunchAgent is loaded for the user
+        launchctl print gui/$USER_ID/$LAUNCHAGENT_LABEL > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            # Unload the LaunchAgent for the user
+            launchctl bootout gui/$USER_ID "$LAUNCHAGENT_PLIST"
+            if [ $? -eq 0 ]; then
+                echo "Successfully unloaded LaunchAgent for user with UID: $USER_ID."
+            else
+                echo "Failed to unload LaunchAgent for user with UID: $USER_ID."
+                ANY_ULOAD_FAILURES="1"
+            fi
+        fi
+    done
+
+    # Legacy unload, don't care about the result
+    /bin/launchctl unload "$LAUNCHAGENT_PLIST" > /dev/null 2>&1
+
+	rm "$LAUNCHAGENT_PLIST"
+
+    if ! [ -z "$ANY_UNLOAD_FAILURES"  ]; then
+        echo "Failed to unload LaunchAgent for one or more users. A machine restart may be required to fully remove the LaunchAgent."
+    fi
 fi
 
 if [ -d /usr/local/duplicati ]; then
     rm -rf /usr/local/duplicati
+    echo "Removed /usr/local/duplicati"
 fi
 
 pkgutil --forget "com.duplicati.cli"


### PR DESCRIPTION
This changes the way launchagents are installed via `.pkg` files.

The installers are updated to no longer use `launchtctl load` but rely on `launchctl bootstrap` instead to load in the current user context.

For the Agent, this fixes a problem where the installer would initially start in a root context. For the GUI package this changes to not rely on `open` to start Duplicati, as that appears to be incompatible with `bootstrap` The uninstallers are updated handle both `load` / `unload` and `bootstrap` / `bootout` before removing the launchagents.

This fixes #5766