### PR TITLE
This commit adds relaxed name parsing.

### DIFF
--- a/Duplicati/Library/Backend/S3/Strings.cs
+++ b/Duplicati/Library/Backend/S3/Strings.cs
@@ -49,6 +49,8 @@ namespace Duplicati.Library.Backend.Strings
         public static string DescriptionDisableChunkEncodingShort { get { return LC.L(@"Disable chunk encoding (aws client only)"); } }
         public static string S3StorageclassDescriptionLong { get { return LC.L(@"Use this option to specify a storage class. If this option is not used, the server will choose a default storage class."); } }
         public static string S3StorageclassDescriptionShort { get { return LC.L(@"Specify storage class"); } }
+        public static string DescriptionStrictNameParsingShort { get { return LC.L(@"Use strict bucket name parsing"); } }
+        public static string DescriptionStrictNameParsingLong { get { return LC.L(@"Use this option to enforce strict bucket name parsing, preserving all leading slashes"); } }
         public static string UnknownS3ClientError(string client) { return LC.L(@"Unknown S3 client: {0}", client); }
     }
 }


### PR DESCRIPTION
In the case either the prefix or the actual content names start with forward slashes, this is considered an error in the input and the slashes are removed.

The option `--s3-strict-name-parsing` can be used to disable the lenient parsing.