### PR TITLE
Fixed duplicate entries in index files

### DIFF
--- a/Duplicati/Library/Compression/ZipCompression/BuiltinZipArchive.cs
+++ b/Duplicati/Library/Compression/ZipCompression/BuiltinZipArchive.cs
@@ -113,7 +113,14 @@ public class BuiltinZipArchive : IZipArchive
             foreach (var entry in m_archive.Entries)
             {
                 if (m_entries.ContainsKey(entry.FullName))
-                    Logging.Log.WriteWarningMessage(LOGTAG, "DuplicateArchiveEntry", null, $"Found duplicate entry in archive: {entry.FullName}");
+                    Logging.Log.WriteMessage(
+                        // Warning in unittest mode to trip tests, verbose otherwise
+                        options.UnittestMode ? Logging.LogMessageType.Warning : Logging.LogMessageType.Verbose,
+                        LOGTAG,
+                        "DuplicateArchiveEntry",
+                        null,
+                        $"Found duplicate entry in archive: {entry.FullName}");
+
                 m_entries[entry.FullName] = entry;
                 m_pathMappings[entry.FullName.Replace('\\', '/')] = entry.FullName;
             }

--- a/Duplicati/Library/Compression/ZipCompression/BuiltinZipArchive.cs
+++ b/Duplicati/Library/Compression/ZipCompression/BuiltinZipArchive.cs
@@ -36,6 +36,10 @@ namespace Duplicati.Library.Compression.ZipCompression;
 public class BuiltinZipArchive : IZipArchive
 {
     /// <summary>
+    /// The log tag
+    /// </summary>
+    private static readonly string LOGTAG = Library.Logging.Log.LogTagFromType<BuiltinZipArchive>();
+    /// <summary>
     /// The wrapped zip archive
     /// </summary>
     private readonly ZipArchive m_archive;
@@ -83,7 +87,7 @@ public class BuiltinZipArchive : IZipArchive
         m_archive = new ZipArchive(
             stream,
             mode == ArchiveMode.Read ? ZipArchiveMode.Read : ZipArchiveMode.Create,
-            true // Mimic SharpCompress behavior, don't dispose base stream
+            leaveOpen: true // Mimic SharpCompress behavior, don't dispose base stream
         );
 
         // Built-in ZipArchive has fewer compression levels
@@ -108,6 +112,8 @@ public class BuiltinZipArchive : IZipArchive
         {
             foreach (var entry in m_archive.Entries)
             {
+                if (m_entries.ContainsKey(entry.FullName))
+                    Logging.Log.WriteWarningMessage(LOGTAG, "DuplicateArchiveEntry", null, $"Found duplicate entry in archive: {entry.FullName}");
                 m_entries[entry.FullName] = entry;
                 m_pathMappings[entry.FullName.Replace('\\', '/')] = entry.FullName;
             }

--- a/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
+++ b/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
@@ -139,7 +139,8 @@ namespace Duplicati.Library.Compression.ZipCompression
             if (options.ContainsKey(COMPRESSION_LIBRARY_OPTION) && options.TryGetValue(COMPRESSION_LIBRARY_OPTION, out var cplib) && Enum.TryParse<CompressionLibrary>(cplib, true, out var tmpcplib))
                 compressionLibrary = tmpcplib;
 
-            var parsedOptions = new ParsedZipOptions(compressionLevel, compressionType, usingZip64);
+            var unittestMode = Utility.Utility.ParseBoolOption(options.AsReadOnly(), "unittest-mode");
+            var parsedOptions = new ParsedZipOptions(compressionLevel, compressionType, usingZip64, unittestMode);
 
             if (compressionLibrary == CompressionLibrary.Auto)
             {

--- a/Duplicati/Library/Compression/ZipCompression/ParsedZipOptions.cs
+++ b/Duplicati/Library/Compression/ZipCompression/ParsedZipOptions.cs
@@ -30,8 +30,10 @@ namespace Duplicati.Library.Compression.ZipCompression;
 /// <param name="DeflateCompressionLevel">The compression level to use</param>
 /// <param name="CompressionType">The compression type to use</param>
 /// <param name="UseZip64">Whether to use zip64 extensions</param>
+/// <param name="UnittestMode">Flag indicating if unittest mode is enabled</param>
 public sealed record ParsedZipOptions(
     CompressionLevel DeflateCompressionLevel,
     CompressionType CompressionType,
-    bool UseZip64
+    bool UseZip64,
+    bool UnittestMode
 );

--- a/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
+++ b/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
@@ -77,9 +77,22 @@ public class SharpCompressZipArchive : IZipArchive
     /// </summary>
     private long m_flushBufferSize = 0;
 
+    /// <summary>
+    /// Flag indicating if we are using Zip64 extensions
+    /// </summary>
     private readonly bool m_usingZip64;
+    /// <summary>
+    /// The default compression level to use
+    /// </summary>
     private readonly CompressionLevel m_defaultCompressionLevel;
+    /// <summary>
+    /// The compression algorithm
+    /// </summary>
     private readonly CompressionType m_compressionType;
+    /// <summary>
+    /// Flag indicating if we are in unittest mode
+    /// </summary>
+    private readonly bool m_unittestMode;
 
     /// <summary>
     /// Constructs a new Zip instance.
@@ -99,6 +112,7 @@ public class SharpCompressZipArchive : IZipArchive
         m_defaultCompressionLevel = options.DeflateCompressionLevel;
         m_compressionType = options.CompressionType;
         m_mode = mode;
+        m_unittestMode = options.UnittestMode;
 
         if (mode == ArchiveMode.Write)
         {
@@ -234,7 +248,14 @@ public class SharpCompressZipArchive : IZipArchive
                 foreach (var en in Archive.Entries)
                 {
                     if (d.ContainsKey(en.Key))
-                        Logging.Log.WriteWarningMessage(LOGTAG, "DuplicateArchiveEntry", null, $"Found duplicate entry in archive: {en.Key}");
+                        Logging.Log.WriteMessage(
+                            // Warning in unittest mode to trip tests, verbose otherwise
+                            m_unittestMode ? Logging.LogMessageType.Warning : Logging.LogMessageType.Verbose,
+                            LOGTAG,
+                            "DuplicateArchiveEntry",
+                            null,
+                            $"Found duplicate entry in archive: {en.Key}");
+
                     d[en.Key] = en;
                 }
                 m_entryDict = d;

--- a/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
+++ b/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
@@ -232,7 +232,11 @@ public class SharpCompressZipArchive : IZipArchive
             {
                 var d = new Dictionary<string, IEntry>(Duplicati.Library.Utility.Utility.ClientFilenameStringComparer);
                 foreach (var en in Archive.Entries)
+                {
+                    if (d.ContainsKey(en.Key))
+                        Logging.Log.WriteWarningMessage(LOGTAG, "DuplicateArchiveEntry", null, $"Found duplicate entry in archive: {en.Key}");
                     d[en.Key] = en;
+                }
                 m_entryDict = d;
             }
             catch (Exception ex)

--- a/Duplicati/Library/Interface/ICompression.cs
+++ b/Duplicati/Library/Interface/ICompression.cs
@@ -61,20 +61,6 @@ namespace Duplicati.Library.Interface
         Noncompressible
     }
 
-    /// <summary>
-    /// An interface for passing additional hints to the compressor
-    /// about the expected contents of the volume
-    /// </summary>
-    public interface ICompressionHinting : ICompression
-    {
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="Duplicati.Library.Interface.ICompression"/>
-        /// instance is in low overhead mode.
-        /// </summary>
-        /// <value><c>true</c> if low overhead mode; otherwise, <c>false</c>.</value>
-        bool LowOverheadMode { get; set; }
-    }
-
     public interface IArchiveReader
     {
         /// <summary>

--- a/Duplicati/Library/Main/Operation/Common/IndexVolumeCreator.cs
+++ b/Duplicati/Library/Main/Operation/Common/IndexVolumeCreator.cs
@@ -20,7 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.IO;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Duplicati.Library.Main.Volumes;
 using Duplicati.Library.Utility;
@@ -35,12 +35,17 @@ namespace Duplicati.Library.Main.Operation.Common
         /// <summary>
         /// The block hashes
         /// </summary>
-        private readonly Library.Utility.FileBackedStringList blockHashes = new Library.Utility.FileBackedStringList();
+        private readonly FileBackedStringList blockHashes = new();
 
         /// <summary>
         /// The blocklist hashes
         /// </summary>
-        private readonly Library.Utility.FileBackedStringList blockListHashes = new Library.Utility.FileBackedStringList();
+        private readonly FileBackedStringList blockListHashes = new();
+
+        /// <summary>
+        /// The known block list hashes
+        /// </summary>
+        private readonly HashSet<string> knownBlockListHashes = new();
 
         /// <summary>
         /// Cached copy of the blocklist hash size
@@ -53,8 +58,8 @@ namespace Duplicati.Library.Main.Operation.Common
         /// </summary>
         /// <param name="options">The options used in this run.</param>
 		public TemporaryIndexVolume(Options options)
-		{
-			m_blockhashsize = options.BlockhashSize;
+        {
+            m_blockhashsize = options.BlockhashSize;
         }
 
         /// <summary>
@@ -79,7 +84,7 @@ namespace Duplicati.Library.Main.Operation.Common
             w.FinishVolume(blockHash, blockSize);
 
             var enumerator = blockListHashes.GetEnumerator();
-            while(enumerator.MoveNext())
+            while (enumerator.MoveNext())
             {
                 var hash = enumerator.Current;
                 enumerator.MoveNext();
@@ -103,9 +108,21 @@ namespace Duplicati.Library.Main.Operation.Common
             if (!onlyBlocklistHashes)
                 foreach (var n in blockHashes)
                     target.blockHashes.Add(n);
-            
-            foreach (var n in blockListHashes)
-                target.blockListHashes.Add(n);
+
+            var enumerator = blockListHashes.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var hash = enumerator.Current;
+                enumerator.MoveNext();
+
+                // Filter duplicates
+                if (target.knownBlockListHashes.Contains(hash))
+                    continue;
+
+                target.knownBlockListHashes.Add(hash);
+                target.blockListHashes.Add(hash);
+                target.blockListHashes.Add(enumerator.Current);
+            }
         }
 
         /// <summary>
@@ -126,8 +143,13 @@ namespace Duplicati.Library.Main.Operation.Common
         /// <param name="data">The block contents.</param>
         public void AddBlockListHash(string hash, long size, byte[] data)
         {
-			if (size % m_blockhashsize != 0)
-				throw new ArgumentException($"The {nameof(size)} value is {size}, but it must be evenly divisible by the blockhash size ({m_blockhashsize})", nameof(size));
+            // Filter out duplicates to reduce size
+            if (knownBlockListHashes.Contains(hash))
+                return;
+            knownBlockListHashes.Add(hash);
+
+            if (size % m_blockhashsize != 0)
+                throw new ArgumentException($"The {nameof(size)} value is {size}, but it must be evenly divisible by the blockhash size ({m_blockhashsize})", nameof(size));
             blockListHashes.Add(hash);
             blockListHashes.Add(Convert.ToBase64String(data, 0, (int)size));
         }
@@ -140,7 +162,7 @@ namespace Duplicati.Library.Main.Operation.Common
     {
         public static async Task<IndexVolumeWriter> CreateIndexVolume(string blockname, Options options, Common.DatabaseCommon database)
         {
-            using(var h = HashFactory.CreateHasher(options.BlockHashAlgorithm))
+            using (var h = HashFactory.CreateHasher(options.BlockHashAlgorithm))
             {
                 var w = new IndexVolumeWriter(options);
                 w.VolumeID = await database.RegisterRemoteVolumeAsync(w.RemoteFilename, RemoteVolumeType.Index, RemoteVolumeState.Temporary);
@@ -148,13 +170,13 @@ namespace Duplicati.Library.Main.Operation.Common
                 var blockvolume = await database.GetVolumeInfoAsync(blockname);
 
                 w.StartVolume(blockname);
-                foreach(var b in await database.GetBlocksAsync(blockvolume.ID))
+                foreach (var b in await database.GetBlocksAsync(blockvolume.ID))
                     w.AddBlock(b.Hash, b.Size);
 
                 w.FinishVolume(blockvolume.Hash, blockvolume.Size);
 
                 if (options.IndexfilePolicy == Options.IndexFileStrategy.Full)
-                    foreach(var b in await database.GetBlocklistsAsync(blockvolume.ID, options.Blocksize, options.BlockhashSize))
+                    foreach (var b in await database.GetBlocklistsAsync(blockvolume.ID, options.Blocksize, options.BlockhashSize))
                     {
                         var bh = Convert.ToBase64String(h.ComputeHash(b.Item2, 0, b.Item3));
                         if (bh != b.Item1)

--- a/Duplicati/Library/Main/Volumes/VolumeBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeBase.cs
@@ -83,7 +83,7 @@ namespace Duplicati.Library.Main.Volumes
                     throw new InvalidManifestException("FileHash", d.FileHash, filehash);
             }
         }
-        
+
         private class ParsedVolume : IParsedVolume
         {
             public RemoteVolumeType FileType { get; private set; }
@@ -104,11 +104,11 @@ namespace Duplicati.Library.Main.Volumes
                 dict[RemoteVolumeType.Blocks] = "dblock";
                 dict[RemoteVolumeType.Files] = "dlist";
                 dict[RemoteVolumeType.Index] = "dindex";
-                
+
                 var reversedict = new Dictionary<string, RemoteVolumeType>(System.StringComparer.OrdinalIgnoreCase);
-                foreach(var x in dict)
+                foreach (var x in dict)
                     reversedict[x.Value] = x.Key;
-                                
+
                 REMOTE_TYPENAME_MAP = dict;
                 REVERSE_REMOTE_TYPENAME_MAP = reversedict;
                 FILENAME_REGEXP = new System.Text.RegularExpressions.Regex(@"(?<prefix>[^\-]+)\-(([i|b|I|B](?<guid>[0-9A-Fa-f]+))|((?<time>\d{8}T\d{6}Z))).(?<filetype>(" + string.Join(")|(", dict.Values) + @"))\.(?<compression>[^\.]+)(\.(?<encryption>.+))?");
@@ -138,7 +138,7 @@ namespace Duplicati.Library.Main.Volumes
                 };
             }
         }
-        
+
         public static string GenerateFilename(RemoteVolumeType filetype, Options options, string guid, DateTime timestamp)
         {
             return GenerateFilename(filetype, options.Prefix, guid, timestamp, options.CompressionModule, options.NoEncryption ? null : options.EncryptionModule);
@@ -155,7 +155,7 @@ namespace Duplicati.Library.Main.Volumes
 
             if (!string.IsNullOrEmpty(encryptionmodule))
                 volumename += "." + encryptionmodule;
-                
+
             return volumename;
         }
 
@@ -182,14 +182,14 @@ namespace Duplicati.Library.Main.Volumes
         protected readonly long m_blocksize;
         protected readonly string m_blockhash;
         protected readonly string m_filehash;
-		protected readonly long m_blockhashsize;
+        protected readonly long m_blockhashsize;
 
         protected VolumeBase(Options options)
         {
             m_blocksize = options.Blocksize;
             m_blockhash = options.BlockHashAlgorithm;
             m_filehash = options.FileHashAlgorithm;
-			m_blockhashsize = options.BlockhashSize;
+            m_blockhashsize = options.BlockhashSize;
         }
     }
 }

--- a/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeWriterBase.cs
@@ -80,9 +80,6 @@ namespace Duplicati.Library.Main.Volumes
             if (m_compression == null)
                 throw new UserInformationException(string.Format("Unsupported compression module: {0}", options.CompressionModule), "UnsupportedCompressionModule");
 
-            if ((this is IndexVolumeWriter || this is FilesetVolumeWriter) && this.m_compression is ICompressionHinting hinting)
-                hinting.LowOverheadMode = true;
-
             AddManifestFile();
         }
 

--- a/Duplicati/UnitTest/CompressionTests.cs
+++ b/Duplicati/UnitTest/CompressionTests.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Duplicati.Library.Logging;
 using NUnit.Framework;
 
 namespace Duplicati.UnitTest
@@ -134,5 +135,62 @@ namespace Duplicati.UnitTest
                 }
             }
         }
+
+        /// <summary>
+        /// Despite archives being able to store multiple files with the same name, this should not leak into the application
+        /// </summary>
+        /// <param name="module">The compression module</param>
+        [TestCase("zip-sc")]
+        [TestCase("zip-io")]
+        public void TestMaskingDuplicates(string module)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var opts = new Dictionary<string, string>();
+                opts["zip-compression-level"] = "9";
+
+                if (module == "zip-sc")
+                {
+                    module = "zip";
+                    opts["zip-compression-library"] = "SharpCompress";
+                }
+                else if (module == "zip-io")
+                {
+                    module = "zip";
+                    opts["zip-compression-library"] = "BuiltIn";
+                }
+
+                // Build archive with duplicate entries
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, stream, Library.Interface.ArchiveMode.Write, opts))
+                {
+                    // Add two identical files to the archive
+                    using (var fs = z0.CreateFile("sample", Library.Interface.CompressionHint.Compressible, DateTime.Now))
+                        fs.Write(new byte[1024]);
+
+                    try
+                    {
+                        using (var fs = z0.CreateFile("sample", Library.Interface.CompressionHint.Compressible, DateTime.Now))
+                            fs.Write(new byte[1024]);
+                    }
+                    catch
+                    {
+                        Assert.Inconclusive("Unable to create faulty archive for testing");
+                    }
+                }
+
+                // Check only a single file is reported
+                var logMessages = new List<LogEntry>();
+                using (var rootscope = Library.Logging.Log.StartIsolatingScope(true))
+                using (var scope = Library.Logging.Log.StartScope(logMessages.Add))
+                using (var z0 = Library.DynamicLoader.CompressionLoader.GetModule(module, stream, Library.Interface.ArchiveMode.Read, opts))
+                {
+                    // Get files list
+                    var files = z0.ListFiles(null);
+                    Assert.AreEqual(1, files.Length);
+                    Assert.That(logMessages.Any(x => x.Level == LogMessageType.Warning && x.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase)));
+                }
+            }
+        }
+
     }
 }

--- a/Duplicati/UnitTest/CompressionTests.cs
+++ b/Duplicati/UnitTest/CompressionTests.cs
@@ -148,6 +148,7 @@ namespace Duplicati.UnitTest
             {
                 var opts = new Dictionary<string, string>();
                 opts["zip-compression-level"] = "9";
+                opts["unittest-mode"] = "true";
 
                 if (module == "zip-sc")
                 {


### PR DESCRIPTION
Fixed an issue where multiple blocklists would be written to a zip file, bloating the size.
Added test to verify that compression modules will mask duplicate entries, if present.
Logging duplicate entries in index volumes as verbose.
