### PR TITLE
Fixed multiple retention settings in delete.

### DIFF
--- a/Duplicati/CommandLine/CLI/Commands.cs
+++ b/Duplicati/CommandLine/CLI/Commands.cs
@@ -464,7 +464,7 @@ namespace Duplicati.CommandLine
 
         public static int Delete(TextWriter outwriter, Action<Duplicati.Library.Main.Controller> setup, List<string> args, Dictionary<string, string> options, Library.Utility.IFilter filter)
         {
-            var requiredOptions = new string[] { "keep-time", "keep-versions", "version" };
+            var requiredOptions = new string[] { "keep-time", "keep-versions", "version", "retention-policy" };
 
             if (!options.Keys.Any(x => requiredOptions.Contains(x, StringComparer.OrdinalIgnoreCase)))
             {

--- a/Duplicati/CommandLine/CLI/help.txt
+++ b/Duplicati/CommandLine/CLI/help.txt
@@ -146,15 +146,17 @@ Usage: %CLI_EXE% delete <storage-URL> [<options>]
   Marks old data deleted and removes outdated dlist files. A backup is deleted when it is older than <keep-time> or when there are more newer versions than <keep-versions>. Data is considered old, when it is not required from any existing backup anymore.
 
   --dry-run
-    Performs the operation, but does not write changes to the local database or the remote storage
+    Performs the operation, but does not write changes to the local database or the remote storage.
   --keep-time=<time>
     Marks data outdated that is older than <time>.
   --keep-versions=<int>
     Marks data outdated that is older than <int> versions.
   --version=<int>
     Deletes all files that belong to the specified version(s).
+  --retention-policy=<policy>
+    Deletes all files that are not preserved by the retention policy.
   --allow-full-removal
-    Disables the protection against removing the final fileset
+    Disables the protection against removing the final fileset.
 
 
 

--- a/Duplicati/Library/Main/Operation/DeleteHandler.cs
+++ b/Duplicati/Library/Main/Operation/DeleteHandler.cs
@@ -69,7 +69,7 @@ namespace Duplicati.Library.Main.Operation
             if (!hasVerifiedBackend)
                 await FilelistProcessor.VerifyRemoteList(backendManager, m_options, db, m_result.BackendWriter, latestVolumesOnly: true, verifyMode: FilelistProcessor.VerifyMode.VerifyStrict, rtr.Transaction).ConfigureAwait(false);
 
-            IListResultFileset[] filesets = db.FilesetsWithBackupVersion.ToArray();
+            var filesets = db.FilesetsWithBackupVersion.ToArray();
             List<IListResultFileset> versionsToDelete =
             [
                 .. new SpecificVersionsRemover(m_options).GetFilesetsToDelete(filesets),
@@ -79,6 +79,9 @@ namespace Duplicati.Library.Main.Operation
 
             // When determining the number of full versions to keep, we need to ignore the versions already marked for removal.
             versionsToDelete.AddRange(new KeepVersionsRemover(m_options).GetFilesetsToDelete(filesets.Except(versionsToDelete)));
+
+            // In case multiple options are supplied, only consider distinct versions to delete.
+            versionsToDelete = versionsToDelete.DistinctBy(x => x.Version).ToList();
 
             if (!m_options.AllowFullRemoval && filesets.Length == versionsToDelete.Count)
             {

--- a/Duplicati/UnitTest/Issue6127.cs
+++ b/Duplicati/UnitTest/Issue6127.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    public class Issue6127 : BasicSetupHelper
+    {
+        [Test]
+        [Category("Targeted")]
+        public void TestMultiRetentionOptions()
+        {
+            var testopts = TestOptions;
+            testopts.Add("upload-unchanged-backups", "true");
+
+            // Prepare some data
+            var data = new byte[1024 * 1024 * 10];
+            File.WriteAllBytes(Path.Combine(DATAFOLDER, "a"), data);
+
+            // Make three backups
+            for (var i = 0; i < 3; i++)
+            {
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                {
+                    var res = c.Backup([DATAFOLDER]);
+                    TestUtils.AssertResults(res);
+                    Assert.AreEqual(i + 1, c.List(null).Filesets.Count());
+                }
+                Thread.Sleep(1000);
+            }
+
+            // Make sure we have something to delete
+            Thread.Sleep(1000);
+
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 2, retention_policy = "1s:U" }), null))
+                TestUtils.AssertResults(c.Delete());
+
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts.Expand(new { version = 2, retention_policy = "1s:U" }), null))
+                Assert.AreEqual(1, c.List(null).Filesets.Count());
+        }
+    }
+}
+


### PR DESCRIPTION
The delete call would select the same fileset multiple times if multiple retention options were present.

This fixes the selection to a distinct set.
This fixes #6127