### PR TITLE
Renaming "folders" to "items"

### DIFF
--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -140,7 +140,7 @@
                     </div>
 
                     <div class="input checklinks">
-                        <a href class="{{EditSourceAdvanced ? 'inactive' : ''}}" ng-click="showhiddenfolders = !showhiddenfolders"><i class="fa {{showhiddenfolders ? 'fa-check' : ''}}"></i> {{'Show hidden folders' | translate}}</a>
+                        <a href class="{{EditSourceAdvanced ? 'inactive' : ''}}" ng-click="showhiddenfolders = !showhiddenfolders"><i class="fa {{showhiddenfolders ? 'fa-check' : ''}}"></i> {{'Show hidden items' | translate}}</a>
                     </div>
                     <div class="resizable filepicker" ng-hide="EditSourceAdvanced">
                         <source-folder-picker ng-sources="Backup.Sources" ng-filters="Backup.Filters" ng-show-hidden="showhiddenfolders" ng-exclude-attributes="ExcludeAttributes" ng-exclude-size="ExcludeFileSize"></source-folder-picker>

--- a/Duplicati/Server/webroot/ngax/templates/backends/file.html
+++ b/Duplicati/Server/webroot/ngax/templates/backends/file.html
@@ -12,8 +12,8 @@
 
     <div class="input" style="padding-bottom: 0px">
         <a href ng-click="ShowHiddenFolders = !ShowHiddenFolders" style="float: right; margin-right: 10px;">
-            <span ng-show="ShowHiddenFolders" translate>Hide hidden folders</span>
-            <span ng-hide="ShowHiddenFolders" translate>Show hidden folders</span>
+            <span ng-show="ShowHiddenFolders" translate>Hide hidden items</span>
+            <span ng-hide="ShowHiddenFolders" translate>Show hidden items</span>
         </a>
 
         <a href ng-click="HideFolderBrowser = true" style="float: right; margin-right: 10px;" translate>Manually type path</a>

--- a/Duplicati/Server/webroot/ngax/templates/restore.html
+++ b/Duplicati/Server/webroot/ngax/templates/restore.html
@@ -95,8 +95,8 @@
 
                 <div class="input" style="padding-bottom: 0px">
                     <a href ng-click="ShowHiddenFolders = !ShowHiddenFolders" style="float: right; margin-right: 10px;">
-                        <span ng-show="ShowHiddenFolders" translate>Hide hidden folders</span>
-                        <span ng-hide="ShowHiddenFolders" translate>Show hidden folders</span>
+                        <span ng-show="ShowHiddenFolders" translate>Hide hidden items</span>
+                        <span ng-hide="ShowHiddenFolders" translate>Show hidden items</span>
                     </a>
 
                     <a href ng-click="HideFolderBrowser = true" style="float: right; margin-right: 10px;" translate>Manually type path</a>


### PR DESCRIPTION
This renames "Show hidden folders" to "Show hidden items" as suggested on the forum:
https://forum.duplicati.com/t/improvement-request-home-folders-naming-convention-macos/19983/4?u=kenkendk