### PR TITLE
Fixed a thread crash on stop

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -225,14 +225,15 @@ namespace Duplicati.GUI.TrayIcon
             var started = DateTime.Now;
             var errorCount = 0;
 
+            // TODO: Add an upper limit to the number of errors,
+            // or implement a "disconnected" state
             while (!m_shutdown)
             {
-                var waitTime = TimeSpan.FromSeconds(Math.Min(10, errorCount * 2)) - (DateTime.Now - started);
-                if (waitTime.TotalSeconds > 0)
-                    Thread.Sleep(waitTime);
-
                 try
                 {
+                    var waitTime = TimeSpan.FromSeconds(Math.Min(10, errorCount * 2)) - (DateTime.Now - started);
+                    if (waitTime.TotalSeconds > 0)
+                        Thread.Sleep(waitTime);
                     started = DateTime.Now;
                     UpdateStatus(true);
                     errorCount = 0;


### PR DESCRIPTION
This protects the `Thread.Sleep()` call with the `try/catch` so interrupting the thread while sleeping will be treated as a logged error and not cause the thread to crash.

Maybe a solves #5776 