### PR TITLE
Add a check for stale database

### DIFF
--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -141,6 +141,13 @@ namespace Duplicati.Library.Main.Operation
                 var progress = 0;
                 var targetProgess = tp.ExtraVolumes.Count() + tp.MissingVolumes.Count() + tp.VerificationRequiredVolumes.Count();
 
+                var mostRecentLocal = db.FilesetTimes.Select(x => x.Value).Append(DateTime.MinValue).Max();
+                var mostRecentRemote = tp.ParsedVolumes.Select(x => x.Time).Append(DateTime.MinValue).Max();
+                if (mostRecentLocal < DateTime.UnixEpoch)
+                    throw new UserInformationException("The local database has no fileset times. Consider deleting the local database and run the repair operation again.", "LocalDatabaseHasNoFilesetTimes");
+                if (mostRecentRemote > mostRecentLocal)
+                    throw new UserInformationException($"The remote files are newer ({mostRecentRemote}) than the local database ({mostRecentLocal}), this is likely because the database is outdated. Consider deleting the local database and run the repair operation again.", "RemoteFilesNewerThanLocalDatabase");
+
                 if (m_options.Dryrun)
                 {
                     if (!tp.ParsedVolumes.Any() && tp.OtherVolumes.Any())


### PR DESCRIPTION
This commit adds a check to verify that the remote database is up-to-date before proceeding to repair the remote storage.

Without this check it is possible to start repairs with an old database, and this will cause the remote data to be deleted.

This fixes #4579

Thanks to @Jojo-1000 for [suggesting the low-impact fix](https://forum.duplicati.com/t/prevent-data-loss-when-repairing-outdated-local-database/16389/1).