### PR TITLE
Integrating the IPv6 & IPv4 detection

### DIFF
--- a/Duplicati/CommandLine/ServerUtil/Settings.cs
+++ b/Duplicati/CommandLine/ServerUtil/Settings.cs
@@ -25,6 +25,7 @@ using Duplicati.Library.Encryption;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using Duplicati.Library.Utility;
+using Utility = Duplicati.Library.Main.Utility;
 
 namespace Duplicati.CommandLine.ServerUtil;
 
@@ -88,7 +89,7 @@ public sealed record Settings(
     /// <returns>The loaded settings</returns>
     public static Settings Load(string? password, System.Uri? hostUrl, string settingsFile, bool insecure, string? settingsPassphrase, string? secretProvider, SecretProviderHelper.CachingLevel secretProviderCache, string secretProviderPattern, string? acceptedHostCertificate)
     {
-        hostUrl ??= new System.Uri("http://localhost:8200");
+        hostUrl ??= new System.Uri($"http://{Library.Utility.Utility.IpVersionCompatibleLoopback}:8200");
 
         ISecretProvider? secretInstance = null;
         if (!string.IsNullOrWhiteSpace(secretProvider))

--- a/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
+++ b/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
@@ -37,7 +37,7 @@ public class SettingsBinder : BinderBase<Settings>
     /// <summary>
     /// The host URL option.
     /// </summary>
-    public static readonly Option<Uri> hostUrlOption = new Option<Uri>("--hosturl", description: "The host URL to use", getDefaultValue: () => new Uri("http://localhost:8200"));
+    public static readonly Option<Uri> hostUrlOption = new Option<Uri>("--hosturl", description: "The host URL to use", getDefaultValue: () => new Uri($"http://{Library.Utility.Utility.IpVersionCompatibleLoopback}:8200"));
     /// <summary>
     /// The server datafolder option.
     /// </summary>

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -66,12 +66,12 @@ namespace Duplicati.GUI.TrayIcon
         private const string DETACHED_PROCESS = "detached-process";
         private const string BROWSER_COMMAND_OPTION = "browser-command";
 
-        private const string DEFAULT_HOSTURL = "http://localhost:8200";
+        private static string DEFAULT_HOSTURL => $"http://{Library.Utility.Utility.IpVersionCompatibleLoopback}:8200";
 
         private static string _browser_command = null;
         private static bool disableTrayIconLogin = false;
         private static bool openui = false;
-        private static Uri serverURL = new Uri(DEFAULT_HOSTURL);
+        private static Uri serverURL = new(DEFAULT_HOSTURL);
         public static string BrowserCommand { get { return _browser_command; } }
         public static Server.Database.Connection databaseConnection = null;
 

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -23,17 +23,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Duplicati.Library.Common.IO;
-using System.Globalization;
-using System.Runtime.Versioning;
-using System.Security.Cryptography.X509Certificates;
-using System.Security.Cryptography;
 
 namespace Duplicati.Library.Utility
 {
@@ -1543,6 +1546,25 @@ namespace Duplicati.Library.Utility
             collection.Import(pfxPath, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
             return collection;
         }
+        
+        /// <summary>
+        /// Probes the system for the presence of a loopback address on IPv4
+        /// </summary>
+        public static bool HasIPv4Loopback =>
+            NetworkInterface.GetAllNetworkInterfaces()
+                .Where(ni => ni.OperationalStatus == OperationalStatus.Up)
+                .SelectMany(ni => ni.GetIPProperties().UnicastAddresses)
+                .Any(addr => addr.Address.AddressFamily == AddressFamily.InterNetwork
+                             && addr.Address.Equals(IPAddress.Loopback));
+
+        /// <summary>
+        /// On systems that have IPV4 and IPV6, the method will return the default loopback ( 127, 0, 0, 1)
+        /// On systems with IPV6 only, the method will return the IPV6 loopback (::1)
+        /// </summary>
+        /// <returns></returns>
+        public static string IpVersionCompatibleLoopback =>
+            HasIPv4Loopback ? IPAddress.Loopback.ToString() : $"[{IPAddress.IPv6Loopback.ToString()}]";
+        
 
         /// <summary>
         /// Flattens an exception and its inner exceptions


### PR DESCRIPTION
It should be noted that I was unable to completely remove IPv4 on Windows 11 to a state where it would not provide the 127.0.0.1 loopback, even when disabling Ipv4 in various ways, including with registry flags.

On ubuntu/linux, after completely disabling ipv4 the ipv6 loopback was returned.

This is a follow up clean PR of the original experimental https://github.com/duplicati/duplicati/pull/5761
