### PR TITLE
Added warning when using the Mega backend

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -865,6 +865,10 @@ namespace Duplicati.Library.Main
             if (string.Equals(new Library.Utility.Uri(m_backendUrl).Scheme, "tardigrade", StringComparison.OrdinalIgnoreCase))
                 Logging.Log.WriteWarningMessage(LOGTAG, "TardigradeRename", null, "The Tardigrade-backend got renamed to Storj DCS - please migrate your backups to the new configuration by changing the destination storage type to Storj DCS.");
 
+            //Inform the user about the unmaintained Mega support library
+            if (string.Equals(new Library.Utility.Uri(m_backendUrl).Scheme, "mega", StringComparison.OrdinalIgnoreCase))
+                Logging.Log.WriteWarningMessage(LOGTAG, "MegaUnmaintained", null, "The Mega support library is currently unmaintained and may not work as expected. Mega has not published an official API so it may break at any moment. Please consider migrating to another backend.");
+
             //TODO: Based on the action, see if all options are relevant
         }
 


### PR DESCRIPTION
Since Mega is no longer supporting 3rd party API access (if they ever did) and the support library is no longer maintained we should warn users to migrate before it fully stops working.

This PR adds a warning everytime an operation is performed on Mega (once per Duplicati operation, not once per backend access).

This fixes #5048