### PR TITLE
Adding 429 observance to backend

### DIFF
--- a/Duplicati/Library/Backend/Backblaze/B2AuthHelper.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2AuthHelper.cs
@@ -202,6 +202,9 @@ public class B2AuthHelper(string userid, string password, HttpClient httpClient)
         if (ex is not HttpRequestException || responseContext == null)
             return;
 
+        if (ex is HttpRequestException && responseContext != null && responseContext.StatusCode == HttpStatusCode.TooManyRequests)
+            throw new TooManyRequestException(responseContext.Headers.RetryAfter);
+
         using var stream = responseContext.Content.ReadAsStream();
         using var reader = new StreamReader(stream);
         var rawData = reader.ReadToEnd();

--- a/Duplicati/Library/Interface/CustomExceptions.cs
+++ b/Duplicati/Library/Interface/CustomExceptions.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Net.Http.Headers;
 using Duplicati.Library.Localization.Short;
 
 namespace Duplicati.Library.Interface
@@ -224,5 +225,14 @@ namespace Duplicati.Library.Interface
         public SettingsEncryptionKeyMissingException()
             : base(Strings.Common.SettingsKeyMissingExceptionError, "SettingsKeyMissing")
         { }
+    }
+    
+    /// <summary>
+    /// An exception for carrying the Retry-After header value on 429 Exceptions
+    /// </summary>
+    [Serializable]
+    public class TooManyRequestException(RetryConditionHeaderValue retryAfter) : Exception
+    {
+        public readonly RetryConditionHeaderValue RetryAfter = retryAfter;
     }
 }


### PR DESCRIPTION
This will make listing buckets with large count of files more reliable, if a 429 response is received it will conform to retry-after headers or if not present (as is the case today) will default to a 5 second delay.
