### PR TITLE
Guards for setting permissions

### DIFF
--- a/Duplicati/Library/AutoUpdater/DataFolderManager.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderManager.cs
@@ -35,6 +35,11 @@ namespace Duplicati.Library.AutoUpdater;
 public static class DataFolderManager
 {
     /// <summary>
+    /// The log tag for this class
+    /// </summary>
+    private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(DataFolderManager));
+
+    /// <summary>
     /// The folder where the machine id is placed
     /// </summary>
     public static readonly string DATAFOLDER;
@@ -184,12 +189,20 @@ public static class DataFolderManager
         if (Directory.Exists(DATAFOLDER))
         {
             if (!File.Exists(Path.Combine(DATAFOLDER, Util.InsecurePermissionsMarkerFile)))
-                SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER);
+                try { SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER); }
+                catch (Exception ex)
+                {
+                    Logging.Log.WriteWarningMessage(LOGTAG, "FailedToSetPermissions", ex, "Failed to set permissions for {0}: {1}", DATAFOLDER, ex.Message);
+                }
         }
         else
         {
             Directory.CreateDirectory(DATAFOLDER);
-            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER);
+            try { SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER); }
+            catch (Exception ex)
+            {
+                Logging.Log.WriteWarningMessage(LOGTAG, "FailedToSetPermissions", ex, "Failed to set permissions for {0}: {1}", DATAFOLDER, ex.Message);
+            }
         }
 
         if (!File.Exists(Path.Combine(DATAFOLDER, INSTALL_FILE)))

--- a/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs
@@ -229,7 +229,8 @@ namespace Duplicati.Library.SQLiteHelper
 
             // Make the file only accessible by the current user, unless opting out
             if (!SystemIO.IO_OS.FileExists(SystemIO.IO_OS.PathCombine(SystemIO.IO_OS.PathGetDirectoryName(path), Util.InsecurePermissionsMarkerFile)))
-                SystemIO.IO_OS.FileSetPermissionUserRWOnly(path);
+                try { SystemIO.IO_OS.FileSetPermissionUserRWOnly(path); }
+                catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, "SQLiteFilePermissionError", ex, "Failed to set permissions on SQLite file '{0}'", path); }
         }
 
         /// <summary>


### PR DESCRIPTION
When setting the permissions, this does not crash the process if it fails, but emits a warning.