### PR TITLE
Improve import feature

### DIFF
--- a/Duplicati/WebserverCore/DayOfWeekStringEnumConverter.cs
+++ b/Duplicati/WebserverCore/DayOfWeekStringEnumConverter.cs
@@ -32,16 +32,18 @@ public class DayOfWeekStringEnumConverter : JsonConverterFactory
             if (reader.TokenType != JsonTokenType.String)
                 throw new JsonException();
 
-            return reader.GetString()?.Trim()?.ToLowerInvariant() switch
+            var value = reader.GetString()?.Trim()?.ToLowerInvariant();
+
+            return value switch
             {
-                "sun" => DayOfWeek.Sunday,
-                "mon" => DayOfWeek.Monday,
-                "tue" => DayOfWeek.Tuesday,
-                "wed" => DayOfWeek.Wednesday,
-                "thu" => DayOfWeek.Thursday,
-                "fri" => DayOfWeek.Friday,
-                "sat" => DayOfWeek.Saturday,
-                _ => throw new JsonException()
+                "sun" or "sunday" => DayOfWeek.Sunday,
+                "mon" or "monday" => DayOfWeek.Monday,
+                "tue" or "tuesday" => DayOfWeek.Tuesday,
+                "wed" or "wednesday" => DayOfWeek.Wednesday,
+                "thu" or "thursday" => DayOfWeek.Thursday,
+                "fri" or "friday" => DayOfWeek.Friday,
+                "sat" or "saturday" => DayOfWeek.Saturday,
+                _ => throw new JsonException($"Invalid day of week: {value}"),
             };
         }
 
@@ -71,7 +73,7 @@ public class DayOfWeekStringEnumConverter : JsonConverterFactory
                     writer.WriteStringValue("sat");
                     break;
                 default:
-                    throw new JsonException();
+                    throw new JsonException($"Invalid day of week: {value}");
             }
             writer.WriteStringValue(value.ToString());
         }


### PR DESCRIPTION
This commit adds support for full names for day-of-week, as it appears that some exported documents contain the full day names instead of their three-letter abbreviations.

In case of errors, the error message now also includes the value that was found.