### PR TITLE
Safeguards for release compile

### DIFF
--- a/ReleaseBuilder/Build/Command.Compile.Post.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Post.cs
@@ -65,6 +65,39 @@ public static partial class Command
         }
 
         /// <summary>
+        /// Verify that some files that are expected to be present in the target directory are there
+        /// </summary>
+        /// <param name="buildDir">The build directory to verify</param>
+        /// <param name="target">The target to verify for</param>
+        /// <returns>An awaitable task</returns>
+        public static Task VerifyTargetDirectory(string buildDir, PackageTarget target)
+        {
+            var rootFiles = Directory.EnumerateFiles(buildDir, "*", SearchOption.TopDirectoryOnly)
+                .Where(x => x.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || x.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                .Select(x => Path.GetFileName(x))
+                .ToHashSet(Duplicati.Library.Utility.Utility.ClientFilenameStringComparer);
+
+            // Random sample of files we expect
+            var probeFiles = new string[] {
+                "System.CommandLine.dll",
+                "System.CommandLine.NamingConventionBinder.dll",
+                "AWSSDK.S3.dll",
+                "CoCoL.dll",
+                "Duplicati.Library.Interface.dll",
+                "Google.Apis.Auth.dll",
+                "Google.Apis.Core.dll",
+                "SQLiteHelper.dll",
+                "SQLite.Interop.dll",
+            };
+
+            foreach (var f in probeFiles)
+                if (!rootFiles.Contains(f))
+                    throw new Exception($"Expected file {f} for {target.BuildTargetString}, but was not found in build directory {buildDir}");
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Set of files that are unwanted despite the OS
         /// </summary>
         static readonly IReadOnlyList<string> UnwantedCommonFiles = [

--- a/ReleaseBuilder/Program.cs
+++ b/ReleaseBuilder/Program.cs
@@ -61,6 +61,8 @@ class Program
         "linux-arm7-cli.zip",
         "linux-arm7-cli.deb",
         "linux-arm7-cli.docker",
+        "linux-arm7-agent.zip",
+        "linux-arm7-agent.deb",
 
         "linux-arm64-gui.zip",
         "linux-arm64-gui.deb",


### PR DESCRIPTION
This adds additional checks for the compile phase to avoid missing files in the released builds.

The build is now done into isolated folders, and then copied into the shared target folder to avoid issues with the compiler replacing or removing files.

Added Armv7 agent builds