### PR TITLE
Added UI warning for unencrypted database

### DIFF
--- a/Duplicati/Library/RestAPI/Database/Connection.cs
+++ b/Duplicati/Library/RestAPI/Database/Connection.cs
@@ -77,6 +77,8 @@ namespace Duplicati.Server.Database
             this.ApplicationSettings = new ServerSettings(this);
         }
 
+        public bool IsEncryptingFields => m_encryptSensitiveFields;
+
         public void ReWriteAllFieldsIfEncryptionChanged()
         {
             // The token is automatically decrypted when the settings are loaded  

--- a/Duplicati/Library/RestAPI/Database/ServerSettings.cs
+++ b/Duplicati/Library/RestAPI/Database/ServerSettings.cs
@@ -70,6 +70,7 @@ namespace Duplicati.Server.Database
             public const string PRELOAD_SETTINGS_HASH = "preload-settings-hash";
             public const string TIMEZONE_OPTION = "server-timezone";
             public const string PAUSED_UNTIL = "paused-until";
+            public const string LAST_UPDATE_CHECK_VERSION = "last-update-check-version";
         }
 
         private readonly Dictionary<string, string?> settings;
@@ -829,6 +830,20 @@ namespace Duplicati.Server.Database
             {
                 lock (databaseConnection.m_lock)
                     settings[CONST.TIMEZONE_OPTION] = value?.Id;
+                SaveSettings();
+            }
+        }
+
+        public string? LastConfigIssueCheckVersion
+        {
+            get
+            {
+                return settings[CONST.LAST_UPDATE_CHECK_VERSION];
+            }
+            set
+            {
+                lock (databaseConnection.m_lock)
+                    settings[CONST.LAST_UPDATE_CHECK_VERSION] = value;
                 SaveSettings();
             }
         }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -270,7 +270,6 @@ namespace Duplicati.Server
                 StartOrStopUsageReporter();
 
                 AdjustApplicationSettings(commandlineOptions);
-                EmitWarningsForConfigurationIssues(commandlineOptions);
 
                 ApplicationExitEvent = new System.Threading.ManualResetEvent(false);
 
@@ -297,6 +296,7 @@ namespace Duplicati.Server
 
                 DataConnection.ReWriteAllFieldsIfEncryptionChanged();
                 DataConnection.SetPreloadSettingsIfChanged(preloadDbSettings);
+                EmitWarningsForConfigurationIssues(commandlineOptions);
 
                 Library.Logging.Log.WriteInformationMessage(LOGTAG, "ServerStarted", Strings.Program.ServerStarted(DuplicatiWebserver.Port));
                 logMessageToConsole(Strings.Program.ServerStarted(DuplicatiWebserver.Port));

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -270,6 +270,7 @@ namespace Duplicati.Server
                 StartOrStopUsageReporter();
 
                 AdjustApplicationSettings(commandlineOptions);
+                EmitWarningsForConfigurationIssues(commandlineOptions);
 
                 ApplicationExitEvent = new System.Threading.ManualResetEvent(false);
 
@@ -573,7 +574,37 @@ namespace Duplicati.Server
                     DataConnection.ApplicationSettings.UpdatedVersion = null;
                 }
             }
+        }
 
+        private static void EmitWarningsForConfigurationIssues(Dictionary<string, string> commandlineOptions)
+        {
+            if (DataConnection.ApplicationSettings.LastConfigIssueCheckVersion != UpdaterManager.SelfVersion.Version)
+            {
+                var updateNotifications = DataConnection.GetNotifications().Where(x => x.Action.StartsWith("config:issue:")).ToList();
+                foreach (var n in updateNotifications)
+                    DataConnection.DismissNotification(n.ID);
+
+                if (!DataConnection.IsEncryptingFields && !Library.Utility.Utility.ParseBoolOption(commandlineOptions, DISABLE_DB_ENCRYPTION_OPTION))
+                {
+                    DataConnection.RegisterNotification(
+                        Serialization.NotificationType.Warning,
+                        "Unencrypted database",
+                        "The database is not encrypted. This is a security risk and should be fixed as soon as possible.",
+                        null,
+                        null,
+                        "config:issue:unencrypted-database",
+                        null,
+                        "UnencryptedDatabase",
+                        null,
+                        (self, all) =>
+                        {
+                            return all.FirstOrDefault(x => x.Action == "config:issue:unencrypted-database") ?? self;
+                        }
+                    );
+                }
+
+                DataConnection.ApplicationSettings.LastConfigIssueCheckVersion = UpdaterManager.SelfVersion.Version;
+            }
         }
 
         private static void CreateApplicationInstance(bool writeToConsoleOnExceptionw)


### PR DESCRIPTION
This adds a warning to the UI that would otherwise only be shown in various logs.
To avoid excessive warning, it shows up once per start per version (i.e., shows when an update has been installed).