### PR TITLE
Migrate from HttpWebClient to HttpClient with async/await  + Refactoring

### DIFF
--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025, The Duplicati Team
+// Copyright (C) 2024, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a 
@@ -22,561 +22,630 @@
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Security.Cryptography;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Reflection;
+using Duplicati.Library.Backend.Backblaze.Model;
 
-namespace Duplicati.Library.Backend.Backblaze
+namespace Duplicati.Library.Backend.Backblaze;
+
+/// <summary>
+/// Backblaze B2 Backend
+/// </summary>
+public class B2 : IStreamingBackend, ITimeoutExemptBackend
 {
-    public class B2 : IBackend, IStreamingBackend
+    /// <summary>
+    /// The default timeout in seconds for LIST/CreateFolder operations
+    /// </summary>
+    private const int SHORT_OPERATION_TIMEOUT_SECONDS = 30;
+
+    /// <summary>
+    /// The option key for specifying the Backblaze B2 account ID
+    /// </summary>
+    private const string B2_ID_OPTION = "b2-accountid";
+
+    /// <summary>
+    /// The option key for specifying the Backblaze B2 application key
+    /// </summary>
+    private const string B2_KEY_OPTION = "b2-applicationkey";
+
+    /// <summary>
+    /// The option key for specifying the number of files to retrieve per API request
+    /// </summary>
+    private const string B2_PAGESIZE_OPTION = "b2-page-size";
+
+    /// <summary>
+    /// The option key for specifying a custom download URL for the B2 service
+    /// </summary>
+    private const string B2_DOWNLOAD_URL_OPTION = "b2-download-url";
+
+    /// <summary>
+    /// The option key for specifying the bucket type when creating new buckets
+    /// </summary>
+    private const string B2_CREATE_BUCKET_TYPE_OPTION = "b2-create-bucket-type";
+
+    /// <summary>
+    /// The default bucket type for new buckets - set to private access
+    /// </summary>
+    private const string DEFAULT_BUCKET_TYPE = "allPrivate";
+
+    /// <summary>
+    /// The default number of files to retrieve per API request
+    /// </summary>
+    private const int DEFAULT_PAGE_SIZE = 500;
+
+    /// <summary>
+    /// Recommended chunk size as per Backblaze B2 documentation (100MB)
+    /// </summary>
+    private const int B2_RECOMMENDED_CHUNK_SIZE = 100 * 1024 * 1024;
+
+    /// <summary>
+    /// The name of the B2 bucket being accessed
+    /// </summary>
+    private readonly string _bucketName;
+
+    /// <summary>
+    /// The path prefix for all operations within the bucket
+    /// </summary>
+    private readonly string _prefix;
+
+    /// <summary>
+    /// URL-encoded version of the path prefix for API requests
+    /// </summary>
+    private readonly string _urlencodedPrefix;
+
+    /// <summary>
+    /// The type of bucket (e.g., allPrivate, allPublic) being accessed or created
+    /// </summary>
+    private readonly string _bucketType;
+
+    /// <summary>
+    /// The number of files to retrieve per API request
+    /// </summary>
+    private readonly int _pageSize;
+
+    /// <summary>
+    /// Custom download URL for the B2 service, if specified
+    /// </summary>
+    private readonly string _downloadUrl;
+
+    /// <summary>
+    /// Helper class for handling B2 authentication and API requests
+    /// </summary>
+    private readonly B2AuthHelper _b2AuthHelper;
+
+    /// <summary>
+    /// Cached upload URL and authorization token for file uploads
+    /// </summary>
+    private UploadUrlResponse _uploadUrl;
+
+    /// <summary>
+    /// Cache of file listings, mapping filenames to their versions
+    /// </summary>
+    private Dictionary<string, List<FileEntity>> _filecache;
+
+    /// <summary>
+    /// The current bucket entity containing bucket information and credentials
+    /// </summary>
+    private BucketEntity _bucket;
+
+    /// <summary>
+    /// A scoped instance of Http client to be used with the backend, this will use a
+    /// infinite timeout as a baseline, and requests will be controlled with timeout
+    /// cancellation tokens. It will be disposed when the backend is disposed
+    /// </summary>
+    private readonly HttpClient _httpClient;
+
+    /// <summary>
+    /// Cache lock for BucketEntity
+    /// </summary>
+    private readonly SemaphoreSlim _cacheLock = new SemaphoreSlim(1, 1);
+
+    /// <summary>
+    /// Empty constructor is required for the backend to be loaded by the backend factory
+    /// </summary>
+    public B2()
     {
-        private const string B2_ID_OPTION = "b2-accountid";
-        private const string B2_KEY_OPTION = "b2-applicationkey";
-        private const string B2_PAGESIZE_OPTION = "b2-page-size";
-        private const string B2_DOWNLOAD_URL_OPTION = "b2-download-url";
+    }
 
-        private const string B2_CREATE_BUCKET_TYPE_OPTION = "b2-create-bucket-type";
-        private const string DEFAULT_BUCKET_TYPE = "allPrivate";
+    /// <summary>
+    /// Actual constructor for the backend that accepts the url and options
+    /// </summary>
+    /// <param name="url">URL in Duplicati Uri format</param>
+    /// <param name="options">options to be used in the backend</param>
+    public B2(string url, Dictionary<string, string> options)
+    {
+        var uri = new Utility.Uri(url);
 
-        private const int DEFAULT_PAGE_SIZE = 500;
+        _bucketName = uri.Host;
+        _prefix = Util.AppendDirSeparator("/" + uri.Path, "/");
 
-        private readonly string m_bucketname;
-        private readonly string m_prefix;
-        private readonly string m_urlencodedprefix;
-        private readonly string m_bucketType;
-        private readonly int m_pagesize;
-        private readonly string m_downloadUrl;
-        private readonly B2AuthHelper m_helper;
-        private UploadUrlResponse m_uploadUrl;
+        // For B2 we do not use a leading slash
+        while (_prefix.StartsWith("/", StringComparison.Ordinal))
+            _prefix = _prefix.Substring(1);
 
-        private Dictionary<string, List<FileEntity>> m_filecache;
+        _urlencodedPrefix = string.Join("/", _prefix.Split(new[] { '/' }).Select(x => Utility.Uri.UrlPathEncode(x)));
 
-        private BucketEntity m_bucket;
+        _bucketType = DEFAULT_BUCKET_TYPE;
+        if (options.TryGetValue(B2_CREATE_BUCKET_TYPE_OPTION, out var option1))
+            _bucketType = option1;
 
-        public B2()
+        string accountId = null;
+        string accountKey = null;
+
+        // Takes the account ID and key from the options, or from the URL with the cascading precedence
+
+        if (options.TryGetValue("auth-username", out var authUsernameOption))
+            accountId = authUsernameOption;
+        if (options.TryGetValue("auth-password", out var authPasswordOption))
+            accountKey = authPasswordOption;
+        if (options.TryGetValue(B2_ID_OPTION, out var accountIdOption))
+            accountId = accountIdOption;
+        if (options.TryGetValue(B2_KEY_OPTION, out var accountKeyOption))
+            accountKey = accountKeyOption;
+        if (!string.IsNullOrEmpty(uri.Username))
+            accountId = uri.Username;
+        if (!string.IsNullOrEmpty(uri.Password))
+            accountKey = uri.Password;
+
+        if (string.IsNullOrEmpty(accountId))
+            throw new UserInformationException(Strings.B2.NoB2UserIDError, "B2MissingUserID");
+
+        if (string.IsNullOrEmpty(accountKey))
+            throw new UserInformationException(Strings.B2.NoB2KeyError, "B2MissingKey");
+
+        _pageSize = DEFAULT_PAGE_SIZE;
+        if (options.ContainsKey(B2_PAGESIZE_OPTION))
         {
+            int.TryParse(options[B2_PAGESIZE_OPTION], out _pageSize);
+
+            if (_pageSize <= 0)
+                throw new UserInformationException(Strings.B2.InvalidPageSizeError(B2_PAGESIZE_OPTION, options[B2_PAGESIZE_OPTION]), "B2InvalidPageSize");
         }
 
-        public B2(string url, Dictionary<string, string> options)
+        _downloadUrl = null;
+        if (options.TryGetValue(B2_DOWNLOAD_URL_OPTION, out var option)) _downloadUrl = option;
+
+        _httpClient = HttpClientHelper.CreateClient();
+        _httpClient.Timeout = Timeout.InfiniteTimeSpan;
+
+        _b2AuthHelper = new B2AuthHelper(accountId, accountKey, _httpClient);
+
+    }
+
+    /// <summary>
+    /// Retrieves the bucket list from the B2 service using the account ID
+    /// and searchs for a match for the configured bucket name.
+    ///
+    /// If not found, throws a FolderMissingException.
+    ///
+    /// Caches the result in the _mBucket field.
+    /// </summary>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <exception cref="FolderMissingException"></exception>
+    private async Task<BucketEntity> GetBucketAsync(CancellationToken cancellationToken)
+    {
+        if (_bucket != null) return _bucket;
+
+        await _cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
         {
-            var uri = new Utility.Uri(url);
+            using var timeoutToken = new CancellationTokenSource();
+            timeoutToken.CancelAfter(TimeSpan.FromSeconds(SHORT_OPERATION_TIMEOUT_SECONDS));
+            using var combinedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken.Token, cancellationToken);
 
-            m_bucketname = uri.Host;
-            m_prefix = Util.AppendDirSeparator("/" + uri.Path, "/");
+            var buckets = await _b2AuthHelper.PostAndGetJsonDataAsync<ListBucketsResponse>(
+                $"{_b2AuthHelper.ApiUrl}/b2api/v1/b2_list_buckets",
+                new ListBucketsRequest(accountId: _b2AuthHelper.AccountId),
+                combinedCancellationToken.Token).ConfigureAwait(false);
 
-            // For B2 we do not use a leading slash
-            while (m_prefix.StartsWith("/", StringComparison.Ordinal))
-                m_prefix = m_prefix.Substring(1);
+            return _bucket ??= buckets?.Buckets?.FirstOrDefault(x =>
+                                    string.Equals(x.BucketName, _bucketName, StringComparison.OrdinalIgnoreCase))
+                                ?? throw new FolderMissingException();
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
 
-            m_urlencodedprefix = string.Join("/", m_prefix.Split(new[] { '/' }).Select(x => Library.Utility.Uri.UrlPathEncode(x)));
+    /// <summary>
+    /// Retrieves the upload URL and authorization token for the current bucket.
+    /// </summary>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    private async Task<UploadUrlResponse> GetUploadUrlDataAsync(CancellationToken cancellationToken)
+    {
+        if (_uploadUrl != null)
+            return _uploadUrl;
 
-            m_bucketType = DEFAULT_BUCKET_TYPE;
-            if (options.ContainsKey(B2_CREATE_BUCKET_TYPE_OPTION))
-                m_bucketType = options[B2_CREATE_BUCKET_TYPE_OPTION];
+        using var timeoutToken = new CancellationTokenSource();
+        timeoutToken.CancelAfter(TimeSpan.FromSeconds(SHORT_OPERATION_TIMEOUT_SECONDS));
+        using var combinedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken.Token, cancellationToken);
 
-            string accountId = null;
-            string accountKey = null;
+        _uploadUrl = await _b2AuthHelper.PostAndGetJsonDataAsync<UploadUrlResponse>(
+            $"{_b2AuthHelper.ApiUrl}/b2api/v1/b2_get_upload_url",
+            new UploadUrlRequest { BucketID = GetBucketAsync(cancellationToken).Await().BucketID },
+            combinedCancellationToken.Token
+        ).ConfigureAwait(false);
 
-            if (options.ContainsKey("auth-username"))
-                accountId = options["auth-username"];
-            if (options.ContainsKey("auth-password"))
-                accountKey = options["auth-password"];
+        return _uploadUrl;
+    }
 
-            if (options.ContainsKey(B2_ID_OPTION))
-                accountId = options[B2_ID_OPTION];
-            if (options.ContainsKey(B2_KEY_OPTION))
-                accountKey = options[B2_KEY_OPTION];
-            if (!string.IsNullOrEmpty(uri.Username))
-                accountId = uri.Username;
-            if (!string.IsNullOrEmpty(uri.Password))
-                accountKey = uri.Password;
+    /// <summary>
+    /// Retrieves the fileID searching by filename.
+    /// </summary>
+    /// <param name="filename">Filename</param>
+    /// <returns></returns>
+    /// <exception cref="FileMissingException">Exception thrown when file is not found</exception>
+    private string GetFileId(string filename)
+    {
+        if (_filecache != null && _filecache.TryGetValue(filename, out var value))
+            return value.OrderByDescending(x => x.UploadTimestamp).First().FileID;
 
-            if (string.IsNullOrEmpty(accountId))
-                throw new UserInformationException(Strings.B2.NoB2UserIDError, "B2MissingUserID");
-            if (string.IsNullOrEmpty(accountKey))
-                throw new UserInformationException(Strings.B2.NoB2KeyError, "B2MissingKey");
+        List();
 
-            m_helper = new B2AuthHelper(accountId, accountKey);
+        if (_filecache != null && _filecache.TryGetValue(filename, out var value1))
+            return value1.OrderByDescending(x => x.UploadTimestamp).First().FileID;
 
-            m_pagesize = DEFAULT_PAGE_SIZE;
-            if (options.ContainsKey(B2_PAGESIZE_OPTION))
-            {
-                int.TryParse(options[B2_PAGESIZE_OPTION], out m_pagesize);
+        throw new FileMissingException();
+    }
 
-                if (m_pagesize <= 0)
-                    throw new UserInformationException(Strings.B2.InvalidPageSizeError(B2_PAGESIZE_OPTION, options[B2_PAGESIZE_OPTION]), "B2InvalidPageSize");
-            }
+    /// <summary>
+    /// Returns the DownloadURL, either cached, or making a call to the server's /b2_authorize_account
+    /// </summary>
+    private string DownloadUrl => string.IsNullOrEmpty(_downloadUrl) ? _b2AuthHelper.DownloadUrl : _downloadUrl;
 
-            m_downloadUrl = null;
-            if (options.ContainsKey(B2_DOWNLOAD_URL_OPTION))
-            {
-                m_downloadUrl = options[B2_DOWNLOAD_URL_OPTION];
-            }
+    /// <inheritdoc/>
+    public IList<ICommandLineArgument> SupportedCommands =>
+        new List<ICommandLineArgument>([
+            new CommandLineArgument(B2_ID_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2accountidDescriptionShort, Strings.B2.B2accountidDescriptionLong, null,
+                ["auth-password"], null),
+            new CommandLineArgument(B2_KEY_OPTION, CommandLineArgument.ArgumentType.Password, Strings.B2.B2applicationkeyDescriptionShort, Strings.B2.B2applicationkeyDescriptionLong, null,
+                ["auth-username"], null),
+            new CommandLineArgument("auth-password", CommandLineArgument.ArgumentType.Password, Strings.B2.AuthPasswordDescriptionShort, Strings.B2.AuthPasswordDescriptionLong),
+            new CommandLineArgument("auth-username", CommandLineArgument.ArgumentType.String, Strings.B2.AuthUsernameDescriptionShort, Strings.B2.AuthUsernameDescriptionLong),
+            new CommandLineArgument(B2_CREATE_BUCKET_TYPE_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2createbuckettypeDescriptionShort, Strings.B2.B2createbuckettypeDescriptionLong, DEFAULT_BUCKET_TYPE),
+            new CommandLineArgument(B2_PAGESIZE_OPTION, CommandLineArgument.ArgumentType.Integer, Strings.B2.B2pagesizeDescriptionShort, Strings.B2.B2pagesizeDescriptionLong, DEFAULT_PAGE_SIZE.ToString()),
+            new CommandLineArgument(B2_DOWNLOAD_URL_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2downloadurlDescriptionShort, Strings.B2.B2downloadurlDescriptionLong)
+        ]);
+
+    public async Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken)
+    {
+        TempFile tmp = null;
+
+        var measure = stream;
+        while (measure is OverrideableStream os &&
+               os.GetType().GetField("m_basestream", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(os) is Stream baseStream)
+        {
+            measure = baseStream;
         }
 
-        private BucketEntity Bucket
+        if (measure == null)
+            throw new Exception($"Unable to unwrap stream from: {stream.GetType()}");
+
+        string sha1;
+        if (measure.CanSeek)
         {
-            get
+            var p = measure.Position;
+
+            // Compute the hash
+            using (var hashalg = HashFactory.CreateHasher("SHA1"))
+                sha1 = Library.Utility.Utility.ByteArrayAsHexString(hashalg.ComputeHash(measure));
+
+            measure.Position = p;
+        }
+        else
+        {
+            // No seeking possible, use a temp file
+            tmp = new TempFile();
+            await using (var sr = File.OpenWrite(tmp))
+            using (var hasher = HashFactory.CreateHasher("SHA1"))
+            await using (var hc = new HashCalculatingStream(measure, hasher))
             {
-                if (m_bucket == null)
+                await Utility.Utility.CopyStreamAsync(hc, sr, cancelToken).ConfigureAwait(false);
+                sha1 = hc.GetFinalHashString();
+            }
+
+            stream = File.OpenRead(tmp);
+        }
+
+        if (_filecache == null)
+            await ListAsync(cancelToken).ConfigureAwait(false);
+
+        var uploadUrlData = await GetUploadUrlDataAsync(cancelToken).ConfigureAwait(false);
+        try
+        {
+
+            // For PutAsync, no timeout is specified. The only thing that can stop it is the cancellation token
+            using var request = new HttpRequestMessage(HttpMethod.Post, uploadUrlData.UploadUrl);
+
+            request.Headers.TryAddWithoutValidation("Authorization", uploadUrlData.AuthorizationToken);
+            request.Headers.Add("X-Bz-Content-Sha1", sha1);
+            request.Headers.Add("X-Bz-File-Name", _urlencodedPrefix + Utility.Uri.UrlPathEncode(remotename));
+            request.Content = new StreamContent(stream, B2_RECOMMENDED_CHUNK_SIZE);
+
+            request.Content.Headers.Add("Content-Type", "application/octet-stream");
+            request.Content.Headers.Add("Content-Length", stream.Length.ToString());
+
+            var response = await _httpClient.UploadStream(request, cancelToken).ConfigureAwait(false);
+            var rdata = await response.Content.ReadAsStreamAsync(cancelToken).ConfigureAwait(false);
+
+            UploadFileResponse fileinfo;
+            using (var tr = new StreamReader(rdata))
+            await using (var jr = new Newtonsoft.Json.JsonTextReader(tr))
+                fileinfo = new Newtonsoft.Json.JsonSerializer().Deserialize<UploadFileResponse>(jr);
+
+            // Delete old versions
+            if (_filecache!.ContainsKey(remotename))
+                await DeleteAsync(remotename, cancelToken).ConfigureAwait(false);
+
+            _filecache[remotename] =
+            [
+                new FileEntity
                 {
-                    var buckets = m_helper.PostAndGetJSONData<ListBucketsResponse>(
-                        string.Format("{0}/b2api/v1/b2_list_buckets", m_helper.APIUrl),
-                        new ListBucketsRequest()
-                        {
-                            AccountID = m_helper.AccountID
-                        }
-                    );
-
-                    if (buckets != null && buckets.Buckets != null)
-                        m_bucket = buckets.Buckets.FirstOrDefault(x => string.Equals(x.BucketName, m_bucketname, StringComparison.OrdinalIgnoreCase));
-
-                    if (m_bucket == null)
-                        throw new FolderMissingException();
+                    FileID = fileinfo.FileID,
+                    FileName = fileinfo.FileName,
+                    Action = "upload",
+                    Size = fileinfo.ContentLength,
+                    UploadTimestamp = (long)(DateTime.UtcNow - Utility.Utility.EPOCH).TotalMilliseconds
                 }
-
-                return m_bucket;
-            }
+            ];
         }
-
-        private UploadUrlResponse UploadUrlData
+        catch (Exception ex)
         {
-            get
-            {
-                if (m_uploadUrl == null)
-                    m_uploadUrl = m_helper.PostAndGetJSONData<UploadUrlResponse>(
-                        string.Format("{0}/b2api/v1/b2_get_upload_url", m_helper.APIUrl),
-                        new UploadUrlRequest() { BucketID = Bucket.BucketID }
-                    );
+            _filecache = null;
 
-                return m_uploadUrl;
-            }
+            var code = (int)B2AuthHelper.GetExceptionStatusCode(ex);
+            if (code is >= 500 and <= 599)
+                _uploadUrl = null;
+
+            throw;
         }
-
-        private string GetFileID(string filename)
+        finally
         {
-            if (m_filecache != null && m_filecache.ContainsKey(filename))
-                return m_filecache[filename].OrderByDescending(x => x.UploadTimestamp).First().FileID;
-
-            List();
-            if (m_filecache.ContainsKey(filename))
-                return m_filecache[filename].OrderByDescending(x => x.UploadTimestamp).First().FileID;
-
-            throw new FileMissingException();
+            tmp?.Dispose();
         }
+    }
 
-        private string DownloadUrl
+    /// <summary>
+    /// Download files from remote
+    /// </summary>
+    /// <param name="remotename">Filename at remote location</param>
+    /// <param name="stream">Destination stream to write to</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution or FileMissingException</exception>
+    public async Task GetAsync(string remotename, Stream stream, CancellationToken cancellationToken)
+    {
+
+        if (_filecache == null || !_filecache.ContainsKey(remotename))
+            await ListAsync(cancellationToken).ConfigureAwait(false);
+
+        using var request = _filecache != null && _filecache.ContainsKey(remotename)
+            ? _b2AuthHelper.CreateRequest(
+                $"{DownloadUrl}/b2api/v1/b2_download_file_by_id?fileId={Utility.Uri.UrlEncode(GetFileId(remotename))}")
+            : _b2AuthHelper.CreateRequest(
+                $"{DownloadUrl}/{_urlencodedPrefix}{Utility.Uri.UrlPathEncode(remotename)}");
+
+        HttpResponseMessage response = null;
+        try
         {
-            get
-            {
-                if (string.IsNullOrEmpty(m_downloadUrl))
+            // For GetAsync, no timeout is specified. The only thing that can stop it is the cancellation token
+            response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await responseStream.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            if (B2AuthHelper.GetExceptionStatusCode(ex) == HttpStatusCode.NotFound)
+                throw new FileMissingException();
+
+            _b2AuthHelper.AttemptParseAndThrowException(ex, response);
+            throw;
+        }
+        finally
+        {
+            response?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Implementation of interface method for listing remote folder contents
+    /// </summary>
+    /// <returns>List of IFileEntry with directory listing result</returns>
+    private async Task<IEnumerable<IFileEntry>> ListAsync(CancellationToken cancellationToken)
+    {
+        _filecache = null;
+        var cache = new Dictionary<string, List<FileEntity>>();
+        string nextFileId = null;
+        string nextFileName = null;
+        do
+        {
+
+            using var timeoutToken = new CancellationTokenSource();
+            timeoutToken.CancelAfter(TimeSpan.FromSeconds(SHORT_OPERATION_TIMEOUT_SECONDS));
+            using var combinedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken.Token, cancellationToken);
+
+            var resp = await _b2AuthHelper.PostAndGetJsonDataAsync<ListFilesResponse>(
+                $"{_b2AuthHelper.ApiUrl}/b2api/v1/b2_list_file_versions",
+                new ListFilesRequest
                 {
-                    return m_helper.DownloadUrl;
-                }
-                else
-                {
-                    return m_downloadUrl;
-                }
-            }
-        }
+                    BucketID = GetBucketAsync(cancellationToken).Await().BucketID,
+                    MaxFileCount = _pageSize,
+                    Prefix = _prefix,
+                    StartFileID = nextFileId,
+                    StartFileName = nextFileName
+                },
+                combinedCancellationToken.Token
+            ).ConfigureAwait(false);
 
-        public IList<ICommandLineArgument> SupportedCommands
+            nextFileId = resp.NextFileID;
+            nextFileName = resp.NextFileName;
+
+            if (resp.Files == null || resp.Files.Length == 0)
+                break;
+
+            foreach (var file in resp.Files)
+            {
+                if (!file.FileName.StartsWith(_prefix, StringComparison.Ordinal))
+                    continue;
+
+                var name = file.FileName[_prefix.Length..];
+                if (name.Contains('/'))
+                    continue;
+
+                cache.TryGetValue(name, out var lst);
+                if (lst == null)
+                    cache[name] = lst = new List<FileEntity>(1);
+                lst.Add(file);
+            }
+
+        } while (nextFileId != null);
+
+        _filecache = cache;
+
+        return
+            (from x in _filecache
+             let newest = x.Value.OrderByDescending(y => y.UploadTimestamp).First()
+             let ts = Utility.Utility.EPOCH.AddMilliseconds(newest.UploadTimestamp)
+             select (IFileEntry)new FileEntry(x.Key, newest.Size, ts, ts)
+            ).ToList();
+    }
+
+    /// <summary>
+    /// Wrapper method of legacy non async call to list files in the remote folder
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<IFileEntry> List() => ListAsync(CancellationToken.None).Await();
+
+    //<inheritdoc/>
+    public async Task PutAsync(string remotename, string filename, CancellationToken cancelToken)
+    {
+        await using FileStream fs = File.OpenRead(filename);
+        await PutAsync(remotename, fs, cancelToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Download files from remote
+    /// </summary>
+    /// <param name="remotename">Filename at remote location</param>
+    /// <param name="filename">Destination file to write to</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution or FileMissingException</exception>
+    public async Task GetAsync(string remotename, string filename, CancellationToken cancellationToken)
+    {
+        await using var fs = File.Create(filename);
+        await GetAsync(remotename, fs, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Delete remote file if it exists, if now, throws FileMissingException
+    /// </summary>
+    /// <param name="remotename">filename to be deleted on the remote</param>
+    /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
+    /// <returns></returns>
+    /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
+    /// <exception cref="Exception">Exceptions arising from either code execution</exception>
+    public async Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+    {
+        try
         {
-            get
-            {
-                return new List<ICommandLineArgument>(new ICommandLineArgument[] {
-                    new CommandLineArgument(B2_ID_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2accountidDescriptionShort, Strings.B2.B2accountidDescriptionLong, null, new string[] {"auth-password"}, null),
-                    new CommandLineArgument(B2_KEY_OPTION, CommandLineArgument.ArgumentType.Password, Strings.B2.B2applicationkeyDescriptionShort, Strings.B2.B2applicationkeyDescriptionLong, null, new string[] {"auth-username"}, null),
-                    new CommandLineArgument("auth-password", CommandLineArgument.ArgumentType.Password, Strings.B2.AuthPasswordDescriptionShort, Strings.B2.AuthPasswordDescriptionLong),
-                    new CommandLineArgument("auth-username", CommandLineArgument.ArgumentType.String, Strings.B2.AuthUsernameDescriptionShort, Strings.B2.AuthUsernameDescriptionLong),
-                    new CommandLineArgument(B2_CREATE_BUCKET_TYPE_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2createbuckettypeDescriptionShort, Strings.B2.B2createbuckettypeDescriptionLong, DEFAULT_BUCKET_TYPE),
-                    new CommandLineArgument(B2_PAGESIZE_OPTION, CommandLineArgument.ArgumentType.Integer, Strings.B2.B2pagesizeDescriptionShort, Strings.B2.B2pagesizeDescriptionLong, DEFAULT_PAGE_SIZE.ToString()),
-                    new CommandLineArgument(B2_DOWNLOAD_URL_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2downloadurlDescriptionShort, Strings.B2.B2downloadurlDescriptionLong),
-                });
+            using var timeoutToken = new CancellationTokenSource();
+            timeoutToken.CancelAfter(TimeSpan.FromSeconds(SHORT_OPERATION_TIMEOUT_SECONDS));
+            using var combinedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken.Token, cancellationToken);
 
-            }
-        }
+            if (_filecache == null || !_filecache.ContainsKey(remotename))
+                await ListAsync(cancellationToken).ConfigureAwait(false);
 
-        public async Task PutAsync(string remotename, System.IO.Stream stream, CancellationToken cancelToken)
-        {
-            TempFile tmp = null;
+            if (!_filecache.TryGetValue(remotename, out var value))
+                throw new FileMissingException();
 
-            // A bit dirty, but we need the underlying stream to compute the hash without any interference
-            var measure = stream;
-            while (measure is OverrideableStream)
-                measure = typeof(OverrideableStream).GetField("m_basestream", System.Reflection.BindingFlags.DeclaredOnly | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(measure) as System.IO.Stream;
-
-            if (measure == null)
-                throw new Exception(string.Format("Unable to unwrap stream from: {0}", stream.GetType()));
-
-            string sha1;
-            if (measure.CanSeek)
-            {
-                var p = measure.Position;
-
-                // Compute the hash
-                using (var hashalg = HashFactory.CreateHasher("SHA1"))
-                    sha1 = Library.Utility.Utility.ByteArrayAsHexString(hashalg.ComputeHash(measure));
-
-                measure.Position = p;
-            }
-            else
-            {
-                // No seeking possible, use a temp file
-                tmp = new TempFile();
-                using (var sr = System.IO.File.OpenWrite(tmp))
-                using (var hasher = HashFactory.CreateHasher("SHA1"))
-                using (var hc = new HashCalculatingStream(measure, hasher))
-                {
-                    await Utility.Utility.CopyStreamAsync(hc, sr, cancelToken).ConfigureAwait(false);
-                    sha1 = hc.GetFinalHashString();
-                }
-
-                stream = System.IO.File.OpenRead(tmp);
-            }
-
-            if (m_filecache == null)
-                List();
-
-            try
-            {
-                var fileinfo = await m_helper.GetJSONDataAsync<UploadFileResponse>(
-                    UploadUrlData.UploadUrl,
-                    cancelToken,
-                    req =>
+            foreach (var n in value.OrderBy(x => x.UploadTimestamp))
+                await _b2AuthHelper.PostAndGetJsonDataAsync<DeleteResponse>(
+                    $"{_b2AuthHelper.ApiUrl}/b2api/v1/b2_delete_file_version",
+                    new DeleteRequest
                     {
-                        req.Method = "POST";
-                        req.Headers["Authorization"] = UploadUrlData.AuthorizationToken;
-                        req.Headers["X-Bz-Content-Sha1"] = sha1;
-                        req.Headers["X-Bz-File-Name"] = m_urlencodedprefix + Utility.Uri.UrlPathEncode(remotename);
-                        req.ContentType = "application/octet-stream";
-                        req.ContentLength = stream.Length;
+                        FileName = _prefix + remotename,
+                        FileId = n.FileID
                     },
-
-                    async (req, reqCancelToken) =>
-                    {
-                        using (var rs = req.GetRequestStream())
-                            await Utility.Utility.CopyStreamAsync(stream, rs, reqCancelToken);
-                    }
+                    combinedCancellationToken.Token
                 ).ConfigureAwait(false);
 
-                // Delete old versions
-                if (m_filecache.ContainsKey(remotename))
-                    await DeleteAsync(remotename, cancelToken).ConfigureAwait(false);
+            _filecache[remotename].Clear();
+        }
+        catch
+        {
+            _filecache = null;
+            throw;
+        }
+    }
 
-                m_filecache[remotename] =
-                [
-                    new FileEntity()
-                    {
-                        FileID = fileinfo.FileID,
-                        FileName = fileinfo.FileName,
-                        Action = "upload",
-                        Size = fileinfo.ContentLength,
-                        UploadTimestamp = (long)(DateTime.UtcNow - Utility.Utility.EPOCH).TotalMilliseconds
-                    }
-                ];
-            }
-            catch (Exception ex)
+    /// <summary>
+    /// Performs test with backend (internally it uses the List() command, which by definition means the backend is working)
+    /// </summary>
+    /// <param name="cancelToken">Cancellation Token</param>
+    public Task TestAsync(CancellationToken cancelToken)
+    {
+        this.TestList();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Create remote folder
+    /// </summary>
+    /// <param name="cancellationToken">CancellationToken that will be combined with internal timeout token</param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public async Task CreateFolderAsync(CancellationToken cancellationToken)
+    {
+        using var timeoutToken = new CancellationTokenSource();
+        timeoutToken.CancelAfter(TimeSpan.FromSeconds(SHORT_OPERATION_TIMEOUT_SECONDS));
+        using var combinedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken.Token, cancellationToken);
+
+        _bucket = await _b2AuthHelper.PostAndGetJsonDataAsync<BucketEntity>(
+            $"{_b2AuthHelper.ApiUrl}/b2api/v1/b2_create_bucket",
+            new BucketEntity
             {
-                m_filecache = null;
+                AccountID = _b2AuthHelper.AccountId,
+                BucketName = _bucketName,
+                BucketType = _bucketType
+            },
+            combinedCancellationToken.Token
+        ).ConfigureAwait(false);
+    }
 
-                var code = (int)B2AuthHelper.GetExceptionStatusCode(ex);
-                if (code >= 500 && code <= 599)
-                    m_uploadUrl = null;
+    /// <inheritdoc/>
+    public string DisplayName => Strings.B2.DisplayName;
 
-                throw;
-            }
-            finally
-            {
-                tmp?.Dispose();
-            }
-        }
+    /// <inheritdoc/>
+    public string ProtocolKey => "b2";
 
-        public async Task GetAsync(string remotename, System.IO.Stream stream, CancellationToken cancelToken)
-        {
-            AsyncHttpRequest req;
-            if (m_filecache == null || !m_filecache.ContainsKey(remotename))
-                List();
+    /// <inheritdoc/>
+    public string Description => Strings.B2.Description;
 
-            if (m_filecache != null && m_filecache.ContainsKey(remotename))
-                req = new AsyncHttpRequest(m_helper.CreateRequest(string.Format("{0}/b2api/v1/b2_download_file_by_id?fileId={1}", DownloadUrl, Library.Utility.Uri.UrlEncode(GetFileID(remotename)))));
-            else
-                req = new AsyncHttpRequest(m_helper.CreateRequest(string.Format("{0}/{1}{2}", DownloadUrl, m_urlencodedprefix, Library.Utility.Uri.UrlPathEncode(remotename))));
-
-            try
-            {
-                using (var resp = req.GetResponse())
-                using (var rs = req.GetResponseStream())
-                    await Library.Utility.Utility.CopyStreamAsync(rs, stream, cancelToken).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                if (B2AuthHelper.GetExceptionStatusCode(ex) == HttpStatusCode.NotFound)
-                    throw new FileMissingException();
-
-                B2AuthHelper.AttemptParseAndThrowException(ex);
-
-                throw;
-            }
-        }
-
-        public IEnumerable<IFileEntry> List()
-        {
-            m_filecache = null;
-            var cache = new Dictionary<string, List<FileEntity>>();
-            string nextFileID = null;
-            string nextFileName = null;
-            do
-            {
-                var resp = m_helper.PostAndGetJSONData<ListFilesResponse>(
-                    string.Format("{0}/b2api/v1/b2_list_file_versions", m_helper.APIUrl),
-                    new ListFilesRequest()
-                    {
-                        BucketID = Bucket.BucketID,
-                        MaxFileCount = m_pagesize,
-                        Prefix = m_prefix,
-                        StartFileID = nextFileID,
-                        StartFileName = nextFileName
-                    }
-                );
-
-                nextFileID = resp.NextFileID;
-                nextFileName = resp.NextFileName;
-
-                if (resp.Files == null || resp.Files.Length == 0)
-                    break;
-
-                foreach (var f in resp.Files)
-                {
-                    if (!f.FileName.StartsWith(m_prefix, StringComparison.Ordinal))
-                        continue;
-
-                    var name = f.FileName.Substring(m_prefix.Length);
-                    if (name.Contains("/"))
-                        continue;
-
-
-                    List<FileEntity> lst;
-                    cache.TryGetValue(name, out lst);
-                    if (lst == null)
-                        cache[name] = lst = new List<FileEntity>(1);
-                    lst.Add(f);
-                }
-
-            } while (nextFileID != null);
-
-            m_filecache = cache;
-
-            return
-                (from x in m_filecache
-                 let newest = x.Value.OrderByDescending(y => y.UploadTimestamp).First()
-                 let ts = Utility.Utility.EPOCH.AddMilliseconds(newest.UploadTimestamp)
-                 select (IFileEntry)new FileEntry(x.Key, newest.Size, ts, ts)
-                ).ToList();
-        }
-
-        public async Task PutAsync(string remotename, string filename, CancellationToken cancelToken)
-        {
-            using (System.IO.FileStream fs = System.IO.File.OpenRead(filename))
-                await PutAsync(remotename, fs, cancelToken);
-        }
-
-        public async Task GetAsync(string remotename, string filename, CancellationToken cancelToken)
-        {
-            using (System.IO.FileStream fs = System.IO.File.Create(filename))
-                await GetAsync(remotename, fs, cancelToken).ConfigureAwait(false);
-        }
-
-        public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
-        {
-            try
-            {
-                if (m_filecache == null || !m_filecache.ContainsKey(remotename))
-                    List();
-
-                if (!m_filecache.ContainsKey(remotename))
-                    throw new FileMissingException();
-
-                foreach (var n in m_filecache[remotename].OrderBy(x => x.UploadTimestamp))
-                    await m_helper.PostAndGetJSONDataAsync<DeleteResponse>(
-                        string.Format("{0}/b2api/v1/b2_delete_file_version", m_helper.APIUrl),
-                        cancelToken,
-                        new DeleteRequest()
-                        {
-                            FileName = m_prefix + remotename,
-                            FileID = n.FileID
-                        }
-                    );
-
-                m_filecache[remotename].Clear();
-            }
-            catch
-            {
-                m_filecache = null;
-                throw;
-            }
-        }
-
-        public Task TestAsync(CancellationToken cancelToken)
-        {
-            this.TestList();
-            return Task.CompletedTask;
-        }
-
-        public async Task CreateFolderAsync(CancellationToken cancelToken)
-        {
-            m_bucket = await m_helper.PostAndGetJSONDataAsync<BucketEntity>(
-                string.Format("{0}/b2api/v1/b2_create_bucket", m_helper.APIUrl),
-                cancelToken,
-                new BucketEntity()
-                {
-                    AccountID = m_helper.AccountID,
-                    BucketName = m_bucketname,
-                    BucketType = m_bucketType
-                }
-            ).ConfigureAwait(false);
-        }
-
-        public string DisplayName
-        {
-            get { return Strings.B2.DisplayName; }
-        }
-
-        public string ProtocolKey
-        {
-            get { return "b2"; }
-        }
-
-        public string Description
-        {
-            get { return Strings.B2.Description; }
-        }
-
-        public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult(new string[] {
+    /// <inheritdoc/>
+    public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult(new string[] {
             new System.Uri(B2AuthHelper.AUTH_URL).Host,
-            m_helper?.APIDnsName,
-            m_helper?.DownloadDnsName
+            _b2AuthHelper?.ApiDnsName,
+            _b2AuthHelper?.DownloadDnsName
         }.Where(x => !string.IsNullOrEmpty(x))
         .ToArray());
 
-        public void Dispose()
+    /// <summary>
+    /// Handles disposal of the backend's resources.
+    /// </summary>
+    public void Dispose()
+    {
+        try
         {
+            _httpClient?.Dispose();
         }
-
-        private class DeleteRequest
+        catch
         {
-            [JsonProperty("fileName")]
-            public string FileName { get; set; }
-            [JsonProperty("fileId")]
-            public string FileID { get; set; }
+            // ignored
         }
-
-        private class DeleteResponse : DeleteRequest
-        {
-        }
-
-        private class UploadUrlRequest : BucketIDEntity
-        {
-        }
-
-        private class UploadUrlResponse : BucketIDEntity
-        {
-            [JsonProperty("uploadUrl")]
-            public string UploadUrl { get; set; }
-            [JsonProperty("authorizationToken")]
-            public string AuthorizationToken { get; set; }
-        }
-
-        private class AccountIDEntity
-        {
-            [JsonProperty("accountId")]
-            public string AccountID { get; set; }
-        }
-
-        private class BucketIDEntity
-        {
-            [JsonProperty("bucketId")]
-            public string BucketID { get; set; }
-        }
-
-        private class BucketEntity : AccountIDEntity
-        {
-            [JsonProperty("bucketId", NullValueHandling = NullValueHandling.Ignore)]
-            public string BucketID { get; set; }
-            [JsonProperty("bucketName")]
-            public string BucketName { get; set; }
-            [JsonProperty("bucketType")]
-            public string BucketType { get; set; }
-        }
-
-        private class ListBucketsRequest : AccountIDEntity
-        {
-        }
-
-        private class ListBucketsResponse
-        {
-            [JsonProperty("buckets")]
-            public BucketEntity[] Buckets { get; set; }
-        }
-
-        private class ListFilesRequest : BucketIDEntity
-        {
-            [JsonProperty("startFileName", NullValueHandling = NullValueHandling.Ignore)]
-            public string StartFileName { get; set; }
-            [JsonProperty("startFileId", NullValueHandling = NullValueHandling.Ignore)]
-            public string StartFileID { get; set; }
-            [JsonProperty("maxFileCount")]
-            public long MaxFileCount { get; set; }
-            [JsonProperty("prefix")]
-            public string Prefix { get; set; }
-        }
-
-        private class ListFilesResponse
-        {
-            [JsonProperty("nextFileName")]
-            public string NextFileName { get; set; }
-            [JsonProperty("nextFileId")]
-            public string NextFileID { get; set; }
-            [JsonProperty("files")]
-            public FileEntity[] Files { get; set; }
-        }
-
-        private class FileEntity
-        {
-            [JsonProperty("fileId")]
-            public string FileID { get; set; }
-            [JsonProperty("fileName")]
-            public string FileName { get; set; }
-            [JsonProperty("action")]
-            public string Action { get; set; }
-            [JsonProperty("size")]
-            public long Size { get; set; }
-            [JsonProperty("uploadTimestamp")]
-            public long UploadTimestamp { get; set; }
-
-        }
-
-        private class UploadFileResponse : AccountIDEntity
-        {
-            [JsonProperty("bucketId")]
-            public string BucketID { get; set; }
-            [JsonProperty("fileId")]
-            public string FileID { get; set; }
-            [JsonProperty("fileName")]
-            public string FileName { get; set; }
-            [JsonProperty("contentLength")]
-            public long ContentLength { get; set; }
-            [JsonProperty("contentSha1")]
-            public string ContentSha1 { get; set; }
-            [JsonProperty("contentType")]
-            public string ContentType { get; set; }
-        }
-
     }
 }
-

--- a/Duplicati/Library/Backend/Backblaze/Duplicati.Library.Backend.Backblaze.csproj
+++ b/Duplicati/Library/Backend/Backblaze/Duplicati.Library.Backend.Backblaze.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <Copyright>Copyright © 2024 Team Duplicati, MIT license</Copyright>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Duplicati/Library/Backend/Backblaze/Model/AccountIDEntity.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/AccountIDEntity.cs
@@ -1,0 +1,33 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Base class with AccountID property
+/// </summary>
+internal abstract class AccountIDEntity
+{
+    [JsonProperty("accountId")]
+    public string AccountID { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/AuthResponse.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/AuthResponse.cs
@@ -1,0 +1,39 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIaM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Model for JSON parsing of AuthResponse
+/// </summary>
+internal class AuthResponse
+{
+    [JsonProperty("accountId")]
+    public string AccountID { get; set; }
+    [JsonProperty("apiUrl")]
+    public string APIUrl { get; set; }
+    [JsonProperty("authorizationToken")]
+    public string AuthorizationToken { get; set; }
+    [JsonProperty("downloadUrl")]
+    public string DownloadUrl { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/BucketEntity.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/BucketEntity.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents a bucket entity in the Backblaze B2 storage system.
+/// Contains information about a storage bucket including its identifier and type.
+/// </summary>
+internal class BucketEntity : AccountIDEntity
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the bucket.
+    /// This property can be null as specified by the NullValueHandling attribute.
+    /// </summary>
+    [JsonProperty("bucketId", NullValueHandling = NullValueHandling.Ignore)]
+    public string BucketID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the bucket.
+    /// </summary>
+    [JsonProperty("bucketName")]
+    public string BucketName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of the bucket (e.g., "allPrivate", "allPublic").
+    /// </summary>
+    [JsonProperty("bucketType")]
+    public string BucketType { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/BucketIDEntity.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/BucketIDEntity.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Base class for BuckedID property
+/// </summary>
+internal abstract class BucketIDEntity
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the bucket.
+    /// </summary>
+    [JsonProperty("bucketId")]
+    public string BucketID { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/DeleteRequest.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/DeleteRequest.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents a request to delete a file from Backblaze B2.
+/// Contains the necessary information to identify the file to be deleted.
+/// </summary>
+internal class DeleteRequest
+{
+    /// <summary>
+    /// Gets or sets the name of the file to be deleted.
+    /// This is the full path of the file in the bucket.
+    /// </summary>
+    [JsonProperty("fileName")]
+    public string FileName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unique identifier of the file to be deleted.
+    /// This ID is assigned by Backblaze B2 when the file is uploaded.
+    /// </summary>
+    [JsonProperty("fileId")]
+    public string FileId { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/DeleteResponse.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/DeleteResponse.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents the response received after deleting a file from Backblaze B2.
+/// Inherits all properties from DeleteRequest as the response contains the same fields.
+/// </summary>
+internal class DeleteResponse : DeleteRequest;

--- a/Duplicati/Library/Backend/Backblaze/Model/ErrorResponse.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/ErrorResponse.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Model for JSON parsing of ErrorResponse
+/// </summary>
+internal class ErrorResponse
+{
+    [JsonProperty("code")]
+    public string Code { get; set; }
+    [JsonProperty("message")]
+    public string Message { get; set; }
+    [JsonProperty("status")]
+    public long Status { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/FileEntity.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/FileEntity.cs
@@ -1,0 +1,67 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents a file entity in the Backblaze B2 storage system.
+/// Contains detailed information about a file including its identifier, name, size, and metadata.
+/// </summary>
+internal class FileEntity
+{
+    /// <summary>
+    /// Gets or sets the unique identifier assigned to the file by Backblaze B2.
+    /// This ID is used to reference the file in various API operations.
+    /// </summary>
+    [JsonProperty("fileId")]
+    public string FileID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the file as stored in Backblaze B2.
+    /// This is the full path of the file within the bucket.
+    /// </summary>
+    [JsonProperty("fileName")]
+    public string FileName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the action performed on the file.
+    /// Possible values include "upload" for new files, "hide" for hidden files,
+    /// and "delete" for deleted files.
+    /// </summary>
+    [JsonProperty("action")]
+    public string Action { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the file in bytes.
+    /// Represents the actual content length of the file.
+    /// </summary>
+    [JsonProperty("size")]
+    public long Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the file was uploaded.
+    /// Value is in milliseconds since epoch (January 1, 1970 00:00:00 UTC).
+    /// </summary>
+    [JsonProperty("uploadTimestamp")]
+    public long UploadTimestamp { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/ListBucketsRequest.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/ListBucketsRequest.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents a request to list buckets in a Backblaze B2 account.
+/// Inherits from AccountIDEntity to include the account identifier.
+/// </summary>
+internal class ListBucketsRequest : AccountIDEntity
+{
+    /// <summary>
+    /// Initializes a new instance of the ListBucketsRequest class.
+    /// </summary>
+    /// <param name="accountId">The account ID for which to list buckets.</param>
+    public ListBucketsRequest(string accountId)
+    {
+        AccountID = accountId;
+    }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/ListBucketsResponse.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/ListBucketsResponse.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents the response from a list buckets operation in Backblaze B2.
+/// Contains an array of bucket entities returned by the API.
+/// </summary>
+internal class ListBucketsResponse
+{
+    /// <summary>
+    /// Gets or sets the array of bucket entities returned by the API.
+    /// Each element contains information about a single bucket in the account.
+    /// </summary>
+    [JsonProperty("buckets")]
+    public BucketEntity[] Buckets { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/ListFilesRequest.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/ListFilesRequest.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents a request to list files in a Backblaze B2 bucket.
+/// Contains parameters for pagination and filtering of the file list.
+/// </summary>
+internal class ListFilesRequest : BucketIDEntity
+{
+    /// <summary>
+    /// Gets or sets the file name to start listing from.
+    /// Used for pagination to continue listing from a specific point.
+    /// </summary>
+    [JsonProperty("startFileName", NullValueHandling = NullValueHandling.Ignore)]
+    public string StartFileName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the file ID to start listing from.
+    /// Used in conjunction with StartFileName for pagination.
+    /// </summary>
+    [JsonProperty("startFileId", NullValueHandling = NullValueHandling.Ignore)]
+    public string StartFileID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of files to return in a single request.
+    /// </summary>
+    [JsonProperty("maxFileCount")]
+    public long MaxFileCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the prefix to filter files by.
+    /// Only files whose names begin with this prefix will be returned.
+    /// </summary>
+    [JsonProperty("prefix")]
+    public string Prefix { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/ListFilesResponse.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/ListFilesResponse.cs
@@ -1,0 +1,52 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents the response from a list files operation in Backblaze B2.
+/// Contains a list of files and pagination information for subsequent requests.
+/// </summary>
+internal class ListFilesResponse
+{
+    /// <summary>
+    /// Gets or sets the name of the next file to use for pagination.
+    /// This value should be used in the next request to continue listing files.
+    /// </summary>
+    [JsonProperty("nextFileName")]
+    public string NextFileName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ID of the next file to use for pagination.
+    /// This value should be used in conjunction with NextFileName for subsequent requests.
+    /// </summary>
+    [JsonProperty("nextFileId")]
+    public string NextFileID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the array of file entities returned by this request.
+    /// Each element contains information about a single file in the bucket.
+    /// </summary>
+    [JsonProperty("files")]
+    public FileEntity[] Files { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/UploadFileResponse.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/UploadFileResponse.cs
@@ -1,0 +1,67 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents the response received after uploading a file to Backblaze B2.
+/// Contains details about the uploaded file including its ID, name, and metadata.
+/// </summary>
+internal class UploadFileResponse : AccountIDEntity
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the bucket containing the file.
+    /// </summary>
+    [JsonProperty("bucketId")]
+    public string BucketID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unique identifier assigned to the uploaded file.
+    /// </summary>
+    [JsonProperty("fileId")]
+    public string FileID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the uploaded file.
+    /// </summary>
+    [JsonProperty("fileName")]
+    public string FileName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the uploaded file in bytes.
+    /// </summary>
+    [JsonProperty("contentLength")]
+    public long ContentLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SHA1 hash of the file content.
+    /// </summary>
+    [JsonProperty("contentSha1")]
+    public string ContentSha1 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the MIME type of the uploaded file.
+    /// </summary>
+    [JsonProperty("contentType")]
+    public string ContentType { get; set; }
+}

--- a/Duplicati/Library/Backend/Backblaze/Model/UploadUrlRequest.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/UploadUrlRequest.cs
@@ -1,0 +1,28 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents a request to get an upload URL for the Backblaze B2 API.
+/// Inherits from BucketIDEntity to include the bucket identifier.
+/// </summary>
+internal class UploadUrlRequest : BucketIDEntity;

--- a/Duplicati/Library/Backend/Backblaze/Model/UploadUrlResponse.cs
+++ b/Duplicati/Library/Backend/Backblaze/Model/UploadUrlResponse.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace Duplicati.Library.Backend.Backblaze.Model;
+
+/// <summary>
+/// Represents the response from a get upload URL request in Backblaze B2.
+/// Contains the URL and authorization token needed for subsequent file uploads.
+/// </summary>
+internal class UploadUrlResponse : BucketIDEntity
+{
+    /// <summary>
+    /// Gets or sets the URL to use for uploading files.
+    /// This URL is specific to the bucket and should be used for subsequent upload requests.
+    /// </summary>
+    [JsonProperty("uploadUrl")]
+    public string UploadUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authorization token required for upload requests.
+    /// This token must be included in the headers when uploading files using the UploadUrl.
+    /// </summary>
+    [JsonProperty("authorizationToken")]
+    public string AuthorizationToken { get; set; }
+}

--- a/Duplicati/Library/Backend/OAuthHelper/JSONWebHelperHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/JSONWebHelperHttpClient.cs
@@ -1,0 +1,282 @@
+// Copyright (C) 2024, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using HttpMethod = System.Net.Http.HttpMethod;
+
+namespace Duplicati.Library;
+
+/// <summary>
+/// Minimalist version of the JSONWebHelper to be used with HttpClient HttpRequestMessage/HttpResponseMessage types
+/// </summary>
+/// <param name="httpClient">HttpClient reference</param>
+public class JsonWebHelperHttpClient(HttpClient httpClient)
+{
+    /// <summary>
+    /// HttpClient reference
+    /// </summary>
+    protected readonly HttpClient _httpClient = httpClient;
+
+    /// <summary>
+    /// Useragent string building method
+    /// </summary>
+    protected string UserAgent => $"Duplicati v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}";
+    public event Action<HttpRequestMessage> CreateSetupHelper;
+
+    /// <summary>
+    /// Centralized method to prepare a request with the given URL and method setting useragent
+    /// </summary>
+    /// <param name="url">Url</param>
+    /// <param name="method">Method</param>
+    public virtual HttpRequestMessage CreateRequest(string url, string method = null)
+    {
+        HttpRequestMessage request = new HttpRequestMessage(string.IsNullOrEmpty(method) ? HttpMethod.Get : new HttpMethod(method), url);
+        request.Headers.Add("User-Agent", UserAgent);
+
+        CreateSetupHelper?.Invoke(request);
+
+        return request;
+    }
+
+    /// <summary>
+    /// Execute Get request and return response and deserializes JSON response into the given type
+    /// </summary>
+    /// <param name="url">Url</param>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    /// <param name="setup">Setup Actions for customizing the request</param>
+    /// <typeparam name="T">Destination Type</typeparam>
+    protected virtual async Task<T> GetJsonDataAsync<T>(string url, CancellationToken cancellationToken, Action<HttpRequestMessage> setup = null)
+    {
+        var req = CreateRequest(url);
+
+        if (setup != null)
+            setup(req);
+
+        return await ReadJsonResponseAsync<T>(req, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Execute Post and return response and deserializes JSON response into the given type
+    /// </summary>
+    /// <param name="url">Url</param>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    /// <param name="item">The item to be serialized into a json and added to the body</param>
+    /// <typeparam name="T">Destination Type</typeparam>
+    public virtual async Task<T> PostAndGetJsonDataAsync<T>(string url, object item, CancellationToken cancellationToken)
+    {
+        var data = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(item));
+
+        return await GetJsonDataAsync<T>(
+            url,
+            cancellationToken,
+            request =>
+            {
+                request.Method = HttpMethod.Post;
+                request.Content = new ByteArrayContent(data);
+                request.Content.Headers.Add("Content-Length", data.Length.ToString());
+                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            }
+        ).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the JSON response from the server and deserializes it into the given type
+    /// </summary>
+    /// <param name="req">Request object</param>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    /// <typeparam name="T">Destination Type</typeparam>
+    protected virtual async Task<T> ReadJsonResponseAsync<T>(HttpRequestMessage req, CancellationToken cancellationToken)
+    {
+        using var resp = await GetResponseAsync(req, cancellationToken).ConfigureAwait(false);
+        return await ReadJsonResponsAsync<T>(resp, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Read the JSON response from the server and deserialize it into the given type
+    /// </summary>
+    /// <param name="response">Response object</param>
+    /// <typeparam name="T">Type to cast to</typeparam>
+    /// <returns></returns>
+    /// <exception cref="IOException">Exception when failing to deserialize the JSON to the Type</exception>
+    protected virtual T ReadJsonResponse<T>(HttpResponseMessage response)
+    {
+        using var rs = response.Content.ReadAsStream();
+        using var ps = new StreamPeekReader(rs);
+        try
+        {
+            using var tr = new StreamReader(ps);
+            using var jr = new JsonTextReader(tr);
+            return new JsonSerializer().Deserialize<T>(jr);
+        }
+        catch (Exception ex)
+        {
+            // If we get invalid JSON, report the peek value
+            if (ex is JsonReaderException)
+                throw new IOException($"Invalid JSON data: \"{ps.PeekData()}\"", ex);
+            // Otherwise, we have no additional help to offer
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Read the JSON response from the server and deserialize it into the given type asynchronously
+    /// </summary>
+    /// <param name="response">Response object</param>
+    /// <param name="cancellationToken"></param>
+    /// <typeparam name="T">Type to cast to</typeparam>
+    /// <returns></returns>
+    /// <exception cref="IOException">Exception when failing to deserialize the JSON to the Type</exception>
+    protected virtual async Task<T> ReadJsonResponsAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        await using var rs = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using var ps = new StreamPeekReader(rs);
+        try
+        {
+            using var tr = new StreamReader(ps);
+            await using var jr = new JsonTextReader(tr);
+            return new JsonSerializer().Deserialize<T>(jr);
+        }
+        catch (Exception ex)
+        {
+            // If we get invalid JSON, report the peek value
+            if (ex is JsonReaderException)
+                throw new IOException($"Invalid JSON data: \"{ps.PeekData()}\"", ex);
+            // Otherwise, we have no additional help to offer
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Use this method to register an exception handler,
+    /// which can throw another, more meaningful exception
+    /// </summary>
+    public virtual void AttemptParseAndThrowException(Exception ex, HttpResponseMessage responseContext = null)
+    {
+
+    }
+
+    /// <summary>
+    /// Execute request and return response
+    /// </summary>
+    /// <param name="req">Request object</param>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    /// <returns></returns>
+    private async Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage req, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            AttemptParseAndThrowException(ex, response);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// A utility class that shadows the real stream but provides access
+    /// to the first 2kb of the stream to use in error reporting
+    /// </summary>
+    private class StreamPeekReader(Stream source) : Stream
+    {
+        private readonly byte[] m_peekbuffer = new byte[1024 * 2];
+        private int m_peekbytes = 0;
+
+        public string PeekData()
+        {
+            if (m_peekbuffer.Length == 0)
+                return string.Empty;
+
+            return Encoding.UTF8.GetString(m_peekbuffer, 0, m_peekbytes);
+        }
+
+        public override bool CanRead => source.CanRead;
+        public override bool CanSeek => source.CanSeek;
+        public override bool CanWrite => source.CanWrite;
+        public override long Length => source.Length;
+        public override long Position { get => source.Position; set => source.Position = value; }
+        public override void Flush() => source.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => source.Seek(offset, origin);
+        public override void SetLength(long value) => source.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => source.Write(buffer, offset, count);
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => source.BeginRead(buffer, offset, count, callback, state);
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => source.BeginWrite(buffer, offset, count, callback, state);
+        public override bool CanTimeout => source.CanTimeout;
+        public override void Close() => source.Close();
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => source.CopyToAsync(destination, bufferSize, cancellationToken);
+        protected override void Dispose(bool disposing) => base.Dispose(disposing);
+        public override int EndRead(IAsyncResult asyncResult) => source.EndRead(asyncResult);
+        public override void EndWrite(IAsyncResult asyncResult) => source.EndWrite(asyncResult);
+        public override Task FlushAsync(CancellationToken cancellationToken) => source.FlushAsync(cancellationToken);
+        public override int ReadTimeout { get => source.ReadTimeout; set => source.ReadTimeout = value; }
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => source.WriteAsync(buffer, offset, count, cancellationToken);
+        public override int WriteTimeout { get => source.WriteTimeout; set => source.WriteTimeout = value; }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var br = 0;
+            if (m_peekbytes < m_peekbuffer.Length - 1)
+            {
+                var maxb = Math.Min(count, m_peekbuffer.Length - m_peekbytes);
+                br = await source.ReadAsync(m_peekbuffer, m_peekbytes, maxb, cancellationToken);
+                Array.Copy(m_peekbuffer, m_peekbytes, buffer, offset, br);
+                m_peekbytes += br;
+                offset += br;
+                count -= br;
+                if (count == 0 || br < maxb)
+                    return br;
+            }
+
+            return await source.ReadAsync(buffer, offset, count, cancellationToken) + br;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var br = 0;
+            if (m_peekbytes < m_peekbuffer.Length - 1)
+            {
+                var maxb = Math.Min(count, m_peekbuffer.Length - m_peekbytes);
+                br = source.Read(m_peekbuffer, m_peekbytes, maxb);
+                Array.Copy(m_peekbuffer, m_peekbytes, buffer, offset, br);
+                m_peekbytes += br;
+                offset += br;
+                count -= br;
+
+                if (count == 0 || br < maxb)
+                    return br;
+            }
+
+            return source.Read(buffer, offset, count) + br;
+        }
+
+    }
+}


### PR DESCRIPTION
- Replace legacy HttpWebClient with modern HttpClient
- Implement proper async/await patterns throughout the codebase
- Add cancellation token support for improved request handling
- Refactor related code for better maintainability

This change is part of our broader initiative to modernize the codebase 
and improve its resilience through proper asynchronous operations.

This also fixes a memory leak [issue](https://github.com/duplicati/duplicati/issues/5810)