### PR TITLE
Fix on JS for CIFS template

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -989,6 +989,8 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         
         if (scope.Path)
             scope.Path = scope.Path.replace(/^[/\\]+/, '').replace(/[/\\]+$/, '');
+        else 
+            scope.Path = '';
 
         return AppUtils.format('{0}://{1}/{2}/{3}/{4}',
             scope.Backend.Key,


### PR DESCRIPTION
When creating a new backup, if path was not set to any value, it would default to Undefined and end up as part of the URI.
