### PR TITLE
Fixed URL parser not treating `file://C:\path` the same as `C:\Path`.

### DIFF
--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -185,8 +185,8 @@ namespace Duplicati.Library.Utility
             // file://c:\test support
             if (h.Length == 1 && p.StartsWith(":", StringComparison.Ordinal))
             {
-                h = h + p;
-                p = "";
+                p = h + p;
+                h = null;
             }
 
             this.Host = h;


### PR DESCRIPTION
This fixes #6071