### PR TITLE
Added a filter to not log application exceptions.

### DIFF
--- a/Duplicati/WebserverCore/DuplicatiWebserver.cs
+++ b/Duplicati/WebserverCore/DuplicatiWebserver.cs
@@ -218,7 +218,8 @@ public partial class DuplicatiWebserver
                 .AddFilter("Microsoft", LogLevel.Warning)
                 .AddFilter("Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager", LogLevel.Error)
                 .AddFilter("System", LogLevel.Warning)
-                .AddFilter("Duplicati", LogLevel.Warning);
+                .AddFilter("Duplicati", LogLevel.Warning)
+                .AddFilter("Microsoft.AspNetCore.Diagnostics", LogLevel.None);
         }
 
         builder.Services.AddHttpClient();
@@ -260,6 +261,10 @@ public partial class DuplicatiWebserver
                 }
                 else
                 {
+                    // These are unexpected exceptions, so log them
+                    app.ApplicationServices.GetRequiredService<ILogger<DuplicatiWebserver>>()
+                        .LogError(thrownException, "Unhandled exception");
+
                     context.Response.StatusCode = 500;
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(JsonSerializer.Serialize(new { Error = "An error occurred", Code = 500 }));


### PR DESCRIPTION
Unknown exceptions are still logged, so we can collect reports of these and eventually wrap them in user information exceptions.