### PR TITLE
Refactoring of how permissions are set whilst obtaining DataFolder

### DIFF
--- a/Duplicati/Agent/Program.cs
+++ b/Duplicati/Agent/Program.cs
@@ -119,7 +119,7 @@ public static class Program
             new Option<SecretProviderHelper.CachingLevel>("--secret-provider-cache", description: "The secret provider cache level", getDefaultValue: () => SecretProviderHelper.CachingLevel.None),
             new Option<string>("--secret-provider-pattern", description: "The secret provider pattern", getDefaultValue: () => SecretProviderHelper.DEFAULT_PATTERN),
             new Option<bool>($"--{DataFolderManager.PORTABLE_MODE_OPTION}", description: "Use portable mode for locating the database and storing configuration", getDefaultValue: () => DataFolderManager.PORTABLE_MODE),
-            new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.DATAFOLDER)),
+            new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.GetDataFolder(true))),
         };
         runcmd.Handler = CommandHandler.Create<CommandLineArguments>(RunAgent);
 

--- a/Duplicati/Agent/Program.cs
+++ b/Duplicati/Agent/Program.cs
@@ -119,7 +119,7 @@ public static class Program
             new Option<SecretProviderHelper.CachingLevel>("--secret-provider-cache", description: "The secret provider cache level", getDefaultValue: () => SecretProviderHelper.CachingLevel.None),
             new Option<string>("--secret-provider-pattern", description: "The secret provider pattern", getDefaultValue: () => SecretProviderHelper.DEFAULT_PATTERN),
             new Option<bool>($"--{DataFolderManager.PORTABLE_MODE_OPTION}", description: "Use portable mode for locating the database and storing configuration", getDefaultValue: () => DataFolderManager.PORTABLE_MODE),
-            new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.GetDataFolder(true))),
+            new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly))),
         };
         runcmd.Handler = CommandHandler.Create<CommandLineArguments>(RunAgent);
 

--- a/Duplicati/CommandLine/CLI/Program.cs
+++ b/Duplicati/CommandLine/CLI/Program.cs
@@ -297,7 +297,7 @@ namespace Duplicati.CommandLine
             new CommandLineArgument("quiet-console", CommandLineArgument.ArgumentType.Boolean, Strings.Program.QuietConsoleOptionShort, Strings.Program.QuietConsoleOptionLong, "false"),
             new CommandLineArgument("auto-update", CommandLineArgument.ArgumentType.Boolean, Strings.Program.AutoUpdateOptionShort, Strings.Program.AutoUpdateOptionLong, "false"),
             new CommandLineArgument(DataFolderManager.PORTABLE_MODE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.PortableModeOptionShort, Strings.Program.PortableModeOptionLong, DataFolderManager.PORTABLE_MODE.ToString().ToLowerInvariant()),
-            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.DataFolderOptionShort, Strings.Program.DataFolderOptionLong, DataFolderManager.DATAFOLDER),
+            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.DataFolderOptionShort, Strings.Program.DataFolderOptionLong, DataFolderManager.GetDataFolder(true)),
         ];
 
         private static bool ReadOptionsFromFile(TextWriter outwriter, string filename, ref Library.Utility.IFilter filter, List<string> cargs, Dictionary<string, string> options)

--- a/Duplicati/CommandLine/CLI/Program.cs
+++ b/Duplicati/CommandLine/CLI/Program.cs
@@ -297,7 +297,7 @@ namespace Duplicati.CommandLine
             new CommandLineArgument("quiet-console", CommandLineArgument.ArgumentType.Boolean, Strings.Program.QuietConsoleOptionShort, Strings.Program.QuietConsoleOptionLong, "false"),
             new CommandLineArgument("auto-update", CommandLineArgument.ArgumentType.Boolean, Strings.Program.AutoUpdateOptionShort, Strings.Program.AutoUpdateOptionLong, "false"),
             new CommandLineArgument(DataFolderManager.PORTABLE_MODE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.PortableModeOptionShort, Strings.Program.PortableModeOptionLong, DataFolderManager.PORTABLE_MODE.ToString().ToLowerInvariant()),
-            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.DataFolderOptionShort, Strings.Program.DataFolderOptionLong, DataFolderManager.GetDataFolder(true)),
+            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.DataFolderOptionShort, Strings.Program.DataFolderOptionLong, DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)),
         ];
 
         private static bool ReadOptionsFromFile(TextWriter outwriter, string filename, ref Library.Utility.IFilter filter, List<string> cargs, Dictionary<string, string> options)

--- a/Duplicati/CommandLine/ServerUtil/Connection.cs
+++ b/Duplicati/CommandLine/ServerUtil/Connection.cs
@@ -198,7 +198,7 @@ public class Connection
             var opts = new Dictionary<string, string>();
             if (settings.Key != null)
                 opts["settings-encryption-key"] = settings.Key.Key;
-            if (File.Exists(Path.Combine(DataFolderManager.DATAFOLDER, DataFolderManager.SERVER_DATABASE_FILENAME)))
+            if (File.Exists(Path.Combine(DataFolderManager.GetDataFolder(true), DataFolderManager.SERVER_DATABASE_FILENAME)))
             {
                 string? cfg = null;
                 using (var connection = Server.Program.GetDatabaseConnection(opts, true))
@@ -230,12 +230,12 @@ public class Connection
                     return CreateConnectionWithClient(client, accessToken);
                 }
             }
-            else if (!string.IsNullOrWhiteSpace(DataFolderManager.DATAFOLDER))
+            else if (!string.IsNullOrWhiteSpace(DataFolderManager.GetDataFolder(true)))
             {
                 if (console != null)
-                    console.AppendConsoleMessage($"No database found in {DataFolderManager.DATAFOLDER}");
+                    console.AppendConsoleMessage($"No database found in {DataFolderManager.GetDataFolder(true)}");
                 else
-                    Console.WriteLine($"No database found in {DataFolderManager.DATAFOLDER}");
+                    Console.WriteLine($"No database found in {DataFolderManager.GetDataFolder(true)}");
             }
         }
         catch (Exception ex)

--- a/Duplicati/CommandLine/ServerUtil/Connection.cs
+++ b/Duplicati/CommandLine/ServerUtil/Connection.cs
@@ -198,7 +198,7 @@ public class Connection
             var opts = new Dictionary<string, string>();
             if (settings.Key != null)
                 opts["settings-encryption-key"] = settings.Key.Key;
-            if (File.Exists(Path.Combine(DataFolderManager.GetDataFolder(true), DataFolderManager.SERVER_DATABASE_FILENAME)))
+            if (File.Exists(Path.Combine(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly), DataFolderManager.SERVER_DATABASE_FILENAME)))
             {
                 string? cfg = null;
                 using (var connection = Server.Program.GetDatabaseConnection(opts, true))
@@ -230,12 +230,12 @@ public class Connection
                     return CreateConnectionWithClient(client, accessToken);
                 }
             }
-            else if (!string.IsNullOrWhiteSpace(DataFolderManager.GetDataFolder(true)))
+            else if (!string.IsNullOrWhiteSpace(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)))
             {
                 if (console != null)
-                    console.AppendConsoleMessage($"No database found in {DataFolderManager.GetDataFolder(true)}");
+                    console.AppendConsoleMessage($"No database found in {DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)}");
                 else
-                    Console.WriteLine($"No database found in {DataFolderManager.GetDataFolder(true)}");
+                    Console.WriteLine($"No database found in {DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)}");
             }
         }
         catch (Exception ex)

--- a/Duplicati/CommandLine/ServerUtil/Settings.cs
+++ b/Duplicati/CommandLine/ServerUtil/Settings.cs
@@ -73,8 +73,8 @@ public sealed record Settings(
     /// <param name="filename">The filename to use</param>
     /// <returns>The default storage folder</returns>
     private static string GetDefaultStorageFolder(string filename)
-        // Ideally, this should use DataFolderManager.DATAFOLDER, but we cannot due to backwards compatibility
-        => DataFolderLocator.GetDefaultStorageFolder(filename, true);
+        // Ideally, this should use DataFolderManager.GetDataFolder(), but we cannot due to backwards compatibility
+        => DataFolderLocator.GetDefaultStorageFolder(filename, true, true);
 
     /// <summary>
     /// Loads the settings from the settings file
@@ -179,7 +179,7 @@ public sealed record Settings(
 
         File.WriteAllText(SettingsFile, JsonSerializer.Serialize(LoadSettings(SettingsFile, thisKey)
             .Where(x => x.HostUrl != HostUrl)
-            .Append(new PersistedSettings(RefreshToken, HostUrl, DataFolderManager.DATAFOLDER))
+            .Append(new PersistedSettings(RefreshToken, HostUrl, DataFolderManager.GetDataFolder(false))) // Explicit false for clarity
             .Select(x => x with
             {
                 RefreshToken = string.IsNullOrWhiteSpace(x.RefreshToken) || thisKey == null

--- a/Duplicati/CommandLine/ServerUtil/Settings.cs
+++ b/Duplicati/CommandLine/ServerUtil/Settings.cs
@@ -179,7 +179,7 @@ public sealed record Settings(
 
         File.WriteAllText(SettingsFile, JsonSerializer.Serialize(LoadSettings(SettingsFile, thisKey)
             .Where(x => x.HostUrl != HostUrl)
-            .Append(new PersistedSettings(RefreshToken, HostUrl, DataFolderManager.GetDataFolder(false))) // Explicit false for clarity
+            .Append(new PersistedSettings(RefreshToken, HostUrl, DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ReadWritePermissionSet)))
             .Select(x => x with
             {
                 RefreshToken = string.IsNullOrWhiteSpace(x.RefreshToken) || thisKey == null

--- a/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
+++ b/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
@@ -45,7 +45,7 @@ public class SettingsBinder : BinderBase<Settings>
     /// <summary>
     /// The server datafolder option.
     /// </summary>
-    public static readonly Option<DirectoryInfo?> serverDatafolderOption = new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The server datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.DATAFOLDER));
+    public static readonly Option<DirectoryInfo?> serverDatafolderOption = new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The server datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.GetDataFolder(true)));
     /// <summary>
     /// The server portable mode option.
     /// </summary>

--- a/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
+++ b/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
@@ -45,7 +45,7 @@ public class SettingsBinder : BinderBase<Settings>
     /// <summary>
     /// The server datafolder option.
     /// </summary>
-    public static readonly Option<DirectoryInfo?> serverDatafolderOption = new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The server datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.GetDataFolder(true)));
+    public static readonly Option<DirectoryInfo?> serverDatafolderOption = new Option<DirectoryInfo?>($"--{DataFolderManager.SERVER_DATAFOLDER_OPTION}", description: "The server datafolder to use for locating the database and storing configuration", getDefaultValue: () => new DirectoryInfo(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)));
     /// <summary>
     /// The server portable mode option.
     /// </summary>

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -179,7 +179,7 @@ namespace Duplicati.GUI.TrayIcon
             }
             else if (Utility.ParseBoolOption(options, READCONFIGFROMDB_OPTION))
             {
-                if (File.Exists(Path.Combine(DataFolderManager.GetDataFolder(), DataFolderManager.SERVER_DATABASE_FILENAME)))
+                if (File.Exists(Path.Combine(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ReadWritePermissionSet), DataFolderManager.SERVER_DATABASE_FILENAME)))
                 {
                     passwordSource = PasswordSource.Database;
                     databaseConnection = Server.Program.GetDatabaseConnection(options, true);

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -179,7 +179,7 @@ namespace Duplicati.GUI.TrayIcon
             }
             else if (Utility.ParseBoolOption(options, READCONFIGFROMDB_OPTION))
             {
-                if (File.Exists(Path.Combine(DataFolderManager.DATAFOLDER, DataFolderManager.SERVER_DATABASE_FILENAME)))
+                if (File.Exists(Path.Combine(DataFolderManager.GetDataFolder(), DataFolderManager.SERVER_DATABASE_FILENAME)))
                 {
                     passwordSource = PasswordSource.Database;
                     databaseConnection = Server.Program.GetDatabaseConnection(options, true);

--- a/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
@@ -51,7 +51,7 @@ public static class DataFolderLocator
     public static string GetDefaultStorageFolder(string targetfilename, bool autoCreate, bool readOnly = false)
     {
         var folder = DataFolderManager.OVERRIDEN_DATAFOLDER
-            ? DataFolderManager.GetDataFolder(true)
+            ? DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)
             : GetDefaultStorageFolderInternal(targetfilename, AutoUpdateSettings.AppName);
 
         if (SystemIO.IO_OS.DirectoryExists(folder))

--- a/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
@@ -48,22 +48,26 @@ public static class DataFolderLocator
     /// <param name="targetfilename">The filename to look for</param>
     /// <param name="autoCreate">Whether to create the folder if it does not exist</param>
     /// <returns>The default storage folder</returns>
-    public static string GetDefaultStorageFolder(string targetfilename, bool autoCreate)
+    public static string GetDefaultStorageFolder(string targetfilename, bool autoCreate, bool readOnly = false)
     {
         var folder = DataFolderManager.OVERRIDEN_DATAFOLDER
-            ? DataFolderManager.DATAFOLDER
+            ? DataFolderManager.GetDataFolder(true)
             : GetDefaultStorageFolderInternal(targetfilename, AutoUpdateSettings.AppName);
 
         if (SystemIO.IO_OS.DirectoryExists(folder))
         {
             if (!SystemIO.IO_OS.FileExists(System.IO.Path.Combine(folder, Util.InsecurePermissionsMarkerFile)))
-                try { SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(folder); }
+                try
+                {
+                    if (!readOnly)
+                        SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(folder);
+                }
                 catch (Exception ex)
                 {
                     Logging.Log.WriteWarningMessage(LOGTAG, "FailedToSetPermissions", ex, "Failed to set permissions for {0}: {1}", folder, ex.Message);
                 }
         }
-        else if (autoCreate)
+        else if (autoCreate && !readOnly) // AutoCreate and readonly become incongruent 
         {
             // Create the folder
             SystemIO.IO_OS.DirectoryCreate(folder);

--- a/Duplicati/Library/AutoUpdater/DataFolderManager.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderManager.cs
@@ -40,11 +40,6 @@ public static class DataFolderManager
     private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(DataFolderManager));
 
     /// <summary>
-    /// The folder where the machine id is placed
-    /// </summary>
-    public static readonly string DATAFOLDER;
-
-    /// <summary>
     /// The installation ID filename stored in <see cref="DATAFOLDER"/>
     /// </summary>
     private const string INSTALL_FILE = "installation.txt";
@@ -81,12 +76,95 @@ public static class DataFolderManager
     /// <summary>
     /// Flag to indicate if the application is running in portable mode
     /// </summary>
-    public static readonly bool PORTABLE_MODE;
+    public static bool PORTABLE_MODE { private set; get; }
 
     /// <summary>
     /// Flag to indicate if the data folder was overriden
     /// </summary>
-    public static readonly bool OVERRIDEN_DATAFOLDER;
+    public static bool OVERRIDEN_DATAFOLDER { private set; get; }
+
+    /// <summary>
+    /// The folder where the machine id is placed
+    /// </summary>
+    public static string GetDataFolder(bool probeOnly = false)
+    {
+        // Trigger portable mode, if the flag is set
+        PORTABLE_MODE = ParseBoolSlim(ExtractOptionSlim(PORTABLE_MODE_OPTION));
+        
+        string dataFolder = string.Empty;
+        
+        // The environment variable is a legacy setting
+        var envOverride = Environment.GetEnvironmentVariable(DATAFOLDER_ENV_NAME);
+
+        // These are mainly supported by the Server
+        var datafolderArg = ExtractOptionSlim(SERVER_DATAFOLDER_OPTION);
+
+        // Prefer the command line argument over the environment variable
+        if (!string.IsNullOrWhiteSpace(datafolderArg))
+        {
+            OVERRIDEN_DATAFOLDER = true;
+            dataFolder = Util.AppendDirSeparator(Environment.ExpandEnvironmentVariables(datafolderArg).Trim('"'));
+        }
+        // Portable mode is prefered over the environment variable
+        else if (PORTABLE_MODE)
+        {
+            OVERRIDEN_DATAFOLDER = true;
+            dataFolder = Util.AppendDirSeparator(Path.Combine(UpdaterManager.INSTALLATIONDIR, "data"));
+        }
+        // Use the legacy environment variable, if set
+        else if (!string.IsNullOrWhiteSpace(envOverride))
+        {
+            OVERRIDEN_DATAFOLDER = true;
+            dataFolder = Util.AppendDirSeparator(Environment.ExpandEnvironmentVariables(envOverride).Trim('"'));
+        }
+        // Use the default location
+        else
+        {
+            OVERRIDEN_DATAFOLDER = false;
+            dataFolder = Util.AppendDirSeparator(DataFolderLocator.GetDefaultStorageFolderInternal(SERVER_DATABASE_FILENAME, APPNAME));
+        }
+
+        if (Directory.Exists(dataFolder))
+        {
+            if (!File.Exists(Path.Combine(dataFolder, Util.InsecurePermissionsMarkerFile)))
+                try
+                {
+                    if (!probeOnly)
+                        SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolder);
+                }
+                catch (Exception ex)
+                {
+                    Logging.Log.WriteWarningMessage(LOGTAG, "FailedToSetPermissions", ex, "Failed to set permissions for {0}: {1}", dataFolder, ex.Message);
+                }
+        }
+        else
+        {
+            Directory.CreateDirectory(dataFolder);
+            try
+            {
+                if (!probeOnly)
+                    SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolder);
+            }
+            catch (Exception ex)
+            {
+                Logging.Log.WriteWarningMessage(LOGTAG, "FailedToSetPermissions", ex, "Failed to set permissions for {0}: {1}", dataFolder, ex.Message);
+            }
+        }
+
+        if (!probeOnly && !File.Exists(Path.Combine(dataFolder, INSTALL_FILE)))
+        {
+            // In case there was already a machine id file from 2.0.8.1 or older, copy it to the new location
+            if (File.Exists(Path.Combine(dataFolder, "updates", INSTALL_FILE)))
+                File.Copy(Path.Combine(dataFolder, "updates", INSTALL_FILE), Path.Combine(dataFolder, INSTALL_FILE), true);
+            else
+                File.WriteAllText(Path.Combine(dataFolder, INSTALL_FILE), AutoUpdateSettings.UpdateInstallFileText);
+        }
+
+        if (!probeOnly && !File.Exists(Path.Combine(dataFolder, MACHINE_FILE)))
+            File.WriteAllText(Path.Combine(dataFolder, MACHINE_FILE), AutoUpdateSettings.UpdateMachineFileText(InstallID));
+        
+        return dataFolder;
+    }
 
     /// <summary>
     /// Replication of the argument parsing from the main Duplicati codebase
@@ -139,85 +217,12 @@ public static class DataFolderManager
             return false;
 #endif
 
-        if (
-            value.Equals("false", StringComparison.OrdinalIgnoreCase)
-            || value.Equals("0", StringComparison.OrdinalIgnoreCase)
-            || value.Equals("no", StringComparison.OrdinalIgnoreCase)
-            || value.Equals("off", StringComparison.OrdinalIgnoreCase)
-        )
-            return false;
-
-        return true;
+        return !value.Equals("false", StringComparison.OrdinalIgnoreCase)
+               && !value.Equals("0", StringComparison.OrdinalIgnoreCase)
+               && !value.Equals("no", StringComparison.OrdinalIgnoreCase)
+               && !value.Equals("off", StringComparison.OrdinalIgnoreCase);
     }
-
-    static DataFolderManager()
-    {
-        // Trigger portable mode, if the flag is set
-        PORTABLE_MODE = ParseBoolSlim(ExtractOptionSlim(PORTABLE_MODE_OPTION));
-
-        // The environment variable is a legacy setting
-        var envOverride = Environment.GetEnvironmentVariable(DATAFOLDER_ENV_NAME);
-
-        // These are mainly supported by the Server
-        var datafolderArg = ExtractOptionSlim(SERVER_DATAFOLDER_OPTION);
-
-        // Prefer the command line argument over the environment variable
-        if (!string.IsNullOrWhiteSpace(datafolderArg))
-        {
-            OVERRIDEN_DATAFOLDER = true;
-            DATAFOLDER = Util.AppendDirSeparator(Environment.ExpandEnvironmentVariables(datafolderArg).Trim('"'));
-        }
-        // Portable mode is prefered over the environment variable
-        else if (PORTABLE_MODE)
-        {
-            OVERRIDEN_DATAFOLDER = true;
-            DATAFOLDER = Util.AppendDirSeparator(Path.Combine(UpdaterManager.INSTALLATIONDIR, "data"));
-        }
-        // Use the legacy environment variable, if set
-        else if (!string.IsNullOrWhiteSpace(envOverride))
-        {
-            OVERRIDEN_DATAFOLDER = true;
-            DATAFOLDER = Util.AppendDirSeparator(Environment.ExpandEnvironmentVariables(envOverride).Trim('"'));
-        }
-        // Use the default location
-        else
-        {
-            OVERRIDEN_DATAFOLDER = false;
-            DATAFOLDER = Util.AppendDirSeparator(DataFolderLocator.GetDefaultStorageFolderInternal(SERVER_DATABASE_FILENAME, APPNAME));
-        }
-
-        if (Directory.Exists(DATAFOLDER))
-        {
-            if (!File.Exists(Path.Combine(DATAFOLDER, Util.InsecurePermissionsMarkerFile)))
-                try { SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER); }
-                catch (Exception ex)
-                {
-                    Logging.Log.WriteWarningMessage(LOGTAG, "FailedToSetPermissions", ex, "Failed to set permissions for {0}: {1}", DATAFOLDER, ex.Message);
-                }
-        }
-        else
-        {
-            Directory.CreateDirectory(DATAFOLDER);
-            try { SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(DATAFOLDER); }
-            catch (Exception ex)
-            {
-                Logging.Log.WriteWarningMessage(LOGTAG, "FailedToSetPermissions", ex, "Failed to set permissions for {0}: {1}", DATAFOLDER, ex.Message);
-            }
-        }
-
-        if (!File.Exists(Path.Combine(DATAFOLDER, INSTALL_FILE)))
-        {
-            // In case there was already a machine id file from 2.0.8.1 or older, copy it to the new location
-            if (File.Exists(Path.Combine(DATAFOLDER, "updates", INSTALL_FILE)))
-                File.Copy(Path.Combine(DATAFOLDER, "updates", INSTALL_FILE), Path.Combine(DATAFOLDER, INSTALL_FILE), true);
-            else
-                File.WriteAllText(Path.Combine(DATAFOLDER, INSTALL_FILE), AutoUpdateSettings.UpdateInstallFileText);
-        }
-
-        if (!File.Exists(Path.Combine(DATAFOLDER, MACHINE_FILE)))
-            File.WriteAllText(Path.Combine(DATAFOLDER, MACHINE_FILE), AutoUpdateSettings.UpdateMachineFileText(InstallID));
-    }
-
+    
     /// <summary>
     /// The unique machine installation ID
     /// </summary>
@@ -228,10 +233,10 @@ public static class DataFolderManager
     /// </summary>
     private static readonly Lazy<string> _installID = new(() =>
     {
-        try { return File.ReadAllLines(Path.Combine(DATAFOLDER!, INSTALL_FILE)).FirstOrDefault(x => !string.IsNullOrWhiteSpace(x))?.Trim() ?? ""; }
+        try { return File.ReadAllLines(Path.Combine(GetDataFolder(true), INSTALL_FILE)).FirstOrDefault(x => !string.IsNullOrWhiteSpace(x))?.Trim() ?? ""; }
         catch { }
 
-        return "";
+        return string.Empty;
     });
 
     /// <summary>
@@ -245,7 +250,7 @@ public static class DataFolderManager
     private static readonly Lazy<string> _machineID = new(() =>
     {
         string? machinedId = null;
-        try { machinedId = File.ReadAllLines(Path.Combine(DATAFOLDER!, MACHINE_FILE)).FirstOrDefault(x => !string.IsNullOrWhiteSpace(x))?.Trim() ?? ""; }
+        try { machinedId = File.ReadAllLines(Path.Combine(GetDataFolder(true), MACHINE_FILE)).FirstOrDefault(x => !string.IsNullOrWhiteSpace(x))?.Trim() ?? ""; }
         catch { }
 
         return string.IsNullOrWhiteSpace(machinedId)

--- a/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
+++ b/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
@@ -109,7 +109,7 @@ public static class PreloadSettingsLoader
 
         // User-context path for preload settings,
         // the same default path as where other data is stored
-        Path.Combine(DataFolderManager.GetDataFolder(true), FILE_NAME),
+        Path.Combine(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly), FILE_NAME),
     }
     .Concat(PortablePreloadPaths)
     .Where(x => !string.IsNullOrEmpty(x))

--- a/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
+++ b/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
@@ -109,7 +109,7 @@ public static class PreloadSettingsLoader
 
         // User-context path for preload settings,
         // the same default path as where other data is stored
-        Path.Combine(DataFolderManager.DATAFOLDER, FILE_NAME),
+        Path.Combine(DataFolderManager.GetDataFolder(true), FILE_NAME),
     }
     .Concat(PortablePreloadPaths)
     .Where(x => !string.IsNullOrEmpty(x))

--- a/Duplicati/Library/AutoUpdater/Program.cs
+++ b/Duplicati/Library/AutoUpdater/Program.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.AutoUpdater
             Console.WriteLine("{0} - Choose different channel than the default {1}, valid settings: {2}", string.Format(AutoUpdateSettings.UPDATECHANNEL_ENVNAME_TEMPLATE, AutoUpdateSettings.AppName), AutoUpdater.AutoUpdateSettings.DefaultUpdateChannel, string.Join(",", Enum.GetNames(typeof(ReleaseType)).Where(x => x != ReleaseType.Unknown.ToString())));
             Console.WriteLine();
             Console.WriteLine("Updates are downloaded from: {0}", string.Join(";", AutoUpdateSettings.URLs));
-            Console.WriteLine("Settings and configuration files are placed in: {0}", DataFolderManager.GetDataFolder(true));
+            Console.WriteLine("Settings and configuration files are placed in: {0}", DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly));
             Console.WriteLine("This version is \"{0}\" ({1}) and is installed in: {2}", UpdaterManager.SelfVersion.Displayname, UpdaterManager.SelfVersion.Version, UpdaterManager.INSTALLATIONDIR);
             Console.WriteLine();
         }

--- a/Duplicati/Library/AutoUpdater/Program.cs
+++ b/Duplicati/Library/AutoUpdater/Program.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.AutoUpdater
             Console.WriteLine("{0} - Choose different channel than the default {1}, valid settings: {2}", string.Format(AutoUpdateSettings.UPDATECHANNEL_ENVNAME_TEMPLATE, AutoUpdateSettings.AppName), AutoUpdater.AutoUpdateSettings.DefaultUpdateChannel, string.Join(",", Enum.GetNames(typeof(ReleaseType)).Where(x => x != ReleaseType.Unknown.ToString())));
             Console.WriteLine();
             Console.WriteLine("Updates are downloaded from: {0}", string.Join(";", AutoUpdateSettings.URLs));
-            Console.WriteLine("Settings and configuration files are placed in: {0}", DataFolderManager.DATAFOLDER);
+            Console.WriteLine("Settings and configuration files are placed in: {0}", DataFolderManager.GetDataFolder(true));
             Console.WriteLine("This version is \"{0}\" ({1}) and is installed in: {2}", UpdaterManager.SelfVersion.Displayname, UpdaterManager.SelfVersion.Version, UpdaterManager.INSTALLATIONDIR);
             Console.WriteLine();
         }

--- a/Duplicati/Library/Main/CLIDatabaseLocator.cs
+++ b/Duplicati/Library/Main/CLIDatabaseLocator.cs
@@ -96,7 +96,7 @@ namespace Duplicati.Library.Main
             if (!string.IsNullOrEmpty(options.Dbpath))
                 return options.Dbpath;
 
-            // Ideally, this should use DataFolderManager.DATAFOLDER, but we cannot due to backwards compatibility
+            // Ideally, this should use DataFolderManager.GetDataFolder(), but we cannot due to backwards compatibility
             var folder = AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(CONFIG_FILE, true);
             // Emit a warning if the database is stored in the Windows folder
             if (Util.IsPathUnderWindowsFolder(folder))
@@ -245,7 +245,7 @@ namespace Duplicati.Library.Main
         /// <returns><c>true</c> if the path is in use, <c>false</c> otherwise</returns>
         public static bool IsDatabasePathInUse(string path)
         {
-            // Ideally, this should use DataFolderManager.DATAFOLDER, but we cannot due to backwards compatibility
+            // Ideally, this should use DataFolderManager.GetDataFolder(), but we cannot due to backwards compatibility
             var file = System.IO.Path.Combine(AutoUpdater.DataFolderLocator.GetDefaultStorageFolder(CONFIG_FILE, false), CONFIG_FILE);
             if (!System.IO.File.Exists(file))
                 return false;

--- a/Duplicati/Library/Main/Operation/SystemInfoHandler.cs
+++ b/Duplicati/Library/Main/Operation/SystemInfoHandler.cs
@@ -37,7 +37,7 @@ namespace Duplicati.Library.Main.Operation
             yield return string.Format("Duplicati: {0} ({1})", Library.Utility.Utility.getEntryAssembly().FullName, System.Reflection.Assembly.GetExecutingAssembly().FullName);
 
             yield return string.Format("Autoupdate urls: {0}", string.Join(";", AutoUpdater.AutoUpdateSettings.URLs));
-            yield return string.Format("Default data folder: {0}", AutoUpdater.DataFolderManager.DATAFOLDER);
+            yield return string.Format("Default data folder: {0}", AutoUpdater.DataFolderManager.GetDataFolder(true));
             yield return string.Format("Install folder: {0}", AutoUpdater.UpdaterManager.INSTALLATIONDIR);
             yield return string.Format("Version name: \"{0}\" ({1})", AutoUpdater.UpdaterManager.SelfVersion.Displayname, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
             yield return string.Format("Current Version folder {0}", System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));

--- a/Duplicati/Library/Main/Operation/SystemInfoHandler.cs
+++ b/Duplicati/Library/Main/Operation/SystemInfoHandler.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
 using System.Threading.Tasks;
+using Duplicati.Library.AutoUpdater;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -37,7 +38,7 @@ namespace Duplicati.Library.Main.Operation
             yield return string.Format("Duplicati: {0} ({1})", Library.Utility.Utility.getEntryAssembly().FullName, System.Reflection.Assembly.GetExecutingAssembly().FullName);
 
             yield return string.Format("Autoupdate urls: {0}", string.Join(";", AutoUpdater.AutoUpdateSettings.URLs));
-            yield return string.Format("Default data folder: {0}", AutoUpdater.DataFolderManager.GetDataFolder(true));
+            yield return string.Format("Default data folder: {0}", AutoUpdater.DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly));
             yield return string.Format("Install folder: {0}", AutoUpdater.UpdaterManager.INSTALLATIONDIR);
             yield return string.Format("Version name: \"{0}\" ({1})", AutoUpdater.UpdaterManager.SelfVersion.Displayname, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
             yield return string.Format("Current Version folder {0}", System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -793,7 +793,7 @@ namespace Duplicati.Server
 
         public static Connection GetDatabaseConnection(Dictionary<string, string> commandlineOptions, bool silentConsole)
         {
-            DataFolder = DataFolderManager.GetDataFolder();
+            DataFolder = DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ReadWritePermissionSet);
 
             // Emit a warning if the database is stored in the Windows folder
             if (Util.IsPathUnderWindowsFolder(DataFolder))
@@ -1015,7 +1015,7 @@ namespace Duplicati.Server
             new CommandLineArgument(PING_PONG_KEEPALIVE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.PingpongkeepaliveShort, Strings.Program.PingpongkeepaliveLong),
             new CommandLineArgument(DISABLE_UPDATE_CHECK_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.DisableupdatecheckShort, Strings.Program.DisableupdatecheckLong),
             new CommandLineArgument(LOG_RETENTION_OPTION, CommandLineArgument.ArgumentType.Timespan, Strings.Program.LogretentionShort, Strings.Program.LogretentionLong, DEFAULT_LOG_RETENTION),
-            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.ServerdatafolderShort, Strings.Program.ServerdatafolderLong(DataFolderManager.GetDataFolder()), DataFolderManager.GetDataFolder()),
+            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.ServerdatafolderShort, Strings.Program.ServerdatafolderLong(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)), DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)),
             new CommandLineArgument(DISABLE_DB_ENCRYPTION_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.DisabledbencryptionShort, Strings.Program.DisabledbencryptionLong),
             new CommandLineArgument(REQUIRE_DB_ENCRYPTION_KEY_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.RequiredbencryptionShort, Strings.Program.RequiredbencryptionLong),
             new CommandLineArgument(SETTINGS_ENCRYPTION_KEY_OPTION, CommandLineArgument.ArgumentType.Password, Strings.Program.SettingsencryptionkeyShort, Strings.Program.SettingsencryptionkeyLong(EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME)),

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -793,7 +793,7 @@ namespace Duplicati.Server
 
         public static Connection GetDatabaseConnection(Dictionary<string, string> commandlineOptions, bool silentConsole)
         {
-            DataFolder = DataFolderManager.DATAFOLDER;
+            DataFolder = DataFolderManager.GetDataFolder();
 
             // Emit a warning if the database is stored in the Windows folder
             if (Util.IsPathUnderWindowsFolder(DataFolder))
@@ -1015,7 +1015,7 @@ namespace Duplicati.Server
             new CommandLineArgument(PING_PONG_KEEPALIVE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.PingpongkeepaliveShort, Strings.Program.PingpongkeepaliveLong),
             new CommandLineArgument(DISABLE_UPDATE_CHECK_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.DisableupdatecheckShort, Strings.Program.DisableupdatecheckLong),
             new CommandLineArgument(LOG_RETENTION_OPTION, CommandLineArgument.ArgumentType.Timespan, Strings.Program.LogretentionShort, Strings.Program.LogretentionLong, DEFAULT_LOG_RETENTION),
-            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.ServerdatafolderShort, Strings.Program.ServerdatafolderLong(DataFolderManager.DATAFOLDER_ENV_NAME), DataFolderManager.DATAFOLDER),
+            new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.ServerdatafolderShort, Strings.Program.ServerdatafolderLong(DataFolderManager.GetDataFolder()), DataFolderManager.GetDataFolder()),
             new CommandLineArgument(DISABLE_DB_ENCRYPTION_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.DisabledbencryptionShort, Strings.Program.DisabledbencryptionLong),
             new CommandLineArgument(REQUIRE_DB_ENCRYPTION_KEY_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.RequiredbencryptionShort, Strings.Program.RequiredbencryptionLong),
             new CommandLineArgument(SETTINGS_ENCRYPTION_KEY_OPTION, CommandLineArgument.ArgumentType.Password, Strings.Program.SettingsencryptionkeyShort, Strings.Program.SettingsencryptionkeyLong(EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME)),


### PR DESCRIPTION
This addresses [Issue](https://github.com/duplicati/duplicati/issues/6114).

Whenever in non-write context, the permissions of the folder are not set.

Changing pattern from static constructor execution.
