### PR TITLE
Fix to Box backend - overwrite default HttpClient 100 second timeout

### DIFF
--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -54,12 +54,11 @@ namespace Duplicati.Library.Backend.Box
         {
             private readonly TimeoutOptionsHelper.Timeouts _timeouts;
             public BoxHelper(string authid, TimeoutOptionsHelper.Timeouts timeouts)
-                : base(authid, "box.com")
+                : base(authid, "box.com", new HttpClient { Timeout = timeouts.ReadWriteTimeout != TimeSpan.Zero ? timeouts.ReadWriteTimeout : Timeout.InfiniteTimeSpan })
             {
                 AutoAuthHeader = true;
                 _timeouts = timeouts;
             }
-
             public override async Task AttemptParseAndThrowExceptionAsync(Exception ex, HttpResponseMessage responseContext, CancellationToken cancellationToken)
             {
                 if (ex is not HttpRequestException || responseContext == null)

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -54,10 +54,11 @@ namespace Duplicati.Library.Backend.Box
         {
             private readonly TimeoutOptionsHelper.Timeouts _timeouts;
             public BoxHelper(string authid, TimeoutOptionsHelper.Timeouts timeouts)
-                : base(authid, "box.com", new HttpClient { Timeout = timeouts.ReadWriteTimeout != TimeSpan.Zero ? timeouts.ReadWriteTimeout : Timeout.InfiniteTimeSpan })
+                : base(authid, "box.com")
             {
                 AutoAuthHeader = true;
                 _timeouts = timeouts;
+                _httpClient.Timeout = Timeout.InfiniteTimeSpan;
             }
             public override async Task AttemptParseAndThrowExceptionAsync(Exception ex, HttpResponseMessage responseContext, CancellationToken cancellationToken)
             {


### PR DESCRIPTION
If timeouts are specified, they are applied, otherwise it will default to infinite timeout rather than the 100 second timeout HttpClient defaults to.
