### PR TITLE
Quota check disabled fix

### DIFF
--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -382,6 +382,9 @@ namespace Duplicati.Library.Main.Operation
 
         private static void CheckQuota(BackendManager backend, Options options, IBackendWriter log, long knownFileSize)
         {
+            if (options.QuotaDisable)
+                return;
+
             var quota = backend.GetQuotaInfoAsync(CancellationToken.None).Await();
             if (quota != null)
             {


### PR DESCRIPTION
The QuotaCheck is done in two places, and only one place was checking if the quota check was supposed to be disabled. This adds the check in the other place.