### PR TITLE
Fix not storing updated timestamps

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1211,6 +1211,23 @@ ORDER BY
             }
         }
 
+        public void PushTimestampChangesToPreviousVersion(long filesetId, System.Data.IDbTransaction transaction)
+        {
+            using (var cmd = m_connection.CreateCommand())
+            {
+                cmd.Transaction = transaction;
+                var query = @"
+UPDATE FilesetEntry AS oldVersion
+SET Lastmodified = tempVersion.Lastmodified
+FROM FilesetEntry AS tempVersion
+WHERE oldVersion.FileID = tempVersion.FileID
+AND tempVersion.FilesetID = ?
+AND oldVersion.FilesetID = (SELECT ID FROM Fileset WHERE ID != ? ORDER BY Timestamp DESC LIMIT 1)";
+
+                cmd.ExecuteNonQuery(query, filesetId, filesetId);
+            }
+        }
+
         /// <summary>
         /// Keeps a list of filenames in a temporary table with a single column Path
         ///</summary>

--- a/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
@@ -255,6 +255,11 @@ namespace Duplicati.Library.Main.Operation.Backup
             return RunOnMain(() => m_database.WriteFileset(fsw, filesetid, GetTransaction()));
         }
 
+        public Task PushTimestampChangesToPreviousVersionAsync(long filesetid)
+        {
+            return RunOnMain(() => m_database.PushTimestampChangesToPreviousVersion(filesetid, GetTransaction()));
+        }
+
         public Task UpdateFilesetAndMarkAsFullBackupAsync(long filesetid)
         {
             return RunOnMain(() => m_database.UpdateFullBackupStateInFileset(filesetid, true, GetTransaction()));

--- a/Duplicati/Library/Main/Operation/Backup/BackupStatsCollector.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackupStatsCollector.cs
@@ -41,15 +41,25 @@ namespace Duplicati.Library.Main.Operation.Backup
 
         public Task AddOpenedFile(long size)
         {
-            return RunOnMain(() => {
+            return RunOnMain(() =>
+            {
                 m_res.SizeOfOpenedFiles += size;
                 m_res.OpenedFiles++;
             });
         }
 
+        public Task AddTimestampChangedFile()
+        {
+            return RunOnMain(() =>
+            {
+                m_res.TimestampChangedFiles++;
+            });
+        }
+
         public Task AddAddedFile(long size)
         {
-            return RunOnMain(() => {
+            return RunOnMain(() =>
+            {
                 m_res.SizeOfAddedFiles += size;
                 m_res.AddedFiles++;
             });
@@ -57,7 +67,8 @@ namespace Duplicati.Library.Main.Operation.Backup
 
         public Task AddModifiedFile(long size)
         {
-            return RunOnMain(() => {
+            return RunOnMain(() =>
+            {
                 m_res.SizeOfModifiedFiles += size;
                 m_res.ModifiedFiles++;
             });
@@ -65,7 +76,8 @@ namespace Duplicati.Library.Main.Operation.Backup
 
         public Task AddExaminedFile(long size)
         {
-            return RunOnMain(() => {
+            return RunOnMain(() =>
+            {
                 m_res.SizeOfExaminedFiles += size;
                 m_res.ExaminedFiles++;
             });

--- a/Duplicati/Library/Main/Operation/Backup/FileBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FileBlockProcessor.cs
@@ -118,6 +118,12 @@ namespace Duplicati.Library.Main.Operation.Backup
                             Logging.Log.WriteVerboseMessage(FILELOGTAG, "FileMetadataChanged", "File has only metadata changes {0}", e.Path);
                             await database.AddFileAsync(e.PathPrefixID, e.Filename, e.LastWrite, filestreamdata.Blocksetid, metadataid);
                         }
+                        else if (e.TimestampChanged)
+                        {
+                            await stats.AddTimestampChangedFile();
+                            Logging.Log.WriteVerboseMessage(FILELOGTAG, "FileTimestampChanged", "File has only timestamp changes {0}", e.Path);
+                            await database.AddUnmodifiedAsync(e.OldId, e.LastWrite);
+                        }
                         else /*if (e.OldId >= 0)*/
                         {
                             // When we write the file to output, update the last modified time

--- a/Duplicati/Library/Main/Operation/Backup/FilePreFilterProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FilePreFilterProcess.cs
@@ -75,7 +75,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                     {
                         filestatsize = snapshot.GetFileSize(e.Path);
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
                         Logging.Log.WriteExplicitMessage(FILELOGTAG, "FailedToReadSize", ex, "Failed to read size of file: {0}", e.Path);
                     }
@@ -96,11 +96,11 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                     // If we disable the filetime check, we always assume that the file has changed
                     // Otherwise we check that the timestamps are different or if any of them are empty
-                    var timestampChanged = DISABLEFILETIMECHECK || e.LastWrite != e.OldModified || e.LastWrite.Ticks == 0 || e.OldModified.Ticks == 0;
+                    e.TimestampChanged = DISABLEFILETIMECHECK || e.LastWrite != e.OldModified || e.LastWrite.Ticks == 0 || e.OldModified.Ticks == 0;
 
                     // Avoid generating a new metadata blob if timestamp has not changed
                     // and we only check for timestamp changes
-                    if (CHECKFILETIMEONLY && !timestampChanged && !isNewFile)
+                    if (CHECKFILETIMEONLY && !e.TimestampChanged && !isNewFile)
                     {
                         Logging.Log.WriteVerboseMessage(FILELOGTAG, "SkipCheckNoTimestampChange", "Skipped checking file, because timestamp was not updated {0}", e.Path);
                         try
@@ -135,9 +135,9 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                     // Check if the file is new, or something indicates a change
                     var filesizeChanged = filestatsize < 0 || e.LastFileSize < 0 || filestatsize != e.LastFileSize;
-                    if (isNewFile || timestampChanged || filesizeChanged || e.MetadataChanged)
+                    if (isNewFile || e.TimestampChanged || filesizeChanged || e.MetadataChanged)
                     {
-                        Logging.Log.WriteVerboseMessage(FILELOGTAG, "CheckFileForChanges", "Checking file for changes {0}, new: {1}, timestamp changed: {2}, size changed: {3}, metadatachanged: {4}, {5} vs {6}", e.Path, isNewFile, timestampChanged, filesizeChanged, e.MetadataChanged, e.LastWrite, e.OldModified);
+                        Logging.Log.WriteVerboseMessage(FILELOGTAG, "CheckFileForChanges", "Checking file for changes {0}, new: {1}, timestamp changed: {2}, size changed: {3}, metadatachanged: {4}, {5} vs {6}", e.Path, isNewFile, e.TimestampChanged, filesizeChanged, e.MetadataChanged, e.LastWrite, e.OldModified);
                         await self.Output.WriteAsync(e);
                     }
                     else

--- a/Duplicati/Library/Main/Operation/Backup/MetadataPreProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/MetadataPreProcess.cs
@@ -63,6 +63,7 @@ namespace Duplicati.Library.Main.Operation.Backup
             // After processing metadata
             public IMetahash MetaHashAndSize;
             public bool MetadataChanged;
+            public bool TimestampChanged;
         }
 
         public static Task Run(Channels channels, Snapshots.ISnapshotService snapshot, Options options, BackupDatabase database, long lastfilesetid, ITaskReader taskReader)

--- a/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
@@ -72,6 +72,12 @@ internal static class UploadRealFilelist
         }
         else
         {
+            if (result.TimestampChangedFiles != 0)
+            {
+                Logging.Log.WriteInformationMessage(LOGTAG, "DetectedTimestampChanges", "Detected timestamp changes, but no data needs to be uploaded, pushing timestamp changes to the latest fileset");
+                await db.PushTimestampChangesToPreviousVersionAsync(filesetid).ConfigureAwait(false);
+            }
+
             Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingLeftoverTempFile", "removing temp files, as no data needs to be uploaded");
             await db.RemoveRemoteVolumeAsync(filesetvolume.RemoteFilename);
         }

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -449,6 +449,7 @@ namespace Duplicati.Library.Main
         public long AddedFolders { get; internal set; }
         public long TooLargeFiles { get; internal set; }
         public long FilesWithError { get; internal set; }
+        public long TimestampChangedFiles { get; internal set; }
         public long ModifiedFolders { get; internal set; }
         public long ModifiedSymlinks { get; internal set; }
         public long AddedSymlinks { get; internal set; }

--- a/Duplicati/UnitTest/Issue4312.cs
+++ b/Duplicati/UnitTest/Issue4312.cs
@@ -1,0 +1,133 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+public class Issue4312 : BasicSetupHelper
+{
+    [Test]
+    [Category("Targeted")]
+    public void ChangeTimestampShouldCreateExtraBackup()
+    {
+        var testopts = TestOptions;
+        // Make sure we detect changes from metadata
+        testopts["upload-unchanged-backups"] = "false";
+        testopts["blocksize"] = "50kb";
+
+        var data = new byte[1024 * 1024 * 10];
+        File.WriteAllBytes(Path.Combine(DATAFOLDER, "a"), data);
+        using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+        {
+            var r = c.Backup(new string[] { DATAFOLDER });
+            Assert.AreEqual(0, r.Errors.Count());
+            Assert.AreEqual(0, r.Warnings.Count());
+            Assert.AreEqual(1, r.AddedFiles);
+            var pr = (Library.Interface.IParsedBackendStatistics)r.BackendStatistics;
+            if (pr.KnownFileSize == 0 || pr.KnownFileCount != 3 || pr.BackupListCount != 1)
+                throw new Exception(string.Format("Failed to get stats from remote backend: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));
+
+            System.Threading.Thread.Sleep(3000);
+
+            r = c.Backup(new string[] { DATAFOLDER });
+            Assert.AreEqual(0, r.Errors.Count());
+            Assert.AreEqual(0, r.Warnings.Count());
+            Assert.AreEqual(0, r.AddedFiles);
+            Assert.AreEqual(0, r.ModifiedFiles);
+            pr = (Library.Interface.IParsedBackendStatistics)r.BackendStatistics;
+            if (pr.KnownFileSize == 0 || pr.KnownFileCount != 3 || pr.BackupListCount != 1)
+                throw new Exception(string.Format("Failed to get stats from remote backend: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));
+
+            System.Threading.Thread.Sleep(3000);
+
+            // Force a change in the file metadata            
+            File.SetLastWriteTimeUtc(Path.Combine(DATAFOLDER, "a"), DateTime.Now);
+
+            r = c.Backup(new string[] { DATAFOLDER });
+            Assert.AreEqual(0, r.Errors.Count());
+            Assert.AreEqual(0, r.Warnings.Count());
+            Assert.AreEqual(0, r.AddedFiles);
+            Assert.AreEqual(1, r.ModifiedFiles);
+            pr = (Library.Interface.IParsedBackendStatistics)r.BackendStatistics;
+            if (pr.KnownFileSize == 0 || pr.KnownFileCount != 6 || pr.BackupListCount != 2)
+                throw new Exception(string.Format("Failed to get stats from remote backend: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));
+        }
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public void BackupFromRecreatedDatabaseShouldUpdateMetadata()
+    {
+        var testopts = TestOptions;
+        // Make sure we detect changes from metadata
+        testopts["upload-unchanged-backups"] = "false";
+        testopts["blocksize"] = "50kb";
+
+        var data = new byte[1024 * 1024 * 10];
+        File.WriteAllBytes(Path.Combine(DATAFOLDER, "a"), data);
+        using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+        {
+            var r = c.Backup(new string[] { DATAFOLDER });
+            Assert.AreEqual(0, r.Errors.Count());
+            Assert.AreEqual(0, r.Warnings.Count());
+            Assert.AreEqual(1, r.AddedFiles);
+            var pr = (Library.Interface.IParsedBackendStatistics)r.BackendStatistics;
+            if (pr.KnownFileSize == 0 || pr.KnownFileCount != 3 || pr.BackupListCount != 1)
+                throw new Exception(string.Format("Failed to get stats from remote backend: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));
+
+            // Remove the database
+            File.Delete(testopts["dbpath"]);
+
+            // Recreate
+            var rr = c.Repair();
+            Assert.AreEqual(0, rr.Errors.Count());
+            Assert.AreEqual(0, rr.Warnings.Count());
+
+            // Because the timestamps are restored with lower precision
+            // this will trigger a rescan of the files
+            r = c.Backup(new string[] { DATAFOLDER });
+            Assert.AreEqual(0, r.Errors.Count());
+            Assert.AreEqual(0, r.Warnings.Count());
+            Assert.AreEqual(0, r.AddedFiles);
+            Assert.AreEqual(0, r.ModifiedFiles);
+            Assert.AreEqual(1, r.OpenedFiles);
+            pr = (Library.Interface.IParsedBackendStatistics)r.BackendStatistics;
+            if (pr.KnownFileSize == 0 || pr.KnownFileCount != 3 || pr.BackupListCount != 1)
+                throw new Exception(string.Format("Looks like the metadata scan failed: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));
+
+            // Make a backup again, and ensure that no files are opened
+            r = c.Backup(new string[] { DATAFOLDER });
+            Assert.AreEqual(0, r.Errors.Count());
+            Assert.AreEqual(0, r.Warnings.Count());
+            Assert.AreEqual(0, r.AddedFiles);
+            Assert.AreEqual(0, r.ModifiedFiles);
+            Assert.AreEqual(0, r.OpenedFiles);
+            pr = (Library.Interface.IParsedBackendStatistics)r.BackendStatistics;
+            if (pr.KnownFileSize == 0 || pr.KnownFileCount != 3 || pr.BackupListCount != 1)
+                throw new Exception(string.Format("Failed to get stats from remote backend: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));
+        }
+
+    }
+}

--- a/Duplicati/UnitTest/Issue4312.cs
+++ b/Duplicati/UnitTest/Issue4312.cs
@@ -22,6 +22,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 
 namespace Duplicati.UnitTest;
@@ -99,6 +100,9 @@ public class Issue4312 : BasicSetupHelper
 
             // Remove the database
             File.Delete(testopts["dbpath"]);
+
+            // Get a second between the two backups
+            Thread.Sleep(2000);
 
             // Recreate
             var rr = c.Repair();


### PR DESCRIPTION
Implemented fix that pushes updated timestamps to previous version, in the case that no files were changed, and no new backup is recorded in remote storage.

This fixes #4312 