### PR TITLE
Add tests to build releases

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Compile releases
         working-directory: ./ReleaseBuilder
+        env:
+          UPDATER_KEYFILE: ./testfile.key1
         run: dotnet run -- build debug --compile-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
 
   # Disabled, as a new test needs to be written for the new UI

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build packages
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -9,7 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [macos-latest, windows-latest]
+        # Super slow on ubuntu-latest
+        # os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Set up .NET

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compile releases
-        run: dotnet run ReleaseBuilder/ReleaseBuilder.sln -- build debug --build-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
+        run: dotnet run --project ReleaseBuilder/ReleaseBuilder.csproj -- build debug --build-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
 
   # Disabled, as a new test needs to be written for the new UI
   # selenium:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Compile releases
         working-directory: ./ReleaseBuilder
-        run: dotnet run -- build debug --build-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
+        run: dotnet run -- build debug --compile-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
 
   # Disabled, as a new test needs to be written for the new UI
   # selenium:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  build_packages:
+    name: Build packages
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Compile releases
+        run: dotnet run ReleaseBuilder/ReleaseBuilder.sln -- build debug --build-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
+
+  # Disabled, as a new test needs to be written for the new UI
+  # selenium:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Selenium
+  #       run: pipeline/selenium/test.sh

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compile releases
-        run: dotnet run --project ReleaseBuilder/ReleaseBuilder.csproj -- build debug --build-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
+        working-directory: ./ReleaseBuilder
+        run: dotnet run -- build debug --build-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
 
   # Disabled, as a new test needs to be written for the new UI
   # selenium:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Create dummy changelog file
+        working-directory: ./ReleaseBuilder
+        run: echo "## Changed" > ./changelog-news.txt
+
       - name: Compile releases
         working-directory: ./ReleaseBuilder
         run: dotnet run -- build debug --compile-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -28,6 +28,7 @@ jobs:
         working-directory: ./ReleaseBuilder
         env:
           UPDATER_KEYFILE: ./testfile.key1
+          WIX:
         run: dotnet run -- build debug --compile-only=true --git-stash-push=false --disable-docker-push=true --keep-builds=true --disable-authenticode=true --disable-signcode=true --disable-notarize-signing=true --disable-gpg-signing=true --disable-s3-upload=true --disable-github-upload=true --disable-update-server-reload=true --disable-discourse-announce=true --disable-clean-source=true --password=test1234 --version=2.0.0.99
 
   # Disabled, as a new test needs to be written for the new UI

--- a/Duplicati/Agent/Program.cs
+++ b/Duplicati/Agent/Program.cs
@@ -23,7 +23,6 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
-using System.Reactive.Linq;
 using System.Security.Cryptography;
 using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Encryption;

--- a/Duplicati/Library/Backend/S3/S3MinioClient.cs
+++ b/Duplicati/Library/Backend/S3/S3MinioClient.cs
@@ -222,6 +222,11 @@ namespace Duplicati.Library.Backend
         {
             if (e.ServerResponse?.StatusCode == System.Net.HttpStatusCode.NotFound || e.Response?.Code == "NoSuchKey")
                 throw new FileMissingException($"File {keyName} not found in bucket {bucketName}");
+
+            if (e is BucketNotFoundException)
+                throw new FolderMissingException($"Bucket {bucketName} not found");
+            if (e is ObjectNotFoundException)
+                throw new FileMissingException($"File {keyName} not found in bucket {bucketName}");
         }
 
         private Task ThrowExceptionIfBucketDoesNotExist(string bucketName, CancellationToken cancelToken)

--- a/ReleaseBuilder/Build/Command.Compile.Post.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Post.cs
@@ -242,7 +242,8 @@ public static partial class Command
 
             // Rename the executables, as symlinks are not supported in DMG files
             await PackageSupport.RenameExecutables(binDir);
-            await PackageSupport.SetPermissionFlags(binDir, rtcfg);
+            if (!OperatingSystem.IsWindows())
+                await PackageSupport.SetPermissionFlags(binDir, rtcfg);
 
             // Move the licenses out of the code folder as the signing tool trips on it
             var licenseTarget = Path.Combine(tmpApp, "Contents", "Licenses");

--- a/ReleaseBuilder/Build/Command.RuntimeConfig.cs
+++ b/ReleaseBuilder/Build/Command.RuntimeConfig.cs
@@ -212,6 +212,14 @@ public static partial class Command
         }
 
         /// <summary>
+        /// Disables docker builds
+        /// </summary>
+        public void DisableDockerBuilds()
+        {
+            _dockerBuild = false;
+        }
+
+        /// <summary>
         /// Cache value for checking if notarize is enabled
         /// </summary>
         private bool? _useNotarizeSigning;

--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -41,7 +41,7 @@ public static partial class Command
     /// <summary>
     /// The primary project to build for CLI builds
     /// </summary>
-    private const string PrimaryCLIProject = "Duplicati.CommandLine.csproj";
+    private const string PrimaryCLIProject = "Duplicati.Server.csproj";
 
     /// <summary>
     /// The primary project to build for Agent builds

--- a/ReleaseBuilder/Program.cs
+++ b/ReleaseBuilder/Program.cs
@@ -102,12 +102,20 @@ class Program
     /// <returns></returns>
     static async Task<int> Main(string[] args)
     {
-        var r = await new RootCommand("Build tool for Duplicati")
+        try
         {
-            Build.Command.Create(),
-            CreateKey.Command.Create(),
-        }.InvokeAsync(args);
+            ReturnCode = await new RootCommand("Build tool for Duplicati")
+            {
+                Build.Command.Create(),
+                CreateKey.Command.Create(),
+            }.InvokeAsync(args);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.ToString());
+            ReturnCode = 1;
+        }
 
-        return ReturnCode ?? r;
+        return ReturnCode ?? 2;
     }
 }


### PR DESCRIPTION
This adds a CI test for building releases so we know in advance if package versions are out-of-order.

This also sets the primary project for CLI to the Server as that covers more than the CLI project.