### PR TITLE
Add back missing Windows example script.

### DIFF
--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -24,13 +24,13 @@
     <ProjectReference Include="..\..\Backend\OAuthHelper\Duplicati.Library.OAuthHelper.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <ItemGroup Condition=" $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win')) Or '$(RuntimeIdentifier)' == '' ">
       <Content Include="run-script-example.bat">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
+  <ItemGroup Condition=" ! $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win'))">
       <Content Include="run-script-example.sh">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -23,14 +23,20 @@
     <ProjectReference Include="..\..\Localization\Duplicati.Library.Localization.csproj" />
     <ProjectReference Include="..\..\Backend\OAuthHelper\Duplicati.Library.OAuthHelper.csproj" />
   </ItemGroup>
-  
-  <ItemGroup Condition=" $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win-')) Or '$(RuntimeIdentifier)' == '' ">
+
+  <PropertyGroup>
+      <!-- Extract the first 4 characters from RuntimeIdentifier -->
+      <RIDPrefix Condition="'$(RuntimeIdentifier)' != ''">$([System.String]::Copy('$(RuntimeIdentifier)'))</RIDPrefix>
+      <RIDPrefix Condition="'$(RuntimeIdentifier)' != '' and $([System.String]::Length('$(RuntimeIdentifier)')) &gt;= 4">$([System.String]::Substring('$(RuntimeIdentifier)', 0, 4))</RIDPrefix>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(RIDPrefix)' == 'win-' Or '$(RuntimeIdentifier)' == '' ">
       <Content Include="run-script-example.bat">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" ! $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win-'))">
+  <ItemGroup Condition=" '$(RIDPrefix)' != 'win-' Or '$(RuntimeIdentifier)' == '' ">
       <Content Include="run-script-example.sh">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -24,10 +24,16 @@
     <ProjectReference Include="..\..\Backend\OAuthHelper\Duplicati.Library.OAuthHelper.csproj" />
   </ItemGroup>
   
-  <ItemGroup>
-    <Content Include="run-script-example.sh">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+      <Content Include="run-script-example.bat">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
+      <Content Include="run-script-example.sh">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -24,13 +24,13 @@
     <ProjectReference Include="..\..\Backend\OAuthHelper\Duplicati.Library.OAuthHelper.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition=" $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win')) Or '$(RuntimeIdentifier)' == '' ">
+  <ItemGroup Condition=" $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win-')) Or '$(RuntimeIdentifier)' == '' ">
       <Content Include="run-script-example.bat">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" ! $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win'))">
+  <ItemGroup Condition=" ! $([MSBuild]::StartsWith('$(RuntimeIdentifier)', 'win-'))">
       <Content Include="run-script-example.sh">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>


### PR DESCRIPTION
This adds back the missing `run-script-example.bat`.

It also makes the output conditional, so the Windows builds get the `.bat` and others get the `.sh` version.

This fixes #5953