### PR TITLE
Bugfix/Restore modified and retargeted (non-overwrite) file gives wrong hash

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -583,6 +583,12 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// <returns>An awaitable `Task`, which returns a collection of data blocks that are missing.</returns>
         private static async Task<(long, List<BlockRequest>)> VerifyLocalBlocks(FileRequest file, List<BlockRequest> blocks, long total_blocks, System.Security.Cryptography.HashAlgorithm filehasher, System.Security.Cryptography.HashAlgorithm blockhasher, Options options, RestoreResults results, IChannel<BlockRequest> block_request)
         {
+            if (file.TargetPath == file.OriginalPath)
+            {
+                // The original file is the same as the target file, so no new blocks can be used.
+                return (0, blocks);
+            }
+
             List<BlockRequest> missing_blocks = [];
             List<BlockRequest> verified_blocks = [];
 

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -295,6 +295,8 @@ namespace Duplicati.Library.Main.Operation.Restore
                                 {
                                     results.BrokenLocalFiles.Add(file.TargetPath);
                                 }
+                                block_request.Retire();
+                                block_response.Retire();
                                 throw;
                             }
                             finally

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -124,7 +124,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     }
                                     else
                                     {
-                                        CopyOldTargetBlocksToNewTarget(file, new_file, verified_blocks);
+                                        await CopyOldTargetBlocksToNewTarget(file, new_file, verified_blocks);
                                     }
                                 }
                                 file = new_file;
@@ -351,7 +351,7 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// <param name="old_file">The old target file.</param>
         /// <param name="new_file">The new target file.</param>
         /// <param name="verified_blocks">The blocks in the old file that were verified.</param>
-        private static void CopyOldTargetBlocksToNewTarget(FileRequest old_file, FileRequest new_file, List<BlockRequest> verified_blocks)
+        private static async Task CopyOldTargetBlocksToNewTarget(FileRequest old_file, FileRequest new_file, List<BlockRequest> verified_blocks)
         {
             using var fs_old = SystemIO.IO_OS.FileOpenRead(old_file.TargetPath);
             using var fs_new = SystemIO.IO_OS.FileOpenWrite(new_file.TargetPath);
@@ -362,8 +362,8 @@ namespace Duplicati.Library.Main.Operation.Restore
                 fs_new.Seek(block.BlockOffset * block.BlockSize, SeekOrigin.Begin);
 
                 var buffer = new byte[block.BlockSize];
-                fs_old.Read(buffer, 0, buffer.Length);
-                fs_new.Write(buffer, 0, buffer.Length);
+                await fs_old.ReadAsync(buffer, 0, buffer.Length);
+                await fs_new.WriteAsync(buffer, 0, buffer.Length);
             }
         }
 

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System;
@@ -66,12 +66,12 @@ namespace Duplicati.Library.Main.Operation.Restore
             },
             async self =>
             {
-                Stopwatch sw_file  = options.InternalProfiling ? new () : null;
-                Stopwatch sw_block = options.InternalProfiling ? new () : null;
-                Stopwatch sw_meta  = options.InternalProfiling ? new () : null;
-                Stopwatch sw_req   = options.InternalProfiling ? new () : null;
-                Stopwatch sw_resp  = options.InternalProfiling ? new () : null;
-                Stopwatch sw_work  = options.InternalProfiling ? new () : null;
+                Stopwatch sw_file = options.InternalProfiling ? new() : null;
+                Stopwatch sw_block = options.InternalProfiling ? new() : null;
+                Stopwatch sw_meta = options.InternalProfiling ? new() : null;
+                Stopwatch sw_req = options.InternalProfiling ? new() : null;
+                Stopwatch sw_resp = options.InternalProfiling ? new() : null;
+                Stopwatch sw_work = options.InternalProfiling ? new() : null;
 
                 try
                 {
@@ -206,7 +206,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                 // Burst the block requests to speed up the restore
                                 int burst = Channels.BufferSize;
                                 int j = 0;
-                                for (int i = 0; i < (int) Math.Min(missing_blocks.Count, burst); i++)
+                                for (int i = 0; i < (int)Math.Min(missing_blocks.Count, burst); i++)
                                 {
                                     await block_request.WriteAsync(missing_blocks[i]);
                                 }
@@ -303,7 +303,8 @@ namespace Duplicati.Library.Main.Operation.Restore
                             }
                         }
 
-                        if (!options.SkipMetadata) {
+                        if (!options.SkipMetadata)
+                        {
                             empty_file_or_symlink |= await RestoreMetadata(db, file, block_request, block_response, options, sw_meta, sw_work, sw_req, sw_resp);
                         }
 
@@ -476,7 +477,7 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// <param name="results">The restoration results.</param>
         /// <param name="block_request">The channel to request blocks from the block manager. Used to inform the block manager which blocks are already present.</param>
         /// <returns>An awaitable `Task`, which returns a collection of data blocks that are missing.</returns>
-        private static async Task<(long,List<BlockRequest>,List<BlockRequest>)> VerifyTargetBlocks(FileRequest file, BlockRequest[] blocks, System.Security.Cryptography.HashAlgorithm filehasher, System.Security.Cryptography.HashAlgorithm blockhasher, Options options, RestoreResults results, IChannel<BlockRequest> block_request)
+        private static async Task<(long, List<BlockRequest>, List<BlockRequest>)> VerifyTargetBlocks(FileRequest file, BlockRequest[] blocks, System.Security.Cryptography.HashAlgorithm filehasher, System.Security.Cryptography.HashAlgorithm blockhasher, Options options, RestoreResults results, IChannel<BlockRequest> block_request)
         {
             long bytes_read = 0;
             List<BlockRequest> missing_blocks = [];
@@ -541,7 +542,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     if (Convert.ToBase64String(filehasher.Hash) == file.Hash)
                     {
                         // Truncate the file if it is larger than the expected size.
-                        FileInfo fi = new (file.TargetPath);
+                        FileInfo fi = new(file.TargetPath);
                         if (file.Length < fi.Length)
                         {
                             if (options.Dryrun)
@@ -611,7 +612,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                         try
                         {
                             f_original.Seek(i * options.Blocksize, SeekOrigin.Begin);
-                            read = await f_original.ReadAsync(buffer, 0, (int) blocks[j].BlockSize);
+                            read = await f_original.ReadAsync(buffer, 0, (int)blocks[j].BlockSize);
                         }
                         catch (Exception)
                         {
@@ -632,19 +633,19 @@ namespace Duplicati.Library.Main.Operation.Restore
                             else
                             {
                                 if (!options.Dryrun)
-                            {
-                                try
                                 {
-                                    f_target.Seek(blocks[j].BlockOffset * options.Blocksize, SeekOrigin.Begin);
-                                    await f_target.WriteAsync(buffer, 0, read);
-                                }
-                                catch (Exception)
-                                {
-                                    lock (results)
+                                    try
                                     {
-                                        results.BrokenLocalFiles.Add(file.TargetPath);
+                                        f_target.Seek(blocks[j].BlockOffset * options.Blocksize, SeekOrigin.Begin);
+                                        await f_target.WriteAsync(buffer, 0, read);
                                     }
-                                    throw;
+                                    catch (Exception)
+                                    {
+                                        lock (results)
+                                        {
+                                            results.BrokenLocalFiles.Add(file.TargetPath);
+                                        }
+                                        throw;
                                     }
                                 }
                                 bytes_read += read;

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -328,8 +328,6 @@ namespace Duplicati.Library.Main.Operation.Restore
                 catch (RetiredException)
                 {
                     Logging.Log.WriteVerboseMessage(LOGTAG, "RetiredProcess", null, "File processor retired");
-                    block_request.Retire();
-                    block_response.Retire();
 
                     if (options.InternalProfiling)
                     {
@@ -340,9 +338,12 @@ namespace Duplicati.Library.Main.Operation.Restore
                 catch (Exception ex)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "FileProcessingError", ex, "Error during file processing");
+                    throw;
+                }
+                finally
+                {
                     block_request.Retire();
                     block_response.Retire();
-                    throw;
                 }
             });
         }

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -617,7 +617,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     (SystemIO.IO_OS.FileExists(file.TargetPath) ?
                         SystemIO.IO_OS.FileOpenRead(file.TargetPath) :
                         null) :
-                    SystemIO.IO_OS.FileOpenWrite(file.TargetPath);
+                    SystemIO.IO_OS.FileOpenReadWrite(file.TargetPath);
                 var buffer = new byte[options.Blocksize];
                 long bytes_read = 0;
                 long bytes_written = 0;
@@ -656,8 +656,8 @@ namespace Duplicati.Library.Main.Operation.Restore
                                 {
                                     try
                                     {
-                                        f_target.Seek(blocks[j].BlockOffset * options.Blocksize, SeekOrigin.Begin);
-                                        await f_target.WriteAsync(buffer, 0, read);
+                                        f_target?.Seek(blocks[j].BlockOffset * options.Blocksize, SeekOrigin.Begin);
+                                        await f_target?.WriteAsync(buffer, 0, read);
                                     }
                                     catch (Exception)
                                     {

--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 using Duplicati.Library.DynamicLoader;
 using Duplicati.Library.Interface;
@@ -311,6 +311,7 @@ namespace Duplicati.UnitTest
 
 
         [Test]
+        [Category("Restore"), Category("Bug")]
         public void Issue5886RestoreModifiedMiddleBlock()
         {
             var blocksize = 1024;
@@ -372,6 +373,68 @@ namespace Duplicati.UnitTest
                     Assert.That(restored_contents, Is.EqualTo(original_contents), "Restored file should be equal to original file");
                 }
             }
+        }
+
+        [Test]
+        [Category("Restore"), Category("Bug")]
+        public void Issue5957RestoreModifiedBlockUseLocalBlocks([Values] bool use_local, [Values] bool overwrite)
+        {
+            var blocksize = 1024;
+            var testopts = new Dictionary<string, string>(TestOptions)
+            {
+                ["blocksize"] = $"{blocksize}b",
+                ["restore-with-local-blocks"] = use_local.ToString().ToLower(),
+                ["overwrite"] = overwrite.ToString().ToLower()
+            };
+
+            var original_dir = Path.Combine(DATAFOLDER, "some_original_dir");
+            Directory.CreateDirectory(original_dir);
+            string f = Path.Combine(original_dir, "some_file");
+            TestUtils.WriteTestFile(f, 3 * blocksize);
+
+            // Backup the files
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup([DATAFOLDER]);
+                TestUtils.AssertResults(backupResults);
+            }
+
+            var original_contents = File.ReadAllBytes(f);
+
+            using (var stream = File.Open(f, FileMode.Open, FileAccess.ReadWrite))
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                byte[] buffer = new byte[1];
+                stream.Read(buffer, 0, 1);
+                buffer[0] = (byte)~buffer[0];
+                stream.Seek(0, SeekOrigin.Begin);
+                stream.Write(buffer, 0, 1);
+            }
+
+            var restored_contents = File.ReadAllBytes(f);
+            Assert.That(restored_contents, Is.Not.EqualTo(original_contents), "Restored file should not be equal to original file");
+
+            // Attempt to restore the file
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                var restoreResults = c.Restore([f]);
+                Assert.That(restoreResults.RestoredFiles, Is.EqualTo(1), "File should have been restored.");
+            }
+
+            // Verify that the files are equal
+            // List files in folder
+            if (overwrite)
+            {
+                restored_contents = File.ReadAllBytes(f);
+            }
+            else
+            {
+                var files = Directory.GetFiles(original_dir, "*", SearchOption.TopDirectoryOnly);
+                Assert.That(files.Length, Is.EqualTo(2), "There should be one file in the folder");
+                var f2 = files.FirstOrDefault(v => v != f);
+                restored_contents = File.ReadAllBytes(f2);
+            }
+            Assert.That(restored_contents, Is.EqualTo(original_contents), "Restored file should be equal to original file");
         }
 
 

--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -430,7 +430,7 @@ namespace Duplicati.UnitTest
             else
             {
                 var files = Directory.GetFiles(original_dir, "*", SearchOption.TopDirectoryOnly);
-                Assert.That(files.Length, Is.EqualTo(2), "There should be one file in the folder");
+                Assert.That(files.Length, Is.EqualTo(2), "There should be two files in the folder");
                 var f2 = files.FirstOrDefault(v => v != f);
                 restored_contents = File.ReadAllBytes(f2);
             }


### PR DESCRIPTION
This PR primarily fixes #5957, which was due to already verified blocks not being properly copied or requested when the target file name was retargeted due to the option `overwrite=false` being set. 

Furthermore, this PR also fixes the following bugs in the reworked restore flow:
- `VerifyLocalBlocks` could sometimes be triggered on the same file, which is exactly what `VerifyTargetBlocks` does, so the Local variant should just skip.
- Before a file was retargeted (due to `overwrite=false`), already verified blocks was evicted from the cache. This is not correct, as if the `restore-use-local-blocks=true` option is set, then the verified blocks should be requested from the remote volumes, i.e. from cache. 
- If the `FileProcessor` encountered an exception, it was handled and rethrown without retiring the rest of the network that was currently "unregistered", resulting in a deadlock. The network now properly shuts down, which throws the error further up to be handled by the caller. 
- The target file in `VerifyLocalBlocks` was opened in an incorrect mode, resulting in it being unreadable. 

To properly catch these errors in the future, a new unit test have been added that covers these cases. 