### PR TITLE
Improve SQLite loading

### DIFF
--- a/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRestoreDatabase.cs
@@ -921,9 +921,11 @@ ORDER BY ""A"".""TargetPath"", ""BB"".""Index""");
         {
             if (!m_connection_pool.TryTake(out var connection))
             {
-                connection = (IDbConnection)Activator.CreateInstance(SQLiteHelper.SQLiteLoader.SQLiteConnectionType);
+                connection = SQLiteHelper.SQLiteLoader.LoadConnection();
                 connection.ConnectionString = m_connection.ConnectionString + ";Cache=Shared;";
                 connection.Open();
+
+                SQLiteHelper.SQLiteLoader.ApplyCustomPragmas(connection);
 
                 using var cmd = connection.CreateCommand();
                 cmd.ExecuteNonQuery("PRAGMA journal_mode = WAL;");

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -100,6 +100,37 @@ namespace Duplicati.Library.SQLiteHelper
         }
 
         /// <summary>
+        /// Applies user-supplied custom pragmas to the SQLite connection
+        /// </summary>
+        /// <param name="con">The connection to apply the pragmas to.</param>
+        /// <returns>The connection with the pragmas applied.</returns>
+        public static System.Data.IDbConnection ApplyCustomPragmas(System.Data.IDbConnection con)
+        {
+            var opts = Environment.GetEnvironmentVariable("CUSTOMSQLITEOPTIONS_DUPLICATI");
+            if (opts == null)
+                return con;
+            var topts = opts.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            if (topts.Length == 0)
+                return con;
+
+            using (var cmd = con.CreateCommand())
+                foreach (var opt in topts)
+                {
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "CustomSQLiteOption", @"Setting custom SQLite option '{0}'.", opt);
+                    try
+                    {
+                        cmd.CommandText = string.Format("pragma {0}", opt);
+                        cmd.ExecuteNonQuery();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logging.Log.WriteWarningMessage(LOGTAG, "CustomSQLiteOption", ex, @"Error setting custom SQLite option '{0}'.", opt);
+                    }
+                }
+            return con;
+        }
+
+        /// <summary>
         /// Loads an SQLite connection instance and opening the database
         /// </summary>
         /// <returns>The SQLite connection instance.</returns>
@@ -109,7 +140,7 @@ namespace Duplicati.Library.SQLiteHelper
             if (string.IsNullOrWhiteSpace(targetpath))
                 throw new ArgumentNullException(nameof(targetpath));
 
-            System.Data.IDbConnection con = LoadConnection();
+            var con = LoadConnection();
 
             try
             {
@@ -124,32 +155,7 @@ namespace Duplicati.Library.SQLiteHelper
             }
 
             // set custom Sqlite options
-            var opts = Environment.GetEnvironmentVariable("CUSTOMSQLITEOPTIONS_DUPLICATI");
-            if (opts != null)
-            {
-                var topts = opts.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                if (topts.Length > 0)
-                {
-                    using (var cmd = con.CreateCommand())
-                    {
-                        foreach (var opt in topts)
-                        {
-                            Logging.Log.WriteVerboseMessage(LOGTAG, "CustomSQLiteOption", @"Setting custom SQLite option '{0}'.", opt);
-                            try
-                            {
-                                cmd.CommandText = string.Format("pragma {0}", opt);
-                                cmd.ExecuteNonQuery();
-                            }
-                            catch (Exception ex)
-                            {
-                                Logging.Log.WriteErrorMessage(LOGTAG, "CustomSQLiteOption", ex, @"Error setting custom SQLite option '{0}'.", opt);
-                            }
-                        }
-                    }
-                }
-            }
-
-            return con;
+            return ApplyCustomPragmas(con);
         }
 
         /// <summary>
@@ -189,9 +195,12 @@ namespace Duplicati.Library.SQLiteHelper
         /// </summary>
         private static void SetEnvironmentVariablesForSQLiteTempDir()
         {
-            System.Environment.SetEnvironmentVariable("SQLITE_TMPDIR", Library.Utility.TempFolder.SystemTempPath);
-            System.Environment.SetEnvironmentVariable("TMP", Library.Utility.TempFolder.SystemTempPath);
-            System.Environment.SetEnvironmentVariable("TEMP", Library.Utility.TempFolder.SystemTempPath);
+            // Allow the user to override the temp folder for SQLite
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SQLITE_TMPDIR")))
+                Environment.SetEnvironmentVariable("SQLITE_TMPDIR", Utility.TempFolder.SystemTempPath);
+            Environment.SetEnvironmentVariable("TMPDIR", Utility.TempFolder.SystemTempPath);
+            Environment.SetEnvironmentVariable("TMP", Utility.TempFolder.SystemTempPath);
+            Environment.SetEnvironmentVariable("TEMP", Utility.TempFolder.SystemTempPath);
         }
 
         /// <summary>

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -107,19 +107,16 @@ namespace Duplicati.Library.SQLiteHelper
         public static System.Data.IDbConnection ApplyCustomPragmas(System.Data.IDbConnection con)
         {
             var opts = Environment.GetEnvironmentVariable("CUSTOMSQLITEOPTIONS_DUPLICATI");
-            if (opts == null)
-                return con;
-            var topts = opts.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            if (topts.Length == 0)
+            if (string.IsNullOrWhiteSpace(opts))
                 return con;
 
             using (var cmd = con.CreateCommand())
-                foreach (var opt in topts)
+                foreach (var opt in opts.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                 {
                     Logging.Log.WriteVerboseMessage(LOGTAG, "CustomSQLiteOption", @"Setting custom SQLite option '{0}'.", opt);
                     try
                     {
-                        cmd.CommandText = string.Format("pragma {0}", opt);
+                        cmd.CommandText = string.Format("PRAGMA {0}", opt);
                         cmd.ExecuteNonQuery();
                     }
                     catch (Exception ex)


### PR DESCRIPTION
This commit changes the way the new restore flow loads the extra database connections so these will also apply the temporary folder settings and custom pragmas.

This also changes the logic around the SQLite temporary folder. Previously, this folder would unconditionally be set to the general temporary folder, allowing only an override with a custom pragma.

Now the setup checks if the system has the environment variable `SQLITE_TMPDIR` set already. If this variable is already set, it will NOT be overwritten. Actual effects of this change depends on how SQLite internally resolves the temporary folder.