### PR TITLE
Primary functionality implemented for CIFS

### DIFF
--- a/Duplicati.sln
+++ b/Duplicati.sln
@@ -164,6 +164,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duplicati.Library.Backend.p
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duplicati.Library.Crashlog", "Duplicati\Library\Crashlog\Duplicati.Library.Crashlog.csproj", "{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Duplicati.Library.Backend.CIFS", "Duplicati\Library\Backend\CIFS\Duplicati.Library.Backend.CIFS.csproj", "{836E0557-B40C-4DC7-9A2A-5C062F9ACC6B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -466,6 +468,10 @@ Global
 		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332}.Release|Any CPU.Build.0 = Release|Any CPU
+		{836E0557-B40C-4DC7-9A2A-5C062F9ACC6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{836E0557-B40C-4DC7-9A2A-5C062F9ACC6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{836E0557-B40C-4DC7-9A2A-5C062F9ACC6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{836E0557-B40C-4DC7-9A2A-5C062F9ACC6B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -525,6 +531,7 @@ Global
 		{E1D32EF7-368E-4148-9367-B328E78C871B} = {6B46F6B1-1898-49B8-ADA7-5CAF68EB77E3}
 		{CA1A0EE8-DFFF-42AF-B15D-EF538357A2DE} = {E1A9B303-F281-45C5-A4F6-CADD9DE3F3C4}
 		{8ACA2736-3C69-4FA5-BCF9-5EDF50CAF332} = {566EBBDA-19A4-4056-A615-D901D57D2439}
+		{836E0557-B40C-4DC7-9A2A-5C062F9ACC6B} = {E1A9B303-F281-45C5-A4F6-CADD9DE3F3C4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B40BAFE-D862-4397-9495-8F5EAF5CE80C}

--- a/Duplicati/Library/Backend/CIFS/CIFS.cs
+++ b/Duplicati/Library/Backend/CIFS/CIFS.cs
@@ -208,7 +208,7 @@ public class CIFSBackend : IStreamingBackend
     /// Download files from remote
     /// </summary>
     /// <param name="remotename">Filename at remote location</param>
-    /// <param name="output">Destination stream to write to</param>
+    /// <param name="localname">Local filename to write to</param>
     /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
     /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
     /// <exception cref="Exception">Exceptions arising from either code execution or FileMissingException</exception>
@@ -235,13 +235,13 @@ public class CIFSBackend : IStreamingBackend
     }
 
     /// <summary>
-    /// Delete remote file if it exists, if now, throws FileMissingException
+    /// Delete remote file if it exists, if not, throws FileMissingException
     /// </summary>
     /// <param name="remotename">filename to be deleted on the remote</param>
     /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
     /// <returns></returns>
     /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
-    /// <exception cref="Exception">Exceptions arising from either code execution or business logic when return code from pcloud indicates an error.</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution or business logic errors</exception>
     public async Task DeleteAsync(string remotename, CancellationToken cancellationToken)
     {
         await using var shareConnection = new SMBShareConnection(_connectionParameters);
@@ -268,11 +268,11 @@ public class CIFSBackend : IStreamingBackend
     }
 
     /// <summary>
-    /// Create remote folder
+    /// Creates the configured remote folder path if it doesn't exist
     /// </summary>
     /// <param name="cancellationToken">CancellationToken that will be combined with internal timeout token</param>
-    /// <returns></returns>
-    /// <exception cref="Exception"></exception>
+    /// <returns>Task representing the asynchronous operation</returns>
+    /// <exception cref="Exception">Thrown when folder creation fails</exception>
     public async Task CreateFolderAsync(CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(_connectionParameters.Path) || _connectionParameters.Path.Split(PATH_SEPARATORS, StringSplitOptions.RemoveEmptyEntries).Length == 0)

--- a/Duplicati/Library/Backend/CIFS/CIFS.cs
+++ b/Duplicati/Library/Backend/CIFS/CIFS.cs
@@ -1,0 +1,292 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using Duplicati.Library.Interface;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.CIFS;
+using Duplicati.Library.Backend.CIFS.Model;
+using Duplicati.Library.Utility;
+using SMBLibrary;
+
+namespace Duplicati.Library.Backend;
+
+/// <summary>
+/// Native CIFS/SMB Backend implementation
+/// </summary>
+public class CIFSBackend : IStreamingBackend
+{
+    /// <summary>
+    /// Implementation of interface property for the backend key
+    /// </summary>
+    public string ProtocolKey => "cifs";
+
+    /// <summary>
+    /// Implementation of interface property for the backend display name
+    /// </summary>
+    public string DisplayName => Strings.CIFSBackend.DisplayName;
+
+    /// <summary>
+    /// Implementation of interface property for the backend description
+    /// </summary>
+    public string Description => Strings.CIFSBackend.Description;
+
+    /// <summary>
+    /// Hostname only (no ports or paths) to be used on DNS resolutions.
+    /// </summary>
+    private string _DnsName;
+
+    /// <summary>
+    /// Path separators (both Windows \ and unix /) to be used in path manipulation
+    /// </summary>
+    private static readonly char[] PATH_SEPARATORS = ['/', '\\'];
+
+    private SMBConnectionParameters _connectionParameters;
+
+    /// <summary>
+    /// Backend option for controlling the transport (directtcp or netbios)
+    /// </summary>
+    private const string TRANSPORT_OPTION = "transport";
+
+    /// <summary>
+    /// Domain (complementary part of authentication) option
+    /// </summary>
+    private const string AUTH_DOMAIN_OPTION = "auth-domain";
+
+    /// <summary>
+    /// Username for authentication
+    /// </summary>
+    private const string AUTH_USERNAME_OPTION = "auth-username";
+
+    /// <summary>
+    /// Password for authentication
+    /// </summary>
+    private const string AUTH_PASSWORD_OPTION = "auth-password";
+
+    /// <summary>
+    /// Defines the default transport to be used in CIFS connection
+    /// </summary>
+    private const string DEFAULT_TRANSPORT = "directtcp";
+
+    /// <summary>
+    /// Mapping of transport string to SMBTransportType enum to be used in parsing the option string
+    /// </summary>
+    private readonly Dictionary<string, SMBTransportType> _transportMap = new()
+    {
+        ["directtcp"] = SMBTransportType.DirectTCPTransport,
+        ["netbios"] = SMBTransportType.NetBiosOverTCP
+    };
+
+    /// <summary>
+    /// Empty constructor is required for the backend to be loaded by the backend factory
+    /// </summary>
+    public CIFSBackend()
+    {
+    }
+
+    /// <summary>
+    /// Actual constructor for the backend that accepts the url and options
+    /// </summary>
+    /// <param name="url">URL in Duplicati Uri format</param>
+    /// <param name="options">options to be used in the backend</param>
+    public CIFSBackend(string url, Dictionary<string, string> options)
+    {
+        var uri = new Utility.Uri(url);
+        uri.RequireHost();
+        _DnsName = uri.Host;
+        
+        var input = uri.Path.TrimEnd('/');
+        var slashIndex = input.IndexOf('/');  // Find first slash to separate server and share if present.
+        
+        options.TryGetValue(AUTH_USERNAME_OPTION, out string authUsername);
+        options.TryGetValue(AUTH_PASSWORD_OPTION, out string authPassword);
+        options.TryGetValue(AUTH_DOMAIN_OPTION, out string authDomain);
+        options.TryGetValue(TRANSPORT_OPTION, out string transport);
+        
+        SMBTransportType transportType = _transportMap.TryGetValue(
+            string.IsNullOrEmpty(transport) ? DEFAULT_TRANSPORT : transport.ToLower(), 
+            out SMBTransportType type)
+            ? type
+            : throw new UserInformationException($"Transport must be one of: {string.Join(", ", _transportMap.Keys)}","CIFSConfig");
+        
+        _connectionParameters = new SMBConnectionParameters(
+            uri.Host,
+            transportType,
+            slashIndex >= 0 ? input[..slashIndex] : input,
+            slashIndex >= 0 ? input[(slashIndex + 1)..] : "",
+            authDomain,
+            authUsername,
+            authPassword
+        );
+    }
+
+    /// <summary>
+    /// Implementation of interface property to return supported command parameters
+    /// </summary>
+    public IList<ICommandLineArgument> SupportedCommands
+    {
+        get
+        {
+            return new List<ICommandLineArgument>(new ICommandLineArgument[]
+            {
+                new CommandLineArgument(AUTH_PASSWORD_OPTION, CommandLineArgument.ArgumentType.Password, Strings.CIFSBackend.DescriptionAuthPasswordShort, Strings.CIFSBackend.DescriptionAuthPasswordLong),
+                new CommandLineArgument(AUTH_USERNAME_OPTION, CommandLineArgument.ArgumentType.String, Strings.CIFSBackend.DescriptionAuthUsernameShort, Strings.CIFSBackend.DescriptionAuthUsernameLong),
+                new CommandLineArgument(AUTH_DOMAIN_OPTION, CommandLineArgument.ArgumentType.String, Strings.CIFSBackend.DescriptionAuthDomainShort, Strings.CIFSBackend.DescriptionAuthDomainLong),
+                new CommandLineArgument(TRANSPORT_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.Options.TransportShort, Strings.Options.TransportLong, DEFAULT_TRANSPORT, null, _transportMap.Keys.ToArray()),
+                });
+        }
+    }
+    
+    /// <summary>
+    /// Implementation of interface method for listing remote folder contents
+    /// </summary>
+    /// <returns>List of IFileEntry with directory listing result</returns>
+    private async Task<IEnumerable<IFileEntry>> ListAsync(CancellationToken cancellationToken)
+    {
+        await using var shareConnection = new SMBShareConnection(_connectionParameters);
+        return await shareConnection.ListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Wrapper method of legacy non async call to list files in the remote folder
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<IFileEntry> List() => ListAsync(CancellationToken.None).Await();
+
+    /// <summary>
+    /// Upload files to remote location
+    /// </summary>
+    /// <param name="remotename">Filename at remote location</param>
+    /// <param name="localname">Filename to read from</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution</exception>
+    public async Task PutAsync(string remotename, string localname, CancellationToken cancellationToken)
+    {
+        await using var fs = File.Open(localname,
+            FileMode.Open, FileAccess.Read, FileShare.Read);
+        await PutAsync(remotename, fs, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Upload files to remote location
+    /// </summary>
+    /// <param name="remotename">Filename at remote location</param>
+    /// <param name="input">Stream to read from</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution</exception>
+    public async Task PutAsync(string remotename, Stream input, CancellationToken cancellationToken)
+    {
+        await using var shareConnection = new SMBShareConnection(_connectionParameters);
+        await shareConnection.PutAsync(remotename, input, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Download files from remote
+    /// </summary>
+    /// <param name="remotename">Filename at remote location</param>
+    /// <param name="output">Destination stream to write to</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution or FileMissingException</exception>
+    public async Task GetAsync(string remotename, string localname, CancellationToken cancellationToken)
+    {
+        await using var fs = File.Open(localname,
+            FileMode.Create, FileAccess.Write,
+            FileShare.None);
+        await GetAsync(remotename, fs, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Download files from remote
+    /// </summary>
+    /// <param name="remotename">Filename at remote location</param>
+    /// <param name="output">Destination stream to write to</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution or FileMissingException</exception>
+    public async Task GetAsync(string remotename, Stream output, CancellationToken cancellationToken)
+    {
+        await using var shareConnection = new SMBShareConnection(_connectionParameters);
+        await shareConnection.GetAsync(remotename, output, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Delete remote file if it exists, if now, throws FileMissingException
+    /// </summary>
+    /// <param name="remotename">filename to be deleted on the remote</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <returns></returns>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution or business logic when return code from pcloud indicates an error.</exception>
+    public async Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+    {
+        await using var shareConnection = new SMBShareConnection(_connectionParameters);
+        await shareConnection.DeleteAsync(remotename, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Implementation of interface function to return hosnames used by the backend
+    /// </summary>
+    /// <param name="cancellationToken">CancellationToken, in this call not used.</param>
+    /// <returns></returns>
+    public Task<string[]> GetDNSNamesAsync(CancellationToken cancellationToken) => Task.FromResult(new[] { _DnsName });
+
+    /// <summary>
+    /// Tests backend connectivity by verifying the configured path exists
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token (not used)</param>
+    /// <exception cref="FolderMissingException">Thrown when configured path does not exist</exception>
+    public async Task TestAsync(CancellationToken cancellationToken)
+    {
+        await using var shareConnection = new SMBShareConnection(_connectionParameters);
+        // This will throw an exception if the folder is missing
+        await shareConnection.ListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Create remote folder
+    /// </summary>
+    /// <param name="cancellationToken">CancellationToken that will be combined with internal timeout token</param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public async Task CreateFolderAsync(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_connectionParameters.Path) || _connectionParameters.Path.Split(PATH_SEPARATORS, StringSplitOptions.RemoveEmptyEntries).Length == 0)
+            return;
+        
+        await using var shareConnection = new SMBShareConnection(_connectionParameters);
+        await shareConnection.CreateFolderAsync(_connectionParameters.Path, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Implementation of Dispose pattern enforced by interface
+    /// in this case, we don't need to dispose anything
+    /// </summary>
+    public void Dispose()
+    {
+    }
+}

--- a/Duplicati/Library/Backend/CIFS/Duplicati.Library.Backend.CIFS.csproj
+++ b/Duplicati/Library/Backend/CIFS/Duplicati.Library.Backend.CIFS.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <Copyright>Copyright © 2024 Team Duplicati, MIT license</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Interface\Duplicati.Library.Interface.csproj" />
+    <ProjectReference Include="..\..\Localization\Duplicati.Library.Localization.csproj" />
+    <ProjectReference Include="..\..\Utility\Duplicati.Library.Utility.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SMBLibrary" Version="1.5.3.5" />
+    <PackageReference Include="SMBLibrary.Win32" Version="1.5.3" />
+  </ItemGroup>
+
+</Project>

--- a/Duplicati/Library/Backend/CIFS/Model/SMBConnectionParameters.cs
+++ b/Duplicati/Library/Backend/CIFS/Model/SMBConnectionParameters.cs
@@ -1,0 +1,93 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using SMBLibrary;
+
+namespace Duplicati.Library.Backend.CIFS.Model;
+
+/// <summary>
+/// Connection parameters for establishing an SMB connection.
+/// </summary>
+public record SMBConnectionParameters
+{
+   /// <summary>
+   /// The name or IP address of the SMB server
+   /// </summary>
+   public string ServerName { get; init; }
+
+   /// <summary>
+   /// The transport protocol type used for SMB communication
+   /// </summary>
+   public SMBTransportType TransportType { get; init; }
+
+   /// <summary>
+   /// The name of the network share to connect to
+   /// </summary>
+   public string ShareName { get; init; }
+
+   /// <summary>
+   /// The path within the share to access
+   /// </summary>
+   public string Path { get; init; }
+
+   /// <summary>
+   /// The authentication domain name
+   /// </summary>
+   public string AuthDomain { get; init; }
+
+   /// <summary>
+   /// The username for authentication
+   /// </summary>
+   public string AuthUser { get; init; }
+
+   /// <summary>
+   /// The password for authentication
+   /// </summary>
+   public string AuthPassword { get; init; }
+
+   /// <summary>
+   /// Creates a new instance of SMB connection parameters
+   /// </summary>
+   /// <param name="serverName">The name or IP address of the SMB server</param>
+   /// <param name="transportType">The transport protocol type used for SMB communication</param>
+   /// <param name="shareName">The name of the network share to connect to</param>
+   /// <param name="path">The path within the share to access</param>
+   /// <param name="authDomain">The authentication domain name</param>
+   /// <param name="authUser">The username for authentication</param>
+   /// <param name="authPassword">The password for authentication</param>
+   public SMBConnectionParameters(
+       string serverName,
+       SMBTransportType transportType,
+       string shareName,
+       string path,
+       string authDomain,
+       string authUser,
+       string authPassword)
+   {
+       ServerName = serverName;
+       TransportType = transportType;
+       ShareName = shareName;
+       Path = path;
+       AuthDomain = authDomain;
+       AuthUser = authUser;
+       AuthPassword = authPassword;
+   }
+}

--- a/Duplicati/Library/Backend/CIFS/SMBShareConnection.cs
+++ b/Duplicati/Library/Backend/CIFS/SMBShareConnection.cs
@@ -1,0 +1,439 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.CIFS.Model;
+using Duplicati.Library.Common.IO;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Localization.Short;
+using SMBLibrary;
+using SMBLibrary.Client;
+using FileAttributes = SMBLibrary.FileAttributes;
+
+namespace Duplicati.Library.Backend.CIFS;
+
+/// <summary>
+/// Class the wraps the SMB connection and file store objects, handling the connection,
+/// logon and logoff operations as well as safely disposing resources.
+/// </summary>
+public class SMBShareConnection : IDisposable, IAsyncDisposable
+{
+    /// <summary>
+    /// SMBConnection client
+    /// </summary>
+    private readonly SMB2Client _smb2Client = new();
+
+    /// <summary>
+    /// Shared fileStore object.
+    /// </summary>
+    private readonly ISMBFileStore _smbFileStore;
+
+    /// <summary>
+    /// Connection parameters
+    /// </summary>
+    private readonly SMBConnectionParameters _connectionParameters;
+
+    /// <summary>
+    /// The semaphore to ensure that only one operation is performed at a time.
+    /// </summary>
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private bool _disposed;
+
+    /// <summary>
+    /// This constructor will connect to the server and share as specified in the connection parameters.
+    /// 
+    /// It throws specific exceptions for connection and authentication failures.
+    /// </summary>
+    /// <param name="connectionParameters">Connection Parameters</param>
+    /// <exception cref="UserInformationException">Exception to be displayed to user</exception>
+    public SMBShareConnection(SMBConnectionParameters connectionParameters)
+    {
+        _connectionParameters = connectionParameters;
+
+        if (!_smb2Client.Connect(connectionParameters.ServerName, connectionParameters.TransportType))
+            throw new UserInformationException($"{LC.L("Failed to connect to server")} {connectionParameters.ServerName}", "ConnectionError");
+
+        var status = _smb2Client.Login(connectionParameters.AuthDomain, connectionParameters.AuthUser, connectionParameters.AuthPassword);
+
+        if (status != NTStatus.STATUS_SUCCESS)
+            throw new UserInformationException($"{LC.L("Failed to authenticate to server")} {connectionParameters.ServerName} with status {status}", "ConnectionError");
+        
+        _smbFileStore = _smb2Client.TreeConnect(connectionParameters.ShareName, out status);
+
+        if (status != NTStatus.STATUS_SUCCESS)
+            throw new UserInformationException($"{LC.L("Failed to connect to share")} {connectionParameters.ShareName} with status {status}", "ConnectionError");
+    }
+
+    /// <summary>
+    /// Deletes the file specified in the path specified in the connection parameters.
+    /// </summary>
+    /// <param name="fileName">Filename to be deleted</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <exception cref="UserInformationException">Exception to be displayed to user</exception>
+    public async Task DeleteAsync(string fileName, CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            NTStatus status;
+            object fileHandle;
+            FileStatus fileStatus;
+            status = _smbFileStore.CreateFile(out fileHandle, out fileStatus, Path.Combine(_connectionParameters.Path, fileName),
+                AccessMask.GENERIC_WRITE | AccessMask.DELETE | AccessMask.SYNCHRONIZE,
+                FileAttributes.Normal,
+                ShareAccess.None,
+                CreateDisposition.FILE_OPEN,
+                CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT,
+                null);
+
+            if (status == NTStatus.STATUS_OBJECT_NAME_NOT_FOUND)
+                throw new FileMissingException();
+
+            if (status == NTStatus.STATUS_SUCCESS)
+            {
+                var fileDispositionInformation = new FileDispositionInformation
+                {
+                    DeletePending = true
+                };
+                status = _smbFileStore.SetFileInformation(fileHandle, fileDispositionInformation);
+                if (status != NTStatus.STATUS_SUCCESS)
+                    throw new UserInformationException($"{LC.L("Failed to delete file on DeleteAsync")} with status {status}", "DeleteFileError");
+                status = _smbFileStore.CloseFile(fileHandle);
+                if (status != NTStatus.STATUS_SUCCESS)
+                    throw new UserInformationException($"{LC.L("Failed to close file on DeleteAsync")} with status {status}", "CloseFileError");
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Create the folder structure specified in the path.
+    /// </summary>
+    /// <param name="path">Path to create</param>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    /// <exception cref="UserInformationException">Exception to be displayed to user</exception>
+    public async Task CreateFolderAsync(string path, CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            // Normalize path separators to forward slashes and trim any trailing separators
+            string normalizedPath = path.Replace('\\', '/').TrimEnd('/');
+            string currentPath = "";
+
+            foreach (string part in normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (string.IsNullOrWhiteSpace(part) || part == ".")
+                    continue;
+
+                currentPath = currentPath.Length == 0 ? part : $"{currentPath}/{part}";
+                object? fileHandle = null;
+                try
+                {
+                    NTStatus status = _smbFileStore.CreateFile(
+                        out fileHandle,
+                        out FileStatus fileStatus,
+                        currentPath,
+                        AccessMask.GENERIC_WRITE | AccessMask.SYNCHRONIZE,
+                        FileAttributes.Normal,
+                        ShareAccess.None,
+                        CreateDisposition.FILE_CREATE,
+                        CreateOptions.FILE_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT,
+                        null
+                    );
+                    if (status != NTStatus.STATUS_SUCCESS &&
+                        status != NTStatus.STATUS_OBJECT_NAME_COLLISION) // Ignore if directory already exists
+                        throw new UserInformationException($"{LC.L("Failed to create directory")} {currentPath} with status{status}", "CreateDirectoryError");
+                }
+                finally
+                {
+                    if (fileHandle != null)
+                    {
+                        var status = _smbFileStore.CloseFile(fileHandle);
+                        if (status != NTStatus.STATUS_SUCCESS)
+                            throw new UserInformationException($"{LC.L("Failed to close file handle on CreateFolderAsync")} with status {status.ToString()}", "HandleCloseError");
+                    }
+                }
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Lists the folder contents of the share and path specified in the connection parameters.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    /// <exception cref="UserInformationException">Exception to be displayed to user</exception>
+    public async Task<List<IFileEntry>> ListAsync(CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+
+        object? directoryHandle = null;
+        FileStatus fileStatus;
+        try
+        {
+            try
+            {
+
+                var status = _smbFileStore.CreateFile(
+                    out directoryHandle,
+                    out fileStatus,
+                    _connectionParameters.Path,
+                    AccessMask.GENERIC_READ,
+                    FileAttributes.Directory,
+                    ShareAccess.Read | ShareAccess.Write,
+                    CreateDisposition.FILE_OPEN,
+                    CreateOptions.FILE_DIRECTORY_FILE,
+                    null);
+
+                if (status != NTStatus.STATUS_SUCCESS && fileStatus != FileStatus.FILE_OPENED)
+                    if (status == NTStatus.STATUS_OBJECT_PATH_NOT_FOUND || status == NTStatus.STATUS_OBJECT_NAME_NOT_FOUND)
+                        throw new FolderMissingException();
+                    else
+                        throw new UserInformationException($"{LC.L("Failed to open directory")} {_connectionParameters.Path} with status {status.ToString()}","DirectoryOpenError");
+
+                List<QueryDirectoryFileInformation> fileList;
+                status = _smbFileStore.QueryDirectory(
+                    out fileList,
+                    directoryHandle,
+                    "*",
+                    FileInformationClass.FileDirectoryInformation);
+
+                 if (status != NTStatus.STATUS_NO_MORE_FILES)
+                    throw new UserInformationException($"{LC.L("Failed to query directory contents")} with status {status.ToString()}","DirectoryQueryError");
+                 
+                return
+                [
+                    ..fileList
+                        .OfType<FileDirectoryInformation>()
+                        .Select(info => new FileEntry(
+                            info.FileName,
+                            info.EndOfFile,
+                            info.LastAccessTime,
+                            info.LastWriteTime)
+                        {
+                            IsFolder = info.FileAttributes == FileAttributes.Directory
+                        })
+                        .ToList()
+                ];
+            }
+            finally
+            {
+                if (directoryHandle != null)
+                {
+                    var status = _smbFileStore.CloseFile(directoryHandle);
+                    if (status != NTStatus.STATUS_SUCCESS)
+                        throw new UserInformationException($"{LC.L("Failed to close directory handle on ListAsync")} with status {status.ToString()}", "HandleCloseError");
+                }
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+    }
+
+    /// <summary>
+    /// Read a file from source and write it to the destination stream.
+    /// </summary>
+    /// <param name="filename">Filename to be read</param>
+    /// <param name="destinationStream">Destination stream to write contents read from source</param>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    public async Task GetAsync(string filename, Stream destinationStream, CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+
+        try
+        {
+            object? fileHandle;
+            FileStatus fileStatus;
+            NTStatus status = _smbFileStore.CreateFile(out fileHandle, out fileStatus,
+                Path.Combine(_connectionParameters.Path, filename), // This is where the file name is concatenated with the path
+                AccessMask.GENERIC_READ | AccessMask.SYNCHRONIZE, FileAttributes.Normal, ShareAccess.Read,
+                CreateDisposition.FILE_OPEN,
+                CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT, null);
+
+            if (status == NTStatus.STATUS_SUCCESS || fileStatus != FileStatus.FILE_DOES_NOT_EXIST)
+            {
+                byte[] data;
+                long bytesRead = 0;
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    status = _smbFileStore.ReadFile(out data, fileHandle, bytesRead, (int)_smb2Client.MaxReadSize);
+                    if (status != NTStatus.STATUS_SUCCESS && status != NTStatus.STATUS_END_OF_FILE)
+                        throw new UserInformationException($"{LC.L("Failed to read file on GetAsync")} {filename} with status {status.ToString()}","FileReadError");
+
+                    if (status == NTStatus.STATUS_END_OF_FILE || data.Length == 0)
+                        break;
+
+                    bytesRead += data.Length;
+                    await destinationStream.WriteAsync(data, 0, data.Length, cancellationToken);
+                }
+
+                await destinationStream.FlushAsync(cancellationToken);
+
+                if (fileHandle != null)
+                {
+                    status = _smbFileStore.CloseFile(fileHandle);
+                    if (status != NTStatus.STATUS_SUCCESS)
+                        throw new UserInformationException($"{LC.L("Failed to close file handle on GetAsync")} {filename} with status {status.ToString()}", "HandleCloseError");
+                }
+            }
+            else if (status == NTStatus.STATUS_OBJECT_NAME_NOT_FOUND)
+                throw new FileMissingException($"{LC.L("The requested file does not exist")} {filename}");
+            else if (status == NTStatus.STATUS_OBJECT_PATH_NOT_FOUND)
+                throw new FolderMissingException();
+            else
+                throw new UserInformationException(
+                    $"{LC.L("Failed to open file with error")} {filename} with status {status.ToString()}",
+                    "FileOpenError");
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Writes file in the remote share and path specified in the connection parameters reading
+    /// from the sourceStream provided.
+    /// </summary>
+    /// <param name="filename"></param>
+    /// <param name="sourceStream"></param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="Exception"></exception>
+    public async Task PutAsync(string filename, Stream sourceStream, CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            object fileHandle;
+            FileStatus fileStatus;
+            NTStatus status = _smbFileStore.CreateFile(out fileHandle, out fileStatus,
+                Path.Combine(_connectionParameters.Path, filename), // This is where the file name is concatenated with the path
+                AccessMask.GENERIC_WRITE | AccessMask.SYNCHRONIZE,
+                FileAttributes.Normal, ShareAccess.None,
+                CreateDisposition.FILE_SUPERSEDE,
+                CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT,
+                null);
+            if (status == NTStatus.STATUS_SUCCESS)
+            {
+
+                byte[] buffer = new byte[_smb2Client.MaxWriteSize];
+                int bytesRead;
+                int numberOfBytesWritten;
+                while (!cancellationToken.IsCancellationRequested && sourceStream.Position < sourceStream.Length)
+                {
+                    bytesRead = await sourceStream.ReadAsync(buffer, cancellationToken);
+                    if (bytesRead == 0)
+                        throw new UserInformationException(LC.L("Failed to read from source stream on PutAsync"),"StreamReadError");
+                    
+                    status = _smbFileStore.WriteFile(out numberOfBytesWritten, fileHandle, 0, buffer.Take(bytesRead).ToArray());
+                    if (numberOfBytesWritten != bytesRead)
+                        throw new UserInformationException(LC.L("Failed to write to file, difference between bytes read and bytes written"), "HandleWriteError");
+                    if (status != NTStatus.STATUS_SUCCESS)
+                        throw new UserInformationException($"{LC.L("Failed to write file on Putasync")} {filename} with status {status.ToString()}", "HandleWriteError");
+                }
+                if (fileHandle != null)
+                {
+                    status = _smbFileStore.CloseFile(fileHandle);
+                    if (status != NTStatus.STATUS_SUCCESS)
+                        throw new UserInformationException($"{LC.L("Failed to close file handle on PutAsync")} {filename} with status {status.ToString()}", "HandleCloseError");
+                }
+            }
+            else
+            {
+                throw new UserInformationException($"{LC.L("Failed to create file for writing")} {filename} with status {status.ToString()}", "FileCreateError");
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Synchronously dispose the resources.
+    /// </summary>
+    public void Dispose()
+    {
+        DisposeResourcesAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Async dispose implementation
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeResourcesAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Inner dispose implementation
+    /// </summary>
+    private async ValueTask DisposeResourcesAsync()
+    {
+        if (_disposed) return;
+
+        await _semaphore.WaitAsync(); // Ensure no operations are in progress
+        try
+        {
+            if (_smbFileStore != null)
+            {
+                try
+                {
+                    await Task.Run(() => _smbFileStore.Disconnect());
+                }
+                catch { /* Can be safely ignored */ }
+            }
+
+            if (_smb2Client != null)
+            {
+                try
+                {
+                    await Task.Run(() => _smb2Client.Logoff());
+                    await Task.Run(() => _smb2Client.Disconnect());
+                }
+                catch { /* Can be safely ignored */ }
+            }
+
+            _semaphore.Dispose();
+        }
+        finally
+        {
+            _disposed = true;
+        }
+    }
+}

--- a/Duplicati/Library/Backend/CIFS/SMBShareConnection.cs
+++ b/Duplicati/Library/Backend/CIFS/SMBShareConnection.cs
@@ -353,13 +353,14 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
                 byte[] buffer = new byte[_smb2Client.MaxWriteSize];
                 int bytesRead;
                 int numberOfBytesWritten;
+                int offset = 0;
                 while (!cancellationToken.IsCancellationRequested && sourceStream.Position < sourceStream.Length)
                 {
                     bytesRead = await sourceStream.ReadAsync(buffer, cancellationToken);
                     if (bytesRead == 0)
-                        throw new UserInformationException(LC.L("Failed to read from source stream on PutAsync"),"StreamReadError");
-                    
-                    status = _smbFileStore.WriteFile(out numberOfBytesWritten, fileHandle, 0, buffer.Take(bytesRead).ToArray());
+                        break;
+                    status = _smbFileStore.WriteFile(out numberOfBytesWritten, fileHandle, offset, buffer.Take(bytesRead).ToArray());
+                    offset += numberOfBytesWritten;
                     if (numberOfBytesWritten != bytesRead)
                         throw new UserInformationException(LC.L("Failed to write to file, difference between bytes read and bytes written"), "HandleWriteError");
                     if (status != NTStatus.STATUS_SUCCESS)

--- a/Duplicati/Library/Backend/CIFS/Strings.cs
+++ b/Duplicati/Library/Backend/CIFS/Strings.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Duplicati.Library.Localization.Short;
+
+namespace Duplicati.Library.Backend.Strings
+{
+    internal static class CIFSBackend
+    {
+
+        public static string DescriptionAuthPasswordLong => LC.L(@"The password used to connect to the server. This may also be supplied as the environment variable ""AUTH_PASSWORD"".");
+        public static string DescriptionAuthPasswordShort => LC.L(@"Supply the password used to connect to the server");
+        public static string DescriptionAuthUsernameLong => LC.L(@"The username used to connect to the server. This may also be supplied as the environment variable ""AUTH_USERNAME"".");
+        public static string DescriptionAuthUsernameShort => LC.L(@"Supply the username used to connect to the server");
+        public static string DescriptionAuthDomainLong => LC.L(@"The domain used to connect to the server. This may also be supplied as the environment variable ""AUTH_DOMAIN"".");
+        public static string DescriptionAuthDomainShort => LC.L(@"Supply the domain used to connect to the server");
+        public static string Description => LC.L(@"This backend can read and write data to CIFS/SMB destinations. Allowed format is ""cifs://server/share"".");
+        public static string DisplayName => LC.L(@"CIFS/SMB");
+    }
+
+    internal static class Options
+    {
+        public static string TransportShort =>
+            LC.L(
+                @"Defines the transport to be used in CIFS connection");
+        public static string TransportLong =>
+            LC.L(
+                @"Defines the transport to be used in CIFS connection. Can be DirectTCP or NetBios");
+    }
+}

--- a/Duplicati/Library/Backends/BackendModules.cs
+++ b/Duplicati/Library/Backends/BackendModules.cs
@@ -66,7 +66,8 @@ public static class BackendModules
         new Backend.TahoeBackend(),
         new Backend.TencentCOS.COS(),
         new Backend.WEBDAV(),
-        new Backend.pCloudBackend()
+        new Backend.pCloudBackend(),
+        new Backend.CIFSBackend()
     }
     .Where(x => x != null)
     .ToList();

--- a/Duplicati/Library/Backends/Duplicati.Library.Backends.csproj
+++ b/Duplicati/Library/Backends/Duplicati.Library.Backends.csproj
@@ -10,6 +10,7 @@
 	<ProjectReference Include="..\Backend\AzureBlob\Duplicati.Library.Backend.AzureBlob.csproj" />
 	<ProjectReference Include="..\Backend\Backblaze\Duplicati.Library.Backend.Backblaze.csproj" />
 	<ProjectReference Include="..\Backend\Box\Duplicati.Library.Backend.Box.csproj" />
+	<ProjectReference Include="..\Backend\CIFS\Duplicati.Library.Backend.CIFS.csproj" />
 	<ProjectReference Include="..\Backend\CloudFiles\Duplicati.Library.Backend.CloudFiles.csproj" />
 	<ProjectReference Include="..\Backend\Dropbox\Duplicati.Library.Backend.Dropbox.csproj" />
 	<ProjectReference Include="..\Backend\File\Duplicati.Library.Backend.File.csproj" />

--- a/Duplicati/Server/webroot/ngax/scripts/services/SystemInfo.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/SystemInfo.js
@@ -49,7 +49,8 @@ backupApp.service('SystemInfo', function($rootScope, $timeout, $cookies, AppServ
                 'webdav': null,
                 'openstack': gettextCatalog.getString('OpenStack Object Storage / Swift'),
                 's3': gettextCatalog.getString('S3 Compatible'),
-                'aftp': gettextCatalog.getString('FTP (Alternative)')
+                'aftp': gettextCatalog.getString('FTP (Alternative)'),
+                'cifs': gettextCatalog.getString('CFIS / SMB'),
             },
             local: {'file': null},
             prop: {

--- a/Duplicati/Server/webroot/ngax/templates/backends/cifs.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/cifs.html
@@ -1,0 +1,44 @@
+
+<div class="input select">
+    <label for="transport" translate>Transport</label>
+    <select name="transport"
+            id="transport"
+            ng-model="$parent.Transport">
+        <option value="directtcp">
+            {{'Direct TCP' | translate}}
+        </option>
+        <option value="netbiox">
+            {{'Netbios over TCP' | translate}}
+        </option>
+    </select>
+</div>
+
+<div class="input text">
+    <label for="generic_server" translate>Server</label>
+    <input type="text" name="generic_server" id="generic_server" ng-model="$parent.Server" placeholder="{{'Server hostname or IP' | translate}}" />
+</div>
+
+
+<div class="input text">
+    <label for="share_name" translate>Share Name</label>
+    <input type="text" name="share_name" id="share_name" ng-model="$parent.ShareName" placeholder="{{'Share name' | translate}}" />
+</div>
+
+<div class="input text">
+    <label for="generic_path" translate>Path on server</label>
+    <input type="text" name="generic_path" id="generic_path" ng-model="$parent.Path" placeholder="{{'Destination path' | translate}}" />
+</div>
+
+<div class="input text">
+    <label for="auth_domain" translate>Domain</label>
+    <input type="text" name="auth_domain" id="auth_domain" ng-model="$parent.Domain" placeholder="{{'Authentication Domain' | translate}}"  />
+</div>
+
+<div class="input text">
+    <label for="generic_username" translate>Username</label>
+    <input type="text" name="generic_username" id="generic_username" ng-model="$parent.Username" placeholder="{{'Authentication username' | translate}}"  />
+</div>
+<div class="input password">
+    <label for="generic_password" translate>Password</label>
+    <input autocomplete="new-password" type="password" name="generic_password" id="generic_password" ng-model="$parent.Password" placeholder="{{'Authentication password' | translate}}"  />
+</div>

--- a/LiveTests/Duplicati.Backend.Tests/CIFS/CIFSTests.cs
+++ b/LiveTests/Duplicati.Backend.Tests/CIFS/CIFSTests.cs
@@ -1,0 +1,117 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+namespace Duplicati.Backend.Tests.CIFS;
+
+/// <summary>
+/// CIFS Tests
+/// </summary>
+[TestClass]
+public sealed class CIFSTests : BaseSftpgoTest
+{
+
+    /// <summary>
+    /// Test CIFS with TestContainers creating a Samba Server with TestContainers.
+    ///
+    /// This test has no requirement of environment variables.
+    /// </summary>
+    [TestMethod]
+    public async Task TestCIFS()
+    {
+        var outputConsumer = new OutputConsumer();
+        var randomPassword = GeneratePassword();
+        var testFilePath = Path.Combine(Path.GetTempPath(), "samba-test");
+        Directory.CreateDirectory(testFilePath);
+        // Create smb.conf
+        var smbConfig = @"[global]
+workgroup = WORKGROUP
+server string = Samba Server
+log file = /var/log/samba/log.%m
+max log size = 50
+security = user
+passdb backend = tdbsam
+
+[testshare1]
+path = /shares/testshare1
+valid users = smbuser1
+writable = yes
+browseable = yes";
+
+        await File.WriteAllTextAsync(Path.Combine(testFilePath, "smb.conf"), smbConfig);
+
+        // Create entrypoint script
+        var entrypoint = $@"#!/bin/bash
+useradd -M -s /sbin/nologin smbuser1
+mkdir -p /shares/testshare1
+chown smbuser1:smbuser1 /shares/testshare1
+chmod 700 /shares/testshare1
+(echo {randomPassword}; echo {randomPassword}) | smbpasswd -a smbuser1 -s
+smbpasswd -e smbuser1
+smbd --foreground --no-process-group --debug-stdout";
+
+        await File.WriteAllTextAsync(Path.Combine(testFilePath, "entrypoint.sh"), entrypoint);
+
+        var container = new ContainerBuilder()
+            .WithImage("ubuntu:22.04")
+            .WithCommand("/bin/bash", "-c", "apt-get update && " +
+                "DEBIAN_FRONTEND=noninteractive apt-get install -y samba && " +
+                "bash /etc/samba/entrypoint.sh")
+            .WithResourceMapping(testFilePath, "/etc/samba", UnixFileModes.UserRead |
+                UnixFileModes.UserWrite | UnixFileModes.GroupRead | UnixFileModes.OtherRead)
+            .WithPortBinding(139, 139)
+            .WithPortBinding(445, 445)
+            .WithOutputConsumer(outputConsumer)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(139))
+            .Build();
+
+        Console.WriteLine("Starting container with wait strategy for port 139");
+        await container.StartAsync();
+        Console.WriteLine("Samba has started and its ready to accept connections");
+
+        var exitCode = CommandLine.BackendTester.Program.Main(
+            new[]
+            {
+                $"cifs://localhost/testshare1/new/?transport=directtcp&auth-domain&auth-username=smbuser1&auth-password={randomPassword}",
+            }.Concat(Parameters.GlobalTestParameters).ToArray());
+
+        Console.WriteLine(await outputConsumer.GetStreamsOutput());
+        if (exitCode != 0)
+        {
+            Assert.Fail("BackendTester is returning non-zero exit code, check logs for details");
+        }
+
+        await container.StopAsync();
+    }
+
+    /// <summary>
+    ///  Simple helper to generate a random password for the test.
+    ///
+    /// Only alphanumeric characters are used.
+    /// </summary>
+    /// <param name="length">Lenght of the password defaulting to 32</param>
+    private string GeneratePassword(int length = 32)
+    {
+        const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        var random = new Random();
+        return new string(Enumerable.Repeat(chars, length)
+            .Select(s => s[random.Next(s.Length)]).ToArray());
+    }
+}

--- a/LiveTests/Duplicati.Backend.Tests/README.md
+++ b/LiveTests/Duplicati.Backend.Tests/README.md
@@ -1,9 +1,7 @@
 
 # Environment variables for tests
 
-On github actions these are mapped 1:1 to secrets, even the non password fields are stored in secrets.
-
-Tests like FTP, SSH and Webdav are self-contained, they do not require any environment variable.
+On Github actions these are mapped 1:1 to secrets, even the non password fields are stored in secrets.
 
 ## General
 
@@ -13,6 +11,17 @@ These control the size and number of files generated.
 MAX_FILE_SIZE    default is 1000kb
 NUMBER_OF_FILES  default is 20
 ```
+
+## Backends that do not require Environment variables
+
+* FTP _(TestContainers required)_
+* SSH _(TestContainers required)_
+* Webdav _(TestContainers required)_
+* CIFS _(TestContainers required)_
+
+Please note that TestContainers token has to be configured in secrets/Github actions yml.
+
+## Backends that require Environment variables
 
 ## Google Drive:
 
@@ -63,7 +72,6 @@ TESTCREDENTIAL_PCLOUD_TOKEN
 TESTCREDENTIAL_PCLOUD_FOLDER
 ```
 For PCloud the server is the API server(eapi.pcloud.com for EU hosted account or api.pcloud.com for non EU). The token is the OAuth token.
-
 
 ## Running the tests
 


### PR DESCRIPTION
This will add CIFS support to Duplicati.

One of the advantages is that the resource does not need to be mounted as the backend connects and authenticates directly to the resource via TCP/or Netbios over TCP.

The authentication supported is domain/username/password. At present integrated Windows authentication is not supported.

This implementation relies on SMBLibrary library (https://github.com/TalAloni/SMBLibrary).

Summited as draft for review & Testing