### PR TITLE
Performance/restore async setresult

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -281,7 +281,7 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                 // If the block is not in the cache, request it from the volume.
                 sw_get_wait?.Start();
-                var tcs = new TaskCompletionSource<byte[]>();
+                var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var new_tcs = m_waiters.GetOrAdd(block_request.BlockID, tcs);
                 if (tcs == new_tcs)
                 {


### PR DESCRIPTION
This PR adds additional internal profiling to the BlockManager to get a higher resolution look at where time is spent. These new timers showed that a significant amount of time was spent waking up waiting block requests on the `BlockManager` cache. This time was essentially removed by allowing the tasks to continue asynchronously, leading to time spent on a restore of 10 000 files totaling 10 GB going from 14.7 seconds to 13.5 seconds. 