### PR TITLE
Workaround for multi-backend.

### DIFF
--- a/Duplicati/Library/Main/BackendManager.cs
+++ b/Duplicati/Library/Main/BackendManager.cs
@@ -387,6 +387,18 @@ namespace Duplicati.Library.Main
         private readonly Boolean m_retrywithexponentialbackoff;
 
         public string BackendUrl { get { return m_backendurl; } }
+        public IBackend BorrowBackend()
+        {
+            var backend = m_backend;
+            m_backend = null;
+            return backend;
+        }
+
+        public void ResetBackend(IBackend instance)
+        {
+            m_backend = instance ?? DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions);
+        }
+
 
         public BackendManager(string backendurl, Options options, IBackendWriter statwriter, LocalDatabase database)
         {

--- a/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackendUploader.cs
@@ -244,7 +244,10 @@ namespace Duplicati.Library.Main.Operation.Backup
                     workers.ForEach(w =>
                     {
                         if (w.Backend == m_backend)
+                        {
+                            Interlocked.Exchange(ref m_backendTaken, 0);
                             w.Backend = null;
+                        }
                         w.Dispose();
                     });
                 }
@@ -276,6 +279,12 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                 Worker finishedWorker = workers.Single(w => w.Task == finishedTask);
                 workers.Remove(finishedWorker);
+                if (finishedWorker.Backend == m_backend && !m_backendDisposed)
+                {
+                    finishedWorker.Backend = null;
+                    Interlocked.Exchange(ref m_backendTaken, 0);
+                }
+
                 finishedWorker.Dispose();
             }
         }

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -536,7 +536,7 @@ namespace Duplicati.Library.Main.Operation
                 {
                     long filesetid;
                     using var counterToken = CancellationTokenSource.CreateLinkedTokenSource(m_taskReader.ProgressToken);
-                    var uploader = new Backup.BackendUploader(() => DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions), m_options, db, m_result.TaskControl, stats);
+                    var uploader = new Backup.BackendUploader(backendManager.BorrowBackend(), () => DynamicLoader.BackendLoader.GetBackend(m_backendurl, m_options.RawOptions), m_options, db, m_result.TaskControl, stats);
                     using (var snapshot = GetSnapshot(sources, m_options))
                     {
                         try
@@ -613,6 +613,9 @@ namespace Duplicati.Library.Main.Operation
 
                     // Make sure we have the database up-to-date
                     await db.CommitTransactionAsync("CommitAfterUpload", false);
+
+                    // Return the backend instance to the manager, if possible
+                    backendManager.ResetBackend(uploader.Backend);
 
                     // TODO: Remove this later
                     m_transaction = m_database.BeginTransaction();


### PR DESCRIPTION
There is currently an issue with creating the BackendManager which has a backend instance. This instance is not used by the uploader, so they will create new instances. The BackendManager instance can then time out, but is used later.

This commit will allow the uploader to "borrow" the instance from the backend manager, so only a single instance is needed.

This is not a clean fix, but doing so requires a full rewrite of the backend manager and uploader, so the controller creates a single instance of the manager, which is then used for all operations.

This would allow the backend manager to keep track of instances across all requests.