### PR TITLE
Handle automatic fallback when reading zip files

### DIFF
--- a/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
+++ b/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
@@ -104,6 +104,16 @@ namespace Duplicati.Library.Compression.ZipCompression
         private readonly IZipArchive m_archive;
 
         /// <summary>
+        /// The fallback archive to use, if any
+        /// </summary>
+        private IZipArchive? m_fallbackArchive = null;
+
+        /// <summary>
+        /// The parameters used to create the archive
+        /// </summary>
+        private readonly (Stream Stream, ParsedZipOptions Options, CompressionLibrary Library) m_creationParams;
+
+        /// <summary>
         /// Default constructor, used to read file extension and supported commands
         /// </summary>
         public FileArchiveZip() { m_archive = null!; }
@@ -142,6 +152,7 @@ namespace Duplicati.Library.Compression.ZipCompression
             var unittestMode = Utility.Utility.ParseBoolOption(options.AsReadOnly(), "unittest-mode");
             var parsedOptions = new ParsedZipOptions(compressionLevel, compressionType, usingZip64, unittestMode);
 
+            var userCompressionLibrary = compressionLibrary;
             if (compressionLibrary == CompressionLibrary.Auto)
             {
                 if (compressionType != CompressionType.Deflate || usingZip64)
@@ -165,6 +176,7 @@ namespace Duplicati.Library.Compression.ZipCompression
             }
 
             m_archive = archive ?? new SharpCompressZipArchive(stream, mode, parsedOptions);
+            m_creationParams = (stream, parsedOptions, userCompressionLibrary);
         }
 
         #region IFileArchive Members
@@ -219,7 +231,9 @@ namespace Duplicati.Library.Compression.ZipCompression
 
         public void Dispose()
         {
-            m_archive.Dispose();
+            if (m_fallbackArchive != null)
+                m_archive.Dispose();
+            m_fallbackArchive?.Dispose();
         }
 
         public string[] ListFiles(string prefix)
@@ -229,7 +243,38 @@ namespace Duplicati.Library.Compression.ZipCompression
             => m_archive.ListFilesWithSize(prefix);
 
         public Stream? OpenRead(string file)
-            => m_archive.OpenRead(file);
+        {
+            // If we have started the fallback archive, we should continue using it
+            if (m_fallbackArchive != null)
+                return m_fallbackArchive.OpenRead(file);
+
+            try
+            {
+                return m_archive.OpenRead(file);
+            }
+            catch (Exception ex)
+            {
+                if (m_creationParams.Library == CompressionLibrary.Auto && m_archive is not SharpCompressZipArchive && m_creationParams.Stream.CanSeek)
+                {
+                    Log.WriteWarningMessage(LOGTAG, "CompressionReadErrorFallback", ex, "Failed to open file with built-in ZIP archive, falling back to SharpCompress");
+
+                    try
+                    {
+                        m_creationParams.Item1.Seek(0, SeekOrigin.Begin);
+                        m_archive.Dispose();
+                    }
+                    catch
+                    {
+
+                    }
+
+                    m_fallbackArchive = new SharpCompressZipArchive(m_creationParams.Stream, ArchiveMode.Read, m_creationParams.Options);
+                    return m_fallbackArchive.OpenRead(file);
+                }
+
+                throw;
+            }
+        }
 
         public DateTime GetLastWriteTime(string file)
             => m_archive.GetLastWriteTime(file);

--- a/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
+++ b/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
@@ -231,7 +231,7 @@ namespace Duplicati.Library.Compression.ZipCompression
 
         public void Dispose()
         {
-            if (m_fallbackArchive != null)
+            if (m_fallbackArchive == null)
                 m_archive.Dispose();
             m_fallbackArchive?.Dispose();
         }

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -116,7 +116,12 @@ namespace Duplicati.Library.Main.Volumes
         {
             using (var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var c = LoadCompressor(compressor, stream, options))
-            using (var s = c.OpenRead(FILESET_FILENAME))
+                return GetFilesetData(c, options);
+        }
+
+        public static FilesetData GetFilesetData(ICompression compressor, Options options)
+        {
+            using (var s = compressor.OpenRead(FILESET_FILENAME))
             {
                 if (s == null)
                 {
@@ -140,7 +145,19 @@ namespace Duplicati.Library.Main.Volumes
         {
             using (var stream = new System.IO.FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var c = LoadCompressor(compressor, stream, options))
-            using (var s = c.OpenRead(MANIFEST_FILENAME))
+                UpdateOptionsFromManifest(c, options);
+
+        }
+
+        /// <summary>
+        /// Updates the options with data from the manifest file, but does not overwrite existing values
+        /// </summary>
+        /// <param name="compressor">The compressor to use</param>
+        /// <param name="file">The file to read the manifest from</param>
+        /// <param name="options">The options to update</param>
+        public static void UpdateOptionsFromManifest(ICompression compressor, Options options)
+        {
+            using (var s = compressor.OpenRead(MANIFEST_FILENAME))
             using (var fs = new StreamReader(s, ENCODING))
             {
                 var d = JsonConvert.DeserializeObject<ManifestData>(fs.ReadToEnd());

--- a/Duplicati/UnitTest/ZipFallbackTest.cs
+++ b/Duplicati/UnitTest/ZipFallbackTest.cs
@@ -1,0 +1,82 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    public class ZipFallbackTest : BasicSetupHelper
+    {
+        [Test]
+        [Category("Targeted")]
+        public void RunCommands()
+        {
+            var testopts = TestOptions;
+            testopts["zip-compression-method"] = "lzma";
+            testopts["zip-compression-library"] = "SharpCompress";
+            testopts["blocksize"] = "50kb";
+
+            var data = new byte[1024 * 1024 * 10];
+            File.WriteAllBytes(Path.Combine(DATAFOLDER, "a"), data);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                var r = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
+            }
+
+            // Delete the local database
+            File.Delete(DBFILE);
+
+            // Switch back to built-in compression
+            testopts.Remove("zip-compression-method");
+            testopts["zip-compression-library"] = "Auto";
+
+            // Recreate the database
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                var r = c.Repair();
+                Assert.AreEqual(0, r.Errors.Count());
+                // Ensure that we get warnings for the fallback, one for the dlist and one for the dindex
+                Assert.AreEqual(2, r.Warnings.Count());
+                Assert.That(r.Warnings.All(x => x.Contains("lzma", StringComparison.OrdinalIgnoreCase)));
+            }
+
+            // Restore files
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { restore_path = RESTOREFOLDER }), null))
+            {
+                var r = c.Restore(null);
+                Assert.AreEqual(0, r.Errors.Count());
+                // Ensure that we get warnings for the fallback, one for the dblock file
+                Assert.AreEqual(1, r.Warnings.Count());
+                Assert.That(r.Warnings.All(x => x.Contains("lzma", StringComparison.OrdinalIgnoreCase)));
+            }
+
+            TestUtils.AssertDirectoryTreesAreEquivalent(DATAFOLDER, RESTOREFOLDER, true, "Restore");
+
+        }
+    }
+}


### PR DESCRIPTION
If some files are compressed with something other than deflate, the .NET zip library cannot decompress them.

This PR adds support for fallback, such that a failure to read a file with .NET zip will cause SharpCompress to be used. This change is transparent to the caller, and there is no functional impact, other than the ability to read files with other compression methods.

Since the module operates on a stream, only one compression library can be active, so after switching to SharpCompress, this will be used for all following decompress operations on the file.