### PR TITLE
Add guards to startup interval

### DIFF
--- a/Duplicati/WebserverCore/Services/StatusService.cs
+++ b/Duplicati/WebserverCore/Services/StatusService.cs
@@ -54,7 +54,7 @@ public class StatusService(
             ProgramState = GetProgramState(),
             HasWarning = settingsService.GetSettings().UnackedWarning,
             HasError = settingsService.GetSettings().UnackedError,
-            EstimatedPauseEnd = liveControls.EstimatedPauseEnd,
+            EstimatedPauseEnd = liveControls.EstimatedPauseEnd.ToUniversalTime(),
             SuggestedStatusIcon = MapStateToIcon(),
             UpdateDownloadLink = settingsService.GetSettings().NewVersionUpdateUrl
         };
@@ -65,7 +65,7 @@ public class StatusService(
 
     private void PullLiveControls(ServerStatusDto status)
     {
-        status.EstimatedPauseEnd = liveControls.EstimatedPauseEnd;
+        status.EstimatedPauseEnd = liveControls.EstimatedPauseEnd.ToUniversalTime();
         status.ProgramState = GetProgramState();
         status.SuggestedStatusIcon = MapStateToIcon();
     }


### PR DESCRIPTION
In some cases the stored database state would be misinterpreted causing abnormal wait periods that crashes the program on startup.

This change converts all time compares to UTC asn the database value was already UTC.

It also adds a clamping function to prevent crashes on extreme values (using 24h pause instead of crash).