### PR TITLE
Handle stop exceptions

### DIFF
--- a/Duplicati/Library/Main/Operation/ListControlFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListControlFilesHandler.cs
@@ -75,11 +75,9 @@ namespace Duplicati.Library.Main.Operation
                             lastEx = null;
                             break;
                         }
-                        catch (Exception ex)
+                        catch (Exception ex) when (!ex.IsAbortException())
                         {
                             lastEx = ex;
-                            if (ex is System.Threading.ThreadAbortException)
-                                throw;
                         }
 
                     if (lastEx != null)

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -250,7 +250,7 @@ namespace Duplicati.Library.Main.Operation
                         catch (Exception ex)
                         {
                             Logging.Log.WriteWarningMessage(LOGTAG, "FileProcessingFailed", ex, "Failed to process file: {0}", entry.Name);
-                            if (ex is System.Threading.ThreadAbortException)
+                            if (ex.IsAbortException())
                             {
                                 m_result.EndTime = DateTime.UtcNow;
                                 throw;
@@ -379,7 +379,7 @@ namespace Duplicati.Library.Main.Operation
                             {
                                 //Not fatal
                                 Logging.Log.WriteErrorMessage(LOGTAG, "IndexFileProcessingFailed", ex, "Failed to process index file: {0}", name);
-                                if (ex is System.Threading.ThreadAbortException)
+                                if (ex.IsAbortException())
                                 {
                                     m_result.EndTime = DateTime.UtcNow;
                                     throw;

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -211,7 +211,7 @@ namespace Duplicati.Library.Main.Operation
                                 catch (Exception ex)
                                 {
                                     Logging.Log.WriteErrorMessage(LOGTAG, "RemoteFileVerificationError", ex, "Failed to perform verification for file: {0}, please run verify; message: {1}", n.Name, ex.Message);
-                                    if (ex is System.Threading.ThreadAbortException)
+                                    if (ex.IsAbortException())
                                         throw;
                                 }
                         }
@@ -298,7 +298,7 @@ namespace Duplicati.Library.Main.Operation
                         catch (Exception ex)
                         {
                             Logging.Log.WriteErrorMessage(LOGTAG, "FailedExtraFileCleanup", ex, "Failed to perform cleanup for extra file: {0}, message: {1}", n.File.Name, ex.Message);
-                            if (ex is System.Threading.ThreadAbortException)
+                            if (ex.IsAbortException())
                                 throw;
                         }
 
@@ -559,7 +559,7 @@ namespace Duplicati.Library.Main.Operation
 
                             Logging.Log.WriteErrorMessage(LOGTAG, "CleanupMissingFileError", ex, "Failed to perform cleanup for missing file: {0}, message: {1}", n.Name, ex.Message);
 
-                            if (ex is System.Threading.ThreadAbortException)
+                            if (ex.IsAbortException())
                                 throw;
                         }
                     }

--- a/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
@@ -90,7 +90,7 @@ namespace Duplicati.Library.Main.Operation
                         catch (Exception ex)
                         {
                             lastEx = ex;
-                            if (ex is System.Threading.ThreadAbortException)
+                            if (ex.IsAbortException())
                                 throw;
                         }
 

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -511,7 +511,7 @@ namespace Duplicati.Library.Main.Operation
                         {
                             brokenFiles.Add(name);
                             Logging.Log.WriteErrorMessage(LOGTAG, "PatchingFailed", ex, "Failed to patch with remote file: \"{0}\", message: {1}", name, ex.Message);
-                            if (ex is System.Threading.ThreadAbortException)
+                            if (ex.IsAbortException())
                                 throw;
                         }
                     }
@@ -535,7 +535,7 @@ namespace Duplicati.Library.Main.Operation
                     {
                         fileErrors++;
                         Logging.Log.WriteErrorMessage(LOGTAG, "RestoreFileFailed", ex, "Failed to restore empty file: \"{0}\". Error message was: {1}", file.Path, ex.Message);
-                        if (ex is System.Threading.ThreadAbortException)
+                        if (ex.IsAbortException())
                             throw;
                     }
                 }
@@ -587,7 +587,7 @@ namespace Duplicati.Library.Main.Operation
                             {
                                 fileErrors++;
                                 Logging.Log.WriteErrorMessage(LOGTAG, "RestoreFileFailed", ex, "Failed to restore file: \"{0}\". Error message was: {1}", file.Path, ex.Message);
-                                if (ex is System.Threading.ThreadAbortException)
+                                if (ex.IsAbortException())
                                     throw;
                             }
                         }
@@ -742,7 +742,7 @@ namespace Duplicati.Library.Main.Operation
                                 catch (Exception ex)
                                 {
                                     Logging.Log.WriteWarningMessage(LOGTAG, "PatchingFileLocalFailed", ex, "Failed to patch file: \"{0}\" with data from local file \"{1}\", message: {2}", targetpath, sourcepath, ex.Message);
-                                    if (ex is System.Threading.ThreadAbortException)
+                                    if (ex.IsAbortException())
                                         throw;
                                 }
                             }
@@ -763,7 +763,7 @@ namespace Duplicati.Library.Main.Operation
                     catch (Exception ex)
                     {
                         Logging.Log.WriteWarningMessage(LOGTAG, "PatchingFileLocalFailed", ex, "Failed to patch file: \"{0}\" with local data, message: {1}", targetpath, ex.Message);
-                        if (ex is System.Threading.ThreadAbortException)
+                        if (ex.IsAbortException())
                             throw;
                         if (options.UnittestMode)
                             throw;
@@ -859,7 +859,7 @@ namespace Duplicati.Library.Main.Operation
                                     catch (Exception ex)
                                     {
                                         Logging.Log.WriteWarningMessage(LOGTAG, "PatchingFileLocalFailed", ex, "Failed to patch file: \"{0}\" with data from local file \"{1}\", message: {2}", targetpath, source.Path, ex.Message);
-                                        if (ex is System.Threading.ThreadAbortException)
+                                        if (ex.IsAbortException())
                                             throw;
                                     }
                                 }
@@ -1108,7 +1108,7 @@ namespace Duplicati.Library.Main.Operation
                         catch (Exception ex)
                         {
                             Logging.Log.WriteWarningMessage(LOGTAG, "TargetFileReadError", ex, "Failed to read target file: \"{0}\", message: {1}", targetpath, ex.Message);
-                            if (ex is System.Threading.ThreadAbortException)
+                            if (ex.IsAbortException())
                                 throw;
                             if (options.UnittestMode)
                                 throw;

--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -121,7 +121,7 @@ namespace Duplicati.Library.Main.Operation
                     {
                         m_results.AddResult(vol.Name, new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>[] { new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>(Duplicati.Library.Interface.TestEntryStatus.Error, ex.Message) });
                         Logging.Log.WriteErrorMessage(LOGTAG, "RemoteFileProcessingFailed", ex, "Failed to process file {0}", vol.Name);
-                        if (ex is System.Threading.ThreadAbortException)
+                        if (ex.IsAbortException())
                         {
                             m_results.EndTime = DateTime.UtcNow;
                             throw;
@@ -184,7 +184,7 @@ namespace Duplicati.Library.Main.Operation
                     {
                         m_results.AddResult(f.Name, [new KeyValuePair<TestEntryStatus, string>(TestEntryStatus.Error, ex.Message)]);
                         Logging.Log.WriteErrorMessage(LOGTAG, "FailedToProcessFile", ex, "Failed to process file {0}", f.Name);
-                        if (ex is ThreadAbortException || ex is TaskCanceledException)
+                        if (ex.IsAbortOrCancelException())
                         {
                             m_results.EndTime = DateTime.UtcNow;
                             throw;

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -297,11 +297,7 @@ namespace Duplicati.Library.Utility
                     var attr = attributeReader?.Invoke(rootpath) ?? FileAttributes.Directory;
                     lst.Push(rootpath);
                 }
-                catch (System.Threading.ThreadAbortException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
+                catch (Exception ex) when (!ex.IsAbortException())
                 {
                     errorCallback?.Invoke(rootpath, rootpath, ex);
                 }
@@ -322,21 +318,13 @@ namespace Duplicati.Library.Utility
                                 var attr = attributeReader?.Invoke(sf) ?? FileAttributes.Directory;
                                 lst.Push(sf);
                             }
-                            catch (System.Threading.ThreadAbortException)
-                            {
-                                throw;
-                            }
-                            catch (Exception ex)
+                            catch (Exception ex) when (!ex.IsAbortException())
                             {
                                 errorCallback?.Invoke(rootpath, sf, ex);
                             }
                         }
                     }
-                    catch (System.Threading.ThreadAbortException)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex)
+                    catch (Exception ex) when (!ex.IsAbortException())
                     {
                         errorCallback?.Invoke(rootpath, f, ex);
                     }
@@ -348,11 +336,7 @@ namespace Duplicati.Library.Utility
                         {
                             files = fileList(f);
                         }
-                        catch (System.Threading.ThreadAbortException)
-                        {
-                            throw;
-                        }
-                        catch (Exception ex)
+                        catch (Exception ex) when (!ex.IsAbortException())
                         {
                             errorCallback?.Invoke(rootpath, f, ex);
                         }
@@ -1650,6 +1634,26 @@ namespace Duplicati.Library.Utility
             }
 
             return sanitizedUrl;
+        }
+
+        /// <summary>
+        /// Checks if an exception is a stop, cancel or timeout exception
+        /// </summary>
+        /// <param name="ex">The operation to check</param>
+        /// <returns><c>true</c> if the exception is a stop or cancel exception, <c>false</c> otherwise</returns>
+        public static bool IsAbortOrCancelException(this Exception ex)
+        {
+            return ex is OperationCanceledException || ex is ThreadAbortException || ex is TaskCanceledException || ex is TimeoutException;
+        }
+
+        /// <summary>
+        /// Checks if an exception is a stop exception
+        /// </summary>
+        /// <param name="ex">The operation to check</param>
+        /// <returns><c>true</c> if the exception is a stop exception, <c>false</c> otherwise</returns>
+        public static bool IsAbortException(this Exception ex)
+        {
+            return ex is OperationCanceledException || ex is ThreadAbortException;
         }
 
         /// <summary>


### PR DESCRIPTION
This adds a common way to catch stop exceptions and handles them so error resilient logic does not continue when a stop exception is thrown.

Previously, the logic would only check for `ThreadAbortException` which was used to signal a stop prior to .NET8.