### PR TITLE
CIFS Fixes and improvements

### DIFF
--- a/Duplicati/Library/Backend/CIFS/CIFS.cs
+++ b/Duplicati/Library/Backend/CIFS/CIFS.cs
@@ -72,6 +72,16 @@ public class CIFSBackend : IStreamingBackend
     /// Shared connection between all methods to avoid re-authentication
     /// </summary>
     private SMBShareConnection _sharedConnection;
+    
+    /// <summary>
+    /// Read buffer size for SMB operations (will be capped automatically by SMB negotiated values)
+    /// </summary>
+    private const string READ_BUFFER_SIZE_OPTION = "read-buffer-size";
+    
+    /// <summary>
+    /// Write buffer size for SMB operations (will be capped automatically by SMB negotiated values)
+    /// </summary>
+    private const string WRITE_BUFFER_SIZE_OPTION = "write-buffer-size";
 
     /// <summary>
     /// Backend option for controlling the transport (directtcp or netbios)
@@ -137,6 +147,18 @@ public class CIFSBackend : IStreamingBackend
         options.TryGetValue(AUTH_PASSWORD_OPTION, out string authPassword);
         options.TryGetValue(AUTH_DOMAIN_OPTION, out string authDomain);
         options.TryGetValue(TRANSPORT_OPTION, out string transport);
+        
+        int? readBufferSize = null, writeBufferSize = null;
+        
+        options.TryGetValue(READ_BUFFER_SIZE_OPTION, out string readBufferSizeConfig);
+        if (!string.IsNullOrWhiteSpace(readBufferSizeConfig)) readBufferSize = Int32.TryParse(readBufferSizeConfig, out int value) ? value : null;
+        
+        options.TryGetValue(WRITE_BUFFER_SIZE_OPTION, out string writeBufferSizeConfig);
+        if (!string.IsNullOrWhiteSpace(writeBufferSizeConfig)) writeBufferSize = Int32.TryParse(readBufferSizeConfig, out int value) ? value : null;
+        
+        // Normalize to 10KB minimum buffers size
+        readBufferSize = readBufferSize < 1024 * 10 ? null : readBufferSize;
+        writeBufferSize = writeBufferSize < 1024 * 10 ? null : writeBufferSize;
 
         SMBTransportType transportType = _transportMap.TryGetValue(
             string.IsNullOrEmpty(transport) ? DEFAULT_TRANSPORT : transport.ToLower(), 
@@ -151,7 +173,9 @@ public class CIFSBackend : IStreamingBackend
             slashIndex >= 0 ? input[(slashIndex + 1)..] : "",
             authDomain,
             authUsername,
-            authPassword
+            authPassword,
+            readBufferSize,
+            writeBufferSize
         );
     }
 
@@ -163,7 +187,9 @@ public class CIFSBackend : IStreamingBackend
             new CommandLineArgument(AUTH_PASSWORD_OPTION, CommandLineArgument.ArgumentType.Password, Strings.CIFSBackend.DescriptionAuthPasswordShort, Strings.CIFSBackend.DescriptionAuthPasswordLong),
             new CommandLineArgument(AUTH_USERNAME_OPTION, CommandLineArgument.ArgumentType.String, Strings.CIFSBackend.DescriptionAuthUsernameShort, Strings.CIFSBackend.DescriptionAuthUsernameLong),
             new CommandLineArgument(AUTH_DOMAIN_OPTION, CommandLineArgument.ArgumentType.String, Strings.CIFSBackend.DescriptionAuthDomainShort, Strings.CIFSBackend.DescriptionAuthDomainLong),
-            new CommandLineArgument(TRANSPORT_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.Options.TransportShort, Strings.Options.TransportLong, DEFAULT_TRANSPORT, null, _transportMap.Keys.ToArray())
+            new CommandLineArgument(TRANSPORT_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.Options.TransportShort, Strings.Options.TransportLong, DEFAULT_TRANSPORT, null, _transportMap.Keys.ToArray()),
+            new CommandLineArgument(READ_BUFFER_SIZE_OPTION, CommandLineArgument.ArgumentType.String, Strings.Options.DescriptionReadBufferSizeShort, Strings.Options.DescriptionReadBufferSizeLong),
+            new CommandLineArgument(WRITE_BUFFER_SIZE_OPTION, CommandLineArgument.ArgumentType.String, Strings.Options.DescriptionWriteBufferSizeShort, Strings.Options.DescriptionWriteBufferSizeLong)
         ]);
 
     /// <summary>

--- a/Duplicati/Library/Backend/CIFS/Model/SMBConnectionParameters.cs
+++ b/Duplicati/Library/Backend/CIFS/Model/SMBConnectionParameters.cs
@@ -62,6 +62,16 @@ public record SMBConnectionParameters
    /// The password for authentication
    /// </summary>
    public string AuthPassword { get; init; }
+   
+   /// <summary>
+   /// Write buffer size for SMB operations (will be capped automatically by SMB negotiated values)
+   /// </summary>
+   public int? WriteBufferSize { get; init; }
+   
+   /// <summary>
+   /// Read buffer size for SMB operations (will be capped automatically by SMB negotiated values)
+   /// </summary>
+   public int? ReadBufferSize { get; init; }
 
    /// <summary>
    /// Creates a new instance of SMB connection parameters
@@ -73,6 +83,8 @@ public record SMBConnectionParameters
    /// <param name="authDomain">The authentication domain name</param>
    /// <param name="authUser">The username for authentication</param>
    /// <param name="authPassword">The password for authentication</param>
+   /// <param name="readBufferSize">Read buffer size for SMB operations (will be capped automatically by SMB negotiated values)</param>
+   /// <param name="writeBufferSize">Write buffer size for SMB operations (will be capped automatically by SMB negotiated values)</param>
    public SMBConnectionParameters(
        string serverName,
        SMBTransportType transportType,
@@ -80,7 +92,9 @@ public record SMBConnectionParameters
        string path,
        string authDomain,
        string authUser,
-       string authPassword)
+       string authPassword,
+       int? readBufferSize,
+       int? writeBufferSize)
    {
        ServerName = serverName;
        TransportType = transportType;
@@ -89,5 +103,7 @@ public record SMBConnectionParameters
        AuthDomain = authDomain;
        AuthUser = authUser;
        AuthPassword = authPassword;
+       ReadBufferSize = readBufferSize;
+       WriteBufferSize = writeBufferSize;
    }
 }

--- a/Duplicati/Library/Backend/CIFS/SMBShareConnection.cs
+++ b/Duplicati/Library/Backend/CIFS/SMBShareConnection.cs
@@ -102,7 +102,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
             NTStatus status;
             object fileHandle;
             FileStatus fileStatus;
-            status = _smbFileStore.CreateFile(out fileHandle, out fileStatus, Path.Combine(_connectionParameters.Path, fileName),
+            status = _smbFileStore.CreateFile(out fileHandle, out fileStatus, NormalizeSlashes(Path.Combine(_connectionParameters.Path, fileName)),
                 AccessMask.GENERIC_WRITE | AccessMask.DELETE | AccessMask.SYNCHRONIZE,
                 FileAttributes.Normal,
                 ShareAccess.None,
@@ -145,15 +145,15 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
         try
         {
             // Normalize path separators to forward slashes and trim any trailing separators
-            string normalizedPath = path.Replace('\\', '/').TrimEnd('/');
+            string linuxNormalizedPath = path.Replace('/', '\\').TrimEnd('\\');
             string currentPath = "";
 
-            foreach (string part in normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries))
+            foreach (string part in linuxNormalizedPath.Split('\\', StringSplitOptions.RemoveEmptyEntries))
             {
                 if (string.IsNullOrWhiteSpace(part) || part == ".")
                     continue;
 
-                currentPath = currentPath.Length == 0 ? part : $"{currentPath}/{part}";
+                currentPath = currentPath.Length == 0 ? part : $"{currentPath}\\{part}";
                 object? fileHandle = null;
                 try
                 {
@@ -208,7 +208,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
                 var status = _smbFileStore.CreateFile(
                     out directoryHandle,
                     out fileStatus,
-                    _connectionParameters.Path,
+                    NormalizeSlashes(_connectionParameters.Path),
                     AccessMask.GENERIC_READ,
                     FileAttributes.Directory,
                     ShareAccess.Read | ShareAccess.Write,
@@ -220,7 +220,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
                     if (status == NTStatus.STATUS_OBJECT_PATH_NOT_FOUND || status == NTStatus.STATUS_OBJECT_NAME_NOT_FOUND)
                         throw new FolderMissingException();
                     else
-                        throw new UserInformationException($"{LC.L("Failed to open directory")} {_connectionParameters.Path} with status {status.ToString()}","DirectoryOpenError");
+                        throw new UserInformationException($"{LC.L("Failed to open directory")} { NormalizeSlashes(_connectionParameters.Path)} with status {status.ToString()}","DirectoryOpenError");
 
                 List<QueryDirectoryFileInformation> fileList;
                 status = _smbFileStore.QueryDirectory(
@@ -279,7 +279,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
             object? fileHandle;
             FileStatus fileStatus;
             NTStatus status = _smbFileStore.CreateFile(out fileHandle, out fileStatus,
-                Path.Combine(_connectionParameters.Path, filename), // This is where the file name is concatenated with the path
+                NormalizeSlashes(Path.Combine(_connectionParameters.Path, filename)),
                 AccessMask.GENERIC_READ | AccessMask.SYNCHRONIZE, FileAttributes.Normal, ShareAccess.Read,
                 CreateDisposition.FILE_OPEN,
                 CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_SYNCHRONOUS_IO_ALERT, null);
@@ -341,7 +341,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
             object fileHandle;
             FileStatus fileStatus;
             NTStatus status = _smbFileStore.CreateFile(out fileHandle, out fileStatus,
-                Path.Combine(_connectionParameters.Path, filename), // This is where the file name is concatenated with the path
+                NormalizeSlashes(Path.Combine(_connectionParameters.Path, filename)),
                 AccessMask.GENERIC_WRITE | AccessMask.SYNCHRONIZE,
                 FileAttributes.Normal, ShareAccess.None,
                 CreateDisposition.FILE_SUPERSEDE,
@@ -382,6 +382,18 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
         {
             _semaphore.Release();
         }
+    }
+    
+    /// <summary>
+    /// Normalizes paths to use backslashes (for Windows shares compatibility) and removes trailing slashes.
+    ///
+    /// Samba deals with \ and / in paths, but Windows shares require backslashes.
+    /// </summary>
+    /// <param name="path">Path to be normalized</param>
+    /// <returns></returns>
+    private string NormalizeSlashes(string path)
+    {
+        return path.Replace('/', '\\').TrimEnd('\\');
     }
 
     /// <summary>

--- a/Duplicati/Library/Backend/CIFS/Strings.cs
+++ b/Duplicati/Library/Backend/CIFS/Strings.cs
@@ -44,5 +44,9 @@ namespace Duplicati.Library.Backend.Strings
         public static string TransportLong =>
             LC.L(
                 @"Defines the transport to be used in CIFS connection. Can be DirectTCP or NetBios");
+        public static string DescriptionReadBufferSizeShort => LC.L(@"Read buffer size for SMB operations.");
+        public static string DescriptionReadBufferSizeLong => LC.L(@"Read buffer size for SMB operations (Will be capped automatically by SMB negotiated values, values bellow 10000 bytes will be ignored)");
+        public static string DescriptionWriteBufferSizeShort => LC.L(@"Write buffer size for SMB operations.");
+        public static string DescriptionWriteBufferSizeLong => LC.L(@"Write buffer size for SMB operations (Will be capped automatically by SMB negotiated values, values bellow 10000 bytes will be ignored)");
     }
 }

--- a/Duplicati/Library/Backend/CIFS/Strings.cs
+++ b/Duplicati/Library/Backend/CIFS/Strings.cs
@@ -44,8 +44,5 @@ namespace Duplicati.Library.Backend.Strings
         public static string TransportLong =>
             LC.L(
                 @"Defines the transport to be used in CIFS connection. Can be DirectTCP or NetBios");
-        
-        public static string DescriptionNoReuseConnectionShort => LC.L(@"CIFS connection reuse control");
-        public static string DescriptionNoReuseConnectionLong => LC.L(@"If set to true, a new connection will be used for each file operation. If set to false, the connection is reused for all file operations of the backup.");
     }
 }

--- a/Duplicati/Library/Backend/CIFS/Strings.cs
+++ b/Duplicati/Library/Backend/CIFS/Strings.cs
@@ -44,5 +44,8 @@ namespace Duplicati.Library.Backend.Strings
         public static string TransportLong =>
             LC.L(
                 @"Defines the transport to be used in CIFS connection. Can be DirectTCP or NetBios");
+        
+        public static string DescriptionNoReuseConnectionShort => LC.L(@"CIFS connection reuse control");
+        public static string DescriptionNoReuseConnectionLong => LC.L(@"If set to true, a new connection will be used for each file operation. If set to false, the connection is reused for all file operations of the backup.");
     }
 }

--- a/Duplicati/Server/webroot/ngax/templates/backends/cifs.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/cifs.html
@@ -7,7 +7,7 @@
         <option value="directtcp">
             {{'Direct TCP' | translate}}
         </option>
-        <option value="netbiox">
+        <option value="netbios">
             {{'Netbios over TCP' | translate}}
         </option>
     </select>


### PR DESCRIPTION
This PR includes three improvements to CIFS functionality:

1. Fixes Netbios option selection in the basic interface 
2. Standardizes path separators to backslash (\) for Windows/Linux compatibility, independent of Duplicati's host OS
3. Adds configurable read/write buffer sizes for SMB operations, defaulting to and respecting protocol-negotiated maximums