### PR TITLE
Remove SHA1 Windows Hashes

### DIFF
--- a/ReleaseBuilder/ProcessRunner.cs
+++ b/ReleaseBuilder/ProcessRunner.cs
@@ -25,7 +25,7 @@ public static class ProcessRunner
     /// <summary>
     /// The hash algorithms used for signing with Authenticode
     /// </summary>
-    private static readonly IReadOnlyList<string> OSSLHashAlgs = new[] { "sha1", "sha256" };
+    private static readonly IReadOnlyList<string> OSSLHashAlgs = ["sha256"];
 
     /// <summary>
     /// The company name to encode in the Authenticode certificate


### PR DESCRIPTION
Since sha1 validation ended in 2020, there is no longer a reason to apply the SHA1 hash to files. The verification is now only using the supported SHA256 hash.