### PR TITLE
Better zip64 support

### DIFF
--- a/Duplicati/Library/Compression/Duplicati.Library.Compression.csproj
+++ b/Duplicati/Library/Compression/Duplicati.Library.Compression.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="sharpcompress" Version="0.36.0" />
+    <PackageReference Include="sharpcompress" Version="0.39.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/Compression/Strings.cs
+++ b/Duplicati/Library/Compression/Strings.cs
@@ -32,6 +32,7 @@ namespace Duplicati.Library.Compression.Strings
         public static string CompressionmethodShort { get { return LC.L(@"Set the ZIP compression method"); } }
         public static string Compressionzip64Long { get { return LC.L(@"The ZIP64 format is required for files larger than 4GiB. Use this option to toggle it."); } }
         public static string Compressionzip64Short { get { return LC.L(@"Toggle ZIP64 support"); } }
+        public static string Compressionzip64Deprecated { get { return LC.L(@"ZIP64 support is now always enabled. This option is deprecated and will be removed in a future version."); } }
         public static string CompressionlibraryLong { get { return LC.L(@"This option changes the compression library used to read and write files. The SharpCompress library has more features and is more resilient where the built-in library is faster. When Auto is chosen, the built-in library will be used unless an option is added that requires SharpCompress."); } }
         public static string CompressionlibraryShort { get { return LC.L(@"Toggles the zip library to use"); } }
         public static string FileNotFoundError(string filename) { return LC.L(@"File not found: {0}", filename); }

--- a/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
+++ b/Duplicati/Library/Compression/ZipCompression/FileArchiveZip.cs
@@ -75,10 +75,6 @@ namespace Duplicati.Library.Compression.ZipCompression
         /// </summary>
         private const string COMPRESSION_METHOD_OPTION = "zip-compression-method";
         /// <summary>
-        /// The commandline option for toggling the ZIP64 support
-        /// </summary>
-        private const string COMPRESSION_ZIP64_OPTION = "zip-compression-zip64";
-        /// <summary>
         /// The commandline option for toggling the compression library
         /// </summary>
         private const string COMPRESSION_LIBRARY_OPTION = "zip-compression-library";
@@ -92,11 +88,6 @@ namespace Duplicati.Library.Compression.ZipCompression
         /// The default compression method
         /// </summary>
         private const CompressionType DEFAULT_COMPRESSION_METHOD = CompressionType.Deflate;
-
-        /// <summary>
-        /// The default setting for the ZIP64 support
-        /// </summary>
-        private const bool DEFAULT_ZIP64 = false;
 
         /// <summary>
         /// The archive to use
@@ -132,10 +123,6 @@ namespace Duplicati.Library.Compression.ZipCompression
             var compressionType = DEFAULT_COMPRESSION_METHOD;
             var compressionLevel = DEFAULT_COMPRESSION_LEVEL;
 
-            var usingZip64 = options.ContainsKey(COMPRESSION_ZIP64_OPTION)
-                ? Utility.Utility.ParseBoolOption(options.AsReadOnly(), COMPRESSION_ZIP64_OPTION)
-                : DEFAULT_ZIP64;
-
             CompressionType tmptype;
             if (options.TryGetValue(COMPRESSION_METHOD_OPTION, out var cpmethod) && Enum.TryParse<SharpCompress.Common.CompressionType>(cpmethod, true, out tmptype))
                 compressionType = tmptype;
@@ -150,12 +137,12 @@ namespace Duplicati.Library.Compression.ZipCompression
                 compressionLibrary = tmpcplib;
 
             var unittestMode = Utility.Utility.ParseBoolOption(options.AsReadOnly(), "unittest-mode");
-            var parsedOptions = new ParsedZipOptions(compressionLevel, compressionType, usingZip64, unittestMode);
+            var parsedOptions = new ParsedZipOptions(compressionLevel, compressionType, unittestMode);
 
             var userCompressionLibrary = compressionLibrary;
             if (compressionLibrary == CompressionLibrary.Auto)
             {
-                if (compressionType != CompressionType.Deflate || usingZip64)
+                if (compressionType != CompressionType.Deflate)
                     compressionLibrary = CompressionLibrary.SharpCompress;
                 else
                     compressionLibrary = CompressionLibrary.BuiltIn;
@@ -217,7 +204,7 @@ namespace Duplicati.Library.Compression.ZipCompression
                     new CommandLineArgument(COMPRESSION_LEVEL_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.FileArchiveZip.CompressionlevelShort, Strings.FileArchiveZip.CompressionlevelLong, DEFAULT_COMPRESSION_LEVEL.ToString(), null, new string[] {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}),
                     new CommandLineArgument(COMPRESSION_LEVEL_OPTION_ALIAS, CommandLineArgument.ArgumentType.Enumeration, Strings.FileArchiveZip.CompressionlevelShort, Strings.FileArchiveZip.CompressionlevelLong, DEFAULT_COMPRESSION_LEVEL.ToString(), null, new string[] {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}, Strings.FileArchiveZip.CompressionlevelDeprecated(COMPRESSION_LEVEL_OPTION)),
                     new CommandLineArgument(COMPRESSION_METHOD_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.FileArchiveZip.CompressionmethodShort, Strings.FileArchiveZip.CompressionmethodLong(COMPRESSION_LEVEL_OPTION), DEFAULT_COMPRESSION_METHOD.ToString(), null, methods),
-                    new CommandLineArgument(COMPRESSION_ZIP64_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.FileArchiveZip.Compressionzip64Short, Strings.FileArchiveZip.Compressionzip64Long, DEFAULT_ZIP64.ToString()),
+                    new CommandLineArgument("zip-compression-zip64", CommandLineArgument.ArgumentType.Boolean, Strings.FileArchiveZip.Compressionzip64Short, Strings.FileArchiveZip.Compressionzip64Long, "true", null, null, Strings.FileArchiveZip.Compressionzip64Deprecated),
                     new CommandLineArgument(COMPRESSION_LIBRARY_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.FileArchiveZip.CompressionlibraryShort, Strings.FileArchiveZip.CompressionlibraryLong, CompressionLibrary.Auto.ToString(), null, Enum.GetNames(typeof(CompressionLibrary)))
                 ]);
             }

--- a/Duplicati/Library/Compression/ZipCompression/ParsedZipOptions.cs
+++ b/Duplicati/Library/Compression/ZipCompression/ParsedZipOptions.cs
@@ -29,11 +29,9 @@ namespace Duplicati.Library.Compression.ZipCompression;
 /// </summary>
 /// <param name="DeflateCompressionLevel">The compression level to use</param>
 /// <param name="CompressionType">The compression type to use</param>
-/// <param name="UseZip64">Whether to use zip64 extensions</param>
 /// <param name="UnittestMode">Flag indicating if unittest mode is enabled</param>
 public sealed record ParsedZipOptions(
     CompressionLevel DeflateCompressionLevel,
     CompressionType CompressionType,
-    bool UseZip64,
     bool UnittestMode
 );

--- a/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
+++ b/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
@@ -80,7 +80,7 @@ public class SharpCompressZipArchive : IZipArchive
     /// <summary>
     /// Flag indicating if we are using Zip64 extensions
     /// </summary>
-    private readonly bool m_usingZip64;
+    private const bool USE_ZIP64 = true;
     /// <summary>
     /// The default compression level to use
     /// </summary>
@@ -108,7 +108,6 @@ public class SharpCompressZipArchive : IZipArchive
         m_stream = stream;
         m_mode = mode;
 
-        m_usingZip64 = options.UseZip64;
         m_defaultCompressionLevel = options.DeflateCompressionLevel;
         m_compressionType = options.CompressionType;
         m_mode = mode;
@@ -120,7 +119,7 @@ public class SharpCompressZipArchive : IZipArchive
             {
                 CompressionType = m_compressionType,
                 DeflateCompressionLevel = m_defaultCompressionLevel,
-                UseZip64 = m_usingZip64
+                UseZip64 = USE_ZIP64
             };
 
             m_writer = WriterFactory.Open(m_stream, ArchiveType.Zip, compression);
@@ -335,7 +334,7 @@ public class SharpCompressZipArchive : IZipArchive
             throw new InvalidOperationException(Constants.CannotWriteWhileReading);
 
         m_flushBufferSize += Constants.CENTRAL_HEADER_ENTRY_SIZE + System.Text.Encoding.UTF8.GetByteCount(file);
-        if (m_usingZip64)
+        if (USE_ZIP64)
             m_flushBufferSize += Constants.CENTRAL_HEADER_ENTRY_SIZE_ZIP64_EXTRA;
 
         return ((ZipWriter)m_writer!).WriteToStream(file, new ZipWriterEntryOptions()

--- a/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
+++ b/Duplicati/Library/Compression/ZipCompression/SharpCompressZipArchive.cs
@@ -119,7 +119,8 @@ public class SharpCompressZipArchive : IZipArchive
             var compression = new ZipWriterOptions(CompressionType.Deflate)
             {
                 CompressionType = m_compressionType,
-                DeflateCompressionLevel = m_defaultCompressionLevel
+                DeflateCompressionLevel = m_defaultCompressionLevel,
+                UseZip64 = m_usingZip64
             };
 
             m_writer = WriterFactory.Open(m_stream, ArchiveType.Zip, compression);


### PR DESCRIPTION
Fixed a bug that would cause SharpCompress to not set the Zip64 mode and fail to compress files larger than 4GiB.
Removed option to toggle Zip64, as all standard tools support this extension now.
Added a test that checks that built-in Zip and SharpCompress handles sources files larger than 4GiB.
Updated SharpCompress from 0.36 to 0.39.