### PR TITLE
Performance/restore parallel download

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.GetOperation.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.GetOperation.cs
@@ -31,6 +31,10 @@ partial class BackendManager
         /// </summary>
         public override long Size { get; }
         /// <summary>
+        /// Flag indicating whether the file should be decrypted
+        /// </summary>
+        public bool Decrypt { get; set; }
+        /// <summary>
         /// The hash of the remote file, or null if unknown
         /// </summary>
         public required string? Hash { get; set; }
@@ -89,6 +93,7 @@ partial class BackendManager
                 }
 
                 // Perform decryption after hash validation, if needed
+                if (Decrypt)
                     tmpfile = DecryptFile(tmpfile, RemoteFilename, Context.Options);
 
                 return (tmpfile, fileHash, dataSizeDownloaded);

--- a/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
@@ -89,6 +89,10 @@ partial class BackendManager
         private static readonly string LOGTAG = Logging.Log.LogTagFromType<Handler>();
 
         /// <summary>
+        /// The list of active downloads
+        /// </summary>
+        private readonly List<Task> activeDownloads = [];
+        /// <summary>
         /// The list of active uploads
         /// </summary>
         private readonly List<Task> activeUploads = [];
@@ -104,6 +108,10 @@ partial class BackendManager
         /// The context for the handler
         /// </summary>
         private readonly ExecuteContext context;
+        /// <summary>
+        /// The maximum number of parallel downloads
+        /// </summary>
+        private readonly int maxParallelDownloads;
         /// <summary>
         /// The maximum number of parallel uploads
         /// </summary>
@@ -155,6 +163,8 @@ partial class BackendManager
             this.backendUrl = backendUrl;
             this.context = context;
 
+            // TODO Currently, only the restore process uses parallel downloads. If others need it as well, maybe use another option.
+            maxParallelDownloads = Math.Max(1, context.Options.RestoreVolumeDownloaders);
             maxParallelUploads = Math.Max(1, context.Options.AsynchronousConcurrentUploadLimit);
             maxRetries = context.Options.NumberOfRetries;
             retryDelay = context.Options.RetryDelay;
@@ -181,6 +191,23 @@ partial class BackendManager
         }
 
         /// <summary>
+        /// Reclaims completed downloads
+        /// </summary>
+        /// <returns>An awaitable task</returns>
+        private async Task ReclaimCompletedDownloads()
+        {
+            for (int i = activeDownloads.Count - 1; i >= 0; i--)
+            {
+                if (activeDownloads[i].IsCompleted)
+                {
+                    // Make sure the task is awaited so we capture any exceptions
+                    await activeDownloads[i].ConfigureAwait(false);
+                    activeDownloads.RemoveAt(i);
+                }
+            }
+        }
+
+        /// <summary>
         /// Reclaims completed uploads
         /// </summary>
         /// <returns>An awaitable task</returns>
@@ -194,6 +221,20 @@ partial class BackendManager
                     await activeUploads[i].ConfigureAwait(false);
                     activeUploads.RemoveAt(i);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Ensures that there are at most N - 1 active downloads
+        /// </summary>
+        /// <param name="n"></param>
+        /// <returns></returns>
+        private async Task EnsureAtMostNActiveDownloads(int n)
+        {
+            while (activeDownloads.Count >= n)
+            {
+                await Task.WhenAny(activeDownloads).ConfigureAwait(false);
+                await ReclaimCompletedDownloads().ConfigureAwait(false);
             }
         }
 
@@ -239,6 +280,13 @@ partial class BackendManager
                             // Operation is accepted into queue, so we can signal completion
                             putOp.SetComplete(true);
                             activeUploads.Add(ExecuteWithRetry(putOp, tcs.Token));
+                        }
+                        else if (op is GetOperation getOp && !getOp.WaitForComplete)
+                        {
+                            await EnsureAtMostNActiveDownloads(maxParallelDownloads).ConfigureAwait(false);
+
+                            // Operation is accepted into queue, so we can signal completion
+                            activeDownloads.Add(ExecuteWithRetry(getOp, tcs.Token));
                         }
                         else
                         {

--- a/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
@@ -281,7 +281,7 @@ partial class BackendManager
                             putOp.SetComplete(true);
                             activeUploads.Add(ExecuteWithRetry(putOp, tcs.Token));
                         }
-                        else if (op is GetOperation getOp && !getOp.WaitForComplete)
+                        else if (op is GetOperation getOp)
                         {
                             await EnsureAtMostNActiveDownloads(maxParallelDownloads).ConfigureAwait(false);
 

--- a/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
@@ -313,7 +313,7 @@ partial class BackendManager
             }
             finally
             {
-                // Terminate any active uploads
+                // Terminate any active uploads and downloads. Exceptions thrown by the downloads should be captured by the callers.
                 tcs.Cancel();
 
                 if (activeUploads.Count > 0)

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -178,7 +178,8 @@ internal partial class BackendManager : IBackendManager
     {
         var op = new GetOperation(remotename, size, context, cancelToken)
         {
-            Hash = hash
+            Hash = hash,
+            Decrypt = true
         };
         await QueueTask(op).ConfigureAwait(false);
         (var file, var _, var downloadSize) = await op.GetResult().ConfigureAwait(false);
@@ -186,9 +187,25 @@ internal partial class BackendManager : IBackendManager
         return file;
     }
 
-    public IBackend GetBackend()
+    /// <summary>
+    /// Gets a file from the remote location without decrypting it
+    /// </summary>
+    /// <param name="remotename">The name of the remote file</param>
+    /// <param name="hash">The hash of the remote file, for verification</param>
+    /// <param name="size">The size of the remote file, for verification</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>A temporary file with the contents of the remote file</returns>
+    public async Task<TempFile> GetDirectAsync(string remotename, string hash, long size, CancellationToken cancelToken)
     {
-        return BackendLoader.GetBackend(m_backendurl, m_options.RawOptions);
+        var op = new GetOperation(remotename, size, context, cancelToken)
+        {
+            Hash = hash,
+            Decrypt = false
+        };
+        await QueueTask(op).ConfigureAwait(false);
+        (var file, var _, var downloadSize) = await op.GetResult().ConfigureAwait(false);
+        LastReadSize = downloadSize;
+        return file;
     }
 
     /// <summary>
@@ -215,7 +232,8 @@ internal partial class BackendManager : IBackendManager
     {
         var op = new GetOperation(remotename, size, context, cancelToken)
         {
-            Hash = hash
+            Hash = hash,
+            Decrypt = true
         };
         await QueueTask(op).ConfigureAwait(false);
         (var file, var downloadHash, var downloadSize) = await op.GetResult().ConfigureAwait(false);

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -140,6 +140,18 @@ internal partial class BackendManager : IBackendManager
     }
 
     /// <summary>
+    /// Decrypts a file using the specified options
+    /// </summary>
+    /// <param name="tmpfile">The file to decrypt</param>
+    /// <param name="filename">The name of the file. Used for detecting encryption algorithm if not specified in options or if it differs from the options</param>
+    /// <param name="options">The Duplicati options</param>
+    /// <returns>The decrypted file</returns>
+    public TempFile DecryptFile(TempFile volume, string volume_name, Options options)
+    {
+        return GetOperation.DecryptFile(volume, volume_name, options);
+    }
+
+    /// <summary>
     /// Deletes a remote file
     /// </summary>
     /// <param name="remotename">The name of the remote file</param>

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using CoCoL;
+using Duplicati.Library.DynamicLoader;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main.Database;
 using Duplicati.Library.Main.Operation.Common;
@@ -29,6 +30,9 @@ internal partial class BackendManager : IBackendManager
     /// List of backend instances that are currently in use
     /// </summary>
     private readonly List<IBackend> backendPool = [];
+
+    private string m_backendurl;
+    private Options m_options;
 
     /// <summary>
     /// The channel for issuing and handling requests
@@ -70,6 +74,9 @@ internal partial class BackendManager : IBackendManager
     {
         if (string.IsNullOrWhiteSpace(backendUrl))
             throw new ArgumentNullException(nameof(backendUrl));
+
+        m_backendurl = backendUrl;
+        m_options = options;
 
         // To avoid excessive parameter passing, the context is captured here
         context = new ExecuteContext(
@@ -165,6 +172,11 @@ internal partial class BackendManager : IBackendManager
         (var file, var _, var downloadSize) = await op.GetResult().ConfigureAwait(false);
         LastReadSize = downloadSize;
         return file;
+    }
+
+    public IBackend GetBackend()
+    {
+        return BackendLoader.GetBackend(m_backendurl, m_options.RawOptions);
     }
 
     /// <summary>

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -26,13 +26,6 @@ internal partial class BackendManager : IBackendManager
     /// The log tag for the class
     /// </summary>
     private static readonly string LOGTAG = Logging.Log.LogTagFromType<BackendManager>();
-    /// <summary>
-    /// List of backend instances that are currently in use
-    /// </summary>
-    private readonly List<IBackend> backendPool = [];
-
-    private string m_backendurl;
-    private Options m_options;
 
     /// <summary>
     /// The channel for issuing and handling requests
@@ -74,9 +67,6 @@ internal partial class BackendManager : IBackendManager
     {
         if (string.IsNullOrWhiteSpace(backendUrl))
             throw new ArgumentNullException(nameof(backendUrl));
-
-        m_backendurl = backendUrl;
-        m_options = options;
 
         // To avoid excessive parameter passing, the context is captured here
         context = new ExecuteContext(

--- a/Duplicati/Library/Main/IBackendManager.cs
+++ b/Duplicati/Library/Main/IBackendManager.cs
@@ -91,6 +91,9 @@ internal interface IBackendManager : IDisposable
     /// <returns></returns>
     Task<TempFile> GetAsync(string remotename, string hash, long size, CancellationToken cancelToken);
 
+
+    public IBackend GetBackend();
+
     /// <summary>
     /// Performs a download of the files specified, with pre-fetch to overlap the download and processing
     /// </summary>

--- a/Duplicati/Library/Main/IBackendManager.cs
+++ b/Duplicati/Library/Main/IBackendManager.cs
@@ -97,11 +97,18 @@ internal interface IBackendManager : IDisposable
     /// <param name="hash">The hash of the file to get, or <c>null</c> if not known</param>
     /// <param name="size">The size of the file to get, or -1 if not known</param>
     /// <param name="cancelToken">The cancellation token</param>
-    /// <returns></returns>
+    /// <returns>The downloaded file</returns>
     Task<TempFile> GetAsync(string remotename, string hash, long size, CancellationToken cancelToken);
 
-
-    public IBackend GetBackend();
+    /// <summary>
+    /// Gets a file from the backend without decrypting it
+    /// </summary>
+    /// <param name="remotename">The name of the remote volume</param>
+    /// <param name="hash">The hash of the volume</param>
+    /// <param name="size">The size of the volume</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>The downloaded file</returns>
+    Task<TempFile> GetDirectAsync(string remotename, string hash, long size, CancellationToken cancelToken);
 
     /// <summary>
     /// Performs a download of the files specified, with pre-fetch to overlap the download and processing

--- a/Duplicati/Library/Main/IBackendManager.cs
+++ b/Duplicati/Library/Main/IBackendManager.cs
@@ -55,6 +55,15 @@ internal interface IBackendManager : IDisposable
     Task<IEnumerable<IFileEntry>> ListAsync(CancellationToken cancelToken);
 
     /// <summary>
+    /// Decrypts the given file and returns the decrypted file
+    /// </summary>
+    /// <param name="volume">The file to decrypt</param>
+    /// <param name="volume_name">The name of the file. Used for detecting encryption algorithm if not specified in options or if it differs from the options</param>
+    /// <param name="options">The Duplicati options</param>
+    /// <returns>The decrypted file</returns>
+    TempFile DecryptFile(TempFile volume, string volume_name, Options options);
+
+    /// <summary>
     /// Deletes a file on the backend
     /// </summary>
     /// <param name="remotename">The name of the file to delete</param>

--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System;

--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -306,7 +306,7 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                 if (m_options.InternalProfiling)
                 {
-                    Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", null, $"Sleepable dictionary - CheckCounts: {sw_checkcounts.ElapsedMilliseconds}ms, Get wait: {sw_get_wait.ElapsedMilliseconds}ms, Cache evict: {sw_cacheevict.ElapsedMilliseconds}ms");
+                    Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", $"Sleepable dictionary - CheckCounts: {sw_checkcounts.ElapsedMilliseconds}ms, Get wait: {sw_get_wait.ElapsedMilliseconds}ms, Cache evict: {sw_cacheevict.ElapsedMilliseconds}ms");
                 }
             }
 
@@ -372,7 +372,7 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         if (options.InternalProfiling)
                         {
-                            Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", null, $"Volume consumer - Read: {sw_read.ElapsedMilliseconds}ms, Set: {sw_set.ElapsedMilliseconds}ms");
+                            Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", $"Volume consumer - Read: {sw_read.ElapsedMilliseconds}ms, Set: {sw_set.ElapsedMilliseconds}ms");
                         }
 
                         // Cancel any remaining readers - although there shouldn't be any.
@@ -426,7 +426,7 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         if (options.InternalProfiling)
                         {
-                            Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", null, $"Block handler - Req: {sw_req.ElapsedMilliseconds}ms, Resp: {sw_resp.ElapsedMilliseconds}ms, Cache: {sw_cache.ElapsedMilliseconds}ms, Get: {sw_get.ElapsedMilliseconds}ms");
+                            Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", $"Block handler - Req: {sw_req.ElapsedMilliseconds}ms, Resp: {sw_resp.ElapsedMilliseconds}ms, Cache: {sw_cache.ElapsedMilliseconds}ms, Get: {sw_get.ElapsedMilliseconds}ms");
                         }
 
                         cache.Retire();

--- a/Duplicati/Library/Main/Operation/Restore/Channels.cs
+++ b/Duplicati/Library/Main/Operation/Restore/Channels.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System.Threading.Tasks;

--- a/Duplicati/Library/Main/Operation/Restore/Channels.cs
+++ b/Duplicati/Library/Main/Operation/Restore/Channels.cs
@@ -19,7 +19,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Threading.Tasks;
 using CoCoL;
 using Duplicati.Library.Main.Volumes;
 using Duplicati.Library.Utility;
@@ -46,12 +45,12 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// <summary>
         /// Channel between <see cref="VolumeManager"/> and <see cref="VolumeDownloader"/>.
         /// </summary>
-        public readonly IChannel<(long, Task<TempFile>)> DownloadRequest = ChannelManager.CreateChannel<(long, Task<TempFile>)>(buffersize: BufferSize);
+        public readonly IChannel<long> DownloadRequest = ChannelManager.CreateChannel<long>(buffersize: BufferSize);
 
         /// <summary>
         /// Channel between <see cref="VolumeDownloader"/> and <see cref="VolumeDecryptor"/>
         /// </summary>
-        public readonly IChannel<(long, TempFile)> DecryptRequest = ChannelManager.CreateChannel<(long, TempFile)>(buffersize: BufferSize);
+        public readonly IChannel<(long, string, TempFile)> DecryptRequest = ChannelManager.CreateChannel<(long, string, TempFile)>(buffersize: BufferSize);
 
         /// <summary>
         /// Channel between <see cref="VolumeManager"/> and <see cref="VolumeDecompressor"/>

--- a/Duplicati/Library/Main/Operation/Restore/FileLister.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileLister.cs
@@ -67,7 +67,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     sw_write?.Start();
                     foreach (var file in files)
                     {
-                        await self.Output.WriteAsync(file);
+                        await self.Output.WriteAsync(file).ConfigureAwait(false);
                     }
                     sw_write?.Stop();
                 }

--- a/Duplicati/Library/Main/Operation/Restore/FileLister.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileLister.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System;
@@ -55,8 +55,8 @@ namespace Duplicati.Library.Main.Operation.Restore
             },
             async self =>
             {
-                Stopwatch sw_prework = options.InternalProfiling ? new () : null;
-                Stopwatch sw_write   = options.InternalProfiling ? new () : null;
+                Stopwatch sw_prework = options.InternalProfiling ? new() : null;
+                Stopwatch sw_write = options.InternalProfiling ? new() : null;
                 try
                 {
                     sw_prework?.Start();

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecompressor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecompressor.cs
@@ -65,7 +65,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     {
                         sw_read?.Start();
                         // Get the block request and volume from the `VolumeDecryptor` process.
-                        var (block_request, volume_reader) = await self.Input.ReadAsync();
+                        var (block_request, volume_reader) = await self.Input.ReadAsync().ConfigureAwait(false);
                         sw_read?.Stop();
 
                         sw_decompress?.Start();
@@ -86,7 +86,7 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         sw_write?.Start();
                         // Send the block to the `BlockManager` process.
-                        await self.Output.WriteAsync((block_request, data));
+                        await self.Output.WriteAsync((block_request, data)).ConfigureAwait(false);
                         sw_write?.Stop();
                     }
                 }

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecompressor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecompressor.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System;
@@ -52,12 +52,13 @@ namespace Duplicati.Library.Main.Operation.Restore
             },
             async self =>
             {
-                Stopwatch sw_read       = options.InternalProfiling ? new () : null;
-                Stopwatch sw_write      = options.InternalProfiling ? new () : null;
-                Stopwatch sw_decompress = options.InternalProfiling ? new () : null;
-                Stopwatch sw_verify     = options.InternalProfiling ? new () : null;
+                Stopwatch sw_read = options.InternalProfiling ? new() : null;
+                Stopwatch sw_write = options.InternalProfiling ? new() : null;
+                Stopwatch sw_decompress = options.InternalProfiling ? new() : null;
+                Stopwatch sw_verify = options.InternalProfiling ? new() : null;
 
-                try {
+                try
+                {
                     using var block_hasher = HashFactory.CreateHasher(options.BlockHashAlgorithm);
 
                     while (true)
@@ -77,7 +78,8 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         sw_verify?.Start();
                         var hash = Convert.ToBase64String(block_hasher.ComputeHash(data, 0, (int)block_request.BlockSize));
-                        if (hash != block_request.BlockHash) {
+                        if (hash != block_request.BlockHash)
+                        {
                             Logging.Log.WriteErrorMessage(LOGTAG, "InvalidBlock", null, $"Invalid block detected for block {block_request.BlockID} in volume {block_request.VolumeID}, expected hash: {block_request.BlockHash}, actual hash: {hash}");
                         }
                         sw_verify?.Stop();

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using CoCoL;
 using Duplicati.Library.Main.Volumes;
@@ -57,15 +58,23 @@ namespace Duplicati.Library.Main.Operation.Restore
                 Stopwatch sw_decrypt = options.InternalProfiling ? new() : null;
                 try
                 {
+                    // Taken from BackendManager.GetOperation
+                    using var encryption = options.NoEncryption
+                                    ? null
+                                    : (DynamicLoader.EncryptionLoader.GetModule(options.EncryptionModule, options.Passphrase, options.RawOptions)
+                                        ?? throw new Exception(Strings.BackendMananger.EncryptionModuleNotFound(options.EncryptionModule))
+                                );
+
                     while (true)
                     {
                         // Get the block request and volume from the `VolumeDownloader` process.
                         sw_read?.Start();
-                        var (volume_id, volume) = await self.Input.ReadAsync();
+                        var (volume_id, volume_name, volume) = await self.Input.ReadAsync().ConfigureAwait(false);
                         sw_read?.Stop();
 
                         sw_decrypt?.Start();
-                        var bvr = new BlockVolumeReader(options.CompressionModule, volume, options);
+                        var tmpfile = DecryptFile(volume, DetectEncryptionModule(volume_name, options, encryption));
+                        var bvr = new BlockVolumeReader(options.CompressionModule, tmpfile, options);
                         sw_decrypt?.Stop();
 
                         sw_write?.Start();
@@ -89,6 +98,83 @@ namespace Duplicati.Library.Main.Operation.Restore
                     throw;
                 }
             });
+        }
+
+        // Taken from BackendManager.GetOperation
+        public static Library.Utility.TempFile DecryptFile(Library.Utility.TempFile tempFile, Interface.IEncryption? decrypter)
+        {
+            // Support no encryption
+            if (decrypter == null)
+                return tempFile;
+
+            Library.Utility.TempFile? decryptTarget = null;
+
+            // Always dispose the source file
+            using (tempFile)
+            using (new Logging.Timer(LOGTAG, "DecryptFile", "Decrypting " + tempFile))
+            {
+                try
+                {
+                    decryptTarget = new Library.Utility.TempFile();
+                    try { decrypter.Decrypt(tempFile, decryptTarget); }
+                    // If we fail here, make sure that we throw a crypto exception
+                    catch (System.Security.Cryptography.CryptographicException) { throw; }
+                    catch (Exception ex) { throw new System.Security.Cryptography.CryptographicException(ex.Message, ex); }
+
+                    var result = decryptTarget;
+                    decryptTarget = null;
+                    return result;
+                }
+                finally
+                {
+                    // Remove temp files on failure
+                    decryptTarget?.Dispose();
+                }
+            }
+        }
+
+        private static Interface.IEncryption? DetectEncryptionModule(string remotefilename, Options options, Interface.IEncryption? encryption)
+        {
+            try
+            {
+                // Auto-guess the encryption module
+                var ext = (System.IO.Path.GetExtension(remotefilename) ?? "").TrimStart('.');
+                if (!ext.Equals(encryption?.FilenameExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Check if the file is not encrypted
+                    if (DynamicLoader.CompressionLoader.Keys.Contains(ext, StringComparer.OrdinalIgnoreCase))
+                    {
+                        if (encryption != null)
+                            Logging.Log.WriteVerboseMessage(LOGTAG, "AutomaticDecryptionDetection", "Filename extension \"{0}\" does not match encryption module \"{1}\", guessing that it is not encrypted", ext, options.EncryptionModule);
+                        return null;
+                    }
+                    // Check if the file is encrypted with something else
+                    else if (DynamicLoader.EncryptionLoader.Keys.Contains(ext, StringComparer.OrdinalIgnoreCase))
+                    {
+                        Logging.Log.WriteVerboseMessage(LOGTAG, "AutomaticDecryptionDetection", "Filename extension \"{0}\" does not match encryption module \"{1}\", attempting to use matching encryption module", ext, options.EncryptionModule);
+
+                        try
+                        {
+                            return DynamicLoader.EncryptionLoader.GetModule(ext, options.Passphrase, options.RawOptions)
+                                ?? encryption;
+                        }
+                        catch (Exception ex)
+                        {
+                            Logging.Log.WriteWarningMessage(LOGTAG, "AutomaticDecryptionDetection", ex, "Failed to load encryption module \"{0}\", using specified encryption module \"{1}\"", ext, options.EncryptionModule);
+                        }
+                    }
+                    // Fallback, lets see what happens...
+                    else
+                    {
+                        Logging.Log.WriteVerboseMessage(LOGTAG, "AutomaticDecryptionDetection", "Filename extension \"{0}\" does not match encryption module \"{1}\", attempting to use specified encryption module as no others match", ext, options.EncryptionModule);
+                    }
+                }
+
+                return encryption;
+            }
+            // If we fail here, make sure that we throw a crypto exception
+            catch (System.Security.Cryptography.CryptographicException) { throw; }
+            catch (Exception ex) { throw new System.Security.Cryptography.CryptographicException(ex.Message, ex); }
         }
     }
 

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
@@ -70,7 +70,7 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         sw_write?.Start();
                         // Pass the decrypted volume to the `VolumeDecompressor` process.
-                        await self.Output.WriteAsync((volume_id, volume, bvr));
+                        await self.Output.WriteAsync((volume_id, volume, bvr)).ConfigureAwait(false);
                         sw_write?.Stop();
                     }
                 }

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System;
@@ -52,9 +52,9 @@ namespace Duplicati.Library.Main.Operation.Restore
             },
             async self =>
             {
-                Stopwatch sw_read    = options.InternalProfiling ? new () : null;
-                Stopwatch sw_write   = options.InternalProfiling ? new () : null;
-                Stopwatch sw_decrypt = options.InternalProfiling ? new () : null;
+                Stopwatch sw_read = options.InternalProfiling ? new() : null;
+                Stopwatch sw_write = options.InternalProfiling ? new() : null;
+                Stopwatch sw_decrypt = options.InternalProfiling ? new() : null;
                 try
                 {
                     while (true)

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System;

--- a/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using CoCoL;

--- a/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
@@ -20,7 +20,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 using CoCoL;
-using Duplicati.Library.Main.Database;
 using Duplicati.Library.Main.Volumes;
 using Duplicati.Library.Utility;
 using System;
@@ -46,11 +45,9 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// <summary>
         /// Runs the volume manager process.
         /// </summary>
-        /// <param name="db">The local restore database, used to find the volume where a block is stored.</param>
-        /// <param name="backend">The backend manager, used to fetch the volumes from the backend.</param>
+        /// <param name="channels">The named channels for the restore operation.</param>
         /// <param name="options">The restore options.</param>
-        /// <param name="results">The restore results.</param>
-        public static Task Run(Channels channels, LocalRestoreDatabase db, IBackendManager backend, Options options, RestoreResults results)
+        public static Task Run(Channels channels, Options options)
         {
             return AutomationExtensions.RunTask(
                 new
@@ -106,13 +103,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                                 }
                                                 else
                                                 {
-                                                    sw_query?.Start();
-                                                    var (volume_name, volume_size, volume_hash) = db.GetVolumeInfo(request.VolumeID).First();
-                                                    sw_query?.Stop();
-                                                    sw_backend?.Start();
-                                                    var handle = backend.GetAsync(volume_name, volume_hash, volume_size, results.TaskControl.TransferToken);
-                                                    sw_backend?.Stop();
-                                                    await self.DownloadRequest.WriteAsync((request.VolumeID, handle));
+                                                    await self.DownloadRequest.WriteAsync(request.VolumeID).ConfigureAwait(false);
                                                     in_flight[request.VolumeID] = [request];
                                                 }
                                             }

--- a/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
@@ -76,7 +76,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     {
                         while (true)
                         {
-                            var msg = await self.VolumeRequestResponse.ReadAsync();
+                            var msg = await self.VolumeRequestResponse.ReadAsync().ConfigureAwait(false);
 
                             switch (msg)
                             {
@@ -96,7 +96,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                             sw_request?.Start();
                                             if (cache.TryGetValue(request.VolumeID, out BlockVolumeReader reader))
                                             {
-                                                await self.DecompressRequest.WriteAsync((request, reader));
+                                                await self.DecompressRequest.WriteAsync((request, reader)).ConfigureAwait(false);
                                             }
                                             else
                                             {
@@ -129,7 +129,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                         sw_wakeup?.Start();
                                         foreach (var request in in_flight[volume_id])
                                         {
-                                            await self.DecompressRequest.WriteAsync((request, reader));
+                                            await self.DecompressRequest.WriteAsync((request, reader)).ConfigureAwait(false);
                                         }
                                         in_flight.Remove(volume_id);
                                         sw_wakeup?.Stop();

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -340,7 +340,7 @@ namespace Duplicati.Library.Main.Operation
             var fileprocessors = Enumerable.Range(0, m_options.RestoreFileProcessors).Select(i => Restore.FileProcessor.Run(channels, database, fileprocessor_requests[i], fileprocessor_responses[i], m_options, m_result)).ToArray();
             var blockmanager = Restore.BlockManager.Run(channels, database, m_options, fileprocessor_requests, fileprocessor_responses);
             var volumecache = Restore.VolumeManager.Run(channels, m_options);
-            var volumedownloaders = Enumerable.Range(0, m_options.RestoreVolumeDownloaders).Select(i => Restore.VolumeDownloader.Run(channels, database, backendManager.GetBackend(), m_options, m_result)).ToArray();
+            var volumedownloaders = Enumerable.Range(0, m_options.RestoreVolumeDownloaders).Select(i => Restore.VolumeDownloader.Run(channels, database, backendManager, m_options, m_result)).ToArray();
             var volumedecryptors = Enumerable.Range(0, m_options.RestoreVolumeDecryptors).Select(i => Restore.VolumeDecryptor.Run(channels, backendManager, m_options)).ToArray();
             var volumedecompressors = Enumerable.Range(0, m_options.RestoreVolumeDecompressors).Select(i => Restore.VolumeDecompressor.Run(channels, m_options)).ToArray();
 

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using System;

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -339,8 +339,8 @@ namespace Duplicati.Library.Main.Operation
             var filelister = Restore.FileLister.Run(channels, database, m_options, m_result);
             var fileprocessors = Enumerable.Range(0, m_options.RestoreFileProcessors).Select(i => Restore.FileProcessor.Run(channels, database, fileprocessor_requests[i], fileprocessor_responses[i], m_options, m_result)).ToArray();
             var blockmanager = Restore.BlockManager.Run(channels, database, m_options, fileprocessor_requests, fileprocessor_responses);
-            var volumecache = Restore.VolumeManager.Run(channels, database, backendManager, m_options, m_result);
-            var volumedownloaders = Enumerable.Range(0, m_options.RestoreVolumeDownloaders).Select(i => Restore.VolumeDownloader.Run(channels, database, m_options, m_result)).ToArray();
+            var volumecache = Restore.VolumeManager.Run(channels, m_options);
+            var volumedownloaders = Enumerable.Range(0, m_options.RestoreVolumeDownloaders).Select(i => Restore.VolumeDownloader.Run(channels, database, backendManager.GetBackend(), m_options, m_result)).ToArray();
             var volumedecryptors = Enumerable.Range(0, m_options.RestoreVolumeDecryptors).Select(i => Restore.VolumeDecryptor.Run(channels, m_options)).ToArray();
             var volumedecompressors = Enumerable.Range(0, m_options.RestoreVolumeDecompressors).Select(i => Restore.VolumeDecompressor.Run(channels, m_options)).ToArray();
 

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -341,7 +341,7 @@ namespace Duplicati.Library.Main.Operation
             var blockmanager = Restore.BlockManager.Run(channels, database, m_options, fileprocessor_requests, fileprocessor_responses);
             var volumecache = Restore.VolumeManager.Run(channels, m_options);
             var volumedownloaders = Enumerable.Range(0, m_options.RestoreVolumeDownloaders).Select(i => Restore.VolumeDownloader.Run(channels, database, backendManager.GetBackend(), m_options, m_result)).ToArray();
-            var volumedecryptors = Enumerable.Range(0, m_options.RestoreVolumeDecryptors).Select(i => Restore.VolumeDecryptor.Run(channels, m_options)).ToArray();
+            var volumedecryptors = Enumerable.Range(0, m_options.RestoreVolumeDecryptors).Select(i => Restore.VolumeDecryptor.Run(channels, backendManager, m_options)).ToArray();
             var volumedecompressors = Enumerable.Range(0, m_options.RestoreVolumeDecompressors).Select(i => Restore.VolumeDecompressor.Run(channels, m_options)).ToArray();
 
             setup_log_timer.Dispose();


### PR DESCRIPTION
This PR enables parallel downloads, which greatly benefits the performance of the reworked restore flow (preliminary tests show that it's several times faster than before). Before, even though multiple processes handling the downloads were spawned, the `BackendManager` would block, resulting in serialized downloads.

- The get operation of the `BackendManager` is now non-blocking in the same fashion as the put operation.
- A get operation can now be triggered without decryption by using `BackendManager.GetDirectAsync()`.

Additionally, this PR makes the following changes:

- Fixed a bug in `BlockManager` where the formatting of the logging strings would throw an exception.
- Added additional profiling logging to the legacy restore flow.
- Added additional `.ConfigureAwait(false)` to the async calls in the reworked restore flow.
- Renamed "pending" to active when referring to the parallel uploads in the BackendManager as this better reflects that the uploads are in progress.
- Exposed the decryption methods of `BackendManager.GetOperation` to allow the restore processes to access the same decryption methods.