### PR TITLE
Remove imaging library

### DIFF
--- a/Duplicati/WebserverCore/Duplicati.WebserverCore.csproj
+++ b/Duplicati/WebserverCore/Duplicati.WebserverCore.csproj
@@ -17,8 +17,6 @@
 		
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.AspNetCore.HostFiltering" Version="2.2.0" />
-	  <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
-	  <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.3" />
 	  <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.0" />


### PR DESCRIPTION
The image library was used in the captcha code, which was previously removed.