### PR TITLE
Disabling unsupported platforms for CI

### DIFF
--- a/.github/workflows/backendtests.yml
+++ b/.github/workflows/backendtests.yml
@@ -427,8 +427,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
-          - macos-latest
     steps:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
@@ -444,10 +442,6 @@ jobs:
         run: >-
           dotnet build --no-restore
           LiveTests/Duplicati.Backend.Tests/Duplicati.Backend.Tests.sln
-      - name: Setup Testcontainers Cloud Client
-        uses: atomicjar/testcontainers-cloud-setup-action@v1
-        with:
-          token: "${{ secrets.TC_CLOUD_TOKEN }}"
       - name: Run CIFS tests
         run: >-
           dotnet test --no-build --filter="ClassName~CIFSTests"


### PR DESCRIPTION
Currently the CIFS Tests on macos and windows require it to run in cloud mode, which means the port binding would not match default netbios/directtcp protocol standards as the container port allocation is random and the backend does not support specifying explicit ports.

The remaining tests on linux nevertheless already grants some degree of assurance the backend is working.
