### PR TITLE
Added support for Topic ID on Telegram

### DIFF
--- a/Duplicati/Library/Modules/Builtin/Strings.cs
+++ b/Duplicati/Library/Modules/Builtin/Strings.cs
@@ -167,11 +167,12 @@ You can supply multiple options with a comma separator, e.g. ""{0},{1}"". The sp
 
     internal static class SendTelegramMessage
     {
-        public static string Description { get { return LC.L(@"This module provides support for sending status reports via Telegram messages"); } }
-        public static string DisplayName { get { return LC.L(@"Telegram report module"); } }
-        public static string SendtelegramchannelLong { get { return LC.L(@"Use this option to set the channel ID."); } }
-        public static string SendtelegramchannelShort { get { return LC.L(@"Telegram channel ID"); } }
-        public static string SendtelegrammessageLong { get { return LC.L(@"This value can be a filename. If the file exists, the file contents will be used as the message.
+        public static string Description => LC.L(@"This module provides support for sending status reports via Telegram messages");
+        public static string DisplayName => LC.L(@"Telegram report module");
+        public static string SendTelegramChannelLong => LC.L(@"Use this option to set the channel ID.");
+        public static string SendTelegramChannelShort => LC.L(@"Telegram channel ID");
+        public static string SendTelegramMessageLong =>
+            LC.L(@"This value can be a filename. If the file exists, the file contents will be used as the message.
 
 In the message, certain tokens are replaced:
 %OPERATIONNAME% - The name of the operation, normally ""Backup""
@@ -179,19 +180,20 @@ In the message, certain tokens are replaced:
 %LOCALPATH% - The path to the local files or folders involved in the operation (if any)
 %PARSEDRESULT% - The parsed result, if the operation is a backup. Possible values are: Error, Warning, Success
 
-All command line options are also reported within %value%, e.g. %volsize%. Any unknown/unset value is removed."); } }
-        public static string SendtelegrammessageShort { get { return LC.L(@"The message template"); } }
-        public static string SendtelegrambotidLong { get { return LC.L(@"Use this option to set a bot ID for the bot that will send the message."); } }
+All command line options are also reported within %value%, e.g. %volsize%. Any unknown/unset value is removed.");
 
-        public static string SendtelegrambotidShort { get { return LC.L(@"The Telegram bot ID"); } }
-        public static string SendtelegramapikeyLong { get { return LC.L(@"Use this option to set a API key for the bot that will send the message."); } }
-        public static string SendtelegramapikeyShort { get { return LC.L(@"The Telegram API key"); } }
-        public static string SendtelegramlevelLong(string success, string warning, string error, string fatal, string all) { return LC.L(@"You can specify one of ""{0}"", ""{1}"", ""{2}"", ""{3}"". 
+        public static string SendTelegramMessageShort => LC.L(@"The message template");
+        public static string SendTelegramBotIdLong => LC.L(@"Use this option to set a bot ID for the bot that will send the message.");
+        public static string SendTelegramBotIdShort => LC.L(@"The Telegram bot ID");
+        public static string SendTelegramApiKeyLong => LC.L(@"Use this option to set a API key for the bot that will send the message.");
+        public static string SendTelegramApiKeyShort => LC.L(@"The Telegram API key");
+        public static string SendTelegramTopicShort => LC.L(@"The Telegram topic ID");
+        public static string SendTelegramTopicLong => LC.L(@"Topic ID for the Topic in the telegram group. For more information on Telegram setup, refer to documentation.");
+        public static string SendTelegramlevelLong(string success, string warning, string error, string fatal, string all) { return LC.L(@"You can specify one of ""{0}"", ""{1}"", ""{2}"", ""{3}"". 
 You can supply multiple options with a comma separator, e.g. ""{0},{1}"". The special value ""{4}"" is a shorthand for ""{0},{1},{2},{3}"" and will cause all backup operations to send a message.", success, warning, error, fatal, all); }
-        public static string SendtelegramlevelShort { get { return LC.L(@"The messages to send"); } }
-        public static string SendtelegramanyoperationLong { get { return LC.L(@"By default, messages will only be sent after a backup operation. Use this option to send messages for all operations."); } }
-        public static string SendtelegramanyoperationShort { get { return LC.L(@"Send messages for all operations"); } }
-        public static string LoginTimeoutError { get { return LC.L(@"Timeout occurred while sending to Telegram server"); } }
+        public static string SendTelegramLevelShort => LC.L(@"The messages to send");
+        public static string SendTelegramManyOperationLong => LC.L(@"By default, messages will only be sent after a backup operation. Use this option to send messages for all operations.");
+        public static string SendTelegramManyOperationShort => LC.L(@"Send messages for all operations");
     }
 
     internal static class SendHttpMessage


### PR DESCRIPTION
This adds support for TopicID as specified in parameter "send-telegram-topid-id" which allows the messages to be organized in topics on a group.

Finding out your topic ID in a group can be rather tricky the easiest way is to use curl to create it.

```bash
export CHAT_ID="-99999999"
export TOPIC_NAME="Your Topic"
export BOT_TOKEN="7777777777:AAAAAAAAA-4WwwwwwwwwwwwwwwwwwwwwwwQ"

curl -X POST \
    -H "Content-Type: application/json" \
    -d "{\"chat_id\":\"$CHAT_ID\",\"name\":\"$TOPIC_NAME\"}" \
    https://api.telegram.org/bot$BOT_TOKEN/createForumTopic
```
Which will response with a json where message_thread_id is the Topic ID
```bash
{"ok":true,"result":{"message_thread_id":33,"name":.....
```
