### PR TITLE
Fixed issues with timeout in msgraph

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Globalization;
 using System.Threading;
 using Duplicati.Library.Utility;
+using Duplicati.StreamUtil;
 
 namespace Duplicati.CommandLine.BackendTester
 {
@@ -140,7 +141,7 @@ namespace Duplicati.CommandLine.BackendTester
 
         static bool Run(List<string> args, Dictionary<string, string> options, bool first)
         {
-            Library.Interface.IBackend backend = Library.DynamicLoader.BackendLoader.GetBackend(args[0], options);
+            var backend = Library.DynamicLoader.BackendLoader.GetBackend(args[0], options);
             if (backend == null)
             {
                 Console.WriteLine("Unsupported backend");
@@ -149,23 +150,21 @@ namespace Duplicati.CommandLine.BackendTester
                 return false;
             }
 
-            string allowedChars = ValidFilenameChars;
+            var allowedChars = ValidFilenameChars;
             if (options.ContainsKey("extended-chars"))
             {
                 allowedChars += String.IsNullOrEmpty(options["extended-chars"]) ? ExtendedChars : options["extended-chars"];
             }
 
-            bool autoCreateFolders = Library.Utility.Utility.ParseBoolOption(options, "auto-create-folder");
+            var autoCreateFolders = Library.Utility.Utility.ParseBoolOption(options, "auto-create-folder");
 
-            string disabledModulesValue;
-            string enabledModulesValue;
-            options.TryGetValue("enable-module", out enabledModulesValue);
-            options.TryGetValue("disable-module", out disabledModulesValue);
-            string[] enabledModules = enabledModulesValue == null ? new string[0] : enabledModulesValue.Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
-            string[] disabledModules = disabledModulesValue == null ? new string[0] : disabledModulesValue.Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
+            options.TryGetValue("enable-module", out var enabledModulesValue);
+            options.TryGetValue("disable-module", out var disabledModulesValue);
+            var enabledModules = enabledModulesValue == null ? new string[0] : enabledModulesValue.Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
+            var disabledModules = disabledModulesValue == null ? new string[0] : disabledModulesValue.Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
 
-            List<Library.Interface.IGenericModule> loadedModules = new List<IGenericModule>();
-            foreach (Library.Interface.IGenericModule m in Library.DynamicLoader.GenericLoader.Modules)
+            var loadedModules = new List<IGenericModule>();
+            foreach (var m in Library.DynamicLoader.GenericLoader.Modules)
                 if (!disabledModules.Contains(m.Key, StringComparer.OrdinalIgnoreCase) && (m.LoadAsDefault || enabledModules.Contains(m.Key, StringComparer.OrdinalIgnoreCase)))
                 {
                     m.Configure(options);
@@ -217,17 +216,17 @@ namespace Duplicati.CommandLine.BackendTester
                     }
 
 
-                int number_of_files = 10;
-                int min_file_size = 1024;
-                int max_file_size = 1024 * 1024 * 50;
-                int min_filename_size = 5;
-                int max_filename_size = 80;
-                bool disableStreaming = Library.Utility.Utility.ParseBoolOption(options, "disable-streaming-transfers");
-                bool skipOverwriteTest = Library.Utility.Utility.ParseBoolOption(options, "skip-overwrite-test");
-                bool trimFilenameSpaces = Library.Utility.Utility.ParseBoolOption(options, "trim-filename-spaces");
+                var number_of_files = 10;
+                var min_file_size = 1024;
+                var max_file_size = 1024 * 1024 * 50;
+                var min_filename_size = 5;
+                var max_filename_size = 80;
+                var disableStreaming = Library.Utility.Utility.ParseBoolOption(options, "disable-streaming-transfers");
+                var skipOverwriteTest = Library.Utility.Utility.ParseBoolOption(options, "skip-overwrite-test");
+                var trimFilenameSpaces = Library.Utility.Utility.ParseBoolOption(options, "trim-filename-spaces");
 
-                long throttleUpload = 0;
-                if (options.TryGetValue("throttle-upload", out string throttleUploadString))
+                var throttleUpload = 0L;
+                if (options.TryGetValue("throttle-upload", out var throttleUploadString))
                 {
                     if (!(backend is IStreamingBackend) || disableStreaming)
                     {
@@ -237,8 +236,8 @@ namespace Duplicati.CommandLine.BackendTester
                     throttleUpload = Duplicati.Library.Utility.Sizeparser.ParseSize(throttleUploadString, "kb");
                 }
 
-                long throttleDownload = 0;
-                if (options.TryGetValue("throttle-download", out string throttleDownloadString))
+                var throttleDownload = 0L;
+                if (options.TryGetValue("throttle-download", out var throttleDownloadString))
                 {
                     if (!(backend is IStreamingBackend) || disableStreaming)
                     {
@@ -247,6 +246,17 @@ namespace Duplicati.CommandLine.BackendTester
 
                     throttleDownload = Duplicati.Library.Utility.Sizeparser.ParseSize(throttleDownloadString, "kb");
                 }
+
+                var readWriteTimeout = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
+                if (backend is ITimeoutExemptBackend)
+                    readWriteTimeout = Timeout.Infinite;
+
+                // Allow overriding the timeout for the backend here, even if timeouts are disabled
+                if (options.TryGetValue("read-write-timeout", out var readWriteTimeoutString))
+                    readWriteTimeout = (int)Timeparser.ParseTimeSpan(readWriteTimeoutString).TotalMilliseconds;
+
+                if (readWriteTimeout <= 0)
+                    readWriteTimeout = Timeout.Infinite;
 
                 if (options.ContainsKey("number-of-files"))
                     number_of_files = int.Parse(options["number-of-files"]);
@@ -260,21 +270,21 @@ namespace Duplicati.CommandLine.BackendTester
                 if (options.ContainsKey("max-filename-length"))
                     max_filename_size = int.Parse(options["max-filename-length"]);
 
-                Random rnd = new Random();
-                System.Security.Cryptography.SHA256 sha = System.Security.Cryptography.SHA256.Create();
+                var rnd = new Random();
+                var sha = System.Security.Cryptography.SHA256.Create();
 
                 //Create random files
-                using (Library.Utility.TempFolder tf = new Duplicati.Library.Utility.TempFolder())
+                using (var tf = new Duplicati.Library.Utility.TempFolder())
                 {
-                    List<TempFile> files = new List<TempFile>();
+                    var files = new List<TempFile>();
                     for (int i = 0; i < number_of_files; i++)
                     {
-                        string filename = CreateRandomRemoteFileName(min_filename_size, max_filename_size, allowedChars, trimFilenameSpaces, rnd);
+                        var filename = CreateRandomRemoteFileName(min_filename_size, max_filename_size, allowedChars, trimFilenameSpaces, rnd);
 
-                        string localfilename = CreateRandomFile(tf, i, min_file_size, max_file_size, rnd);
+                        var localfilename = CreateRandomFile(tf, i, min_file_size, max_file_size, rnd);
 
                         //Calculate local hash and length
-                        using (System.IO.FileStream fs = new System.IO.FileStream(localfilename, System.IO.FileMode.Open, System.IO.FileAccess.Read))
+                        using (var fs = new System.IO.FileStream(localfilename, System.IO.FileMode.Open, System.IO.FileAccess.Read))
                             files.Add(new TempFile(filename, localfilename, sha.ComputeHash(fs), fs.Length));
                     }
 
@@ -282,16 +292,16 @@ namespace Duplicati.CommandLine.BackendTester
                     if (!skipOverwriteTest)
                     {
                         Console.WriteLine("Uploading wrong files ...");
-                        using (Library.Utility.TempFile dummy = Library.Utility.TempFile.WrapExistingFile(CreateRandomFile(tf, files.Count, 1024, 2048, rnd)))
+                        using (var dummy = Library.Utility.TempFile.WrapExistingFile(CreateRandomFile(tf, files.Count, 1024, 2048, rnd)))
                         {
-                            using (System.IO.FileStream fs = new System.IO.FileStream(dummy, System.IO.FileMode.Open, System.IO.FileAccess.Read))
+                            using (var fs = new System.IO.FileStream(dummy, System.IO.FileMode.Open, System.IO.FileAccess.Read))
                                 dummyFileHash = sha.ComputeHash(fs);
 
                             //Upload a dummy file for entry 0 and the last one, they will be replaced by the real files afterwards
                             //We upload entry 0 twice just to try to freak any internal cache list
-                            Uploadfile(dummy, 0, files[0].remotefilename, backend, disableStreaming, throttleUpload);
-                            Uploadfile(dummy, 0, files[0].remotefilename, backend, disableStreaming, throttleUpload);
-                            Uploadfile(dummy, files.Count - 1, files[files.Count - 1].remotefilename, backend, disableStreaming, throttleUpload);
+                            Uploadfile(dummy, 0, files[0].remotefilename, backend, disableStreaming, throttleUpload, readWriteTimeout);
+                            Uploadfile(dummy, 0, files[0].remotefilename, backend, disableStreaming, throttleUpload, readWriteTimeout);
+                            Uploadfile(dummy, files.Count - 1, files[files.Count - 1].remotefilename, backend, disableStreaming, throttleUpload, readWriteTimeout);
                         }
 
                     }
@@ -299,7 +309,7 @@ namespace Duplicati.CommandLine.BackendTester
                     Console.WriteLine("Uploading files ...");
 
                     for (int i = 0; i < files.Count; i++)
-                        Uploadfile(files[i].localfilename, i, files[i].remotefilename, backend, disableStreaming, throttleUpload);
+                        Uploadfile(files[i].localfilename, i, files[i].remotefilename, backend, disableStreaming, throttleUpload, readWriteTimeout);
 
                     TempFile originalRenamedFile = null;
                     string renamedFileNewName = null;
@@ -320,11 +330,11 @@ namespace Duplicati.CommandLine.BackendTester
                     Console.WriteLine("Verifying file list ...");
 
                     curlist = backend.List();
-                    foreach (Library.Interface.IFileEntry fe in curlist)
+                    foreach (var fe in curlist)
                         if (!fe.IsFolder)
                         {
                             bool found = false;
-                            foreach (TempFile tx in files)
+                            foreach (var tx in files)
                                 if (tx.remotefilename == fe.Name)
                                 {
                                     if (tx.found)
@@ -349,7 +359,7 @@ namespace Duplicati.CommandLine.BackendTester
                                 }
                         }
 
-                    foreach (TempFile tx in files)
+                    foreach (var tx in files)
                         if (!tx.found)
                             Console.WriteLine("*** File with name {0} was uploaded but not found afterwards", tx.remotefilename);
 
@@ -357,7 +367,7 @@ namespace Duplicati.CommandLine.BackendTester
 
                     for (int i = 0; i < files.Count; i++)
                     {
-                        using (Duplicati.Library.Utility.TempFile cf = new Duplicati.Library.Utility.TempFile())
+                        using (var cf = new Duplicati.Library.Utility.TempFile())
                         {
                             Exception e = null;
                             Console.Write("Downloading file {0} ... ", i);
@@ -366,10 +376,11 @@ namespace Duplicati.CommandLine.BackendTester
                             {
                                 if (backend is IStreamingBackend streamingBackend && !disableStreaming)
                                 {
-                                    using (System.IO.FileStream fs = new System.IO.FileStream(cf, System.IO.FileMode.Create, System.IO.FileAccess.Write, System.IO.FileShare.None))
-                                    using (Library.Utility.ThrottledStream ts = new Library.Utility.ThrottledStream(fs, throttleDownload, throttleDownload))
-                                    using (NonSeekableStream nss = new NonSeekableStream(ts))
-                                        streamingBackend.GetAsync(files[i].remotefilename, nss, CancellationToken.None).Await();
+                                    using (var fs = new System.IO.FileStream(cf, System.IO.FileMode.Create, System.IO.FileAccess.Write, System.IO.FileShare.None))
+                                    using (var timeoutStream = new TimeoutObservingStream(fs) { WriteTimeout = readWriteTimeout })
+                                    using (var ts = new Library.Utility.ThrottledStream(timeoutStream, throttleDownload, throttleDownload))
+                                    using (var nss = new NonSeekableStream(ts))
+                                        streamingBackend.GetAsync(files[i].remotefilename, nss, timeoutStream.TimeoutToken).Await();
                                 }
                                 else
                                     backend.GetAsync(files[i].remotefilename, cf, CancellationToken.None).Await();
@@ -388,7 +399,7 @@ namespace Duplicati.CommandLine.BackendTester
 
                             Console.Write("Checking hash ... ");
 
-                            using (System.IO.FileStream fs = new System.IO.FileStream(cf, System.IO.FileMode.Open, System.IO.FileAccess.Read))
+                            using (var fs = new System.IO.FileStream(cf, System.IO.FileMode.Open, System.IO.FileAccess.Read))
                                 if (Convert.ToBase64String(sha.ComputeHash(fs)) != Convert.ToBase64String(files[i].hash))
                                 {
                                     if (dummyFileHash != null && Convert.ToBase64String(sha.ComputeHash(fs)) == Convert.ToBase64String(dummyFileHash))
@@ -403,7 +414,7 @@ namespace Duplicati.CommandLine.BackendTester
 
                     Console.WriteLine("Deleting files...");
 
-                    foreach (TempFile tx in files)
+                    foreach (var tx in files)
                         try { backend.DeleteAsync(tx.remotefilename, CancellationToken.None).Await(); }
                         catch (Exception ex)
                         {
@@ -411,7 +422,7 @@ namespace Duplicati.CommandLine.BackendTester
                         }
 
                     curlist = backend.List();
-                    foreach (Library.Interface.IFileEntry fe in curlist)
+                    foreach (var fe in curlist)
                         if (!fe.IsFolder)
                         {
                             Console.WriteLine("*** Remote folder contains {0} after cleanup", fe.Name);
@@ -419,10 +430,10 @@ namespace Duplicati.CommandLine.BackendTester
 
                     // Test some error cases
                     Console.WriteLine("Checking retrieval of non-existent file...");
-                    bool caughtExpectedException = false;
+                    var caughtExpectedException = false;
                     try
                     {
-                        using (Duplicati.Library.Utility.TempFile tempFile = new Duplicati.Library.Utility.TempFile())
+                        using (var tempFile = new Duplicati.Library.Utility.TempFile())
                         {
                             backend.GetAsync(string.Format("NonExistentFile-{0}", Guid.NewGuid()), tempFile.Name, CancellationToken.None).Await();
                         }
@@ -444,8 +455,7 @@ namespace Duplicati.CommandLine.BackendTester
                 }
 
                 // Test quota retrieval
-                IQuotaEnabledBackend quotaEnabledBackend = backend as IQuotaEnabledBackend;
-                if (quotaEnabledBackend != null)
+                if (backend is IQuotaEnabledBackend quotaEnabledBackend)
                 {
                     Console.WriteLine("Checking quota...");
                     IQuotaInfo quota = null;
@@ -499,7 +509,7 @@ namespace Duplicati.CommandLine.BackendTester
             }
             finally
             {
-                foreach (Library.Interface.IGenericModule m in loadedModules)
+                foreach (var m in loadedModules)
                     if (m is IDisposable disposable)
                         disposable.Dispose();
             }
@@ -507,7 +517,7 @@ namespace Duplicati.CommandLine.BackendTester
             return true;
         }
 
-        private static void Uploadfile(string localfilename, int i, string remotefilename, IBackend backend, bool disableStreaming, long throttle)
+        private static void Uploadfile(string localfilename, int i, string remotefilename, IBackend backend, bool disableStreaming, long throttle, int readWriteTimeout)
         {
             Console.Write("Uploading file {0}, {1} ... ", i, Duplicati.Library.Utility.Utility.FormatSizeString(new System.IO.FileInfo(localfilename).Length));
             Exception e = null;
@@ -516,10 +526,11 @@ namespace Duplicati.CommandLine.BackendTester
             {
                 if (backend is IStreamingBackend streamingBackend && !disableStreaming)
                 {
-                    using (System.IO.FileStream fs = new System.IO.FileStream(localfilename, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
-                    using (Library.Utility.ThrottledStream ts = new Library.Utility.ThrottledStream(fs, throttle, throttle))
-                    using (NonSeekableStream nss = new NonSeekableStream(ts))
-                        streamingBackend.PutAsync(remotefilename, nss, CancellationToken.None).Await();
+                    using (var fs = new System.IO.FileStream(localfilename, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
+                    using (var timeoutStream = new TimeoutObservingStream(fs) { ReadTimeout = readWriteTimeout })
+                    using (var ts = new Library.Utility.ThrottledStream(timeoutStream, throttle, throttle))
+                    using (var nss = new NonSeekableStream(ts))
+                        streamingBackend.PutAsync(remotefilename, nss, timeoutStream.TimeoutToken).Await();
                 }
                 else
                     backend.PutAsync(remotefilename, localfilename, CancellationToken.None).Await();

--- a/Duplicati/Library/Backend/OAuthHelper/RetryAfterHelper.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/RetryAfterHelper.cs
@@ -156,7 +156,7 @@ namespace Duplicati.Library
                     "Waiting for {0} to respect Retry-After header",
                     delay);
 
-                await Task.Delay(delay).ConfigureAwait(false);
+                await Task.Delay(delay, cancelToken).ConfigureAwait(false);
             }
         }
 

--- a/Duplicati/Library/Interface/ITimeoutExemptBackend.cs
+++ b/Duplicati/Library/Interface/ITimeoutExemptBackend.cs
@@ -1,0 +1,29 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+namespace Duplicati.Library.Interface;
+
+/// <summary>
+/// Marker interface for backends that do not support timeouts on the streams
+/// </summary>
+public interface ITimeoutExemptBackend
+{
+}

--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -721,7 +721,7 @@ namespace Duplicati.Library.Main
             if (m_backend is Library.Interface.IStreamingBackend streamingBackend && !m_options.DisableStreamingTransfers)
             {
                 using (var fs = System.IO.File.OpenRead(item.LocalFilename))
-                using (var act = new Duplicati.StreamUtil.TimeoutObservingStream(fs) { ReadTimeout = m_backend is ITimeoutExemptBackend ? -1 : m_options.ReadWriteTimeout })
+                using (var act = new Duplicati.StreamUtil.TimeoutObservingStream(fs) { ReadTimeout = m_backend is ITimeoutExemptBackend ? Timeout.Infinite : m_options.ReadWriteTimeout })
                 using (var ts = new ThrottledStream(act, m_options.MaxUploadPrSecond, 0))
                 using (var pgs = new Library.Utility.ProgressReportingStream(ts, pg => HandleProgress(ts, pg)))
                 using (var linkedToken = System.Threading.CancellationTokenSource.CreateLinkedTokenSource(m_taskReader.TransferToken, act.TimeoutToken))
@@ -762,7 +762,7 @@ namespace Duplicati.Library.Main
                 {
                     // extended to use stacked streams
                     using (var fs = System.IO.File.OpenWrite(dlTarget))
-                    using (var act = new Duplicati.StreamUtil.TimeoutObservingStream(fs) { WriteTimeout = m_backend is ITimeoutExemptBackend ? -1 : m_options.ReadWriteTimeout })
+                    using (var act = new Duplicati.StreamUtil.TimeoutObservingStream(fs) { WriteTimeout = m_backend is ITimeoutExemptBackend ? Timeout.Infinite : m_options.ReadWriteTimeout })
                     using (var hasher = HashFactory.CreateHasher(m_options.FileHashAlgorithm))
                     using (var hs = new HashCalculatingStream(act, hasher))
                     using (var ss = new ShaderStream(hs, true))

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -871,7 +871,7 @@ namespace Duplicati.Library.Main
                 if (string.IsNullOrWhiteSpace(v))
                     v = DEFAULT_READ_WRITE_TIMEOUT;
 
-                var res = Library.Utility.Timeparser.ParseTimeSpan(DEFAULT_READ_WRITE_TIMEOUT);
+                var res = Library.Utility.Timeparser.ParseTimeSpan(v);
                 if (res.Ticks <= 0)
                     return -1;
 

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using System.Globalization;
+using System.Threading;
 
 namespace Duplicati.Library.Main
 {
@@ -861,7 +862,7 @@ namespace Duplicati.Library.Main
 
         /// <summary>
         /// The maximum time to allow inactivity before a connection is closed.
-        /// Returns -1 if disabled.
+        /// Returns <c>Timeout.Infinite</c> if disabled.
         /// </summary>
         public int ReadWriteTimeout
         {
@@ -873,7 +874,7 @@ namespace Duplicati.Library.Main
 
                 var res = Library.Utility.Timeparser.ParseTimeSpan(v);
                 if (res.Ticks <= 0)
-                    return -1;
+                    return Timeout.Infinite;
 
                 return (int)res.TotalMilliseconds;
             }


### PR DESCRIPTION
Fixed a place where the cancellation token was not applied.

Fixed a problem with msgraph not sending correct DNS information.

Fixed a problem with msgraph downloading the entire file before streaming it, bypassing throttle and tripping the timeout.

Added `ITimeoutExemptBackend` to selectively disable timeouts for backends that do not support it.

Updated the backendmanager to support `ITimeoutExemptBackend`.

Updated the backendmanager to abort as soon as a timeout happens.

Updated BackendTester to use the TimeoutObservingStream and support the `--read-write-timeout` setting.

Updated backend tester code to use `var`.

This fixes #5777 