### PR TITLE
Fix locale-sensitive time parsing

### DIFF
--- a/Duplicati/Library/RestAPI/Scheduler.cs
+++ b/Duplicati/Library/RestAPI/Scheduler.cs
@@ -190,12 +190,9 @@ namespace Duplicati.Server
             var res = basetime;
             var ts = Timeparser.ParseTimeSpan(repetition);
 
-            // If we move in days or more, we keep the time of day across DST changes
-            var keepTimeOfDay = ts.Hours == 0 && ts.Minutes == 0 && ts.Seconds == 0;
-
             var i = 50000;
             while (res < firstdate && i-- > 0)
-                res = Timeparser.DSTAwareParseTimeInterval(repetition, res, timeZoneInfo, keepTimeOfDay);
+                res = Timeparser.DSTAwareParseTimeInterval(repetition, res, timeZoneInfo);
 
             // If we arrived somewhere after the first allowed date
             if (res >= firstdate)
@@ -215,7 +212,7 @@ namespace Duplicati.Server
                     // we hit a valid day
                     i = 50000;
                     while (!IsDateAllowed(res, allowedDays, timeZoneInfo) && i-- > 0)
-                        res = Timeparser.DSTAwareParseTimeInterval(repetition, res, timeZoneInfo, keepTimeOfDay);
+                        res = Timeparser.DSTAwareParseTimeInterval(repetition, res, timeZoneInfo);
                 }
             }
 

--- a/Duplicati/Library/Utility/Strings.cs
+++ b/Duplicati/Library/Utility/Strings.cs
@@ -43,6 +43,7 @@ namespace Duplicati.Library.Utility.Strings
         public static string InvalidIntegerError(string segment) { return LC.L(@"Failed to parse the segment: {0}, invalid integer", segment); }
         public static string InvalidSpecifierError(char specifier) { return LC.L(@"Invalid specifier: {0}", specifier); }
         public static string UnparsedDataFragmentError(string data) { return LC.L(@"Unparsed data: {0}", data); }
+        public static string InvalidDateTimeError(string data) { return LC.L(@"The string ""{0}"" could not be parsed into a DateTime", data); }
     }
     internal static class Uri
     {

--- a/Duplicati/Library/Utility/TimeZoneHelper.cs
+++ b/Duplicati/Library/Utility/TimeZoneHelper.cs
@@ -28,7 +28,6 @@ using System.Linq;
 namespace Duplicati.Library.Utility;
 
 /// <summary>
-/// Adds the specified number of minutes to the given DateTime, taking into account the time zone's daylight saving time rules.
 /// A helper class to get the time zone information
 /// </summary>
 public static class TimeZoneHelper
@@ -89,83 +88,4 @@ public static class TimeZoneHelper
         return TimeZoneInfo.GetSystemTimeZones()
                 .FirstOrDefault(tz => tz.Id.Equals(search, StringComparison.OrdinalIgnoreCase) || tz.DisplayName.Contains(search, StringComparison.OrdinalIgnoreCase));
     }
-
-    /// <summary>
-    /// Corrects the time for daylight saving time, by checking if the offset has changed
-    /// </summary>
-    /// <param name="timeZoneInfo">The timezone to use for the correction</param>
-    /// <param name="before">The time before in UTC</param>
-    /// <param name="after">The time after in UTC</param>
-    /// <returns>The corrected time in UTC</returns>
-    public static DateTime DSTAwareTimeAdjust(this TimeZoneInfo timeZoneInfo, DateTime before, DateTime after)
-    {
-        var beforeLocal = TimeZoneInfo.ConvertTime(new DateTimeOffset(before.Kind is DateTimeKind.Local ? before.ToUniversalTime() : before, TimeSpan.Zero), timeZoneInfo);
-        var afterLocal = TimeZoneInfo.ConvertTime(new DateTimeOffset(after.Kind is DateTimeKind.Local ? after.ToUniversalTime() : after, TimeSpan.Zero), timeZoneInfo);
-
-        if (beforeLocal.Offset == afterLocal.Offset)
-            return after;
-
-        var diff = beforeLocal.Offset - afterLocal.Offset;
-        return after.Add(diff);
-    }
-
-    /// <summary>
-    /// Adds seconds to a time in a specific time zone
-    /// </summary>
-    /// <param name="timeZoneInfo">The time zone to use for the calculation</param>
-    /// <param name="dt">The time to add seconds to</param>
-    /// <param name="seconds">The number of seconds to add</param>
-    /// <returns>The new time</returns>
-    public static DateTime DSTAwareAddSeconds(this TimeZoneInfo timeZoneInfo, DateTime dt, long seconds)
-        => DSTAwareTimeAdjust(timeZoneInfo, dt, dt.AddSeconds(seconds));
-
-    /// <summary>
-    /// Adds the specified number of minutes to the given DateTime, taking into account the time zone's daylight saving time rules.
-    /// </summary>
-    /// <param name="timeZoneInfo">The time zone information.</param>
-    /// <param name="dt">The DateTime to which minutes will be added.</param>
-    /// <param name="minutes">The number of minutes to add.</param>
-    /// <returns>A DateTime that is the result of adding the specified number of minutes to the given DateTime, adjusted for daylight saving time.</returns>
-    public static DateTime DSTAwareAddMinutes(this TimeZoneInfo timeZoneInfo, DateTime dt, int minutes)
-        => DSTAwareTimeAdjust(timeZoneInfo, dt, dt.AddMinutes(minutes));
-
-    /// <summary>
-    /// Adds the specified number of hours to the given DateTime, taking into account the time zone's daylight saving time rules.
-    /// </summary>
-    /// <param name="timeZoneInfo">The time zone information.</param>
-    /// <param name="dt">The DateTime to which hours will be added.</param>
-    /// <param name="hours">The number of hours to add.</param>
-    /// <returns>A DateTime that is the result of adding the specified number of hours to the given DateTime, adjusted for daylight saving time.</returns>
-    public static DateTime DSTAwareAddHours(this TimeZoneInfo timeZoneInfo, DateTime dt, int hours)
-        => DSTAwareTimeAdjust(timeZoneInfo, dt, dt.AddHours(hours));
-
-    /// <summary>
-    /// Adds the specified number of days to the given DateTime, taking into account the time zone's daylight saving time rules.
-    /// </summary>
-    /// <param name="timeZoneInfo">The time zone information.</param>
-    /// <param name="dt">The DateTime to which days will be added.</param>
-    /// <param name="days">The number of days to add.</param>
-    /// <returns>A DateTime that is the result of adding the specified number of days to the given DateTime, adjusted for daylight saving time.</returns>
-    public static DateTime DSTAwareAddDays(this TimeZoneInfo timeZoneInfo, DateTime dt, int days)
-        => DSTAwareTimeAdjust(timeZoneInfo, dt, dt.AddDays(days));
-
-    /// <summary>
-    /// Adds the specified number of months to the given DateTime, taking into account the time zone's daylight saving time rules.
-    /// </summary>
-    /// <param name="timeZoneInfo">The time zone information.</param>
-    /// <param name="dt">The DateTime to which months will be added.</param>
-    /// <param name="months">The number of months to add.</param>
-    /// <returns>A DateTime that is the result of adding the specified number of months to the given DateTime, adjusted for daylight saving time.</returns>
-    public static DateTime DSTAwareAddMonths(this TimeZoneInfo timeZoneInfo, DateTime dt, int months)
-        => DSTAwareTimeAdjust(timeZoneInfo, dt, dt.AddMonths(months));
-
-    /// <summary>
-    /// Adds the specified number of years to the given DateTime, taking into account the time zone's daylight saving time rules.
-    /// </summary>
-    /// <param name="timeZoneInfo">The time zone information.</param>
-    /// <param name="dt">The DateTime to which years will be added.</param>
-    /// <param name="years">The number of years to add.</param>
-    /// <returns>A DateTime that is the result of adding the specified number of years to the given DateTime, adjusted for daylight saving time.</returns>
-    public static DateTime DSTAwareAddYears(this TimeZoneInfo timeZoneInfo, DateTime dt, int years)
-        => DSTAwareTimeAdjust(timeZoneInfo, dt, dt.AddYears(years));
 }

--- a/Duplicati/UnitTest/TimeSpanParserTests.cs
+++ b/Duplicati/UnitTest/TimeSpanParserTests.cs
@@ -1,0 +1,291 @@
+
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+public class TimeparserTests : BasicSetupHelper
+{
+    [Category("Utility")]
+    [TestCase("0s", 0)]
+    [TestCase("10s", 10000)]
+    [TestCase("1m", 60000)]
+    [TestCase("2h", 7200000)]
+    [TestCase("1D", 86400000)]
+    [TestCase("1W", 604800000)]
+    [Category("Utility")]
+    public void TestParseTimeSpan_EnglishLocale(string input, long expectedMilliseconds)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+            var ts = Timeparser.ParseTimeSpan(input);
+            Assert.AreEqual(expectedMilliseconds, (long)ts.TotalMilliseconds);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Category("Utility")]
+    [TestCase("fr-CA", "0s", 0)]
+    [TestCase("fr-CA", "10s", 10000)]
+    [TestCase("de-DE", "5m", 300000)]
+    [TestCase("en-GB", "2h", 7200000)]
+    [TestCase("sv-SE", "1D", 86400000)]
+    public void TestParseTimeSpan_LocaleVariations(string locale, string input, long expectedMilliseconds)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(locale);
+            var ts = Timeparser.ParseTimeSpan(input);
+            Assert.AreEqual(expectedMilliseconds, (long)ts.TotalMilliseconds);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void TestParseTimeSpan_InvalidInput_Throws()
+    {
+        Assert.Throws<Exception>(() => Timeparser.ParseTimeSpan("xyz"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void TestParseTimeSpan_EmptyString()
+    {
+        var ts = Timeparser.ParseTimeSpan("");
+        Assert.AreEqual(TimeSpan.Zero, ts);
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void TestParseTimeSpan_Now()
+    {
+        var now = DateTime.Now;
+        var parsed = Timeparser.ParseTimeInterval("now", now);
+        Assert.That((parsed - now).TotalSeconds, Is.LessThan(1));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void TestParseTimeInterval_WithOffsetAndNegate()
+    {
+        var offset = new DateTime(2020, 1, 1);
+        var result = Timeparser.ParseTimeInterval("10s", offset, negate: true);
+        Assert.AreEqual(offset.AddSeconds(-10), result);
+    }
+
+    [Category("Utility")]
+    [TestCase("0s", 0)]
+    [TestCase("15m", 900000)]
+    [TestCase("1h30m", 5400000)]
+    public void TestParseTimeInterval_SpecialCases(string input, long expectedMilliseconds)
+    {
+        var baseTime = new DateTime(2023, 1, 1, 0, 0, 0);
+        var result = Timeparser.ParseTimeInterval(input, baseTime);
+        var diff = (long)(result - baseTime).TotalMilliseconds;
+        Assert.AreEqual(expectedMilliseconds, diff);
+    }
+
+    [Category("Utility")]
+    [TestCase("0s", "fr-CA")]
+    [TestCase("0s", "de-DE")]
+    public void TestParseTimeInterval_LocaleSensitiveAmbiguity(string input, string locale)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(locale);
+            var baseTime = new DateTime(2023, 1, 1);
+            var result = Timeparser.ParseTimeInterval(input, baseTime);
+            Assert.AreEqual(baseTime, result); // 0s should not change the time
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Category("Utility")]
+    [TestCase("en-US")]
+    [TestCase("fr-CA")]
+    [TestCase("de-DE")]
+    public void DSTAware_AddHour_SpringForward_ShouldSkipMissingHour(string culture)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo(culture);
+        try
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            var start = new DateTime(2024, 3, 10, 6, 30, 0, DateTimeKind.Utc); // UTC 1:30 AM EST
+            var result = Timeparser.DSTAwareParseTimeInterval("1h", start, tz);
+            var expected = new DateTime(2024, 3, 10, 7, 30, 0, DateTimeKind.Utc); // UTC 3:30 AM EDT
+            Assert.AreEqual(expected, result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Category("Utility")]
+    [TestCase("en-US")]
+    [TestCase("fr-CA")]
+    [TestCase("de-DE")]
+    public void DSTAware_AddHour_FallBack_ShouldHandleAmbiguousTime(string culture)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo(culture);
+        try
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            var start = new DateTime(2024, 11, 3, 5, 30, 0, DateTimeKind.Utc); // 1:30 AM EDT
+            var result = Timeparser.DSTAwareParseTimeInterval("1h", start, tz);
+            var expected = new DateTime(2024, 11, 3, 6, 30, 0, DateTimeKind.Utc); // 1:30 AM EST
+            Assert.AreEqual(expected, result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Category("Utility")]
+    [TestCase("en-US")]
+    [TestCase("fr-CA")]
+    [TestCase("de-DE")]
+    public void DSTAware_AddMultipleUnits_Combined(string culture)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo(culture);
+        try
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            var start = new DateTime(2024, 3, 10, 4, 0, 0, DateTimeKind.Utc); // March 9, 11 PM EST
+            var result = Timeparser.DSTAwareParseTimeInterval("1D2h", start, tz);
+            var expected = new DateTime(2024, 3, 11, 6, 0, 0, DateTimeKind.Utc); // March 11, 1 AM EDT
+            Assert.AreEqual(expected, result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Category("Utility")]
+    [TestCase("en-US")]
+    [TestCase("fr-CA")]
+    [TestCase("de-DE")]
+    public void DSTAware_KeepTime_SpringForward_ShouldKeepClockTime(string culture)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo(culture);
+        try
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            var start = new DateTime(2024, 3, 9, 6, 30, 0, DateTimeKind.Utc); // March 9, 1:30 AM EST
+            var result = Timeparser.DSTAwareParseTimeInterval("1D", start, tz);
+            var expected = new DateTime(2024, 3, 10, 6, 30, 0, DateTimeKind.Utc); // March 10, 1:30 AM EDT
+            Assert.AreEqual(expected, result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Category("Utility")]
+    [TestCase("en-US")]
+    [TestCase("fr-CA")]
+    [TestCase("de-DE")]
+    public void DSTAware_KeepTime_FallBack_ShouldKeepClockTime(string culture)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo(culture);
+        try
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            var start = new DateTime(2024, 11, 2, 5, 30, 0, DateTimeKind.Utc); // Nov 2, 1:30 AM EDT
+            var result = Timeparser.DSTAwareParseTimeInterval("1D", start, tz);
+            var expected = new DateTime(2024, 11, 3, 5, 30, 0, DateTimeKind.Utc); // Nov 3, 1:30 AM EST
+            Assert.AreEqual(expected, result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Test]
+    public void SpringForward_Add1Hour_ShouldNeverReturnNonexistentLocalTime()
+    {
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        var rawStart = new DateTime(2024, 3, 10, 6, 30, 0, DateTimeKind.Utc); // 1:30 AM EST (UTC)
+
+        var resultUtc = Timeparser.DSTAwareParseTimeInterval("1h", rawStart, tz);
+
+        // Convert the result back to local time in the given time zone
+        var resultLocal = TimeZoneInfo.ConvertTimeFromUtc(resultUtc, tz);
+
+        // Verify the returned local time is not within the invalid DST range
+        Assert.IsFalse(tz.IsInvalidTime(resultLocal), $"Returned a non-existent local time: {resultLocal}");
+    }
+
+    [Test]
+    public void MultipleUnits_SpringForward_ShouldAvoidInvalidLocalTime()
+    {
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        var rawStart = new DateTime(2024, 3, 10, 4, 30, 0, DateTimeKind.Utc); // 11:30 PM March 9 EST (UTC)
+
+        var resultUtc = Timeparser.DSTAwareParseTimeInterval("1D2h", rawStart, tz);
+
+        var resultLocal = TimeZoneInfo.ConvertTimeFromUtc(resultUtc, tz);
+        Assert.IsFalse(tz.IsInvalidTime(resultLocal), $"Returned a non-existent local time: {resultLocal}");
+    }
+
+    [Test]
+    public void AmbiguousTime_FallBack_ShouldReturnValidLocalTime()
+    {
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        var rawStart = new DateTime(2024, 11, 3, 5, 30, 0, DateTimeKind.Utc); // 1:30 AM EDT (UTC)
+
+        var resultUtc = Timeparser.DSTAwareParseTimeInterval("1h", rawStart, tz);
+        var resultLocal = TimeZoneInfo.ConvertTimeFromUtc(resultUtc, tz);
+
+        // This will be an ambiguous time but still valid
+        Assert.IsTrue(tz.IsAmbiguousTime(resultLocal) || !tz.IsInvalidTime(resultLocal),
+            $"Returned an invalid or ambiguous local time incorrectly: {resultLocal}");
+    }
+}

--- a/Duplicati/UnitTest/TimeZoneHelperTests.cs
+++ b/Duplicati/UnitTest/TimeZoneHelperTests.cs
@@ -28,13 +28,13 @@ namespace Duplicati.UnitTest;
 
 public class TimeZoneHelperTests : BasicSetupHelper
 {
-    private static string CETName = OperatingSystem.IsWindows() 
+    private static string CETName = OperatingSystem.IsWindows()
         // For some reason CET is not recognized on Windows
         // It has no effect outside the tests, as the string is not
         // present outside the tests
         ? "Central European Standard Time"
         : "CET";
-    
+
     [Test]
     [Category("TimeZoneHelper")]
     public void GetTimeZoneFromAbbreviationTest()
@@ -74,52 +74,17 @@ public class TimeZoneHelperTests : BasicSetupHelper
 
     [Test]
     [Category("TimeZoneHelper")]
-    public void CheckAddIsStableOverDSTForward()
-    {
-        var timeZone = TimeZoneHelper.FindTimeZone(CETName);
-        var localTime = new DateTimeOffset(2024, 3, 31, 1, 59, 59, timeZone.BaseUtcOffset);
-
-        var utcTime = localTime.ToUniversalTime().DateTime;
-
-        var adjustedTimeSeconds = timeZone.DSTAwareAddSeconds(utcTime, 2);
-        var adjustedTimeHours = timeZone.DSTAwareAddHours(utcTime, 1);
-        var adjustedTimeDays = timeZone.DSTAwareAddDays(utcTime, 1);
-        Assert.AreEqual(utcTime.AddHours(-1).AddSeconds(2), adjustedTimeSeconds);
-        Assert.AreEqual(utcTime.AddHours(-1).AddHours(1), adjustedTimeHours);
-        Assert.AreEqual(utcTime.AddHours(-1).AddDays(1), adjustedTimeDays);
-    }
-
-    [Test]
-    [Category("TimeZoneHelper")]
-    public void CheckAddIsStableOverDSTBackward()
-    {
-        var timeZone = TimeZoneHelper.FindTimeZone(CETName);
-        var dstOffset = timeZone.GetUtcOffset(new DateTimeOffset(2024, 10, 26, 14, 0, 0, timeZone.BaseUtcOffset));
-        var localTime = new DateTimeOffset(2024, 10, 27, 2, 59, 59, dstOffset);
-
-        var utcTime = localTime.ToUniversalTime().DateTime;
-
-        var adjustedTimeSeconds = timeZone.DSTAwareAddSeconds(utcTime, 2);
-        var adjustedTimeHours = timeZone.DSTAwareAddHours(utcTime, 1);
-        var adjustedTimeDays = timeZone.DSTAwareAddDays(utcTime, 1);
-        Assert.AreEqual(utcTime.AddHours(1).AddSeconds(2), adjustedTimeSeconds);
-        Assert.AreEqual(utcTime.AddHours(1).AddHours(1), adjustedTimeHours);
-        Assert.AreEqual(utcTime.AddHours(1).AddDays(1), adjustedTimeDays);
-    }
-
-    [Test]
-    [Category("TimeZoneHelper")]
     public void CheckRepeatScheduleIsStableOverDSTForward()
     {
         var timeZone = TimeZoneHelper.FindTimeZone(CETName);
         var localTime = new DateTimeOffset(2024, 3, 30, 14, 0, 0, timeZone.BaseUtcOffset);
         var localTimeOfDay = localTime.TimeOfDay;
 
-        var utcTime = localTime.ToUniversalTime().DateTime;
+        var utcTime = localTime.ToUniversalTime().UtcDateTime;
 
-        var adjustedTimeSeconds = Timeparser.DSTAwareParseTimeInterval("2s", utcTime, timeZone, false);
-        var adjustedTimeHours = Timeparser.DSTAwareParseTimeInterval("1h", utcTime, timeZone, false);
-        var adjustedTimeDays = Timeparser.DSTAwareParseTimeInterval("1D", utcTime, timeZone, true);
+        var adjustedTimeSeconds = Timeparser.DSTAwareParseTimeInterval("2s", utcTime, timeZone);
+        var adjustedTimeHours = Timeparser.DSTAwareParseTimeInterval("1h", utcTime, timeZone);
+        var adjustedTimeDays = Timeparser.DSTAwareParseTimeInterval("1D", utcTime, timeZone);
 
         // Non-day-based times are not corrected for DST
         Assert.AreEqual(utcTime.AddSeconds(2), adjustedTimeSeconds);
@@ -131,13 +96,6 @@ public class TimeZoneHelperTests : BasicSetupHelper
         var adjustedLocalTimeDays = TimeZoneInfo.ConvertTimeFromUtc(adjustedTimeDays, timeZone);
         var adjustedLocalTimeOfDay = adjustedLocalTimeDays.TimeOfDay;
         Assert.AreEqual(localTimeOfDay, adjustedLocalTimeOfDay);
-
-        var origTimeSeconds = timeZone.DSTAwareAddSeconds(adjustedTimeSeconds, -2);
-        var origTimeHours = timeZone.DSTAwareAddHours(adjustedTimeHours, -1);
-        var origTimeDays = timeZone.DSTAwareAddDays(adjustedTimeDays, -1);
-        Assert.AreEqual(utcTime, origTimeSeconds);
-        Assert.AreEqual(utcTime, origTimeHours);
-        Assert.AreEqual(utcTime, origTimeDays);
 
         // Since we adjust and keep the time of day, the time should be the same, even when going back
         adjustedLocalTimeDays = TimeZoneInfo.ConvertTimeFromUtc(adjustedTimeDays, timeZone);
@@ -155,12 +113,12 @@ public class TimeZoneHelperTests : BasicSetupHelper
         var crossTime = new DateTimeOffset(2024, 10, 27, 2, 59, 59, dstOffset);
         var localTimeOfDay = localTime.TimeOfDay;
 
-        var utcTime = localTime.ToUniversalTime().DateTime;
-        var utcCrossTime = crossTime.ToUniversalTime().DateTime;
+        var utcTime = localTime.ToUniversalTime().UtcDateTime;
+        var utcCrossTime = crossTime.ToUniversalTime().UtcDateTime;
 
-        var adjustedTimeSeconds = Timeparser.DSTAwareParseTimeInterval("2s", utcCrossTime, timeZone, false);
-        var adjustedTimeHours = Timeparser.DSTAwareParseTimeInterval("1h", utcCrossTime, timeZone, false);
-        var adjustedTimeDays = Timeparser.DSTAwareParseTimeInterval("1D", utcTime, timeZone, true);
+        var adjustedTimeSeconds = Timeparser.DSTAwareParseTimeInterval("2s", utcCrossTime, timeZone);
+        var adjustedTimeHours = Timeparser.DSTAwareParseTimeInterval("1h", utcCrossTime, timeZone);
+        var adjustedTimeDays = Timeparser.DSTAwareParseTimeInterval("1D", utcTime, timeZone);
 
         // Non-day-based times are not corrected for DST
         Assert.AreEqual(utcCrossTime.AddSeconds(2), adjustedTimeSeconds);
@@ -172,9 +130,6 @@ public class TimeZoneHelperTests : BasicSetupHelper
         var adjustedLocalTimeDays = TimeZoneInfo.ConvertTimeFromUtc(adjustedTimeDays, timeZone);
         var adjustedLocalTimeOfDay = adjustedLocalTimeDays.TimeOfDay;
         Assert.AreEqual(localTimeOfDay, adjustedLocalTimeOfDay);
-
-        var origTimeDays = timeZone.DSTAwareAddDays(adjustedTimeDays, -1);
-        Assert.AreEqual(utcTime, origTimeDays);
 
         // Since we adjust and keep the time of day, the time should be the same, even when going back
         adjustedLocalTimeDays = TimeZoneInfo.ConvertTimeFromUtc(adjustedTimeDays, timeZone);


### PR DESCRIPTION
On some locales, odd strings would parse as valid full dates, causing relative dates to be incorrectly calculated.

This commit fixes the issues and revisits the DST aware calculations with more tests.