### PR TITLE
Prevent blocksize near remote volume size

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -749,7 +749,7 @@ namespace Duplicati.Library.Main
             if (!string.IsNullOrWhiteSpace(m_options.Prefix) && m_options.Prefix.Contains("-"))
                 throw new Interface.UserInformationException("The prefix cannot contain hyphens (-)", "PrefixCannotContainHyphens");
 
-            if (m_options.VolumeSize <= m_options.Blocksize * 2)
+            if (m_options.VolumeSize < m_options.Blocksize * 2)
                 throw new Interface.UserInformationException("The volume size must be at least twice the block size", "VolumeSizeTooSmall");
 
             //Check validity of retention-policy option value

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -749,6 +749,9 @@ namespace Duplicati.Library.Main
             if (!string.IsNullOrWhiteSpace(m_options.Prefix) && m_options.Prefix.Contains("-"))
                 throw new Interface.UserInformationException("The prefix cannot contain hyphens (-)", "PrefixCannotContainHyphens");
 
+            if (m_options.VolumeSize <= m_options.Blocksize * 2)
+                throw new Interface.UserInformationException("The volume size must be at least twice the block size", "VolumeSizeTooSmall");
+
             //Check validity of retention-policy option value
             try
             {

--- a/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
@@ -119,7 +119,7 @@ namespace Duplicati.Library.Main.Operation.Backup
                                 indexvolume.AddBlock(b.HashKey, b.Size);
 
                             // If the volume is full, send to upload
-                            if (blockvolume.Filesize > options.VolumeSize - options.Blocksize)
+                            if (blockvolume.Filesize > (options.VolumeSize - options.Blocksize))
                             {
                                 //When uploading a new volume, we register the volumes and then flush the transaction
                                 // this ensures that the local database and remote storage are as closely related as possible

--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -195,7 +195,7 @@ namespace Duplicati.Library.Main.Operation
                                             db.RegisterDuplicatedBlock(e.Key, e.Value, newvol.VolumeID, transaction);
                                             blocksInVolume++;
 
-                                            if (newvol.Filesize > m_options.VolumeSize)
+                                            if (newvol.Filesize > (m_options.VolumeSize - m_options.Blocksize))
                                             {
                                                 FinishVolumeAndUpload(db, backendManager, newvol, newvolindex, uploadedVolumes);
 

--- a/Duplicati/UnitTest/BorderTests.cs
+++ b/Duplicati/UnitTest/BorderTests.cs
@@ -54,6 +54,7 @@ namespace Duplicati.UnitTest
             RunCommands(1024 * 10, modifyOptions: opts =>
             {
                 opts["blocksize"] = "10mb";
+                opts["dblock-size"] = "25mb";
             });
         }
 


### PR DESCRIPTION
If the user selects the blocksize to be the same as the remote volume size, this will cause each block to be in a separate volume and will trigger repeated compact calls.

This commit adds a check that ensures the volume size is large enough to hold at least two blocks.

Also fixed an issue where the compact could create volumes larger than the set limit (at most one block larger).