### PR TITLE
Fix FTP library failures

### DIFF
--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -676,6 +676,7 @@ namespace Duplicati.Library.Backend
                 };
 
                 client.ValidateCertificate += HandleValidateCertificate;
+                await client.Connect(cancellationToken).ConfigureAwait(false);
 
                 // Set up for relative paths
                 if (_relativePaths)


### PR DESCRIPTION
This commit ensures the client connects on first use, instead of relying on the library to connect.
Previously, it would mostly work because the FTP library auto-connects for most calls, but not all.

Depending on the order the backend was used in, this could end up in a case where the library would not auto connect.
With the forced connect, this is no longer possible.

This fixes #5730