### PR TITLE
Fixes to timeouts on WebDav

### DIFF
--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -409,7 +409,8 @@ namespace Duplicati.Library.Backend
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"{m_url}{Utility.Uri.UrlEncode(remotename).Replace("+", "%20")}");
             request.Headers.Add(HttpRequestHeader.UserAgent.ToString(), "Duplicati WEBDAV Client v" + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
-            request.Headers.ConnectionClose = true; // Equivalent to KeepAlive = false
+            
+            request.Headers.ConnectionClose = !m_useIntegratedAuthentication; // ConnectionClose is incompatible with integrated authentication
 
             if (method != null)
                 request.Method = method;

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -1037,8 +1037,17 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         if (res)
             EditUriBackendConfig.recommend_path(scope, continuation);
     };
+    
+    EditUriBackendConfig.validaters['webdav'] = function (scope, continuation) {
+        var res =
+            EditUriBackendConfig.require_server(scope) &&
+            EditUriBackendConfig.require_username(scope);
 
-    EditUriBackendConfig.validaters['webdav'] = EditUriBackendConfig.validaters['ssh'];
+        if (res)
+            EditUriBackendConfig.recommend_path(scope, continuation);
+    };
+
+    EditUriBackendConfig.validaters['webdav'] = EditUriBackendConfig.validaters['webdav'];
     EditUriBackendConfig.validaters['cloudfiles'] = EditUriBackendConfig.validaters['ssh'];
     EditUriBackendConfig.validaters['tahoe'] = EditUriBackendConfig.validaters['ssh'];
 


### PR DESCRIPTION
Increases the timeout duration for WebDav directory listing operations to handle large filesystems more effectively. This change addresses a user-reported issue where operations were timing out when dealing with directories containing numerous files.

- Extended List operation timeout from 30 seconds to 10 minutes (default)
- Maintains existing 30-second timeout for CreateFolder and DeleteAsync operations
- Includes minor code formatting and refactoring improvements

Motivation:
Directory listing operations on large filesystems can require significant processing time. The previous 30-second timeout was insufficient, causing operations to fail prematurely in certain scenarios.

Forum issue: https://forum.duplicati.com/t/webdav-gives-the-operation-was-cancelled/19928