### PR TITLE
Async operation handlers

### DIFF
--- a/Duplicati/Library/Main/Database/ReusableTransaction.cs
+++ b/Duplicati/Library/Main/Database/ReusableTransaction.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Data;
+
+#nullable enable
+
+namespace Duplicati.Library.Main.Database;
+
+/// <summary>
+/// Wraps a transaction so it can be comitted and restarted
+/// </summary>
+internal class ReusableTransaction : IDisposable
+{
+    /// <summary>
+    /// The tag used for logging
+    /// </summary>
+    private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(LocalDatabase));
+
+    /// <summary>
+    /// The database to use
+    /// </summary>
+    private readonly LocalDatabase m_db;
+    /// <summary>
+    /// The current transaction
+    /// </summary>
+    private IDbTransaction? m_transaction;
+
+    /// <summary>
+    /// Creates a new reusable transaction
+    /// </summary>
+    /// <param name="db">The database to use</param>
+    public ReusableTransaction(LocalDatabase db, IDbTransaction? transaction = null)
+    {
+        m_db = db;
+        m_transaction = transaction ?? db.BeginTransaction();
+    }
+
+    /// <summary>
+    /// The current transaction
+    /// </summary>
+    public IDbTransaction Transaction => m_transaction ?? throw new InvalidOperationException("Transaction is disposed");
+
+    /// <summary>
+    /// Commits the current transaction and optionally restarts it
+    /// </summary>
+    /// <param name="message">The log message to use</param>
+    /// <param name="restart">True if the transaction should be restarted</param>
+    public void Commit(string? message = null, bool restart = true)
+    {
+        if (m_transaction == null)
+            throw new InvalidOperationException("Transaction is already disposed");
+
+        if (m_transaction != null)
+        {
+            using (var timer = string.IsNullOrWhiteSpace(message) ? null : new Logging.Timer(LOGTAG, message, "CommitTransaction"))
+                m_transaction.Commit();
+            m_transaction.Dispose();
+            m_transaction = null;
+        }
+
+        if (restart)
+            m_transaction = m_db.BeginTransaction();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        m_transaction?.Dispose();
+        m_transaction = null;
+    }
+}

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -26,6 +26,7 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Main.Database;
 using Duplicati.Library.Utility;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -45,59 +46,43 @@ namespace Duplicati.Library.Main.Operation
             m_result = result;
         }
 
-        public void Run(IBackendManager backendManager)
+        public async Task RunAsync(IBackendManager backendManager)
         {
             if (!System.IO.File.Exists(m_options.Dbpath))
                 throw new UserInformationException(string.Format("Database file does not exist: {0}", m_options.Dbpath), "DatabaseFileMissing");
 
-            using (var db = new Database.LocalDeleteDatabase(m_options.Dbpath, "Delete"))
+            using (var db = new LocalDeleteDatabase(m_options.Dbpath, "Delete"))
+            using (var tr = new ReusableTransaction(db))
             {
-                var tr = db.BeginTransaction();
-                try
+                m_result.SetDatabase(db);
+                Utility.UpdateOptionsFromDb(db, m_options);
+                Utility.VerifyOptionsAndUpdateDatabase(db, m_options);
+
+                await DoRunAsync(db, tr, false, false, backendManager).ConfigureAwait(false);
+
+                if (!m_options.Dryrun)
                 {
-                    m_result.SetDatabase(db);
-                    Utility.UpdateOptionsFromDb(db, m_options);
-                    Utility.VerifyOptionsAndUpdateDatabase(db, m_options);
-
-                    DoRun(db, ref tr, false, false, backendManager);
-
-                    if (!m_options.Dryrun)
-                    {
-                        using (new Logging.Timer(LOGTAG, "CommitDelete", "CommitDelete"))
-                            tr.Commit();
-
-                        db.WriteResults();
-                    }
-                    else
-                        tr.Rollback();
-
-                    tr = null;
-                }
-                finally
-                {
-                    if (tr != null)
-                        try { tr.Rollback(); }
-                        catch { }
+                    tr.Commit("ComitDelete", restart: false);
+                    db.WriteResults();
                 }
             }
         }
 
-        public void DoRun(Database.LocalDeleteDatabase db, ref System.Data.IDbTransaction transaction, bool hasVerifiedBackend, bool forceCompact, IBackendManager backendManager)
+        public async Task DoRunAsync(LocalDeleteDatabase db, ReusableTransaction rtr, bool hasVerifiedBackend, bool forceCompact, IBackendManager backendManager)
         {
-            CancellationToken cancellationToken = CancellationToken.None;
             if (!hasVerifiedBackend)
-                FilelistProcessor.VerifyRemoteList(backendManager, m_options, db, m_result.BackendWriter, latestVolumesOnly: true, verifyMode: FilelistProcessor.VerifyMode.VerifyStrict, transaction).Await();
+                await FilelistProcessor.VerifyRemoteList(backendManager, m_options, db, m_result.BackendWriter, latestVolumesOnly: true, verifyMode: FilelistProcessor.VerifyMode.VerifyStrict, rtr.Transaction).ConfigureAwait(false);
 
             IListResultFileset[] filesets = db.FilesetsWithBackupVersion.ToArray();
             List<IListResultFileset> versionsToDelete =
             [
-                .. new SpecificVersionsRemover(this.m_options).GetFilesetsToDelete(filesets),
-                .. new KeepTimeRemover(this.m_options).GetFilesetsToDelete(filesets),
-                .. new RetentionPolicyRemover(this.m_options).GetFilesetsToDelete(filesets),
+                .. new SpecificVersionsRemover(m_options).GetFilesetsToDelete(filesets),
+                .. new KeepTimeRemover(m_options).GetFilesetsToDelete(filesets),
+                .. new RetentionPolicyRemover(m_options).GetFilesetsToDelete(filesets),
             ];
 
             // When determining the number of full versions to keep, we need to ignore the versions already marked for removal.
-            versionsToDelete.AddRange(new KeepVersionsRemover(this.m_options).GetFilesetsToDelete(filesets.Except(versionsToDelete)));
+            versionsToDelete.AddRange(new KeepVersionsRemover(m_options).GetFilesetsToDelete(filesets.Except(versionsToDelete)));
 
             if (!m_options.AllowFullRemoval && filesets.Length == versionsToDelete.Count)
             {
@@ -108,31 +93,28 @@ namespace Duplicati.Library.Main.Operation
             if (versionsToDelete.Count > 0)
                 Logging.Log.WriteInformationMessage(LOGTAG, "DeleteRemoteFileset", "Deleting {0} remote fileset(s) ...", versionsToDelete.Count);
 
-            var lst = db.DropFilesetsFromTable(versionsToDelete.Select(x => x.Time).ToArray(), transaction).ToArray();
+            var lst = db.DropFilesetsFromTable(versionsToDelete.Select(x => x.Time).ToArray(), rtr.Transaction).ToArray();
             foreach (var f in lst)
-                db.UpdateRemoteVolume(f.Key, RemoteVolumeState.Deleting, f.Value, null, transaction);
+                db.UpdateRemoteVolume(f.Key, RemoteVolumeState.Deleting, f.Value, null, rtr.Transaction);
 
             if (!m_options.Dryrun)
-            {
-                transaction.Commit();
-                transaction = db.BeginTransaction();
-            }
+                rtr.Commit();
 
             foreach (var f in lst)
             {
-                if (!m_result.TaskControl.ProgressRendevouz().Await())
+                if (!await m_result.TaskControl.ProgressRendevouz().ConfigureAwait(false))
                 {
-                    backendManager.WaitForEmptyAsync(db, transaction, cancellationToken).Await();
+                    await backendManager.WaitForEmptyAsync(db, rtr.Transaction, m_result.TaskControl.ProgressToken).ConfigureAwait(false);
                     return;
                 }
 
                 if (!m_options.Dryrun)
-                    backendManager.DeleteAsync(f.Key, f.Value, false, cancellationToken).Await();
+                    await backendManager.DeleteAsync(f.Key, f.Value, false, m_result.TaskControl.ProgressToken).ConfigureAwait(false);
                 else
                     Logging.Log.WriteDryrunMessage(LOGTAG, "WouldDeleteRemoteFileset", "Would delete remote fileset: {0}", f.Key);
             }
 
-            backendManager.WaitForEmptyAsync(db, transaction, cancellationToken).Await();
+            await backendManager.WaitForEmptyAsync(db, rtr.Transaction, m_result.TaskControl.ProgressToken).ConfigureAwait(false);
 
             var count = lst.Length;
             if (!m_options.Dryrun)
@@ -157,8 +139,8 @@ namespace Duplicati.Library.Main.Operation
             if (!m_options.NoAutoCompact && (forceCompact || versionsToDelete.Count > 0))
             {
                 m_result.CompactResults = new CompactResults(m_result);
-                var (_, tr) = new CompactHandler(m_options, (CompactResults)m_result.CompactResults).DoCompact(db, true, transaction, backendManager).Await();
-                transaction = tr;
+                await new CompactHandler(m_options, (CompactResults)m_result.CompactResults)
+                    .DoCompactAsync(db, true, rtr, backendManager).ConfigureAwait(false);
             }
 
             m_result.SetResults(versionsToDelete.Select(v => new Tuple<long, DateTime>(v.Version, v.Time)), m_options.Dryrun);

--- a/Duplicati/Library/Main/Operation/ListAffected.cs
+++ b/Duplicati/Library/Main/Operation/ListAffected.cs
@@ -23,6 +23,8 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using Duplicati.Library.Interface;
+using System.Threading.Tasks;
+using System.IO;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -36,13 +38,13 @@ namespace Duplicati.Library.Main.Operation
             m_options = options;
             m_result = result;
         }
-            
-        public void Run(List<string> args, Action<Duplicati.Library.Interface.IListAffectedResults> callback = null)
+
+        public Task RunAsync(List<string> args, Action<IListAffectedResults> callback = null)
         {
-            if (!System.IO.File.Exists(m_options.Dbpath))
+            if (!File.Exists(m_options.Dbpath))
                 throw new UserInformationException(string.Format("Database file does not exist: {0}", m_options.Dbpath), "DatabaseDoesNotExist");
 
-            using(var db = new Database.LocalListAffectedDatabase(m_options.Dbpath))
+            using (var db = new Database.LocalListAffectedDatabase(m_options.Dbpath))
             {
                 m_result.SetDatabase(db);
                 if (callback == null)
@@ -66,6 +68,8 @@ namespace Duplicati.Library.Main.Operation
                     callback(m_result);
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
@@ -22,7 +22,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 
@@ -43,19 +45,19 @@ namespace Duplicati.Library.Main.Operation
             m_result = result;
         }
 
-        public void Run(IBackendManager backendManager, IFilter filter, Func<long, DateTime, long, string, long, bool> callbackhandler = null)
+        public async Task RunAsync(IBackendManager backendManager, IFilter filter, Func<long, DateTime, long, string, long, bool> callbackhandler = null)
         {
-            if (!System.IO.File.Exists(m_options.Dbpath))
+            if (!File.Exists(m_options.Dbpath))
                 throw new UserInformationException(string.Format("Database file does not exist: {0}", m_options.Dbpath), "DatabaseDoesNotExist");
 
             using (var db = new Database.LocalListBrokenFilesDatabase(m_options.Dbpath))
             using (var tr = db.BeginTransaction())
-                DoRun(backendManager, db, tr, filter, callbackhandler);
+                await DoRunAsync(backendManager, db, tr, filter, callbackhandler).ConfigureAwait(false);
         }
 
-        public static Tuple<DateTime, long, long>[] GetBrokenFilesetsFromRemote(IBackendManager backendManager, BasicResults result, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, Options options, out List<Database.RemoteVolumeEntry> missing)
+        public static async Task<(Tuple<DateTime, long, long>[], List<Database.RemoteVolumeEntry> Missing)> GetBrokenFilesetsFromRemote(IBackendManager backendManager, BasicResults result, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, Options options)
         {
-            missing = null;
+            List<Database.RemoteVolumeEntry> missing = null;
             var brokensets = db.GetBrokenFilesets(options.Time, options.Version, transaction).ToArray();
 
             if (brokensets.Length == 0)
@@ -65,7 +67,7 @@ namespace Duplicati.Library.Main.Operation
 
                 Logging.Log.WriteInformationMessage(LOGTAG, "NoBrokenFilesetsInDatabase", "No broken filesets found in database, checking for missing remote files");
 
-                var remotestate = FilelistProcessor.RemoteListAnalysis(backendManager, options, db, result.BackendWriter, null, null, FilelistProcessor.VerifyMode.VerifyOnly).Await();
+                var remotestate = await FilelistProcessor.RemoteListAnalysis(backendManager, options, db, result.BackendWriter, null, null, FilelistProcessor.VerifyMode.VerifyOnly).ConfigureAwait(false);
                 if (!remotestate.ParsedVolumes.Any())
                     throw new UserInformationException("No remote volumes were found, refusing purge", "CannotPurgeWithNoRemoteVolumes");
 
@@ -73,7 +75,7 @@ namespace Duplicati.Library.Main.Operation
                 if (missing.Count == 0)
                 {
                     Logging.Log.WriteInformationMessage(LOGTAG, "NoMissingFilesFound", "Skipping operation because no files were found to be missing, and no filesets were recorded as broken.");
-                    return null;
+                    return (null, missing);
                 }
 
                 // Mark all volumes as disposable
@@ -87,10 +89,10 @@ namespace Duplicati.Library.Main.Operation
                 brokensets = db.GetBrokenFilesets(options.Time, options.Version, transaction).ToArray();
             }
 
-            return brokensets;
+            return (brokensets, missing);
         }
 
-        private void DoRun(IBackendManager backendManager, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, Library.Utility.IFilter filter, Func<long, DateTime, long, string, long, bool> callbackhandler)
+        private async Task DoRunAsync(IBackendManager backendManager, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, IFilter filter, Func<long, DateTime, long, string, long, bool> callbackhandler)
         {
             if (filter != null && !filter.Empty)
                 throw new UserInformationException("Filters are not supported for this operation", "FiltersAreNotSupportedForListBrokenFiles");
@@ -98,14 +100,13 @@ namespace Duplicati.Library.Main.Operation
             if (db.PartiallyRecreated)
                 throw new UserInformationException("The command does not work on partially recreated databases", "ListBrokenFilesDoesNotWorkOnPartialDatabase");
 
-            List<Database.RemoteVolumeEntry> missing;
-            var brokensets = GetBrokenFilesetsFromRemote(backendManager, m_result, db, transaction, m_options, out missing);
+            (var brokensets, var missing) = await GetBrokenFilesetsFromRemote(backendManager, m_result, db, transaction, m_options).ConfigureAwait(false);
             if (brokensets == null)
                 return;
 
             if (brokensets.Length == 0)
             {
-                m_result.BrokenFiles = new Tuple<long, DateTime, IEnumerable<Tuple<string, long>>>[0];
+                m_result.BrokenFiles = [];
 
                 if (missing == null)
                     Logging.Log.WriteInformationMessage(LOGTAG, "NoBrokenFilesets", "Found no broken filesets");

--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -45,7 +45,7 @@ namespace Duplicati.Library.Main.Operation
             m_result = result;
         }
 
-        public async Task Run(IBackendManager backendManager, IEnumerable<string> filterstrings, IFilter compositefilter)
+        public async Task RunAsync(IBackendManager backendManager, IEnumerable<string> filterstrings, IFilter compositefilter)
         {
             var cancellationToken = m_result.TaskControl.ProgressToken;
             var parsedfilter = new FilterExpression(filterstrings);

--- a/Duplicati/Library/Main/Operation/SystemInfoHandler.cs
+++ b/Duplicati/Library/Main/Operation/SystemInfoHandler.cs
@@ -23,15 +23,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
+using System.Threading.Tasks;
 
 namespace Duplicati.Library.Main.Operation
 {
     internal static class SystemInfoHandler
     {
-        public static void Run(SystemInfoResults results)
-        {
-            results.Lines = GetSystemInfo().ToArray();
-        }
+        public static Task RunAsync(SystemInfoResults results)
+            => Task.Run(() => results.Lines = GetSystemInfo().ToArray());
 
         public static IEnumerable<string> GetSystemInfo()
         {

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -46,7 +46,7 @@ namespace Duplicati.Library.Main.Operation
             m_results = results;
         }
 
-        public void Run(long samples, IBackendManager backendManager)
+        public async Task RunAsync(long samples, IBackendManager backendManager)
         {
             if (!System.IO.File.Exists(m_options.Dbpath))
                 throw new UserInformationException(string.Format("Database file does not exist: {0}", m_options.Dbpath), "DatabaseDoesNotExist");
@@ -57,14 +57,14 @@ namespace Duplicati.Library.Main.Operation
                 Utility.UpdateOptionsFromDb(db, m_options);
                 Utility.VerifyOptionsAndUpdateDatabase(db, m_options);
                 db.VerifyConsistency(m_options.Blocksize, m_options.BlockhashSize, !m_options.DisableFilelistConsistencyChecks, null);
-                FilelistProcessor.VerifyRemoteList(backendManager, m_options, db, m_results.BackendWriter, latestVolumesOnly: true, verifyMode: FilelistProcessor.VerifyMode.VerifyOnly, null).Await();
+                await FilelistProcessor.VerifyRemoteList(backendManager, m_options, db, m_results.BackendWriter, latestVolumesOnly: true, verifyMode: FilelistProcessor.VerifyMode.VerifyOnly, null).ConfigureAwait(false);
 
-                DoRun(samples, db, backendManager).Await();
+                await DoRunAsync(samples, db, backendManager).ConfigureAwait(false);
                 db.WriteResults();
             }
         }
 
-        public async Task DoRun(long samples, LocalTestDatabase db, IBackendManager backend)
+        public async Task DoRunAsync(long samples, LocalTestDatabase db, IBackendManager backend)
         {
             var files = db.SelectTestTargets(samples, m_options).ToList();
 
@@ -74,14 +74,14 @@ namespace Duplicati.Library.Main.Operation
 
             if (m_options.FullRemoteVerification != Options.RemoteTestStrategy.False)
             {
-                await foreach (var (tf, hash, size, name) in backend.GetFilesOverlappedAsync(files, CancellationToken.None).ConfigureAwait(false))
+                await foreach (var (tf, hash, size, name) in backend.GetFilesOverlappedAsync(files, m_results.TaskControl.ProgressToken).ConfigureAwait(false))
                 {
                     var vol = new RemoteVolume(name, hash, size);
                     try
                     {
-                        if (!m_results.TaskControl.ProgressRendevouz().Await())
+                        if (!await m_results.TaskControl.ProgressRendevouz().ConfigureAwait(false))
                         {
-                            backend.WaitForEmptyAsync(db, null, CancellationToken.None).Await();
+                            await backend.WaitForEmptyAsync(db, null, m_results.TaskControl.ProgressToken).ConfigureAwait(false);
                             m_results.EndTime = DateTime.UtcNow;
                             return;
                         }
@@ -138,7 +138,7 @@ namespace Duplicati.Library.Main.Operation
                 {
                     try
                     {
-                        if (!m_results.TaskControl.ProgressRendevouz().Await())
+                        if (!await m_results.TaskControl.ProgressRendevouz().ConfigureAwait(false))
                         {
                             m_results.EndTime = DateTime.UtcNow;
                             return;
@@ -152,7 +152,7 @@ namespace Duplicati.Library.Main.Operation
                             Logging.Log.WriteInformationMessage(LOGTAG, "MissingRemoteHash", "No hash or size recorded for {0}, performing full verification", f.Name);
                             KeyValuePair<string, IEnumerable<KeyValuePair<TestEntryStatus, string>>> res;
 
-                            (var tf, var hash, var size) = backend.GetWithInfoAsync(f.Name, f.Hash, f.Size, CancellationToken.None).Await();
+                            (var tf, var hash, var size) = await backend.GetWithInfoAsync(f.Name, f.Hash, f.Size, m_results.TaskControl.ProgressToken).ConfigureAwait(false);
 
                             using (tf)
                                 res = TestVolumeInternals(db, f, tf, m_options, 1);
@@ -176,7 +176,7 @@ namespace Duplicati.Library.Main.Operation
                         }
                         else
                         {
-                            using (var tf = backend.GetAsync(f.Name, f.Hash, f.Size, CancellationToken.None).Await())
+                            using (var tf = await backend.GetAsync(f.Name, f.Hash, f.Size, m_results.TaskControl.ProgressToken).ConfigureAwait(false))
                             { }
                         }
 

--- a/Duplicati/Library/Main/Operation/VacuumHandler.cs
+++ b/Duplicati/Library/Main/Operation/VacuumHandler.cs
@@ -37,15 +37,16 @@ namespace Duplicati.Library.Main.Operation
             m_result = result;
         }
 
-        public virtual void Run()
-        {
-            using (var db = new Database.LocalDatabase(m_options.Dbpath, "Vacuum", false))
+        public virtual Task RunAsync()
+            => Task.Run(() =>
             {
-                m_result.SetDatabase(db);
-                m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Vacuum_Running);
-                db.Vacuum();
-                m_result.EndTime = DateTime.UtcNow;
-            }
-        }
+                using (var db = new Database.LocalDatabase(m_options.Dbpath, "Vacuum", false))
+                {
+                    m_result.SetDatabase(db);
+                    m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Vacuum_Running);
+                    db.Vacuum();
+                    m_result.EndTime = DateTime.UtcNow;
+                }
+            });
     }
 }


### PR DESCRIPTION
Rewrote all operation handlers to be async.
This moves the async/sync threshold out into the controller.

Fixed all the uses of cancellation token in the handlers to use the provided cancellation token.

Introduced a new ReusableTransaction that can be passed around, avoiding a ref parameter passing of the transaction instance.