### PR TITLE
Rename OneDrive v2

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/OneDrive.cs
+++ b/Duplicati/Library/Backend/OneDrive/OneDrive.cs
@@ -24,7 +24,7 @@ using Duplicati.Library.Interface;
 
 namespace Duplicati.Library.Backend
 {
-    public class OneDriveV2 : MicrosoftGraphBackend
+    public class OneDrive : MicrosoftGraphBackend
     {
         private const string DRIVE_ID_OPTION = "drive-id";
         private const string DEFAULT_DRIVE_PATH = "/me/drive";
@@ -32,10 +32,10 @@ namespace Duplicati.Library.Backend
 
         private readonly string drivePath;
 
-        public OneDriveV2() { } // Constructor needed for dynamic loading to find it
+        public OneDrive() { } // Constructor needed for dynamic loading to find it
 
-        public OneDriveV2(string url, Dictionary<string, string> options)
-            : base(url, OneDriveV2.PROTOCOL_KEY, options)
+        public OneDrive(string url, Dictionary<string, string> options)
+            : base(url, OneDrive.PROTOCOL_KEY, options)
         {
             string driveId;
             if (options.TryGetValue(DRIVE_ID_OPTION, out driveId))
@@ -50,12 +50,12 @@ namespace Duplicati.Library.Backend
 
         public override string ProtocolKey
         {
-            get { return OneDriveV2.PROTOCOL_KEY; }
+            get { return OneDrive.PROTOCOL_KEY; }
         }
 
         public override string DisplayName
         {
-            get { return Strings.OneDriveV2.DisplayName; }
+            get { return Strings.OneDrive.DisplayName; }
         }
 
         protected override string DrivePath
@@ -67,7 +67,7 @@ namespace Duplicati.Library.Backend
         {
             get
             {
-                return Strings.OneDriveV2.Description;
+                return Strings.OneDrive.Description;
             }
         }
 
@@ -77,7 +77,7 @@ namespace Duplicati.Library.Backend
             {
                 return new ICommandLineArgument[]
                 {
-                    new CommandLineArgument(DRIVE_ID_OPTION, CommandLineArgument.ArgumentType.String, Strings.OneDriveV2.DriveIdShort, Strings.OneDriveV2.DriveIdLong(DEFAULT_DRIVE_PATH)),
+                    new CommandLineArgument(DRIVE_ID_OPTION, CommandLineArgument.ArgumentType.String, Strings.OneDrive.DriveIdShort, Strings.OneDrive.DriveIdLong(DEFAULT_DRIVE_PATH)),
                 };
             }
         }

--- a/Duplicati/Library/Backend/OneDrive/Strings.cs
+++ b/Duplicati/Library/Backend/OneDrive/Strings.cs
@@ -36,7 +36,7 @@ namespace Duplicati.Library.Backend.Strings
         public static string UseHttpClientShort { get { return LC.L(@"Whether the HttpClient class should be used"); } }
     }
 
-    internal static class OneDriveV2
+    internal static class OneDrive
     {
         public static string Description(string mssadescription, string mssalink, string msopdescription, string msoplink) { return LC.L(@"Store files in Microsoft OneDrive or Microsoft OneDrive for Business via the Microsoft Graph API. Usage of this backend requires that you agree to the terms in {0} ({1}) and {2} ({3}).", mssadescription, mssalink, msopdescription, msoplink); }
         public static string DisplayName { get { return LC.L(@"Microsoft OneDrive"); } }

--- a/Duplicati/Library/Backend/OneDrive/Strings.cs
+++ b/Duplicati/Library/Backend/OneDrive/Strings.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Library.Backend.Strings
     internal static class OneDriveV2
     {
         public static string Description(string mssadescription, string mssalink, string msopdescription, string msoplink) { return LC.L(@"Store files in Microsoft OneDrive or Microsoft OneDrive for Business via the Microsoft Graph API. Usage of this backend requires that you agree to the terms in {0} ({1}) and {2} ({3}).", mssadescription, mssalink, msopdescription, msoplink); }
-        public static string DisplayName { get { return LC.L(@"Microsoft OneDrive v2"); } }
+        public static string DisplayName { get { return LC.L(@"Microsoft OneDrive"); } }
         public static string DriveIdLong(string defaultDrive) { return LC.L(@"ID of the drive to store data in. If no drive is specified, the default OneDrive or OneDrive for Business drive will be used via '{0}'.", defaultDrive); }
         public static string DriveIdShort { get { return LC.L(@"Optional ID of the drive"); } }
     }

--- a/Duplicati/Library/Backends/BackendModules.cs
+++ b/Duplicati/Library/Backends/BackendModules.cs
@@ -53,7 +53,7 @@ public static class BackendModules
         new Backend.Jottacloud(),
         new Backend.Mega.MegaBackend(),
         new Backend.MicrosoftGroup(),
-        new Backend.OneDriveV2(),
+        new Backend.OneDrive(),
         new Backend.OpenStack.OpenStackStorage(),
         new Backend.Rclone(),
         new Backend.S3(),


### PR DESCRIPTION
Since there is no longer a `OneDrive v1` this renames the `OneDrive v2` strings to just `OneDrive`.
The url is still using the `onedrivev2://` prefix for backwards compatibility.
Once ngclient is the default UI, we can rename the prefix and do the mapping.