### PR TITLE
Added interuption test

### DIFF
--- a/Duplicati/UnitTest/CompactDisruptionTests.cs
+++ b/Duplicati/UnitTest/CompactDisruptionTests.cs
@@ -135,13 +135,13 @@ namespace Duplicati.UnitTest
             target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
             // Fail the compact after the first dblock put is completed
             bool firstPutCompleted = false;
-            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
             {
-                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                if (firstPutCompleted && action.IsGetOperation)
                 {
                     return true;
                 }
-                if (action == "put_1" || action == "put_async")
+                if (action == DeterministicErrorBackend.BackendAction.PutAfter)
                 {
                     firstPutCompleted = true;
                 }
@@ -250,13 +250,13 @@ namespace Duplicati.UnitTest
             target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
             // Fail the compact after the first dblock put is completed
             bool firstPutCompleted = false;
-            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
             {
-                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                if (firstPutCompleted && action.IsGetOperation)
                 {
                     return true;
                 }
-                if (action == "put_1" || action == "put_async")
+                if (action == DeterministicErrorBackend.BackendAction.PutAfter)
                 {
                     firstPutCompleted = true;
                 }
@@ -382,13 +382,13 @@ namespace Duplicati.UnitTest
             target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
             // Fail the compact after the first dblock put is completed
             bool firstPutCompleted = false;
-            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
             {
-                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                if (firstPutCompleted && action.IsGetOperation)
                 {
                     return true;
                 }
-                if (action == "put_1" || action == "put_async")
+                if (action == DeterministicErrorBackend.BackendAction.PutAfter)
                 {
                     firstPutCompleted = true;
                 }
@@ -523,13 +523,13 @@ namespace Duplicati.UnitTest
             target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
             // Fail the compact after the first dblock put is completed
             bool firstPutCompleted = false;
-            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
             {
-                if (firstPutCompleted && (action == "get_0" || action == "get_1"))
+                if (firstPutCompleted && action.IsGetOperation)
                 {
                     return true;
                 }
-                if (action == "put_1" || action == "put_async")
+                if (action == DeterministicErrorBackend.BackendAction.PutAfter)
                 {
                     firstPutCompleted = true;
                 }

--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025, The Duplicati Team
+﻿// Copyright (C) 2025, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -68,10 +68,10 @@ namespace Duplicati.UnitTest
             // Fail after index file put
             target = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
             string interruptedName = "";
-            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
             {
                 // Fail dindex upload
-                if (action.StartsWith("put") && remotename.Contains("dindex"))
+                if (action == DeterministicErrorBackend.BackendAction.PutAfter && remotename.Contains("dindex"))
                 {
                     interruptedName = remotename;
                     return true;
@@ -460,7 +460,7 @@ namespace Duplicati.UnitTest
             bool failed = false;
             long accessCounter = 0;
             long errorIdx = 0;
-            DeterministicErrorBackend.ErrorGenerator = (string action, string remotename) =>
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
             {
                 ++accessCounter;
                 if (accessCounter >= errorIdx)


### PR DESCRIPTION
This adds a test with a failed upload.

The failed upload is done in parallel, so (at least) one of the uploads succeeeds and one upload fails.

The backup then errors, but a subsequent backup continues without errors and creates a synthetic filelist.

Also refactored the DeterministicErrorBackend to not use magic strings. And made it actually deterministic.