### PR TITLE
Improve build stability again

### DIFF
--- a/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
+++ b/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.7.400.45" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.402.39" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.405.9" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="Minio" Version="3.1.13" />
   </ItemGroup>
   

--- a/Duplicati/Library/RestAPI/Duplicati.Library.RestAPI.csproj
+++ b/Duplicati/Library/RestAPI/Duplicati.Library.RestAPI.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/RestAPI/Duplicati.Library.RestAPI.csproj
+++ b/Duplicati/Library/RestAPI/Duplicati.Library.RestAPI.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
+++ b/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.0" />
     <!-- Important! Avalonia also depends on this package, so make sure the versions are in sync -->
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.20.0" />
+
+    <!-- Important! These are used elsewhere, make sure we pull in a recent version -->
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="7.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
+++ b/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.20.0" />
 
     <!-- Important! These are used elsewhere, make sure we pull in a recent version -->
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="7.5.0" />
   </ItemGroup>
 

--- a/Duplicati/WindowsService/Duplicati.WindowsService.csproj
+++ b/Duplicati/WindowsService/Duplicati.WindowsService.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="5.0.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ReleaseBuilder/Build/Command.Compile.cs
+++ b/ReleaseBuilder/Build/Command.Compile.cs
@@ -93,7 +93,7 @@ public static partial class Command
                 // Make sure there is no cache from previous builds
                 if (!disableCleanSource)
                     await RemoveAllBuildTempFolders(baseDir).ConfigureAwait(false);
-                await Verify.AnalyzeProject(Path.Combine(baseDir, "Duplicati.sln")).ConfigureAwait(false);
+                verifyRootJson = await Verify.AnalyzeProject(Path.Combine(baseDir, "Duplicati.sln")).ConfigureAwait(false);
             }
 
             foreach ((var target, var outputFolder) in buildOutputFolders)

--- a/ReleaseBuilder/Build/Command.Compile.cs
+++ b/ReleaseBuilder/Build/Command.Compile.cs
@@ -18,6 +18,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace ReleaseBuilder.Build;
@@ -70,7 +71,7 @@ public static partial class Command
         /// <param name="disableCleanSource">A flag that allows skipping the clean source step</param>
         /// <param name="rtcfg">The runtime configuration</param>
         /// <returns>A task that completes when the build is done</returns>
-        public static async Task BuildProjects(string baseDir, string buildDir, Dictionary<InterfaceType, IEnumerable<string>> sourceProjects, IEnumerable<string> windowsOnlyProjects, IEnumerable<PackageTarget> buildTargets, ReleaseInfo releaseInfo, bool keepBuilds, RuntimeConfig rtcfg, bool useHostedBuilds, bool disableCleanSource)
+        public static async Task BuildProjects(string baseDir, string buildDir, Dictionary<InterfaceType, IEnumerable<string>> sourceProjects, IEnumerable<string> windowsOnlyProjects, IEnumerable<PackageTarget> buildTargets, ReleaseInfo releaseInfo, bool keepBuilds, RuntimeConfig rtcfg, bool useHostedBuilds, bool disableCleanSource, bool allowAssemblyMismatch)
         {
             // For tracing, create a log folder and store all logs there
             var logFolder = Path.Combine(buildDir, "logs");
@@ -135,6 +136,8 @@ public static partial class Command
                         .Where(x => target.OS == OSType.Windows || !windowsOnlyProjects.Contains(x))
                         .ToList();
 
+                    var incorrectAssemblyVersions = new Dictionary<string, HashSet<Version>>();
+
                     foreach (var project in actualBuildProjects)
                     {
                         string logNameFn(int pid, bool isStdOut)
@@ -177,7 +180,20 @@ public static partial class Command
                         if (Regex.Match(logData, @"[\\/]bin[\\/]Debug[\\/]", RegexOptions.IgnoreCase).Success)
                             throw new InvalidOperationException($"Build for {target.BuildTargetString} failed. Debug build found in log: {stdoutLog}.");
 
-                        EnvHelper.CopyDirectory(buildfolder, tmpfolder, true);
+                        EnvHelper.CopyDirectory(buildfolder, tmpfolder, true, (current, update) =>
+                        {
+                            var c = CompareAssemblyVersions(current.FullName, update.FullName);
+                            if (c != 0)
+                            {
+                                if (!incorrectAssemblyVersions.TryGetValue(Path.GetFileName(current.FullName), out var versions))
+                                    incorrectAssemblyVersions[Path.GetFileName(current.FullName)] = versions = new HashSet<Version>();
+
+                                versions.Add(AssemblyName.GetAssemblyName(current.FullName).Version ?? new Version(0, 0));
+                                versions.Add(AssemblyName.GetAssemblyName(update.FullName).Version ?? new Version(0, 0));
+                            }
+                            return c >= 0;
+                        });
+                        // EnvHelper.CopyDirectory(buildfolder, tmpfolder, true);
                         Directory.Delete(buildfolder, true);
                     }
 
@@ -187,12 +203,80 @@ public static partial class Command
                     await Verify.VerifyExecutables(tmpfolder, actualBuildProjects, target);
                     await Verify.VerifyDuplicatedVersionsAreMaxVersions(tmpfolder, verifyRootJson);
 
+                    if (incorrectAssemblyVersions.Count > 0)
+                    {
+                        Console.WriteLine($"Incorrect assembly versions found in {target.BuildTargetString}:");
+                        foreach (var file in incorrectAssemblyVersions.Keys.Order())
+                            Console.WriteLine($"  {file}: {string.Join(", ", incorrectAssemblyVersions[file].OrderByDescending(x => x))}");
+
+                        throw new InvalidOperationException($"Incorrect assembly versions found in {target.BuildTargetString}");
+                    }
+
                     // Move the final build to the output folder
                     Directory.Move(tmpfolder, outputFolder);
                 }
 
                 Console.WriteLine("Completed!");
             }
+        }
+
+        /// <summary>
+        /// Checks if the file is a PE file
+        /// </summary>
+        /// <param name="path">The path to the file</param>
+        /// <returns>>True if the file is a PE file, false otherwise</returns>
+        private static bool IsPEFile(string path)
+        {
+            if (!File.Exists(path)) return false;
+
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read);
+            using var br = new BinaryReader(fs);
+
+            // Check for MZ header
+            if (br.ReadUInt16() != 0x5A4D) // "MZ"
+                return false;
+
+            fs.Seek(0x3C, SeekOrigin.Begin);
+            var peHeaderOffset = br.ReadInt32();
+
+            if (peHeaderOffset <= 0 || peHeaderOffset > fs.Length - 4)
+                return false;
+
+            fs.Seek(peHeaderOffset, SeekOrigin.Begin);
+            var peSignature = br.ReadUInt32();
+
+            return peSignature == 0x00004550; // "PE\0\0"
+        }
+
+        /// <summary>
+        /// Compares the assembly versions of two files
+        /// </summary>
+        /// <param name="p1">Path to the first file</param>
+        /// <param name="p2">Path to the second file</param>
+        /// <returns>0 if the versions are equal, -1 if the first is is largest, 1 if the second is largest</returns>
+        private static int CompareAssemblyVersions(string p1, string p2)
+        {
+            try
+            {
+                if (!IsPEFile(p1))
+                    return 0;
+
+                var version1 = AssemblyName.GetAssemblyName(p1)?.Version;
+                var version2 = AssemblyName.GetAssemblyName(p2)?.Version;
+
+                if (version1 == null || version2 == null)
+                    return 0;
+                if (version1 > version2)
+                    return -1;
+                if (version1 < version2)
+                    return 1;
+            }
+            catch
+            {
+            }
+
+            return 0;
+
         }
     }
 }

--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -319,6 +319,12 @@ public static partial class Command
             getDefaultValue: () => false
         );
 
+        var allowAssemblyMismatchOption = new Option<bool>(
+            name: "--allow-assembly-mismatch",
+            description: "Allow mismatched assembly versions",
+            getDefaultValue: () => false
+        );
+
         var command = new System.CommandLine.Command("build", "Builds the packages for a release") {
             gitStashPushOption,
             releaseChannelArgument,
@@ -345,7 +351,8 @@ public static partial class Command
             useHostedBuildsOption,
             resumeFromUploadOption,
             propagateReleaseOption,
-            disableCleanSourceOption
+            disableCleanSourceOption,
+            allowAssemblyMismatchOption
         };
 
         command.Handler = CommandHandler.Create<CommandInput>(DoBuild);
@@ -381,6 +388,7 @@ public static partial class Command
     /// <param name="ResumeFromUpload">If the process should resume from the upload step</param>
     /// <param name="PropagateRelease">If the release should be propagated to the next channel</param>
     /// <param name="DisableCleanSource">If the source tree should not be cleaned</param>
+    /// <param name="AllowAssemblyMismatch">If the assembly mismatch should be allowed</param>
     record CommandInput(
         PackageTarget[] Targets,
         DirectoryInfo BuildPath,
@@ -407,7 +415,8 @@ public static partial class Command
         bool UseHostedBuilds,
         bool ResumeFromUpload,
         bool PropagateRelease,
-        bool DisableCleanSource
+        bool DisableCleanSource,
+        bool AllowAssemblyMismatch
     );
 
     static async Task DoBuild(CommandInput input)
@@ -577,7 +586,7 @@ public static partial class Command
             }
         };
 
-        await Compile.BuildProjects(baseDir, input.BuildPath.FullName, sourceBuildMap, windowsOnly, buildTargets, releaseInfo, input.KeepBuilds, rtcfg, input.UseHostedBuilds, input.DisableCleanSource);
+        await Compile.BuildProjects(baseDir, input.BuildPath.FullName, sourceBuildMap, windowsOnly, buildTargets, releaseInfo, input.KeepBuilds, rtcfg, input.UseHostedBuilds, input.DisableCleanSource, input.AllowAssemblyMismatch);
 
         if (input.BuildOnly)
         {


### PR DESCRIPTION
Fixed check for incorrect versions.

More elaborate way to detect and stop builds with wrong dependencies.
Introduced a few forced dependency inclusions to avoid build issues.