### PR TITLE
Improve Windows anti-sleep

### DIFF
--- a/Duplicati/Library/Main/ProcessController.cs
+++ b/Duplicati/Library/Main/ProcessController.cs
@@ -21,7 +21,8 @@
 
 using System;
 using System.Linq;
-using Duplicati.Library.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Duplicati.Library.Utility;
 
 namespace Duplicati.Library.Main
@@ -79,6 +80,11 @@ namespace Duplicati.Library.Main
         private bool m_hasStartedBackgroundMode = false;
 
         /// <summary>
+        /// A timer used to prevent sleep
+        /// </summary>
+        private CancellationTokenSource m_timerCancellation;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="T:Duplicati.Library.Main.ProcessController"/> class.
         /// </summary>
         /// <param name="options">The options to use.</param>
@@ -86,7 +92,7 @@ namespace Duplicati.Library.Main
         {
             if (options == null)
                 return;
-            
+
             try
             {
                 Start(options);
@@ -96,7 +102,6 @@ namespace Duplicati.Library.Main
             {
                 Logging.Log.WriteWarningMessage(LOGTAG, "ProcessControllerStartError", ex, "Failed to start the process controller: {0}", ex.Message);
             }
-
         }
 
         /// <summary>
@@ -108,7 +113,30 @@ namespace Duplicati.Library.Main
             {
                 try
                 {
-                    Win32.SetThreadExecutionState(Win32.EXECUTION_STATE.ES_CONTINUOUS | Win32.EXECUTION_STATE.ES_SYSTEM_REQUIRED);
+                    m_timerCancellation?.Cancel();
+                    m_timerCancellation = new CancellationTokenSource();
+
+                    Task.Run(async () =>
+                    {
+                        try
+                        {
+                            while (!m_timerCancellation.Token.IsCancellationRequested)
+                            {
+                                if (OperatingSystem.IsWindows())
+                                    Win32.SetThreadExecutionState(Win32.EXECUTION_STATE.ES_CONTINUOUS | Win32.EXECUTION_STATE.ES_SYSTEM_REQUIRED);
+                                await Task.Delay(TimeSpan.FromSeconds(10), m_timerCancellation.Token);
+                            }
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            // Ignore
+                        }
+                        catch (Exception ex)
+                        {
+                            Logging.Log.WriteWarningMessage(LOGTAG, "SleepPrevetionError", ex, "Failed to set sleep prevention");
+                        }
+                    });
+
                     m_runningSleepPrevention = true;
                 }
                 catch (Exception ex)
@@ -220,7 +248,7 @@ namespace Duplicati.Library.Main
                     {
                         m_originalNiceClass = 0;
                         // Only allowed for "best-effort" and "realtime"
-                        m_originalNiceLevel = -1; 
+                        m_originalNiceLevel = -1;
                     }
                     else if (string.Equals(ioclass, "best-effort", StringComparison.OrdinalIgnoreCase))
                     {
@@ -293,6 +321,9 @@ namespace Duplicati.Library.Main
                     if (m_runningSleepPrevention)
                     {
                         m_runningSleepPrevention = false;
+                        m_timerCancellation?.Dispose();
+                        m_timerCancellation = null;
+
                         Win32.SetThreadExecutionState(Win32.EXECUTION_STATE.ES_CONTINUOUS);
                     }
                 }
@@ -463,7 +494,7 @@ namespace Duplicati.Library.Main
                 {
                     Stop();
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Logging.Log.WriteWarningMessage(LOGTAG, "ProcessControllerStopError", ex, "Failed to stop the process controller: {0}", ex.Message);
                 }


### PR DESCRIPTION
This updates the Windows sleep prevention code to repeatedly reset the sleep timer every 10s if sleep is not allowed.

Previous implementation would only call it once, which is not sufficient to prevent sleep as the timer will eventually run out.