### PR TITLE
Add permission protection to data folder and database

### DIFF
--- a/Duplicati/Agent/Settings.cs
+++ b/Duplicati/Agent/Settings.cs
@@ -149,10 +149,7 @@ public sealed record Settings(
     private static string GetSettingsPath()
     {
         // Ideally, this should use DataFolderManager.DATAFOLDER, but we cannot due to backwards compatibility
-        var folder = Library.AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(DefaultSettingsFilename);
-        if (!Directory.Exists(folder))
-            Directory.CreateDirectory(folder);
-
+        var folder = Library.AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(DefaultSettingsFilename, true);
         return Path.Combine(folder, DefaultSettingsFilename);
     }
 }

--- a/Duplicati/CommandLine/ServerUtil/Settings.cs
+++ b/Duplicati/CommandLine/ServerUtil/Settings.cs
@@ -70,14 +70,8 @@ public sealed record Settings(
     /// <param name="filename">The filename to use</param>
     /// <returns>The default storage folder</returns>
     private static string GetDefaultStorageFolder(string filename)
-    {
         // Ideally, this should use DataFolderManager.DATAFOLDER, but we cannot due to backwards compatibility
-        var folder = DataFolderLocator.GetDefaultStorageFolder(filename);
-        if (!Directory.Exists(folder))
-            Directory.CreateDirectory(folder);
-
-        return folder;
-    }
+        => DataFolderLocator.GetDefaultStorageFolder(filename, true);
 
     /// <summary>
     /// Loads the settings from the settings file

--- a/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
@@ -49,8 +49,12 @@ public static class DataFolderLocator
             ? DataFolderManager.DATAFOLDER
             : GetDefaultStorageFolderInternal(targetfilename, AutoUpdateSettings.AppName);
 
-        // If the folder does not exist, and we are allowed to create it, we do so
-        if (autoCreate && !SystemIO.IO_OS.DirectoryExists(folder))
+        if (SystemIO.IO_OS.DirectoryExists(folder))
+        {
+            if (!SystemIO.IO_OS.FileExists(System.IO.Path.Combine(folder, Util.InsecurePermissionsMarkerFile)))
+                SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(folder);
+        }
+        else if (autoCreate)
         {
             // Create the folder
             SystemIO.IO_OS.DirectoryCreate(folder);

--- a/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using Duplicati.Library.Common.IO;
 
 #nullable enable
 
@@ -32,7 +33,6 @@ namespace Duplicati.Library.AutoUpdater;
 /// </summary>
 public static class DataFolderLocator
 {
-
     /// <summary>
     /// Finds a default storage folder, using the operating system specific locations.
     /// The targetfilename is used to detect locations that are used in previous versions.
@@ -41,11 +41,26 @@ public static class DataFolderLocator
     /// If the data folder is overriden, the overriden folder is used, and no search is performed.
     /// </summary>
     /// <param name="targetfilename">The filename to look for</param>
+    /// <param name="autoCreate">Whether to create the folder if it does not exist</param>
     /// <returns>The default storage folder</returns>
-    public static string GetDefaultStorageFolder(string targetfilename)
-        => DataFolderManager.OVERRIDEN_DATAFOLDER
+    public static string GetDefaultStorageFolder(string targetfilename, bool autoCreate)
+    {
+        var folder = DataFolderManager.OVERRIDEN_DATAFOLDER
             ? DataFolderManager.DATAFOLDER
             : GetDefaultStorageFolderInternal(targetfilename, AutoUpdateSettings.AppName);
+
+        // If the folder does not exist, and we are allowed to create it, we do so
+        if (autoCreate && !SystemIO.IO_OS.DirectoryExists(folder))
+        {
+            // Create the folder
+            SystemIO.IO_OS.DirectoryCreate(folder);
+
+            // Make sure the folder is only accessible by the current user
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(folder);
+        }
+
+        return folder;
+    }
 
     /// <summary>
     /// Finds a default storage folder, using the operating system specific locations.

--- a/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
@@ -92,11 +92,7 @@ public static class DataFolderLocator
 
             // If %LOCALAPPDATA% is inside the Windows folder, prefer a LocalService folder instead
             if (Common.IO.Util.IsPathUnderWindowsFolder(newlocation))
-            {
-                var userProfilesFolder = Library.Utility.SHGetFolder.UserProfilesFolder;
-                if (!string.IsNullOrWhiteSpace(userProfilesFolder))
-                    folderOrder.Add(System.IO.Path.Combine(userProfilesFolder, "LocalService", appName));
-            }
+                folderOrder.Add(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), appName));
 
             // Prefer the most recent location
             var matches = folderOrder.AsEnumerable()

--- a/Duplicati/Library/AutoUpdater/DataFolderManager.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderManager.cs
@@ -181,7 +181,12 @@ public static class DataFolderManager
             DATAFOLDER = Util.AppendDirSeparator(DataFolderLocator.GetDefaultStorageFolderInternal(SERVER_DATABASE_FILENAME, APPNAME));
         }
 
-        if (!Directory.Exists(DATAFOLDER))
+        if (Directory.Exists(DATAFOLDER))
+        {
+            if (!File.Exists(Path.Combine(DATAFOLDER, Util.InsecurePermissionsMarkerFile)))
+                SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER);
+        }
+        else
         {
             Directory.CreateDirectory(DATAFOLDER);
             SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER);

--- a/Duplicati/Library/AutoUpdater/DataFolderManager.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderManager.cs
@@ -182,7 +182,10 @@ public static class DataFolderManager
         }
 
         if (!Directory.Exists(DATAFOLDER))
+        {
             Directory.CreateDirectory(DATAFOLDER);
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER);
+        }
 
         if (!File.Exists(Path.Combine(DATAFOLDER, INSTALL_FILE)))
         {

--- a/Duplicati/Library/Common/IO/ISystemIO.cs
+++ b/Duplicati/Library/Common/IO/ISystemIO.cs
@@ -82,6 +82,16 @@ namespace Duplicati.Library.Common.IO
 
         void SetMetadata(string path, Dictionary<string, string> metdata, bool restorePermissions);
         Dictionary<string, string> GetMetadata(string path, bool isSymlink, bool followSymlink);
+        /// <summary>
+        /// Sets the permission to read-write only for the current user.
+        /// </summary>
+        /// <param name="path">The file to set permissions on.</param>
+        void FileSetPermissionUserRWOnly(string path);
+        /// <summary>
+        /// Sets the permission to read-write only for the current user.
+        /// </summary>
+        /// <param name="path">The directory to set permissions on.</param>
+        void DirectorySetPermissionUserRWOnly(string path);
     }
 
 }

--- a/Duplicati/Library/Common/IO/SystemIO.cs
+++ b/Duplicati/Library/Common/IO/SystemIO.cs
@@ -20,42 +20,25 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Runtime.Versioning;
 namespace Duplicati.Library.Common.IO
 {
     public static class SystemIO
     {
-
-        /// <summary>
-        /// A cached lookup for windows methods for dealing with long filenames
-        /// </summary>
-        [SupportedOSPlatform("windows")]
-        public static readonly ISystemIO IO_WIN;
-
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
-        public static readonly ISystemIO IO_SYS;
-
         public static readonly ISystemIO IO_OS;
 
         static SystemIO()
         {
-            // TODO: These interfaces cannot be properly guarded by the supported platform attribute in this form.
-            // They are used in static methods of USNJournal on all platforms.
-            
-            // Since that is the case, the warnings will be suppressed with pragma.
-            
-#pragma warning disable CA1416
-            IO_WIN = new SystemIOWindows();
-            IO_SYS = new SystemIOLinux();
-#pragma warning restore CA1416
             if (OperatingSystem.IsWindows())
             {
-                IO_OS = IO_WIN;
+                IO_OS = new SystemIOWindows();
             }
             else if (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
             {
-                IO_OS = IO_SYS;
+                IO_OS = new SystemIOLinux();
+            }
+            else
+            {
+                throw new PlatformNotSupportedException("The current platform is not supported");
             }
         }
     }

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -28,9 +28,11 @@ using System.Linq;
 using Duplicati.Library.Interface;
 using Newtonsoft.Json;
 using System.Runtime.Versioning;
+using System.Security.Principal;
 
 namespace Duplicati.Library.Common.IO
 {
+    [SupportedOSPlatform("windows")]
     public struct SystemIOWindows : ISystemIO
     {
         // Based on the constant names used in
@@ -41,6 +43,8 @@ namespace Duplicati.Library.Common.IO
         private const string UncExtendedPathPrefix = @"\\?\UNC\";
 
         private static readonly string DIRSEP = Util.DirectorySeparatorString;
+
+        private static readonly string CURRENT_USERNAME = WindowsIdentity.GetCurrent().Name;
 
         /// <summary>
         /// Prefix path with one of the extended device path prefixes
@@ -670,6 +674,52 @@ namespace Duplicati.Library.Common.IO
 
             if ((attr & System.IO.FileAttributes.ReparsePoint) == 0)
                 throw new System.IO.IOException(string.Format("Unable to create symlink, check account permissions: {0}", symlinkfile));
+        }
+
+        /// <summary>
+        /// Sets the unix permission user read-write Only.
+        /// </summary>
+        /// <param name="path">The file to set permissions on.</param>
+        public void FileSetPermissionUserRWOnly(string path)
+        {
+            // Create directory security settings
+            var security = new FileSecurity();
+
+            // Remove inherited permissions to ensure only the current user has access
+            security.SetAccessRuleProtection(true, false);
+
+            // Grant the current user read access
+            security.AddAccessRule(new FileSystemAccessRule(
+                CURRENT_USERNAME,
+                FileSystemRights.FullControl,
+                AccessControlType.Allow
+            ));
+
+            // Adjust with the new security settings
+            new FileInfo(path).SetAccessControl(security);
+        }
+
+        /// <summary>
+        /// Sets the permission to read-write only for the current user.
+        /// </summary>
+        /// <param name="path">The directory to set permissions on.</param>
+        public void DirectorySetPermissionUserRWOnly(string path)
+        {
+            // Create directory security settings
+            var security = new DirectorySecurity();
+
+            // Remove inherited permissions to ensure only the current user has access
+            security.SetAccessRuleProtection(true, false);
+
+            // Grant the current user read access
+            security.AddAccessRule(new FileSystemAccessRule(
+                CURRENT_USERNAME,
+                FileSystemRights.FullControl,
+                AccessControlType.Allow
+            ));
+
+            // Adjust with the new security settings
+            new DirectoryInfo(path).SetAccessControl(security);
         }
         #endregion
     }

--- a/Duplicati/Library/Common/IO/Util.cs
+++ b/Duplicati/Library/Common/IO/Util.cs
@@ -31,7 +31,15 @@ namespace Duplicati.Library.Common.IO
         /// </summary>
         public static readonly string DirectorySeparatorString = Path.DirectorySeparatorChar.ToString();
 
+        /// <summary>
+        /// A cached instance of the alternate directory separator as a string
+        /// </summary>
         public static readonly string AltDirectorySeparatorString = Path.AltDirectorySeparatorChar.ToString();
+
+        /// <summary>
+        /// Filename of a marker file that can be put inside the data folder to prevent Duplicati from fixing lax permissions
+        /// </summary>
+        public const string InsecurePermissionsMarkerFile = "insecure-permissions.txt";
 
         /// <summary>
         /// Appends the appropriate directory separator to paths, depending on OS.

--- a/Duplicati/Library/Common/IO/VssBackupComponents.cs
+++ b/Duplicati/Library/Common/IO/VssBackupComponents.cs
@@ -160,7 +160,7 @@ namespace Duplicati.Library.Common.IO
                 }
                 else
                 {
-                    var fileWithSpec = SystemIO.IO_WIN.PathCombine(file.Path, file.FileSpecification);
+                    var fileWithSpec = SystemIO.IO_OS.PathCombine(file.Path, file.FileSpecification);
                     if (File.Exists(fileWithSpec))
                         paths.Add(fileWithSpec);
                 }
@@ -222,7 +222,7 @@ namespace Duplicati.Library.Common.IO
             _volumes = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
             foreach (var s in sources)
             {
-                var drive = SystemIO.IO_WIN.GetPathRoot(s);
+                var drive = SystemIO.IO_OS.GetPathRoot(s);
                 if (!_volumes.ContainsKey(drive))
                 {
                     if (!_vssBackupComponents.IsVolumeSupported(drive))

--- a/Duplicati/Library/Main/CLIDatabaseLocator.cs
+++ b/Duplicati/Library/Main/CLIDatabaseLocator.cs
@@ -97,7 +97,7 @@ namespace Duplicati.Library.Main
                 return options.Dbpath;
 
             // Ideally, this should use DataFolderManager.DATAFOLDER, but we cannot due to backwards compatibility
-            var folder = AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(CONFIG_FILE);
+            var folder = AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(CONFIG_FILE, true);
             // Emit a warning if the database is stored in the Windows folder
             if (Util.IsPathUnderWindowsFolder(folder))
                 Logging.Log.WriteWarningMessage(LOGTAG, "DatabaseInWindowsFolder", null, "The database config is stored in the Windows folder, this is not recommended as it will be deleted on Windows upgrades.");
@@ -209,9 +209,6 @@ namespace Duplicati.Library.Main
                     ParameterFile = null
                 });
 
-                if (!System.IO.Directory.Exists(folder))
-                    System.IO.Directory.CreateDirectory(folder);
-
                 var settings = new Newtonsoft.Json.JsonSerializerSettings();
                 settings.Formatting = Newtonsoft.Json.Formatting.Indented;
                 System.IO.File.WriteAllText(file, Newtonsoft.Json.JsonConvert.SerializeObject(configs, settings), System.Text.Encoding.UTF8);
@@ -249,7 +246,7 @@ namespace Duplicati.Library.Main
         public static bool IsDatabasePathInUse(string path)
         {
             // Ideally, this should use DataFolderManager.DATAFOLDER, but we cannot due to backwards compatibility
-            var file = System.IO.Path.Combine(AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(CONFIG_FILE), CONFIG_FILE);
+            var file = System.IO.Path.Combine(AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(CONFIG_FILE, false), CONFIG_FILE);
             if (!System.IO.File.Exists(file))
                 return false;
 

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -225,9 +225,16 @@ namespace Duplicati.Library.SQLiteHelper
                 sqlitecon.SetConfigurationOption(System.Data.SQLite.SQLiteConfigDbOpsEnum.SQLITE_DBCONFIG_DQS_DML, false);
             }
 
-            // Make the file only accessible by the current user if we just created it
-            if (!fileExists)
+            // Make the file only accessible by the current user
+            if (fileExists)
+            {
+                if (!SystemIO.IO_OS.FileExists(SystemIO.IO_OS.PathCombine(SystemIO.IO_OS.PathGetDirectoryName(path), Util.InsecurePermissionsMarkerFile)))
+                    SystemIO.IO_OS.FileSetPermissionUserRWOnly(path);
+            }
+            else
+            {
                 SystemIO.IO_OS.FileSetPermissionUserRWOnly(path);
+            }
         }
 
         /// <summary>

--- a/Duplicati/Library/Snapshots/HyperVUtility.cs
+++ b/Duplicati/Library/Snapshots/HyperVUtility.cs
@@ -24,7 +24,6 @@ using System.IO;
 using System.Linq;
 using System.Management;
 using System.Runtime.Versioning;
-using Duplicati.Library.Common;
 using Duplicati.Library.Common.IO;
 
 namespace Duplicati.Library.Snapshots
@@ -89,6 +88,11 @@ namespace Duplicati.Library.Snapshots
         /// The tag used for logging
         /// </summary>
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<HyperVUtility>();
+
+        /// <summary>
+        /// The System.IO abstraction for the Windows platform
+        /// </summary>
+        private static readonly ISystemIO IO_WIN = SystemIO.IO_OS;
 
         private readonly ManagementScope _wmiScope;
         private readonly string _vmIdField;
@@ -251,7 +255,7 @@ namespace Duplicati.Library.Snapshots
             using (var mObject1 = new ManagementObjectSearcher(_wmiScope, new ObjectQuery(wmiQuery)).Get().Cast<ManagementObject>().First())
                 if (_wmiv2Namespace)
                 {
-                    path = SystemIO.IO_WIN.PathCombine((string)mObject1["ConfigurationDataRoot"], (string)mObject1["ConfigurationFile"]);
+                    path = IO_WIN.PathCombine((string)mObject1["ConfigurationDataRoot"], (string)mObject1["ConfigurationFile"]);
                     if (File.Exists(path))
                         result.Add(path);
 
@@ -261,10 +265,10 @@ namespace Duplicati.Library.Snapshots
                     {
                         foreach (var snap in snaps)
                         {
-                            path = SystemIO.IO_WIN.PathCombine((string)snap["ConfigurationDataRoot"], (string)snap["ConfigurationFile"]);
+                            path = IO_WIN.PathCombine((string)snap["ConfigurationDataRoot"], (string)snap["ConfigurationFile"]);
                             if (File.Exists(path))
                                 result.Add(path);
-                            path = Util.AppendDirSeparator(SystemIO.IO_WIN.PathCombine((string)snap["ConfigurationDataRoot"], (string)snap["SuspendDataRoot"]));
+                            path = Util.AppendDirSeparator(IO_WIN.PathCombine((string)snap["ConfigurationDataRoot"], (string)snap["SuspendDataRoot"]));
                             if (Directory.Exists(path))
                                 result.Add(path);
                         }
@@ -272,10 +276,10 @@ namespace Duplicati.Library.Snapshots
                 }
                 else
                 {
-                    path = SystemIO.IO_WIN.PathCombine((string)mObject1["ExternalDataRoot"], "Virtual Machines", vmID + ".xml");
+                    path = IO_WIN.PathCombine((string)mObject1["ExternalDataRoot"], "Virtual Machines", vmID + ".xml");
                     if (File.Exists(path))
                         result.Add(path);
-                    path = Util.AppendDirSeparator(SystemIO.IO_WIN.PathCombine((string)mObject1["ExternalDataRoot"], "Virtual Machines", vmID));
+                    path = Util.AppendDirSeparator(IO_WIN.PathCombine((string)mObject1["ExternalDataRoot"], "Virtual Machines", vmID));
                     if (Directory.Exists(path))
                         result.Add(path);
 
@@ -285,10 +289,10 @@ namespace Duplicati.Library.Snapshots
 
                     foreach (var snapID in snapsIDs)
                     {
-                        path = SystemIO.IO_WIN.PathCombine((string)mObject1["SnapshotDataRoot"], "Snapshots", snapID.Replace("Microsoft:", "") + ".xml");
+                        path = IO_WIN.PathCombine((string)mObject1["SnapshotDataRoot"], "Snapshots", snapID.Replace("Microsoft:", "") + ".xml");
                         if (File.Exists(path))
                             result.Add(path);
-                        path = Util.AppendDirSeparator(SystemIO.IO_WIN.PathCombine((string)mObject1["SnapshotDataRoot"], "Snapshots", snapID.Replace("Microsoft:", "")));
+                        path = Util.AppendDirSeparator(IO_WIN.PathCombine((string)mObject1["SnapshotDataRoot"], "Snapshots", snapID.Replace("Microsoft:", "")));
                         if (Directory.Exists(path))
                             result.Add(path);
                     }

--- a/Duplicati/Library/Snapshots/LinuxSnapshot.cs
+++ b/Duplicati/Library/Snapshots/LinuxSnapshot.cs
@@ -40,7 +40,7 @@ namespace Duplicati.Library.Snapshots
     [SupportedOSPlatform("macOS")]
     public sealed class LinuxSnapshot : SnapshotBase
     {
-		/// <summary>
+        /// <summary>
         /// The tag used for logging messages
         /// </summary>
         public static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(WindowsSnapshot));
@@ -94,9 +94,9 @@ namespace Duplicati.Library.Snapshots
                 {
                     Dispose();
                 }
-				catch (Exception ex)
+                catch (Exception ex)
                 {
-					Logging.Log.WriteVerboseMessage(LOGTAG, "SnapshotCleanupError", ex, "Failed to clean up after error");
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "SnapshotCleanupError", ex, "Failed to clean up after error");
                 }
 
                 throw;
@@ -111,10 +111,10 @@ namespace Duplicati.Library.Snapshots
                 if (disposing)
                 {
                     // Attempt to clean out as many as possible
-                    foreach(var s in m_snapShots)
+                    foreach (var s in m_snapShots)
                     {
                         try { s.Dispose(); }
-						catch (Exception ex) { Logging.Log.WriteVerboseMessage(LOGTAG, "SnapshotCloseError", ex, "Failed to close a snapshot"); }
+                        catch (Exception ex) { Logging.Log.WriteVerboseMessage(LOGTAG, "SnapshotCloseError", ex, "Failed to close a snapshot"); }
                     }
                 }
 
@@ -466,7 +466,7 @@ namespace Duplicati.Library.Snapshots
         /// <returns>The symlink target</returns>
         public override string GetSymlinkTarget(string localPath)
         {
-            return SystemIO.IO_SYS.GetSymlinkTarget(ConvertToSnapshotPath(localPath));
+            return SystemIO.IO_OS.GetSymlinkTarget(ConvertToSnapshotPath(localPath));
         }
 
         /// <summary>
@@ -478,7 +478,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="followSymlink">A flag indicating if a symlink should be followed</param>
         public override Dictionary<string, string> GetMetadata(string localPath, bool isSymlink, bool followSymlink)
         {
-            return SystemIO.IO_SYS.GetMetadata(ConvertToSnapshotPath(localPath), isSymlink, followSymlink);
+            return SystemIO.IO_OS.GetMetadata(ConvertToSnapshotPath(localPath), isSymlink, followSymlink);
         }
 
         /// <summary>
@@ -500,8 +500,8 @@ namespace Duplicati.Library.Snapshots
                     default:
                         return true;
                 }
-            } 
-            catch 
+            }
+            catch
             {
                 if (!System.IO.File.Exists(SystemIOLinux.NormalizePath(localPath)))
                     return false;
@@ -509,7 +509,7 @@ namespace Duplicati.Library.Snapshots
                 throw;
             }
         }
-        
+
         /// <summary>
         /// Gets a unique hardlink target ID
         /// </summary>
@@ -518,10 +518,10 @@ namespace Duplicati.Library.Snapshots
         public override string HardlinkTargetID(string localPath)
         {
             var snapshotPath = ConvertToSnapshotPath(localPath);
-            
+
             if (PosixFile.GetHardlinkCount(snapshotPath) <= 1)
                 return null;
-            
+
             return PosixFile.GetInodeTargetID(snapshotPath);
         }
 

--- a/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotLinux.cs
@@ -82,7 +82,7 @@ namespace Duplicati.Library.Snapshots
         /// <returns>The symlink target</returns>
         public override string GetSymlinkTarget(string localPath)
         {
-            return SystemIO.IO_SYS.GetSymlinkTarget(localPath);
+            return SystemIO.IO_OS.GetSymlinkTarget(localPath);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="followSymlink">A flag indicating if a symlink should be followed</param>
         public override Dictionary<string, string> GetMetadata(string localPath, bool isSymlink, bool followSymlink)
         {
-            return SystemIO.IO_SYS.GetMetadata(localPath, isSymlink, followSymlink);
+            return SystemIO.IO_OS.GetMetadata(localPath, isSymlink, followSymlink);
         }
 
         /// <summary>

--- a/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
+++ b/Duplicati/Library/Snapshots/NoSnapshotWindows.cs
@@ -34,13 +34,18 @@ namespace Duplicati.Library.Snapshots
     public sealed class NoSnapshotWindows : SnapshotBase
     {
         /// <summary>
+        /// The system IO implementation for Windows
+        /// </summary>
+        private static readonly ISystemIO IO_WIN = SystemIO.IO_OS;
+
+        /// <summary>
         /// Returns the symlink target if the entry is a symlink, and null otherwise
         /// </summary>
         /// <param name="localPath">The file or folder to examine</param>
         /// <returns>The symlink target</returns>
         public override string GetSymlinkTarget(string localPath)
         {
-            return SystemIO.IO_WIN.GetSymlinkTarget(localPath);
+            return IO_WIN.GetSymlinkTarget(localPath);
         }
 
         /// <summary>
@@ -48,9 +53,9 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <returns>The file attributes</returns>
         /// <param name="localPath">The file or folder to examine</param>
-        public override System.IO.FileAttributes GetAttributes (string localPath)
+        public override System.IO.FileAttributes GetAttributes(string localPath)
         {
-            return SystemIO.IO_WIN.GetFileAttributes(localPath);
+            return IO_WIN.GetFileAttributes(localPath);
         }
 
         /// <summary>
@@ -58,9 +63,9 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
         /// <returns>The length of the file</returns>
-        public override long GetFileSize (string localPath)
+        public override long GetFileSize(string localPath)
         {
-            return SystemIO.IO_WIN.FileLength(localPath);
+            return IO_WIN.FileLength(localPath);
         }
 
         /// <summary>
@@ -80,9 +85,9 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
         /// <returns>The last write time of the file</returns>
-        public override DateTime GetLastWriteTimeUtc (string localPath)
+        public override DateTime GetLastWriteTimeUtc(string localPath)
         {
-            return SystemIO.IO_WIN.FileGetLastWriteTimeUtc(localPath);
+            return IO_WIN.FileGetLastWriteTimeUtc(localPath);
         }
 
         /// <summary>
@@ -90,9 +95,9 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
         /// <returns>The last write time of the file</returns>
-        public override DateTime GetCreationTimeUtc (string localPath)
+        public override DateTime GetCreationTimeUtc(string localPath)
         {
-            return SystemIO.IO_WIN.FileGetCreationTimeUtc(localPath);
+            return IO_WIN.FileGetCreationTimeUtc(localPath);
         }
 
         /// <summary>
@@ -100,9 +105,9 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <param name="localPath">The full path to the file in non-snapshot format</param>
         /// <returns>An open filestream that can be read</returns>
-        public override System.IO.Stream OpenRead (string localPath)
+        public override System.IO.Stream OpenRead(string localPath)
         {
-            return SystemIO.IO_WIN.FileOpenRead(localPath);
+            return IO_WIN.FileOpenRead(localPath);
         }
 
         /// <summary>
@@ -110,25 +115,25 @@ namespace Duplicati.Library.Snapshots
         /// </summary>
         /// <returns>All folders found in the folder</returns>
         /// <param name='localFolderPath'>The folder to examinate</param>
-        protected override string[] ListFiles (string localFolderPath)
+        protected override string[] ListFiles(string localFolderPath)
         {
-            string[] tmp = SystemIO.IO_WIN.GetFiles(localFolderPath);
+            string[] tmp = IO_WIN.GetFiles(localFolderPath);
             string[] res = new string[tmp.Length];
-            for(int i = 0; i < tmp.Length; i++)
+            for (int i = 0; i < tmp.Length; i++)
                 res[i] = SystemIOWindows.RemoveExtendedDevicePathPrefix(tmp[i]);
 
             return res;
         }
 
-        
+
         /// <summary>
         /// Lists all folders in the given folder
         /// </summary>
         /// <returns>All folders found in the folder</returns>
         /// <param name='localFolderPath'>The folder to examinate</param>
-        protected override string[] ListFolders (string localFolderPath)
+        protected override string[] ListFolders(string localFolderPath)
         {
-            string[] tmp = SystemIO.IO_WIN.GetDirectories(SystemIOWindows.AddExtendedDevicePathPrefix(localFolderPath));
+            string[] tmp = IO_WIN.GetDirectories(SystemIOWindows.AddExtendedDevicePathPrefix(localFolderPath));
             string[] res = new string[tmp.Length];
             for (int i = 0; i < tmp.Length; i++)
                 res[i] = SystemIOWindows.RemoveExtendedDevicePathPrefix(tmp[i]);
@@ -145,7 +150,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="followSymlink">A flag indicating if a symlink should be followed</param>
         public override Dictionary<string, string> GetMetadata(string localPath, bool isSymlink, bool followSymlink)
         {
-            return SystemIO.IO_WIN.GetMetadata(localPath, isSymlink, followSymlink);
+            return IO_WIN.GetMetadata(localPath, isSymlink, followSymlink);
         }
 
         /// <inheritdoc />

--- a/Duplicati/Library/Snapshots/USNJournal.cs
+++ b/Duplicati/Library/Snapshots/USNJournal.cs
@@ -178,7 +178,7 @@ namespace Duplicati.Library.Snapshots
             if (path == null)
                 throw new Exception(Strings.USNHelper.UnexpectedPathFormat);
 
-            return SystemIO.IO_WIN.GetPathRoot(path);
+            return SystemIO.IO_OS.GetPathRoot(path);
         }
 
         public static string GetDeviceNameFromPath(string path)
@@ -509,7 +509,7 @@ namespace Duplicati.Library.Snapshots
                     var path = m_volume;
                     foreach (var r in pathList)
                     {
-                        path = SystemIO.IO_WIN.PathCombine(path, r.FileName);
+                        path = SystemIO.IO_OS.PathCombine(path, r.FileName);
                     }
 
                     if (rec.UsnRecord.FileAttributes.HasFlag(Win32USN.FileAttributes.Directory))

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -45,6 +45,11 @@ namespace Duplicati.Library.Snapshots
         public static readonly string LOGTAG = Logging.Log.LogTagFromType<WindowsSnapshot>();
 
         /// <summary>
+        /// The system IO for the current platform
+        /// </summary>
+        private static readonly ISystemIO IO_WIN = SystemIO.IO_OS;
+
+        /// <summary>
         /// The main reference to the backup controller
         /// </summary>
         private readonly VssBackupComponents _vssBackupComponents;
@@ -115,8 +120,8 @@ namespace Duplicati.Library.Snapshots
         {
             string[] tmp = null;
             var spath = ConvertToSnapshotPath(localFolderPath);
-            tmp = SystemIO.IO_WIN.GetDirectories(spath);
-            var root = Util.AppendDirSeparator(SystemIO.IO_WIN.GetPathRoot(localFolderPath));
+            tmp = IO_WIN.GetDirectories(spath);
+            var root = Util.AppendDirSeparator(IO_WIN.GetPathRoot(localFolderPath));
             var volumePath = Util.AppendDirSeparator(ConvertToSnapshotPath(root));
             volumePath = SystemIOWindows.AddExtendedDevicePathPrefix(volumePath);
 
@@ -140,10 +145,10 @@ namespace Duplicati.Library.Snapshots
 
             string[] files = null;
             var spath = ConvertToSnapshotPath(localFolderPath);
-            files = SystemIO.IO_WIN.GetFiles(spath);
+            files = IO_WIN.GetFiles(spath);
 
             // convert back to non-shadow, i.e., non-vss version
-            var root = Util.AppendDirSeparator(SystemIO.IO_WIN.GetPathRoot(localFolderPath));
+            var root = Util.AppendDirSeparator(IO_WIN.GetPathRoot(localFolderPath));
             var volumePath = Util.AppendDirSeparator(ConvertToSnapshotPath(root));
             volumePath = SystemIOWindows.AddExtendedDevicePathPrefix(volumePath);
 
@@ -179,7 +184,7 @@ namespace Duplicati.Library.Snapshots
         {
             var spath = ConvertToSnapshotPath(localPath);
 
-            return SystemIO.IO_WIN.GetLastWriteTimeUtc(SystemIOWindows.AddExtendedDevicePathPrefix(spath));
+            return IO_WIN.GetLastWriteTimeUtc(SystemIOWindows.AddExtendedDevicePathPrefix(spath));
         }
 
         /// <summary>
@@ -191,7 +196,7 @@ namespace Duplicati.Library.Snapshots
         {
             var spath = ConvertToSnapshotPath(localPath);
 
-            return SystemIO.IO_WIN.GetCreationTimeUtc(SystemIOWindows.AddExtendedDevicePathPrefix(spath));
+            return IO_WIN.GetCreationTimeUtc(SystemIOWindows.AddExtendedDevicePathPrefix(spath));
         }
 
         /// <summary>
@@ -201,7 +206,7 @@ namespace Duplicati.Library.Snapshots
         /// <returns>An open filestream that can be read</returns>
         public override Stream OpenRead(string localPath)
         {
-            return SystemIO.IO_WIN.FileOpenRead(ConvertToSnapshotPath(localPath));
+            return IO_WIN.FileOpenRead(ConvertToSnapshotPath(localPath));
         }
 
         /// <summary>
@@ -211,7 +216,7 @@ namespace Duplicati.Library.Snapshots
         /// <returns>The length of the file</returns>
         public override long GetFileSize(string localPath)
         {
-            return SystemIO.IO_WIN.FileLength(ConvertToSnapshotPath(localPath));
+            return IO_WIN.FileLength(ConvertToSnapshotPath(localPath));
         }
 
         /// <summary>
@@ -221,7 +226,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="localPath">The file or folder to examine</param>
         public override FileAttributes GetAttributes(string localPath)
         {
-            return SystemIO.IO_WIN.GetFileAttributes(ConvertToSnapshotPath(localPath));
+            return IO_WIN.GetFileAttributes(ConvertToSnapshotPath(localPath));
         }
 
         /// <summary>
@@ -232,7 +237,7 @@ namespace Duplicati.Library.Snapshots
         public override string GetSymlinkTarget(string localPath)
         {
             var spath = ConvertToSnapshotPath(localPath);
-            return SystemIO.IO_WIN.GetSymlinkTarget(spath);
+            return IO_WIN.GetSymlinkTarget(spath);
         }
 
         /// <summary>
@@ -244,7 +249,7 @@ namespace Duplicati.Library.Snapshots
         /// <param name="followSymlink">A flag indicating if a symlink should be followed</param>
         public override Dictionary<string, string> GetMetadata(string localPath, bool isSymlink, bool followSymlink)
         {
-            return SystemIO.IO_WIN.GetMetadata(ConvertToSnapshotPath(localPath), isSymlink, followSymlink);
+            return IO_WIN.GetMetadata(ConvertToSnapshotPath(localPath), isSymlink, followSymlink);
         }
 
         /// <inheritdoc />
@@ -268,7 +273,7 @@ namespace Duplicati.Library.Snapshots
             foreach (var kvp in _vssBackupComponents.SnapshotDeviceAndVolumes)
             {
                 if (snapshotPath.StartsWith(kvp.Key, Utility.Utility.ClientFilenameStringComparison))
-                    return SystemIO.IO_WIN.PathCombine(kvp.Value, snapshotPath.Substring(kvp.Key.Length));
+                    return IO_WIN.PathCombine(kvp.Value, snapshotPath.Substring(kvp.Key.Length));
             }
 
             throw new InvalidOperationException();
@@ -283,7 +288,7 @@ namespace Duplicati.Library.Snapshots
             if (!Path.IsPathRooted(localPath))
                 throw new InvalidOperationException();
 
-            var root = SystemIO.IO_WIN.GetPathRoot(localPath);
+            var root = IO_WIN.GetPathRoot(localPath);
             var volumePath = _vssBackupComponents.GetVolumeFromCache(root);
 
             // Note that using a simple Path.Combine() for the following code
@@ -303,13 +308,13 @@ namespace Duplicati.Library.Snapshots
         /// <inheritdoc />
         public override bool FileExists(string localFilePath)
         {
-            return SystemIO.IO_WIN.FileExists(ConvertToSnapshotPath(localFilePath));
+            return IO_WIN.FileExists(ConvertToSnapshotPath(localFilePath));
         }
 
         /// <inheritdoc />
         public override bool DirectoryExists(string localFolderPath)
         {
-            return SystemIO.IO_WIN.DirectoryExists(ConvertToSnapshotPath(localFolderPath));
+            return IO_WIN.DirectoryExists(ConvertToSnapshotPath(localFolderPath));
         }
 
         /// <inheritdoc />

--- a/Duplicati/UnitTest/IOTests.cs
+++ b/Duplicati/UnitTest/IOTests.cs
@@ -23,8 +23,6 @@ using System.Text;
 using NUnit.Framework;
 
 using Duplicati.Library.Common.IO;
-using Duplicati.Library.Utility;
-using Duplicati.Library.Common;
 using System.Collections.Generic;
 using System;
 
@@ -62,13 +60,13 @@ namespace Duplicati.UnitTest
             var filePath = root + filename;
             var filePathWithExtendedDevicePathPrefix = SystemIOWindows.AddExtendedDevicePathPrefix(filePath);
 
-            var filePathWithExtendedDevicePathPrefixRoot = SystemIO.IO_WIN.GetPathRoot(filePathWithExtendedDevicePathPrefix);
+            var filePathWithExtendedDevicePathPrefixRoot = SystemIO.IO_OS.GetPathRoot(filePathWithExtendedDevicePathPrefix);
 
             //Prefixed with extended device path prefix remains prefixed
             Assert.AreEqual(SystemIOWindows.AddExtendedDevicePathPrefix(root), filePathWithExtendedDevicePathPrefixRoot);
 
             //Without extended device path prefix, no prefix. 
-            var filePathRoot = SystemIO.IO_WIN.GetPathRoot(filePath);
+            var filePathRoot = SystemIO.IO_OS.GetPathRoot(filePath);
             Assert.AreEqual(root, filePathRoot);
         }
 
@@ -282,7 +280,7 @@ namespace Duplicati.UnitTest
                 };
             foreach (var path in testCasesWherePathGetFullGivesSameResultsAsDotNet)
             {
-                var actual = SystemIO.IO_WIN.PathGetFullPath(path); 
+                var actual = SystemIO.IO_OS.PathGetFullPath(path);
                 var expected = System.IO.Path.GetFullPath(path);
                 Assert.AreEqual(expected, actual, $"Path: {path}");
             }
@@ -313,7 +311,7 @@ namespace Duplicati.UnitTest
             foreach (var keyValuePair in testCasesWherePathGetFullGivesDifferentResultsThanDotNet)
             {
                 var path = keyValuePair.Key;
-                var actual = SystemIO.IO_WIN.PathGetFullPath(path);
+                var actual = SystemIO.IO_OS.PathGetFullPath(path);
                 var expected = keyValuePair.Value;
                 Assert.AreEqual(expected, actual, $"Path: {path}");
             }


### PR DESCRIPTION
This PR updates the logic around the data folder and the databases so these are only accessible by the current user.

On Linux/MacOS this means applying `chmod 600` to the database and `chmod 700` to the folder.
For Windows, this means setting a protected ACL on the file and folder for the current user.

To ensure most users have these more secure settings, Duplicati will now set the permissions on startup.
It is possible to opt-out of having the permissions reset by placing a file named `insecure-permissions.txt` inside the datafolder.

This also changes the folder used for a Windows service from `C:\Users\LocalService\Duplicati` to `C:\ProgramData\Duplicati` as [discussed on the forum](https://forum.duplicati.com/t/release-2-1-0-108-canary-2025-01-31).