### PR TITLE
Untangle the results and database

### DIFF
--- a/Duplicati/Library/Interface/ResultInterfaces.cs
+++ b/Duplicati/Library/Interface/ResultInterfaces.cs
@@ -46,6 +46,11 @@ namespace Duplicati.Library.Interface
         bool Interrupted { get; }
     }
 
+    public interface IResultsWithVacuum
+    {
+        IVacuumResults VacuumResults { get; set; }
+    }
+
     public interface IBackendStatstics
     {
         long RemoteCalls { get; }
@@ -125,7 +130,7 @@ namespace Duplicati.Library.Interface
         bool Dryrun { get; }
     }
 
-    public interface IBackupResults : IBasicResults, IBackendStatsticsReporter
+    public interface IBackupResults : IBasicResults, IBackendStatsticsReporter, IResultsWithVacuum
     {
         long DeletedFiles { get; }
         long DeletedFolders { get; }
@@ -149,7 +154,6 @@ namespace Duplicati.Library.Interface
         bool Dryrun { get; }
 
         ICompactResults CompactResults { get; }
-        IVacuumResults VacuumResults { get; }
         IDeleteResults DeleteResults { get; }
         IRepairResults RepairResults { get; }
     }
@@ -177,7 +181,7 @@ namespace Duplicati.Library.Interface
         IEnumerable<IFileEntry> Files { get; }
     }
 
-    public interface ICompactResults : IBasicResults
+    public interface ICompactResults : IBasicResults, IResultsWithVacuum
     {
         long DeletedFileCount { get; }
         long DownloadedFileCount { get; }
@@ -186,8 +190,6 @@ namespace Duplicati.Library.Interface
         long DownloadedFileSize { get; }
         long UploadedFileSize { get; }
         bool Dryrun { get; }
-
-        IVacuumResults VacuumResults { get; }
     }
 
     public interface ICreateLogDatabaseResults : IBasicResults

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -62,8 +62,6 @@ namespace Duplicati.Library.Main.Database
         private readonly IDbCommand m_findpathprefixCommand;
         private readonly IDbCommand m_insertpathprefixCommand;
 
-        protected BasicResults m_result;
-
         public const long FOLDER_BLOCKSET_ID = -100;
         public const long SYMLINK_BLOCKSET_ID = -200;
 
@@ -130,7 +128,6 @@ namespace Duplicati.Library.Main.Database
             OperationTimestamp = db.OperationTimestamp;
             m_connection = db.m_connection;
             m_operationid = db.m_operationid;
-            m_result = db.m_result;
         }
 
         /// <summary>
@@ -182,11 +179,6 @@ namespace Duplicati.Library.Main.Database
             m_insertIndexBlockLink = connection.CreateCommand(@"INSERT INTO ""IndexBlockLink"" (""IndexVolumeID"", ""BlockVolumeID"") VALUES (?, ?)");
             m_findpathprefixCommand = connection.CreateCommand(@"SELECT ""ID"" FROM ""PathPrefix"" WHERE ""Prefix"" = ?");
             m_insertpathprefixCommand = connection.CreateCommand(@"INSERT INTO ""PathPrefix"" (""Prefix"") VALUES (?); SELECT last_insert_rowid(); ");
-        }
-
-        internal void SetResult(BasicResults result)
-        {
-            m_result = result;
         }
 
         /// <summary>
@@ -1601,20 +1593,23 @@ AND oldVersion.FilesetID = (SELECT ID FROM Fileset WHERE ID != ? ORDER BY Timest
                 throw new AggregateException(exceptions);
         }
 
-        public void WriteResults()
+        public void WriteResults(IBasicResults result)
         {
             if (IsDisposed)
                 return;
 
-            if (m_connection != null && m_result != null)
+            if (m_connection != null && result != null)
             {
-                m_result.FlushLog();
-                if (m_result.EndTime.Ticks == 0)
-                    m_result.EndTime = DateTime.UtcNow;
+                if (result is BasicResults basicResults)
+                {
+                    basicResults.FlushLog(this);
+                    if (basicResults.EndTime.Ticks == 0)
+                        basicResults.EndTime = DateTime.UtcNow;
+                }
 
                 var serializer = new JsonFormatSerializer();
                 LogMessage("Result",
-                    serializer.SerializeResults(m_result),
+                    serializer.SerializeResults(result),
                     null,
                     null
                 );

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -295,7 +295,6 @@ namespace Duplicati.Library.Main.Operation
                 try
                 {
                     database = new LocalBackupDatabase(options.Dbpath, options);
-                    result.SetDatabase(database);
                     result.Dryrun = options.Dryrun;
 
                     // Check the database integrity
@@ -343,14 +342,12 @@ namespace Duplicati.Library.Main.Operation
                             database.Dispose();
 
                             database = null;
-                            result.SetDatabase(null);
                             await new RepairHandler(options, (RepairResults)result.RepairResults)
                                 .RunAsync(backendManager, null)
                                 .ConfigureAwait(false);
 
                             // Re-open the database and backend manager
                             database = new LocalBackupDatabase(options.Dbpath, options);
-                            result.SetDatabase(database);
 
                             Log.WriteInformationMessage(LOGTAG, "BackendCleanupFinished", "Backend cleanup finished, retrying verification");
                             await FilelistProcessor.VerifyRemoteList(backendManager, options, database, result.BackendWriter, [lastTempFilelist.Name], [], logErrors: true, verifyMode: FilelistProcessor.VerifyMode.VerifyStrict).ConfigureAwait(false);
@@ -731,17 +728,6 @@ namespace Duplicati.Library.Main.Operation
                         }
                     }
 
-
-                    m_database.WriteResults();
-                    m_database.PurgeLogData(m_options.LogRetention);
-                    m_database.PurgeDeletedVolumes(DateTime.UtcNow);
-
-                    if (m_options.AutoVacuum)
-                    {
-                        m_result.VacuumResults = new VacuumResults(m_result);
-                        await new VacuumHandler(m_options, (VacuumResults)m_result.VacuumResults)
-                            .RunAsync();
-                    }
                     m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_Complete);
                     return;
                 }

--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -55,7 +55,6 @@ namespace Duplicati.Library.Main.Operation
             using (var db = new LocalDeleteDatabase(m_options.Dbpath, "Compact"))
             using (var tr = new ReusableTransaction(db))
             {
-                m_result.SetDatabase(db);
                 Utility.UpdateOptionsFromDb(db, m_options);
                 Utility.VerifyOptionsAndUpdateDatabase(db, m_options);
 
@@ -69,7 +68,7 @@ namespace Duplicati.Library.Main.Operation
                     tr.Commit("CommitCompact", restart: false);
                     if (changed)
                     {
-                        db.WriteResults();
+                        db.WriteResults(m_result);
                         if (m_options.AutoVacuum)
                         {
                             m_result.VacuumResults = new VacuumResults(m_result);

--- a/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
+++ b/Duplicati/Library/Main/Operation/CreateBugReportHandler.cs
@@ -69,7 +69,6 @@ namespace Duplicati.Library.Main.Operation
                 File.Copy(m_options.Dbpath, tmp, true);
                 using (var db = new LocalBugReportDatabase(tmp))
                 {
-                    m_result.SetDatabase(db);
                     db.Fix();
                     if (m_options.AutoVacuum)
                         db.Vacuum();

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -54,17 +54,13 @@ namespace Duplicati.Library.Main.Operation
             using (var db = new LocalDeleteDatabase(m_options.Dbpath, "Delete"))
             using (var tr = new ReusableTransaction(db))
             {
-                m_result.SetDatabase(db);
                 Utility.UpdateOptionsFromDb(db, m_options);
                 Utility.VerifyOptionsAndUpdateDatabase(db, m_options);
 
                 await DoRunAsync(db, tr, false, false, backendManager).ConfigureAwait(false);
 
                 if (!m_options.Dryrun)
-                {
                     tr.Commit("ComitDelete", restart: false);
-                    db.WriteResults();
-                }
             }
         }
 

--- a/Duplicati/Library/Main/Operation/ListAffected.cs
+++ b/Duplicati/Library/Main/Operation/ListAffected.cs
@@ -46,7 +46,6 @@ namespace Duplicati.Library.Main.Operation
 
             using (var db = new Database.LocalListAffectedDatabase(m_options.Dbpath))
             {
-                m_result.SetDatabase(db);
                 if (callback == null)
                 {
                     m_result.SetResult(

--- a/Duplicati/Library/Main/Operation/ListChangesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListChangesHandler.cs
@@ -83,8 +83,6 @@ namespace Duplicati.Library.Main.Operation
             using (var db = new Database.LocalListChangesDatabase(useLocalDb ? m_options.Dbpath : (string)tmpdb))
             using (var storageKeeper = db.CreateStorageHelper())
             {
-                m_result.SetDatabase(db);
-
                 if (useLocalDb)
                 {
                     var dbtimes = db.FilesetTimes.ToList();

--- a/Duplicati/Library/Main/Operation/ListControlFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListControlFilesHandler.cs
@@ -45,8 +45,6 @@ namespace Duplicati.Library.Main.Operation
             using (var tmpdb = new TempFile())
             using (var db = new LocalDatabase(System.IO.File.Exists(m_options.Dbpath) ? m_options.Dbpath : (string)tmpdb, "ListControlFiles", true))
             {
-                m_result.SetDatabase(db);
-
                 var filter = JoinedFilterExpression.Join(new Library.Utility.FilterExpression(filterstrings), compositefilter);
 
                 try

--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -56,7 +56,6 @@ namespace Duplicati.Library.Main.Operation
             if (!m_options.NoLocalDb && System.IO.File.Exists(m_options.Dbpath))
                 using (var db = new Database.LocalListDatabase(m_options.Dbpath))
                 {
-                    m_result.SetDatabase(db);
                     using (var filesets = db.SelectFileSets(m_options.Time, m_options.Version))
                     {
                         if (!filter.Empty)
@@ -122,8 +121,6 @@ namespace Duplicati.Library.Main.Operation
             using (var tmpdb = new TempFile())
             using (var db = new LocalDatabase(tmpdb, "List", true))
             {
-                m_result.SetDatabase(db);
-
                 var filteredList = ParseAndFilterFilesets(await backendManager.ListAsync(cancellationToken).ConfigureAwait(false), m_options);
                 if (filteredList.Count == 0)
                     throw new UserInformationException("No filesets found on remote target", "EmptyRemoteFolder");

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -116,10 +116,7 @@ namespace Duplicati.Library.Main.Operation
                                 .DoRunAsync(rmdb, deltr, true, false, backendManager).ConfigureAwait(false);
 
                             if (!m_options.Dryrun)
-                            {
                                 deltr.Commit("CommitDelete", restart: false);
-                                rmdb.WriteResults();
-                            }
                         }
 
                         pgoffset += (pgspan * fully_emptied.Length);

--- a/Duplicati/Library/Main/Operation/PurgeFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeFilesHandler.cs
@@ -245,7 +245,6 @@ namespace Duplicati.Library.Main.Operation
                             .ConfigureAwait(false);
 
                         ctr.Commit(restart: false);
-                        cdb.WriteResults();
                     }
                 }
 

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -65,11 +65,7 @@ namespace Duplicati.Library.Main.Operation
                 throw new UserInformationException(string.Format("Cannot recreate database because file already exists: {0}", path), "RecreateTargetDatabaseExists");
 
             using (var db = new LocalDatabase(path, "Recreate", true))
-            {
-                m_result.SetDatabase(db);
                 await DoRunAsync(backendManager, db, false, filter, filelistfilter, blockprocessor).ConfigureAwait(false);
-                db.WriteResults();
-            }
         }
 
         /// <summary>
@@ -85,8 +81,6 @@ namespace Duplicati.Library.Main.Operation
 
             using (var db = new LocalDatabase(m_options.Dbpath, "Recreate", true))
             {
-                m_result.SetDatabase(db);
-
                 if (db.FindMatchingFilesets(m_options.Time, m_options.Version).Any())
                     throw new UserInformationException("The version(s) being updated to, already exists", "UpdateVersionAlreadyExists");
 
@@ -101,7 +95,6 @@ namespace Duplicati.Library.Main.Operation
                     Utility.VerifyOptionsAndUpdateDatabase(db, m_options, null);
 
                 await DoRunAsync(backendManager, db, true, filter, filelistfilter, blockprocessor).ConfigureAwait(false);
-                db.WriteResults();
             }
         }
 

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -126,7 +126,6 @@ namespace Duplicati.Library.Main.Operation
 
             using (var db = new LocalRepairDatabase(m_options.Dbpath))
             {
-                m_result.SetDatabase(db);
                 Utility.UpdateOptionsFromDb(db, m_options);
                 Utility.VerifyOptionsAndUpdateDatabase(db, m_options);
 
@@ -574,7 +573,6 @@ namespace Duplicati.Library.Main.Operation
                 await backendManager.WaitForEmptyAsync(db, null, cancellationToken).ConfigureAwait(false);
                 if (!m_options.Dryrun)
                     db.TerminatedWithActiveUploads = false;
-                db.WriteResults();
             }
         }
 
@@ -587,8 +585,6 @@ namespace Duplicati.Library.Main.Operation
 
             using (var db = new LocalRepairDatabase(m_options.Dbpath))
             {
-                db.SetResult(m_result);
-
                 Utility.UpdateOptionsFromDb(db, m_options);
 
                 if (db.RepairInProgress || db.PartiallyRecreated)

--- a/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
@@ -48,8 +48,6 @@ namespace Duplicati.Library.Main.Operation
             using (var tmpdb = new TempFile())
             using (var db = new Database.LocalDatabase(File.Exists(m_options.Dbpath) ? m_options.Dbpath : (string)tmpdb, "RestoreControlFiles", true))
             {
-                m_result.SetDatabase(db);
-
                 var filter = JoinedFilterExpression.Join(new FilterExpression(filterstrings), compositefilter);
 
                 try
@@ -103,8 +101,6 @@ namespace Duplicati.Library.Main.Operation
                 {
                     await backendManager.WaitForEmptyAsync(db, null, m_result.TaskControl.ProgressToken).ConfigureAwait(false);
                 }
-
-                db.WriteResults();
             }
         }
     }

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -116,7 +116,6 @@ namespace Duplicati.Library.Main.Operation
                 if (!m_options.NoLocalDb && SystemIO.IO_OS.FileExists(m_options.Dbpath))
                 {
                     db = new LocalRestoreDatabase(m_options.Dbpath);
-                    db.SetResult(m_result);
                 }
                 else
                 {
@@ -143,8 +142,6 @@ namespace Duplicati.Library.Main.Operation
                     await DoRunAsync(backendManager, db, filter, m_result.TaskControl.ProgressToken).ConfigureAwait(false);
                 else
                     await DoRunNewAsync(backendManager, db, filter, m_result.TaskControl.ProgressToken).ConfigureAwait(false);
-
-                db.WriteResults();
             }
             finally
             {
@@ -328,7 +325,6 @@ namespace Duplicati.Library.Main.Operation
             m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Restore_CreateTargetFolders);
             using (new Logging.Timer(LOGTAG, "CreateDirectory", "CreateDirectory"))
                 await CreateDirectoryStructure(database, m_options, m_result).ConfigureAwait(false);
-            database.SetResult(m_result);
 
             using var setup_log_timer = new Logging.Timer(LOGTAG, "RestoreNetworkSetup", "RestoreNetworkSetup");
             // Create the channels between BlockManager and FileProcessor
@@ -424,7 +420,6 @@ namespace Duplicati.Library.Main.Operation
             //using (var database = new LocalRestoreDatabase(dbparent))
             using (var metadatastorage = new RestoreHandlerMetadataStorage())
             {
-                database.SetResult(m_result);
                 Utility.UpdateOptionsFromDb(database, m_options);
                 Utility.VerifyOptionsAndUpdateDatabase(database, m_options);
                 m_blockbuffer = new byte[m_options.Blocksize];

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -53,14 +53,11 @@ namespace Duplicati.Library.Main.Operation
 
             using (var db = new LocalTestDatabase(m_options.Dbpath))
             {
-                db.SetResult(m_results);
                 Utility.UpdateOptionsFromDb(db, m_options);
                 Utility.VerifyOptionsAndUpdateDatabase(db, m_options);
                 db.VerifyConsistency(m_options.Blocksize, m_options.BlockhashSize, !m_options.DisableFilelistConsistencyChecks, null);
                 await FilelistProcessor.VerifyRemoteList(backendManager, m_options, db, m_results.BackendWriter, latestVolumesOnly: true, verifyMode: FilelistProcessor.VerifyMode.VerifyOnly, null).ConfigureAwait(false);
-
                 await DoRunAsync(samples, db, backendManager).ConfigureAwait(false);
-                db.WriteResults();
             }
         }
 

--- a/Duplicati/Library/Main/Operation/VacuumHandler.cs
+++ b/Duplicati/Library/Main/Operation/VacuumHandler.cs
@@ -42,7 +42,6 @@ namespace Duplicati.Library.Main.Operation
             {
                 using (var db = new Database.LocalDatabase(m_options.Dbpath, "Vacuum", false))
                 {
-                    m_result.SetDatabase(db);
                     m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Vacuum_Running);
                     db.Vacuum();
                     m_result.EndTime = DateTime.UtcNow;


### PR DESCRIPTION
The code was using a two-way reference linking the database to the results and the results to the database.

However, this was not really used so it ended up just cluttering the code. With this commit, the results and databases are no longer keeping track of each other, and the only interaction is when the results are written to the database at the end of the operation.

To ensure result data is always written, this code has been moved into the controller, which will now flush the results for all operations. Prior to this, only some operations would write result data to the log.

The controller now also handles logic for cleaning old log data and invoking the vacuum command.

Fixed a bug due to using System.Text.Json where some attributes from NewtonSoft.Json were being applied and not picked up.