### PR TITLE
Fixed TrayIcon disconnecting.

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -313,9 +313,12 @@ namespace Duplicati.GUI.TrayIcon
                 {
                     return PerformRequestInternal<T>(method, urlfragment, body, timeout);
                 }
-                catch (AggregateException aex)
+                catch (Exception ex)
+                    when (ex is HttpRequestException hex && (hex.StatusCode == HttpStatusCode.Unauthorized || hex.StatusCode == HttpStatusCode.Forbidden)
+                        || ex is AggregateException aex && aex.InnerExceptions.Any(x => x is HttpRequestException hex && (hex.StatusCode == HttpStatusCode.Unauthorized || hex.StatusCode == HttpStatusCode.Forbidden))
+                )
                 {
-                    if (hasTriedPassword || !aex.InnerExceptions.Any(x => x is HttpRequestException hex && hex.StatusCode == HttpStatusCode.Unauthorized))
+                    if (hasTriedPassword)
                         throw;
 
                     // Only try once, and clear the token for the next try


### PR DESCRIPTION
This fixes a problem where the exception was not correctly detected causing the token to not be re-obtained.

This fixes #5818