### PR TITLE
Fix Resource Leak in BackendManager Connection Handling

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -388,7 +388,9 @@ internal partial class BackendManager : IBackendManager
                 Logging.Log.WriteWarningMessage(LOGTAG, "BackendManagerShutdown", null, "Backend manager queue runner did not stop");
             if (queueRunner.IsFaulted)
                 Logging.Log.WriteWarningMessage(LOGTAG, "BackendManagerShutdown", queueRunner.Exception, "Backend manager queue runner crashed");
-
         }
+
+        if (queueRunner.IsCompleted)
+            queueRunner.Dispose();
     }
 }


### PR DESCRIPTION
While investigating issue [#6103](https://github.com/duplicati/duplicati/issues/6103), found that connections were not disposed due to the backend pool in BackendManager's handler. Set up a FileZilla server to test the issue before and after the change, confirming that connections now close as expected with this fix.