### PR TITLE
Improve S3 logic for permission tests

### DIFF
--- a/Duplicati/Library/Backend/S3/S3IAM.cs
+++ b/Duplicati/Library/Backend/S3/S3IAM.cs
@@ -26,6 +26,7 @@ using Duplicati.Library.Interface;
 using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
 using Duplicati.Library.Localization.Short;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.Library.Backend
 {
@@ -196,12 +197,13 @@ namespace Duplicati.Library.Backend
             User user;
             try
             {
-                user = cl.GetUserAsync().GetAwaiter().GetResult().User;
+                user = cl.GetUserAsync().Await().User;
             }
-            catch (Exception ex) when (ex is NoSuchEntityException || ex is ServiceFailureException)
+            catch (Exception ex)
             {
                 return new Dictionary<string, string>
                 {
+                    ["isroot"] = false.ToString(),
                     ["ex"] = ex.ToString(),
                     ["error"] = $"Exception occurred while retrieving user {awsid} : {ex.Message}"
                 };


### PR DESCRIPTION
This changes the logic a bit, so any error while testing for permissions, is an indication that the user does not have S3 root privileges.

This check is less important now that AWS is no longer default using root credentials to access buckets.