### PR TITLE
Add tests for lost uploads

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
@@ -415,7 +415,7 @@ partial class BackendManager
                         }
                     }
 
-                    context.Statwriter.SendEvent(op.Operation, retries < maxRetries ? BackendEventType.Retrying : BackendEventType.Failed, op.RemoteFilename, op.Size);
+                    context.Statwriter.SendEvent(op.Operation, retries <= maxRetries ? BackendEventType.Retrying : BackendEventType.Failed, op.RemoteFilename, op.Size);
 
                     // Check if we can recover from the error
                     var recovered = false;
@@ -428,14 +428,14 @@ partial class BackendManager
                     }
 
                     // We did not recover, so wait or give up
-                    if (!recovered && retries < maxRetries && retryDelay.Ticks != 0)
+                    if (!recovered && retries <= maxRetries && retryDelay.Ticks != 0)
                     {
                         var delay = Library.Utility.Utility.GetRetryDelay(retryDelay, retries, retryWithExponentialBackoff);
                         await Task.Delay(delay, context.TaskReader.ProgressToken).ConfigureAwait(false);
                     }
                 }
 
-            } while (retries < maxRetries);
+            } while (retries <= maxRetries);
 
             // If we have a last exception, we failed
             if (lastException != null)

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -66,7 +66,7 @@ namespace Duplicati.UnitTest
                 {
                     if (path.EndsWith(this.fileSizes[2] + "MB"))
                     {
-                        Thread.Sleep(500);
+                        Thread.Sleep(2000);
                         controller.Stop();
                         stopped.TrySetResult(true);
                     }

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Logging;
 using Duplicati.Library.Main;
 using Duplicati.Library.Main.Database;
 using Duplicati.Library.Main.Volumes;
@@ -812,6 +813,319 @@ namespace Duplicati.UnitTest
             Assert.That(secondUploadStarted, Is.True, "Second upload was not started");
             Assert.That(secondUploadCompleted, Is.True, "Second upload was not started");
 
+            // Create a regular backup
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Verify that all is in order
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { full_remote_verification = true }), null))
+            {
+                var r = c.Test(long.MaxValue);
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
+                Assert.IsFalse(r.Verifications.Any(p => p.Value.Any()));
+            }
+
+            // Test that we can recreate
+            var recreatedDatabaseFile = Path.Combine(BASEFOLDER, "recreated-database.sqlite");
+            if (File.Exists(recreatedDatabaseFile))
+                File.Delete(recreatedDatabaseFile);
+
+            testopts["dbpath"] = recreatedDatabaseFile;
+
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
+            }
+
+            // Check that we have 3 versions
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IListResults listResults = c.List();
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
+                Assert.AreEqual(3, listResults.Filesets.Count());
+            }
+        }
+
+        private class LogSink : IMessageSink
+        {
+            public List<string> StartedFiles { get; } = new List<string>();
+            public List<string> CompletedFiles { get; } = new List<string>();
+            public void BackendEvent(BackendActionType action, BackendEventType type, string path, long size)
+            {
+                if (action == BackendActionType.Put && type == BackendEventType.Started)
+                {
+                    this.StartedFiles.Add(path);
+                }
+                if (action == BackendActionType.Put && type == BackendEventType.Completed)
+                {
+                    this.CompletedFiles.Add(path);
+                }
+            }
+
+            public void SetBackendProgress(IBackendProgress progress)
+            {
+            }
+
+            public void SetOperationProgress(IOperationProgress progress)
+            {
+            }
+
+            public void WriteMessage(LogEntry entry)
+            {
+            }
+        }
+
+        [Test]
+        [Category("Disruption")]
+        public void TestFailedDblockUploadWithOperationCancellation()
+        {
+            var testopts = TestOptions;
+            testopts["number-of-retries"] = "1";
+            testopts["dblock-size"] = "10mb";
+
+            // Make a base backup
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Make a new backup that fails uploading a dblock file
+            ModifySourceFiles();
+
+            // Deterministic error backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var failtarget = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+            var uploadCount = 0;
+            var failedFile = string.Empty;
+
+            // Fail the dlist upload
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
+            {
+                if (action == DeterministicErrorBackend.BackendAction.PutBefore && remotename.Contains(".dblock."))
+                {
+                    // Fail once with a cancellation
+                    if (Interlocked.Increment(ref uploadCount) == 1)
+                    {
+                        failedFile = remotename;
+                        throw new OperationCanceledException();
+                    }
+                }
+
+                return false;
+            };
+
+            using (var c = new Library.Main.Controller(failtarget, testopts, null))
+            {
+                var sink = new LogSink();
+                c.AppendSink(sink);
+                var res = c.Backup(new string[] { DATAFOLDER });
+                if (uploadCount == 0)
+                    Assert.Fail("Upload count was not incremented");
+
+                Assert.AreEqual(2, c.List().Filesets.Count());
+                Assert.AreEqual(7 * 2 + 1, sink.CompletedFiles.Count); // 7 completed (dblock + dindex) + 1 dlist
+                Assert.AreEqual(7 * 2 + 2, sink.StartedFiles.Count); // 1 retry
+                Assert.AreEqual(1, res.BackendStatistics.RetryAttempts);
+            }
+
+            ModifySourceFiles();
+            // Create a regular backup
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Verify that all is in order
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { full_remote_verification = true }), null))
+            {
+                var r = c.Test(long.MaxValue);
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
+                Assert.IsFalse(r.Verifications.Any(p => p.Value.Any()));
+            }
+
+            // Test that we can recreate
+            var recreatedDatabaseFile = Path.Combine(BASEFOLDER, "recreated-database.sqlite");
+            if (File.Exists(recreatedDatabaseFile))
+                File.Delete(recreatedDatabaseFile);
+
+            testopts["dbpath"] = recreatedDatabaseFile;
+
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
+            }
+
+            // Check that we have 3 versions
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IListResults listResults = c.List();
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
+                Assert.AreEqual(3, listResults.Filesets.Count());
+            }
+        }
+
+        [Test]
+        [Category("Disruption")]
+        public void TestFailedDindexUploadWithOperationCancellation()
+        {
+            var testopts = TestOptions;
+            testopts["number-of-retries"] = "1";
+            testopts["dblock-size"] = "10mb";
+
+            // Make a base backup
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Make a new backup that fails uploading a dblock file
+            ModifySourceFiles();
+
+            // Deterministic error backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var failtarget = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+            var uploadCount = 0;
+            var failedFile = string.Empty;
+
+            // Fail the dlist upload
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
+            {
+                if (action == DeterministicErrorBackend.BackendAction.PutBefore && remotename.Contains(".dindex."))
+                {
+                    // Fail once with a cancellation
+                    if (Interlocked.Increment(ref uploadCount) == 1)
+                    {
+                        failedFile = remotename;
+                        throw new OperationCanceledException();
+                    }
+                }
+
+                return false;
+            };
+
+            using (var c = new Library.Main.Controller(failtarget, testopts, null))
+            {
+                var sink = new LogSink();
+                c.AppendSink(sink);
+                var res = c.Backup(new string[] { DATAFOLDER });
+                if (uploadCount == 0)
+                    Assert.Fail("Upload count was not incremented");
+
+                Assert.AreEqual(2, c.List().Filesets.Count());
+                Assert.AreEqual(7 * 2 + 1, sink.CompletedFiles.Count); // 7 completed (dblock + dindex) + 1 dlist
+                Assert.AreEqual(7 * 2 + 2, sink.StartedFiles.Count); // 1 retry
+                Assert.AreEqual(sink.CompletedFiles.Count(x => x.Contains(".dblock.")), sink.CompletedFiles.Count(x => x.Contains(".dindex.")));
+                Assert.AreEqual(1, res.BackendStatistics.RetryAttempts);
+            }
+
+            ModifySourceFiles();
+            // Create a regular backup
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Verify that all is in order
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { full_remote_verification = true }), null))
+            {
+                var r = c.Test(long.MaxValue);
+                Assert.AreEqual(0, r.Errors.Count());
+                Assert.AreEqual(0, r.Warnings.Count());
+                Assert.IsFalse(r.Verifications.Any(p => p.Value.Any()));
+            }
+
+            // Test that we can recreate
+            var recreatedDatabaseFile = Path.Combine(BASEFOLDER, "recreated-database.sqlite");
+            if (File.Exists(recreatedDatabaseFile))
+                File.Delete(recreatedDatabaseFile);
+
+            testopts["dbpath"] = recreatedDatabaseFile;
+
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
+            }
+
+            // Check that we have 3 versions
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IListResults listResults = c.List();
+                Assert.AreEqual(0, listResults.Errors.Count());
+                Assert.AreEqual(0, listResults.Warnings.Count());
+                Assert.AreEqual(3, listResults.Filesets.Count());
+            }
+        }
+
+        [Test]
+        [Category("Disruption")]
+        public void TestFailedDlistUploadWithOperationCancellation()
+        {
+            var testopts = TestOptions;
+            testopts["number-of-retries"] = "1";
+            testopts["dblock-size"] = "10mb";
+
+            // Make a base backup
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                IBackupResults backupResults = c.Backup(new string[] { DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Make a new backup that fails uploading a dblock file
+            ModifySourceFiles();
+
+            // Deterministic error backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var failtarget = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+            var uploadCount = 0;
+
+            // Fail the dlist upload
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
+            {
+                if (action == DeterministicErrorBackend.BackendAction.PutBefore && remotename.Contains(".dlist."))
+                {
+                    if (Interlocked.Increment(ref uploadCount) == 1)
+                        throw new OperationCanceledException();
+                }
+
+                return false;
+            };
+
+            using (var c = new Library.Main.Controller(failtarget, testopts, null))
+            {
+                var res = c.Backup(new string[] { DATAFOLDER });
+                var dlistCount = Directory.GetFiles(TARGETFOLDER, "*.dlist.*", SearchOption.TopDirectoryOnly).Count();
+                if (uploadCount == 0)
+                    Assert.Fail("Upload count was not incremented");
+                Assert.AreEqual(2, c.List().Filesets.Count());
+                Assert.AreEqual(2, dlistCount);
+                Assert.AreEqual(1, res.BackendStatistics.RetryAttempts);
+            }
+
+            ModifySourceFiles();
             // Create a regular backup
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {


### PR DESCRIPTION
This PR adds the tests developer for 2.1.0.5 to the main branch.
It also fixes an off-by-one error where the number of retries performed was one less than what the user specified.