### PR TITLE
Fixed CORS preflight

### DIFF
--- a/Duplicati/WebserverCore/DuplicatiWebserver.cs
+++ b/Duplicati/WebserverCore/DuplicatiWebserver.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025, The Duplicati Team
+﻿// Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a 
@@ -284,6 +284,9 @@ public class DuplicatiWebserver
         var app = builder.Build();
         HttpClientHelper.Configure(app.Services.GetRequiredService<IHttpClientFactory>());
 
+        if (useCors)
+            app.UseCors(CorsPolicyName);
+
         app.UseAuthentication();
         app.UseAuthorization();
 
@@ -298,9 +301,6 @@ public class DuplicatiWebserver
 
         if (!settings.DisableStaticFiles)
             app.UseDefaultStaticFiles(settings.WebRoot, settings.SPAPaths);
-
-        if (useCors)
-            app.UseCors(CorsPolicyName);
 
         app.UseExceptionHandler(app =>
         {


### PR DESCRIPTION
This fixes the CORS preflight by allowing the preflight requests to be sent without being authenticated. Without this fix all CORS requests would fail due to the access token not being included in preflight requests.