### PR TITLE
Do not encode http form extra parameters.

### DIFF
--- a/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
@@ -289,7 +289,7 @@ namespace Duplicati.Library.Modules.Builtin
                 contenttype = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
                 var postData = $"{m_messageParameterName}={System.Uri.EscapeDataString(body)}";
                 if (!string.IsNullOrEmpty(m_extraParameters))
-                    postData += $"&{System.Uri.EscapeDataString(m_extraParameters)}";
+                    postData += $"&{m_extraParameters}";
                 data = Encoding.UTF8.GetBytes(postData);
             }
 


### PR DESCRIPTION
This changes the encoding that broke because the encoding function was changed.

The new logic is to not encode the parameters, but just use them as provided.

Any escaping needs to then be applied to the input by the user/caller.

This fixes #5900