### PR TITLE
Fix code scanning alert no. 16: Useless regular-expression character escape

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -1221,7 +1221,7 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
 		if(res && scope['storj_auth_method'] == 'API key' && scope['storj_secret'] != scope['storj_secret_verify'])
 			res = EditUriBackendConfig.show_error_dialog(gettextCatalog.getString('The encryption passphrases do not match'));
 		
-		var re = new RegExp('^([a-z0-9]+([a-z0-9\-][a-z0-9])*)+(.[a-z0-9]+([a-z0-9\-][a-z0-9])*)*$');
+		var re = new RegExp('^([a-z0-9]+([a-z0-9-][a-z0-9])*)+(.[a-z0-9]+([a-z0-9-][a-z0-9])*)*$');
 		if(res && scope['storj_bucket'] && (!re.test(scope['storj_bucket']) || !(scope['storj_bucket'].length > 2 && scope['storj_bucket'].length < 64))){
 			res = EditUriBackendConfig.show_error_dialog(gettextCatalog.getString('Bucket name can only be between 3 and 63 characters long and contain only lower-case characters, numbers, periods and dashes'));
 		}


### PR DESCRIPTION
Fixes [https://github.com/duplicati/duplicati/security/code-scanning/16](https://github.com/duplicati/duplicati/security/code-scanning/16)

To fix the problem, we need to remove the unnecessary escape sequence `\-` from the regular expression on line 1224. The hyphen `-` does not need to be escaped within the character class `[a-z0-9\-]`, so we can safely remove the backslash.

- Locate the regular expression on line 1224 in the file `Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js`.
- Remove the backslash before the hyphen in the character class `[a-z0-9\-]`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
