### PR TITLE
Fix code scanning alert no. 19: Incorrect suffix check

### DIFF
--- a/Duplicati/Server/webroot/index.html
+++ b/Duplicati/Server/webroot/index.html
@@ -28,7 +28,7 @@
         // Make an absolute path redirect, as relative redirects break if the port is non-standard
         var path = window.location.pathname;
         
-        if (path.lastIndexOf('.html') == path.length - '.html'.length)
+        if (path.lastIndexOf('.html') !== -1 && path.lastIndexOf('.html') == path.length - '.html'.length)
             path = path.substr(0, path.lastIndexOf('/'));
         
         if (path.lastIndexOf('/') + 1 != path.length)


### PR DESCRIPTION
Fixes [https://github.com/duplicati/duplicati/security/code-scanning/19](https://github.com/duplicati/duplicati/security/code-scanning/19)

To fix the problem, we need to ensure that the check for the suffix `.html` correctly handles the case where `lastIndexOf` returns -1. We can achieve this by explicitly checking if the returned index is not -1 before comparing it to the expected position.

- Modify the condition on line 31 to first check if `lastIndexOf` does not return -1.
- If the index is not -1, then compare it to `path.length - '.html'.length`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
