### PR TITLE
Ensure commit before upload

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Backup/DataBlockProcessor.cs
@@ -127,8 +127,6 @@ namespace Duplicati.Library.Main.Operation.Backup
 
                                 blockvolume.Close();
 
-                                await database.CommitTransactionAsync("CommitAddBlockToOutputFlush");
-
                                 IndexVolumeWriter indexVolumeCopy = null;
                                 if (indexvolume != null)
                                 {
@@ -138,6 +136,9 @@ namespace Duplicati.Library.Main.Operation.Backup
                                     // Create link before upload is started, it will be removed later if upload fails
                                     await database.AddIndexBlockLinkAsync(indexVolumeCopy.VolumeID, blockvolume.VolumeID).ConfigureAwait(false);
                                 }
+
+                                // Make sure we have stored information about pending uploads
+                                await database.CommitTransactionAsync("CommitAddBlockToOutputFlush");
 
                                 var blockVolumeCopy = blockvolume;
                                 blockvolume = null;

--- a/Duplicati/Library/Main/Operation/Backup/SpillCollectorProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/SpillCollectorProcess.cs
@@ -172,6 +172,9 @@ namespace Duplicati.Library.Main.Operation.Backup
                 await database.AddIndexBlockLinkAsync(indexVolumeCopy.VolumeID, target.BlockVolume.VolumeID).ConfigureAwait(false);
             }
 
+            // Make sure we have stored information about pending uploads
+            await database.UpdateRemoteVolumeAsync(target.BlockVolume.RemoteFilename, RemoteVolumeState.Uploading, -1, null).ConfigureAwait(false);
+            await database.CommitTransactionAsync("CommitSpillUpload").ConfigureAwait(false);
             await backendManager.PutAsync(target.BlockVolume, indexVolumeCopy, null, false, taskreader.ProgressToken).ConfigureAwait(false);
         }
     }

--- a/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
@@ -66,7 +66,6 @@ internal static class UploadRealFilelist
 
                 await db.UpdateRemoteVolumeAsync(filesetvolume.RemoteFilename, RemoteVolumeState.Uploading, -1, null).ConfigureAwait(false);
                 await db.CommitTransactionAsync("CommitUpdateRemoteVolume").ConfigureAwait(false);
-
                 await backendManager.PutAsync(filesetvolume, null, null, false, taskreader.ProgressToken).ConfigureAwait(false);
             }
         }

--- a/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
@@ -114,8 +114,8 @@ namespace Duplicati.Library.Main.Operation.Backup
                 // Because it is registered as "Deleting", it will be removed from remote storage by the cleanup process if it exists
                 if (!string.IsNullOrWhiteSpace(lastTempFilelist.Name) && (lastTempFilelist.State == RemoteVolumeState.Uploading || lastTempFilelist.State == RemoteVolumeState.Temporary))
                     await database.UpdateRemoteVolumeAsync(lastTempFilelist.Name, RemoteVolumeState.Deleting, -1, null);
-                await database.CommitTransactionAsync("CommitUpdateFilelistVolume");
 
+                await database.CommitTransactionAsync("CommitUpdateFilelistVolume");
                 await backendManager.PutAsync(fsw, null, null, false, taskreader.ProgressToken);
             }
             catch


### PR DESCRIPTION
This makes the commits a bit more explicit.
The underlying problem is that prior to the backend performing any operation, it should write and commit the changes to the database.

This is problematic because the other tables in the database may be in an inconsistent state when the commit should be made.

Since SQLite only supports a single transaction this needs some manual transaction handling, where temporary tables are copied in before a commit, or multiple databases are in use.

The fix here does not address the underlying issue.