### PR TITLE
Clean up options for file backend

### DIFF
--- a/Duplicati/Library/Backend/File/Strings.cs
+++ b/Duplicati/Library/Backend/File/Strings.cs
@@ -19,8 +19,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 using Duplicati.Library.Localization.Short;
-namespace Duplicati.Library.Backend.Strings {
-    internal static class FileBackend {
+namespace Duplicati.Library.Backend.Strings
+{
+    internal static class FileBackend
+    {
         public static string Description { get { return LC.L(@"This backend can read and write data to an file based backend. Allowed formats are ""file://hostname/folder"" and ""file://username:password@hostname/folder"". You may supply UNC paths (e.g.: ""file://\\server\folder"") or local paths (e.g.: (win) ""file://c:\folder"", (linux) ""file:///usr/pub/files"")"); } }
         public static string DisplayName { get { return LC.L(@"Local folder or drive"); } }
         public static string AlternateDestinationMarkerLong(string optionname) { return LC.L(@"This option only works when the option --{0} is also specified. If there are alternate paths specified, this option indicates the name of a marker file that must be present in the folder. This can be used to handle situations where an external drive changes drive letter or mount point. By ensuring that a certain file exists, it is possible to prevent writing data to an unwanted external drive. The contents of the file are never examined, only file existence.", optionname); }

--- a/Duplicati/Library/Backend/File/Win32.cs
+++ b/Duplicati/Library/Backend/File/Win32.cs
@@ -20,12 +20,12 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Duplicati.Library.Backend
 {
+    [SupportedOSPlatform("windows")]
     internal class Win32
     {
         [DllImport("mpr.dll")]


### PR DESCRIPTION
This removes unsupported arguments from non-windows clients, so the reported options fit what is supported.