### PR TITLE
Update release builder signing

### DIFF
--- a/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
+++ b/Duplicati/Library/Modules/Builtin/Duplicati.Library.Modules.Builtin.csproj
@@ -24,19 +24,13 @@
     <ProjectReference Include="..\..\Backend\OAuthHelper\Duplicati.Library.OAuthHelper.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-      <!-- Extract the first 4 characters from RuntimeIdentifier -->
-      <RIDPrefix Condition="'$(RuntimeIdentifier)' != ''">$([System.String]::Copy('$(RuntimeIdentifier)'))</RIDPrefix>
-      <RIDPrefix Condition="'$(RuntimeIdentifier)' != '' and $([System.String]::Length('$(RuntimeIdentifier)')) &gt;= 4">$([System.String]::Substring('$(RuntimeIdentifier)', 0, 4))</RIDPrefix>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(RIDPrefix)' == 'win-' Or '$(RuntimeIdentifier)' == '' ">
+  <ItemGroup Condition=" $([System.Text.RegularExpressions.Regex]::IsMatch('$(RuntimeIdentifier)', '^win-')) Or '$(RuntimeIdentifier)' == '' ">
       <Content Include="run-script-example.bat">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(RIDPrefix)' != 'win-' Or '$(RuntimeIdentifier)' == '' ">
+  <ItemGroup Condition=" ! $([System.Text.RegularExpressions.Regex]::IsMatch('$(RuntimeIdentifier)', '^win-')) Or '$(RuntimeIdentifier)' == '' ">
       <Content Include="run-script-example.sh">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/ReleaseBuilder/Build/Command.Compile.Post.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Post.cs
@@ -316,7 +316,7 @@ public static partial class Command
         /// <returns>An awaitable task</returns>
         static async Task SignWindowsExecutables(string buildDir, RuntimeConfig rtcfg)
         {
-            var cfg = Program.Configuration;
+            var cfg = rtcfg.Configuration;
             if (!rtcfg.UseAuthenticodeSigning)
                 return;
 

--- a/ReleaseBuilder/Build/Command.Compile.Post.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Post.cs
@@ -248,14 +248,7 @@ public static partial class Command
             var licenseTarget = Path.Combine(tmpApp, "Contents", "Licenses");
             Directory.Move(Path.Combine(binDir, "licenses"), licenseTarget);
 
-            // Apply code signing, if requested
-            if (rtcfg.UseCodeSignSigning)
-            {
-                var entitlementFile = Path.Combine(resourcesDir, "Entitlements.plist");
-                await PackageSupport.SignMacOSBinaries(rtcfg, binDir, entitlementFile);
-                await rtcfg.Codesign(tmpApp, entitlementFile);
-            }
-
+            // Make files executable
             if (!OperatingSystem.IsWindows())
                 foreach (var f in Directory.EnumerateFiles(binDir, "*.launchagent.plist", SearchOption.TopDirectoryOnly))
                     File.SetUnixFileMode(f, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);

--- a/ReleaseBuilder/Build/Command.CreatePackage.cs
+++ b/ReleaseBuilder/Build/Command.CreatePackage.cs
@@ -175,7 +175,7 @@ public static partial class Command
             {
                 // # Notarize and staple takes a while...
                 Console.WriteLine($"Performing notarize and staple of {packageFile} ...");
-                await ProcessHelper.Execute(["xcrun", "notarytool", "submit", tempFile, "--keychain-profile", Program.Configuration.ConfigFiles.NotarizeProfile, "--wait"]);
+                await ProcessHelper.Execute(["xcrun", "notarytool", "submit", tempFile, "--keychain-profile", rtcfg.Configuration.ConfigFiles.NotarizeProfile, "--wait"]);
                 await ProcessHelper.Execute(["xcrun", "stapler", "staple", tempFile]);
             }
 
@@ -322,7 +322,7 @@ public static partial class Command
                     .Replace(originalNamespace, wixv4Namespace));
 
                 wixArgs = [
-                    Program.Configuration.Commands.Wix!,
+                    rtcfg.Configuration.Commands.Wix!,
                     "build",
                     "-define", $"HarvestPath={sourceFiles}",
                     "-arch", msiArch,
@@ -336,7 +336,7 @@ public static partial class Command
             {
                 // wixl needs the UI extension
                 wixArgs = [
-                    Program.Configuration.Commands.Wix!,
+                    rtcfg.Configuration.Commands.Wix!,
                     "--ext", "ui",
                     "--extdir", Path.Combine(resourcesDir, "WixUIExtension"),
                     "--define", $"HarvestPath={sourceFiles}",
@@ -1180,11 +1180,11 @@ public static partial class Command
     private static async Task BuildDockerImages(string baseDir, string buildRoot, IEnumerable<PackageTarget> targets, RuntimeConfig rtcfg)
     {
         // Make sure any dangling buildx instances are removed
-        try { await ProcessHelper.Execute([Program.Configuration.Commands.Docker!, "buildx", "rm", "duplicati-builder"], codeIsError: _ => false, suppressStdErr: true); }
+        try { await ProcessHelper.Execute([rtcfg.Configuration.Commands.Docker!, "buildx", "rm", "duplicati-builder"], codeIsError: _ => false, suppressStdErr: true); }
         catch { }
 
         // Prepare multi-build
-        await ProcessHelper.Execute([Program.Configuration.Commands.Docker!, "buildx", "create", "--use", "--name", "duplicati-builder"]);
+        await ProcessHelper.Execute([rtcfg.Configuration.Commands.Docker!, "buildx", "create", "--use", "--name", "duplicati-builder"]);
 
         // Perform a distict build for each interface type, but keep the buildx instance
         foreach (var interfaceType in Enum.GetValues<InterfaceType>())
@@ -1239,7 +1239,7 @@ public static partial class Command
             var repo = $"{rtcfg.DockerRepo}{(interfaceType == InterfaceType.Agent ? "-agent" : "")}";
 
             // Build the images
-            var args = new List<string> { Program.Configuration.Commands.Docker!, "buildx", "build" };
+            var args = new List<string> { rtcfg.Configuration.Commands.Docker!, "buildx", "build" };
             args.AddRange(tags.SelectMany(x => new[] { "-t", $"{repo}:{x.ToLowerInvariant()}" }));
             args.AddRange([
                 "--platform", string.Join(",", dockerArchs),
@@ -1258,6 +1258,6 @@ public static partial class Command
         }
 
         // Clean up
-        await ProcessHelper.Execute([Program.Configuration.Commands.Docker!, "buildx", "rm", "duplicati-builder"]);
+        await ProcessHelper.Execute([rtcfg.Configuration.Commands.Docker!, "buildx", "rm", "duplicati-builder"]);
     }
 }

--- a/ReleaseBuilder/Build/Command.CreatePackage.cs
+++ b/ReleaseBuilder/Build/Command.CreatePackage.cs
@@ -372,8 +372,10 @@ public static partial class Command
             if (rtcfg.UseCodeSignSigning)
             {
                 var entitlementFile = Path.Combine(installerDir, "Entitlements.plist");
-                await PackageSupport.SignMacOSBinaries(rtcfg, appFolder, entitlementFile);
-                await rtcfg.Codesign(appFolder, true, entitlementFile);
+                // In principle, it should be enough to deep sign the bundle, but the signtool is broken
+                await PackageSupport.SignMacOSBinaries(rtcfg, Path.Combine(appFolder, "Contents", "MacOS"), entitlementFile);
+                await rtcfg.Codesign(appFolder, false, entitlementFile);
+                await rtcfg.VerifyCodeSign(appFolder);
             }
         }
 
@@ -451,6 +453,7 @@ public static partial class Command
             Directory.Delete(mountDir, false);
 
             await rtcfg.Codesign(dmgFile, false, Path.Combine(resourcesDir, "Entitlements.plist"));
+            await rtcfg.VerifyCodeSign(dmgFile);
         }
 
         /// <summary>

--- a/ReleaseBuilder/Build/Command.GitPush.cs
+++ b/ReleaseBuilder/Build/Command.GitPush.cs
@@ -39,29 +39,29 @@ public static partial class Command
             File.WriteAllText(Path.Combine(baseDir, "ReleaseBuilder", "build_version.txt"), releaseInfo.Version.ToString());
 
             // Add modified files
-            await ProcessHelper.Execute(new[] {
+            await ProcessHelper.Execute([
                     "git", "add",
                     "ReleaseBuilder/build_version.txt",
                     "changelog.txt"
-                }, workingDirectory: baseDir);
+                ], workingDirectory: baseDir);
 
             // Make a commit
-            await ProcessHelper.Execute(new[] {
+            await ProcessHelper.Execute([
                     "git", "commit",
                     "-m", $"Version bump to v{releaseInfo.Version}-{releaseInfo.ReleaseName}",
                     "-m", "You can download this build from: ",
                     "-m", $"Binaries: https://updates.duplicati.com/{releaseInfo.Channel.ToString().ToLowerInvariant()}/?version={releaseInfo.Version}",
                     "-m", $"Signature file: https://updates.duplicati.com/{releaseInfo.Channel.ToString().ToLowerInvariant()}/duplicati-{releaseInfo.ReleaseName}.signatures.zip"
-                }, workingDirectory: baseDir);
+                ], workingDirectory: baseDir);
 
             // And tag the release
-            await ProcessHelper.Execute(new[] {
+            await ProcessHelper.Execute([
                     "git", "tag", $"v{releaseInfo.Version}-{releaseInfo.ReleaseName}",
-                }, workingDirectory: baseDir);
+                ], workingDirectory: baseDir);
 
             // Then push the release
-            await ProcessHelper.Execute(new[] { "git", "push", "-u", "origin", "head" }, workingDirectory: baseDir);
-            await ProcessHelper.Execute(new[] { "git", "push", "--tags" }, workingDirectory: baseDir);
+            await ProcessHelper.Execute(["git", "push", "-u", "origin", "head"], workingDirectory: baseDir);
+            await ProcessHelper.Execute(["git", "push", "--tags"], workingDirectory: baseDir);
         }
     }
 }

--- a/ReleaseBuilder/Build/Command.GpgSign.cs
+++ b/ReleaseBuilder/Build/Command.GpgSign.cs
@@ -53,7 +53,7 @@ public static partial class Command
 
                         await ProcessHelper.Execute(
                             [
-                                Program.Configuration.Commands.Gpg!,
+                                rtcfg.Configuration.Commands.Gpg!,
                                 "--pinentry-mode", "loopback",
                                 "--passphrase-fd", "0",
                                 "--batch", "--yes",
@@ -86,7 +86,7 @@ public static partial class Command
         static (string GpgId, string GpgPassphrase) GetGpgIdAndPassphrase(RuntimeConfig rtcfg)
         {
             using var ms = new MemoryStream();
-            using var fs = File.OpenRead(Program.Configuration.ConfigFiles.GpgKeyfile);
+            using var fs = File.OpenRead(rtcfg.Configuration.ConfigFiles.GpgKeyfile);
             SharpAESCrypt.SharpAESCrypt.Decrypt(rtcfg.KeyfilePassword, fs, ms);
             var parts = System.Text.Encoding.UTF8.GetString(ms.ToArray()).Split('\n', 2, StringSplitOptions.RemoveEmptyEntries);
             return (parts[0], parts[1]);

--- a/ReleaseBuilder/Build/Command.PackageSupport.cs
+++ b/ReleaseBuilder/Build/Command.PackageSupport.cs
@@ -115,7 +115,7 @@ public static partial class Command
                     .ToList();
 
                 foreach (var f in signtargets)
-                    await rtcfg.Codesign(f, entitlementFile);
+                    await rtcfg.Codesign(f, false, entitlementFile);
             }
         }
     }

--- a/ReleaseBuilder/Build/Command.RuntimeConfig.cs
+++ b/ReleaseBuilder/Build/Command.RuntimeConfig.cs
@@ -473,15 +473,17 @@ public static partial class Command
         /// Performs codesign on the given file
         /// </summary>
         /// <param name="file">The file to sign</param>
+        /// <param name="deep">A value indicating if deep signing should be used</param>
         /// <param name="entitlements">The entitlements to apply</param>
         /// <returns>An awaitable task</returns>
-        public Task Codesign(string file, string entitlements)
+        public Task Codesign(string file, bool deep, string entitlements)
             => UseCodeSignSigning
                 ? ProcessRunner.MacOSCodeSign(
                     Configuration.Commands.Codesign!,
                     Configuration.ConfigFiles.CodesignIdentity,
                     entitlements,
-                    file
+                    file,
+                    deep
                 )
                 : Task.CompletedTask;
 

--- a/ReleaseBuilder/Build/Command.RuntimeConfig.cs
+++ b/ReleaseBuilder/Build/Command.RuntimeConfig.cs
@@ -488,6 +488,19 @@ public static partial class Command
                 : Task.CompletedTask;
 
         /// <summary>
+        /// Verifies the codesign of the given file or app bundle
+        /// </summary>
+        /// <param name="file">The file to verify</param>
+        /// <returns>An awaitable task</returns>
+        public Task VerifyCodeSign(string file)
+            => UseCodeSignSigning
+                ? ProcessRunner.MacOSVerifyCodeSign(
+                    Configuration.Commands.Codesign!,
+                    file
+                )
+                : Task.CompletedTask;
+
+        /// <summary>
         /// Performs productsign on the given file
         /// </summary>
         /// <param name="file">The file to sign</param>

--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -222,6 +222,12 @@ public static partial class Command
 
         var passwordOption = SharedOptions.passwordOption;
 
+        var signkeyPinOption = new Option<string>(
+            name: "--signkey-pin",
+            description: "The pin to use for the signing key",
+            getDefaultValue: () => string.Empty
+        );
+
         var disableDockerPushOption = new Option<bool>(
             name: "--disable-docker-push",
             description: "Disables pushing the docker image to the repository",
@@ -317,6 +323,7 @@ public static partial class Command
             disableAuthenticodeOption,
             disableCodeSignOption,
             passwordOption,
+            signkeyPinOption,
             macOsAppNameOption,
             disableDockerPushOption,
             dockerRepoOption,
@@ -351,6 +358,7 @@ public static partial class Command
     /// <param name="DisableAuthenticode">If authenticode signing should be disabled</param>
     /// <param name="DisableSignCode">If signcode should be disabled</param>
     /// <param name="Password">The password to use for the keyfile</param>
+    /// <param name="SignkeyPin">The pin to use for the signing key</param>
     /// <param name="DisableDockerPush">If the docker push should be disabled</param>
     /// <param name="MacOSAppName">The name of the MacOS app bundle</param>
     /// <param name="DockerRepo">The docker repository to push to</param>
@@ -376,6 +384,7 @@ public static partial class Command
         bool DisableAuthenticode,
         bool DisableSignCode,
         string Password,
+        string SignkeyPin,
         bool DisableDockerPush,
         string MacOSAppName,
         string DockerRepo,

--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -888,7 +888,7 @@ public static partial class Command
             EnvHelper.CopyDirectory(target, tmp, true);
 
             // Run npm install in the temporary folder
-            await ProcessHelper.Execute(new[] { rtcfg.Configuration.Commands.Npm, "ci" }, workingDirectory: tmp);
+            await ProcessHelper.Execute([rtcfg.Configuration.Commands.Npm, "ci"], workingDirectory: tmp);
             var basefolder = Directory.EnumerateDirectories(Path.Combine(tmp, "node_modules"), "*", SearchOption.AllDirectories)
                 .Where(x => File.Exists(Path.Combine(x, "index.html")))
                 .OrderBy(x => x.Length)

--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -394,6 +394,7 @@ public static partial class Command
     static async Task DoBuild(CommandInput input)
     {
         Console.WriteLine($"Building {input.Channel} release ...");
+        var configuration = Configuration.Create(input.Channel);
 
         var buildTargets = input.Targets;
 
@@ -404,15 +405,15 @@ public static partial class Command
             throw new FileNotFoundException($"Solution file not found: {input.SolutionFile.FullName}");
 
         // This could be fixed, so we will throw an exception if the build is not possible
-        if (buildTargets.Any(x => x.Package == PackageType.MSI) && !Program.Configuration.IsMSIBuildPossible())
+        if (buildTargets.Any(x => x.Package == PackageType.MSI) && !configuration.IsMSIBuildPossible())
             throw new Exception("WiX toolset not configured, cannot build MSI files");
 
         // This will be fixed in the future, but requires a new http-interface for Synology DSM
-        if (buildTargets.Any(x => x.Package == PackageType.SynologySpk) && !Program.Configuration.IsSynologyPkgPossible())
+        if (buildTargets.Any(x => x.Package == PackageType.SynologySpk) && !configuration.IsSynologyPkgPossible())
             throw new Exception("Synology SPK files are currently not supported");
 
         // This will not work, so to make it easier for non-MacOS developers, we will remove the MacOS packages
-        if (buildTargets.Any(x => x.Package == PackageType.MacPkg || x.Package == PackageType.DMG) && !Program.Configuration.IsMacPkgBuildPossible())
+        if (buildTargets.Any(x => x.Package == PackageType.MacPkg || x.Package == PackageType.DMG) && !configuration.IsMacPkgBuildPossible())
         {
             Console.WriteLine("MacOS packages requested but not running on MacOS, removing from build targets");
             buildTargets = buildTargets.Where(x => x.Package != PackageType.MacPkg && x.Package != PackageType.DMG).ToArray();
@@ -481,13 +482,14 @@ public static partial class Command
         if (string.IsNullOrWhiteSpace(keyfilePassword))
             keyfilePassword = ConsoleHelper.ReadPassword("Enter keyfile password");
 
-        var primarySignKey = LoadKeyFile(Program.Configuration.ConfigFiles.UpdaterKeyfile.FirstOrDefault(), keyfilePassword, false);
-        var additionalKeys = Program.Configuration.ConfigFiles.UpdaterKeyfile
+        var primarySignKey = LoadKeyFile(configuration.ConfigFiles.UpdaterKeyfile.FirstOrDefault(), keyfilePassword, false);
+        var additionalKeys = configuration.ConfigFiles.UpdaterKeyfile
             .Skip(1)
             .Select(x => LoadKeyFile(x, keyfilePassword, true));
 
         // Configure runtime environment
         var rtcfg = new RuntimeConfig(
+            configuration,
             releaseInfo,
             additionalKeys.Prepend(primarySignKey).ToList(),
             keyfilePassword,
@@ -590,11 +592,11 @@ public static partial class Command
                 }),
                 Path.Combine(input.BuildPath.FullName, "packages"),
                 version: releaseInfo.Version.ToString(),
-                incompatibleUpdateUrl: ReplaceVersionPlaceholders(Program.Configuration.ExtraSettings.UpdateFromIncompatibleVersionUrl, releaseInfo),
-                genericUpdatePageUrl: ReplaceVersionPlaceholders(Program.Configuration.ExtraSettings.GenericUpdatePageUrl, releaseInfo),
+                incompatibleUpdateUrl: ReplaceVersionPlaceholders(configuration.ExtraSettings.UpdateFromIncompatibleVersionUrl, releaseInfo),
+                genericUpdatePageUrl: ReplaceVersionPlaceholders(configuration.ExtraSettings.GenericUpdatePageUrl, releaseInfo),
                 releaseType: releaseInfo.Channel.ToString().ToLowerInvariant(),
                 packages: builtPackages.Select(x => new PackageEntry(
-                    RemoteUrls: Program.Configuration.ExtraSettings.PackageUrls
+                    RemoteUrls: configuration.ExtraSettings.PackageUrls
                         .Select(u =>
                             ReplaceVersionPlaceholders(u, releaseInfo)
                             .Replace("${FILENAME}", HttpUtility.UrlEncode(Path.GetFileName(x.CreatedFile)))
@@ -784,7 +786,7 @@ public static partial class Command
     /// <returns>Modified files</returns>
     static Task<List<string>> PrepareSourceDirectory(string baseDir, ReleaseInfo releaseInfo, RuntimeConfig rtcfg)
     {
-        var urlstring = string.Join(";", Program.Configuration.ExtraSettings.UpdaterUrls.Select(x =>
+        var urlstring = string.Join(";", rtcfg.Configuration.ExtraSettings.UpdaterUrls.Select(x =>
             ReplaceVersionPlaceholders(x, releaseInfo)
             .Replace("${FILENAME}", HttpUtility.UrlEncode("latest-v2.manifest"))
         ));
@@ -832,8 +834,8 @@ public static partial class Command
             JsonSerializer.Serialize(new { Displayname = $"Duplicati v{releaseInfo.Version} - {releaseInfo.Channel}" }),
             Path.Combine(baseDir, "Duplicati", "Library", "AutoUpdater"),
             version: releaseInfo.Version.ToString(),
-            incompatibleUpdateUrl: ReplaceVersionPlaceholders(Program.Configuration.ExtraSettings.UpdateFromIncompatibleVersionUrl, releaseInfo),
-            genericUpdatePageUrl: ReplaceVersionPlaceholders(Program.Configuration.ExtraSettings.GenericUpdatePageUrl, releaseInfo),
+            incompatibleUpdateUrl: ReplaceVersionPlaceholders(rtcfg.Configuration.ExtraSettings.UpdateFromIncompatibleVersionUrl, releaseInfo),
+            genericUpdatePageUrl: ReplaceVersionPlaceholders(rtcfg.Configuration.ExtraSettings.GenericUpdatePageUrl, releaseInfo),
             releaseType: releaseInfo.Channel.ToString().ToLowerInvariant()
         );
 
@@ -868,7 +870,7 @@ public static partial class Command
 
         foreach (var target in targets)
         {
-            if (string.IsNullOrWhiteSpace(Program.Configuration.Commands.Npm))
+            if (string.IsNullOrWhiteSpace(rtcfg.Configuration.Commands.Npm))
                 throw new Exception("NPM command not found, but required for building");
 
             // Remove existing node_modules folder
@@ -886,7 +888,7 @@ public static partial class Command
             EnvHelper.CopyDirectory(target, tmp, true);
 
             // Run npm install in the temporary folder
-            await ProcessHelper.Execute(new[] { Program.Configuration.Commands.Npm, "ci" }, workingDirectory: tmp);
+            await ProcessHelper.Execute(new[] { rtcfg.Configuration.Commands.Npm, "ci" }, workingDirectory: tmp);
             var basefolder = Directory.EnumerateDirectories(Path.Combine(tmp, "node_modules"), "*", SearchOption.AllDirectories)
                 .Where(x => File.Exists(Path.Combine(x, "index.html")))
                 .OrderBy(x => x.Length)

--- a/ReleaseBuilder/Configuration.cs
+++ b/ReleaseBuilder/Configuration.cs
@@ -77,13 +77,26 @@ public record Configuration(
             ExtraSettings.Create()
         );
 
+
     /// <summary>
-    /// Checks if signing with authenticode is possible given the current configuration
+    /// Checks if signing with authenticode using jsign is possible given the current configuration
     /// </summary>
     /// <returns>A boolean indicating if signing is possible</returns>
-    public bool IsAuthenticodePossible()
+    public bool IsAuthenticodePossibleWithJsignTool()
     {
-        if (string.IsNullOrWhiteSpace(ConfigFiles.AuthenticodePasswordFile) || string.IsNullOrWhiteSpace(ConfigFiles.AuthenticodePfxFile) || string.IsNullOrWhiteSpace(Commands.OsslSignCode))
+        if (string.IsNullOrWhiteSpace(Commands.JSign))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks if signing with authenticode is possible with signtool given the current configuration
+    /// </summary>
+    /// <returns>A boolean indicating if signing is possible</returns>
+    public bool IsAuthenticodePossibleWithSignTool()
+    {
+        if (string.IsNullOrWhiteSpace(ConfigFiles.AuthenticodePasswordFile) || string.IsNullOrWhiteSpace(ConfigFiles.AuthenticodePfxFile) || string.IsNullOrWhiteSpace(Commands.SignCode))
             return false;
 
         if (!File.Exists(ConfigFiles.AuthenticodePasswordFile) || !File.Exists(ConfigFiles.AuthenticodePfxFile))
@@ -329,7 +342,8 @@ public record ConfigFiles(
 /// <param name="Dotnet">The &quot;build&quot; command</param>
 /// <param name="Gpg">The &quot;gpg&quot; command</param>
 /// <param name="AwsCli">The &quot;aws&quot; command</param>
-/// <param name="OsslSignCode">The &quot;osslsigncode&quot; command</param>
+/// <param name="SignCode">The &quot;osslsigncode&quot; command</param>
+/// <param name="Jsign">The &quot;jsign&quot; command</param>
 /// <param name="Codesign">The &quot;codesign&quot; command</param>
 /// <param name="Productsign">The &quot;productsign&quot; command</param>
 /// <param name="Wix">The &quot;wix&quot; command</param>
@@ -338,7 +352,8 @@ public record ConfigFiles(
 public record Commands(
     string Dotnet,
     string? Gpg,
-    string? OsslSignCode,
+    string? SignCode,
+    string? JSign,
     string? Codesign,
     string? Productsign,
     string? Wix,
@@ -355,6 +370,7 @@ public record Commands(
             FindCommand("dotnet", "DOTNET") ?? throw new Exception("Failed to find the \"dotnet\" command"),
             FindCommand("gpg2", "GPG", FindCommand("gpg", "GPG")),
             FindCommand(OperatingSystem.IsWindows() ? "signtool.exe" : "osslsigncode", "SIGNTOOL"),
+            FindCommand("jsign", "JSIGNTOOL"),
             OperatingSystem.IsMacOS() ? FindCommand("codesign", "CODESIGN") : null,
             OperatingSystem.IsMacOS() ? FindCommand("productsign", "PRODUCTSIGN") : null,
             FindCommand(OperatingSystem.IsWindows() ? "wix" : "wixl", "WIX"),

--- a/ReleaseBuilder/CreateKey/Command.cs
+++ b/ReleaseBuilder/CreateKey/Command.cs
@@ -32,7 +32,7 @@ public static class Command
         var keyfileArgument = new Argument<FileInfo>(
             name: "keyfile",
             description: "Path to keyfile to use for signing release manifests",
-            getDefaultValue: () => new FileInfo(Program.Configuration.ConfigFiles.UpdaterKeyfile.FirstOrDefault() ?? "./signkey.key")
+            getDefaultValue: () => new FileInfo(Configuration.Create(ReleaseChannel.Debug).ConfigFiles.UpdaterKeyfile.FirstOrDefault() ?? "./signkey.key")
         );
 
         var command = new System.CommandLine.Command("create-key", "Creates a new key for signing releases")

--- a/ReleaseBuilder/EnvHelper.cs
+++ b/ReleaseBuilder/EnvHelper.cs
@@ -206,7 +206,7 @@ public static class EnvHelper
         var targetEntry = Path.GetFileName(path);
 
         // Use docker to set the ownership
-        await ProcessHelper.Execute(new[] { "docker", "run", "--mount", $"type=bind,source={baseFolder},target=/opt/mount", "alpine:latest", "chown", recursive ? "-R" : "", $"{uid}:{gid}", Path.Combine("/opt/mount", targetEntry) });
+        await ProcessHelper.Execute(["docker", "run", "--mount", $"type=bind,source={baseFolder},target=/opt/mount", "alpine:latest", "chown", recursive ? "-R" : "", $"{uid}:{gid}", Path.Combine("/opt/mount", targetEntry)]);
     }
 
     /// <summary>

--- a/ReleaseBuilder/EnvHelper.cs
+++ b/ReleaseBuilder/EnvHelper.cs
@@ -41,11 +41,20 @@ public static class EnvHelper
         if (string.IsNullOrWhiteSpace(value))
             value = defaultValue ?? string.Empty;
 
+        return ExpandEnv(value);
+    }
+
+    /// <summary>
+    /// Reads the environment key, and expands environment variables inside.
+    /// If no key is found, the default value is returned
+    /// </summary>
+    /// <param name="key">The key to use</param>
+    /// <returns>The expanded string</returns>
+    public static string ExpandEnv(string value)
         // Bash-style env expansion "${name}", done after normal env expansion
-        return Regex.Replace(Environment.ExpandEnvironmentVariables(value), "\\${(?<name>[^}]+)}", m =>
+        => Regex.Replace(Environment.ExpandEnvironmentVariables(value), "\\${(?<name>[^}]+)}", m =>
             Environment.GetEnvironmentVariable(m.Groups["name"].Value) ?? string.Empty
         );
-    }
 
     /// <summary>
     /// Reads the environment key, and expands environment variables inside.

--- a/ReleaseBuilder/ProcessHelper.cs
+++ b/ReleaseBuilder/ProcessHelper.cs
@@ -249,7 +249,7 @@ public static class ProcessHelper
 
         await p.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
         if (codeIsError(p.ExitCode))
-            throw new Exception($"Execution of {executable} gave error code {p.ExitCode}");
+            throw new Exception($"Execution of {executable} gave error code {p.ExitCode}, see log file {Path.Combine(logFolder, logFilename(p.Id, true))}");
 
         await t1.ConfigureAwait(false);
         await t2.ConfigureAwait(false);

--- a/ReleaseBuilder/ProcessRunner.cs
+++ b/ReleaseBuilder/ProcessRunner.cs
@@ -83,6 +83,7 @@ public static class ProcessRunner
     public static Task MacOSCodeSign(string codesign, string codesignIdentity, string entitlementFile, string file)
         => ProcessHelper.Execute([
             codesign,
+            "--deep",
             "--force",
             "--timestamp",
             "--options=runtime",

--- a/ReleaseBuilder/ProcessRunner.cs
+++ b/ReleaseBuilder/ProcessRunner.cs
@@ -52,20 +52,19 @@ public static class ProcessRunner
             var tmp = Path.GetTempFileName();
             File.Delete(tmp);
 
-            var args = new[] {
+            await ProcessHelper.Execute([
                 osslsigncode, "sign",
                 "-pkcs12", pfxfile,
                 "-pass", pfxpassword,
                 "-n", OSSLOrganization,
                 "-i", OSSLUrl,
                 "-h", hashalg,
-                first ? "" : "-nest",
+                first ? null : "-nest",
                 "-t", $"http://timestamp.digicert.com?alg={hashalg}",
                 "-in", executable,
                 "-out", tmp
-            };
+            ]);
 
-            await ProcessHelper.Execute(args.Where(x => !string.IsNullOrWhiteSpace(x)));
             File.Move(tmp, executable, true);
 
             first = false;

--- a/ReleaseBuilder/ProcessRunner.cs
+++ b/ReleaseBuilder/ProcessRunner.cs
@@ -93,6 +93,21 @@ public static class ProcessRunner
         ]);
 
     /// <summary>
+    /// Verifies the MacOS codesign of a file or app bundle
+    /// </summary>
+    /// <param name="codesign">The path to the codesign binary</param>
+    /// <param name="file">The file to verify</param>
+    /// <returns>An awaitable task</returns>
+    public static Task MacOSVerifyCodeSign(string codesign, string file)
+        => ProcessHelper.Execute([
+            codesign,
+            "--verify",
+            "--deep",
+            "--strict",
+            file
+        ]);
+
+    /// <summary>
     /// Runs MacOS codesign on a single file
     /// </summary>
     /// <param name="productsign">The path to the productsign binary</param>

--- a/ReleaseBuilder/ProcessRunner.cs
+++ b/ReleaseBuilder/ProcessRunner.cs
@@ -78,11 +78,12 @@ public static class ProcessRunner
     /// <param name="codesignIdentity">The identity used for codesign</param>
     /// <param name="entitlementFile">The entitlements to activate for the file</param>
     /// <param name="file">The file to sign</param>
+    /// <param name="deep">Whether to sign deeply</param>
     /// <returns>An awaitable task</returns>
-    public static Task MacOSCodeSign(string codesign, string codesignIdentity, string entitlementFile, string file)
+    public static Task MacOSCodeSign(string codesign, string codesignIdentity, string entitlementFile, string file, bool deep)
         => ProcessHelper.Execute([
             codesign,
-            "--deep",
+            (deep ? "--deep" : null),
             "--force",
             "--timestamp",
             "--options=runtime",

--- a/ReleaseBuilder/Program.cs
+++ b/ReleaseBuilder/Program.cs
@@ -89,11 +89,6 @@ class Program
     .ToList();
 
     /// <summary>
-    /// The environment shared configuration
-    /// </summary>
-    public static readonly Configuration Configuration = Configuration.Create();
-
-    /// <summary>
     /// The return code of the application; shared state
     /// </summary>
     public static int? ReturnCode = 0;


### PR DESCRIPTION
This adds support for configuration profiles for the release builder.
It also modifies the MacOS signing to be a bit more consistent, and it adds support for using `jsign` to sign Windows executables with Authenticode.