### PR TITLE
Added warning for volume size

### DIFF
--- a/Duplicati/Server/webroot/ngax/index.html
+++ b/Duplicati/Server/webroot/ngax/index.html
@@ -96,7 +96,6 @@
     <script type="text/javascript" src="scripts/controllers/DialogController.js?v=2.0.0.7"></script>
     <script type="text/javascript" src="scripts/controllers/LocalDatabaseController.js?v=2.0.0.7"></script>
     <script type="text/javascript" src="scripts/controllers/DeleteController.js?v=2.0.0.7"></script>
-    <script type="text/javascript" src="scripts/controllers/CaptchaController.js?v=2.0.0.7"></script>
     <script type="text/javascript" src="scripts/controllers/RestoreWizardController.js?v=2.0.0.7"></script>
     <script type="text/javascript" src="scripts/controllers/AddWizardController.js?v=2.0.0.7"></script>
     <script type="text/javascript" src="scripts/controllers/PauseController.js?v=2.0.0.7"></script>
@@ -191,7 +190,7 @@
                         <button ng-hide="state.activeTask != null || state.programState == 'Running'" class="resume" ng-click="sendResume()" translate></button>
                     </div>
 
-                    <div class="progress-bar progress-bar-striped" ng-class="{active: Progress < 0}" role="progressbar" aria-valuenow="{{Progress * 100}}" aria-valuemin="0" aria-valuemax="100" style="width:{{Progress * 100}}%"></div>
+                    <div class="progress-bar progress-bar-striped" ng-class="{active: Progress &lt; 0}" role="progressbar" aria-valuenow="{{Progress * 100}}" aria-valuemin="0" aria-valuemax="100" ng-style="{'width': (Progress * 100) + '%'}"></div>
 
                 </div>
 

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -49,6 +49,9 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
 
     $scope.$watch('Options["passphrase"]', computePassPhraseStrength);
     $scope.$watch('RepeatPasshrase', computePassPhraseStrength);
+    $scope.parseSizeString = function(v) { 
+        return AppUtils.parseSizeString(v);
+    }
 
     $scope.checkGpgAsymmetric = function() {
         if (!this.Options) {

--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -310,9 +310,11 @@
                     </select>
 
                     <div class="hint" translate>
-                        The backups will be split up into multiple files called volumes. Here you can set the maximum size of the individual volume files. <external-link link="'https://www.duplicati.com/articles/Choosing-Sizes/#remote-volume-size'">See this page for more information.</external-link>
+                        <p ng-show="(parseSizeString(Options['dblock-size']) &gt; 1024 * 1024 * 1024 * 2) || (parseSizeString(Options['dblock-size']) &lt; 1024 * 1024 * 5)" class="warning" translate>
+                            The chosen size is outside the recommended range. This may cause performance issues, excessively large temporary files or other problems.
+                        </p>
+                        The backups will be split up into multiple files called volumes. Here you can set the maximum size of the individual volume files. <external-link link="'https://forum.duplicati.com/t/choosing-sizes-in-duplicati/17683'">See this page for more information.</external-link>
                     </div>
-
                 </div>
 
                 <div class="input multiple text select keepBackups">


### PR DESCRIPTION
This adds a warning text if the user selects a very large or very small value for the `dblock-size`.

Currently "large" is over 2GiB and "small" is less than 5MiB.

This fixes #5687 