### PR TITLE
Fixed not uploading dlist on failure.

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -37,15 +37,6 @@ internal partial class BackendManager : IBackendManager
     private readonly Task queueRunner;
 
     /// <summary>
-    /// The last file read size
-    /// </summary>
-    public long LastReadSize { get; private set; }
-    /// <summary>
-    /// The last file write size
-    /// </summary>
-    public long LastWriteSize { get; private set; }
-
-    /// <summary>
     /// The execution context
     /// </summary>
     private readonly ExecuteContext context;
@@ -172,7 +163,6 @@ internal partial class BackendManager : IBackendManager
         };
         await QueueTask(op).ConfigureAwait(false);
         (var file, var _, var downloadSize) = await op.GetResult().ConfigureAwait(false);
-        LastReadSize = downloadSize;
         return file;
     }
 
@@ -193,7 +183,6 @@ internal partial class BackendManager : IBackendManager
         };
         await QueueTask(op).ConfigureAwait(false);
         (var file, var _, var downloadSize) = await op.GetResult().ConfigureAwait(false);
-        LastReadSize = downloadSize;
         return file;
     }
 
@@ -226,7 +215,6 @@ internal partial class BackendManager : IBackendManager
         };
         await QueueTask(op).ConfigureAwait(false);
         (var file, var downloadHash, var downloadSize) = await op.GetResult().ConfigureAwait(false);
-        LastReadSize = downloadSize;
         return (file, downloadHash, downloadSize);
     }
 

--- a/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalBackupDatabase.cs
@@ -660,6 +660,15 @@ SELECT ""BlocklistHash"".""BlocksetID"" FROM ""BlocklistHash"" WHERE ""Blocklist
             base.Dispose();
         }
 
+        public long GetLastWrittenVolumeSize(IDbTransaction? transaction)
+        {
+            using (var cmd = m_connection.CreateCommand(transaction))
+                return cmd.SetCommandAndParameters(@"SELECT ""Size"" FROM ""RemoteVolume"" WHERE ""State"" = @State AND ""Type"" = @Type ORDER BY ""ID"" DESC LIMIT 1")
+                    .SetParameterValue("@State", RemoteVolumeState.Uploaded.ToString())
+                    .SetParameterValue("@Type", RemoteVolumeType.Blocks.ToString())
+                    .ExecuteScalarInt64(-1);
+        }
+
         private long GetPreviousFilesetID(IDbCommand cmd)
         {
             return GetPreviousFilesetID(cmd, OperationTimestamp, m_filesetId, cmd.Transaction);

--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -201,17 +201,17 @@ namespace Duplicati.Library.Main.Database
             return Library.Utility.Utility.EPOCH.AddSeconds(seconds);
         }
 
-        public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string hash, IDbTransaction? transaction = null)
+        public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string? hash, IDbTransaction? transaction = null)
         {
             UpdateRemoteVolume(name, state, size, hash, false, transaction);
         }
 
-        public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string hash, bool suppressCleanup, IDbTransaction? transaction = null)
+        public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string? hash, bool suppressCleanup, IDbTransaction? transaction = null)
         {
             UpdateRemoteVolume(name, state, size, hash, suppressCleanup, new TimeSpan(0), transaction);
         }
 
-        public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string hash, bool suppressCleanup, TimeSpan deleteGraceTime, IDbTransaction? transaction = null)
+        public void UpdateRemoteVolume(string name, RemoteVolumeState state, long size, string? hash, bool suppressCleanup, TimeSpan deleteGraceTime, IDbTransaction? transaction = null)
         {
             m_updateremotevolumeCommand.Transaction = transaction;
             var c = m_updateremotevolumeCommand.SetParameterValue("@OperationID", m_operationid)
@@ -386,7 +386,7 @@ namespace Duplicati.Library.Main.Database
         /// <param name="operation">The operation performed</param>
         /// <param name="path">The path involved</param>
         /// <param name="data">Any data relating to the operation</param>
-        public void LogRemoteOperation(string operation, string path, string data, IDbTransaction transaction)
+        public void LogRemoteOperation(string operation, string path, string? data, IDbTransaction? transaction)
         {
             m_insertremotelogCommand
                 .SetParameterValue("@OperationID", m_operationid)
@@ -1429,7 +1429,7 @@ AND oldVersion.FilesetID = (SELECT ID FROM Fileset WHERE ID != @FilesetId ORDER 
             }
         }
 
-        public void RenameRemoteFile(string oldname, string newname, IDbTransaction transaction)
+        public void RenameRemoteFile(string oldname, string newname, IDbTransaction? transaction)
         {
             using (var tr = new TemporaryTransactionWrapper(m_connection, transaction))
             using (var cmd = m_connection.CreateCommand(tr.Parent))

--- a/Duplicati/Library/Main/IBackendManager.cs
+++ b/Duplicati/Library/Main/IBackendManager.cs
@@ -117,15 +117,4 @@ internal interface IBackendManager : IDisposable
     /// <param name="cancelToken">The cancellation token</param>
     /// <returns>The downloaded files, hash, size, and name</returns>
     IAsyncEnumerable<(TempFile File, string Hash, long Size, string Name)> GetFilesOverlappedAsync(IEnumerable<IRemoteVolume> volumes, CancellationToken cancelToken);
-
-    /// <summary>
-    /// Gets the size of the last read operation
-    /// </summary>
-    long LastReadSize { get; }
-
-    /// <summary>
-    /// Gets the size of the last write operation
-    /// </summary>
-    long LastWriteSize { get; }
-
 }

--- a/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
@@ -65,9 +65,11 @@ internal static class UploadRealFilelist
                 await taskreader.ProgressRendevouz().ConfigureAwait(false);
 
                 await db.UpdateRemoteVolumeAsync(filesetvolume.RemoteFilename, RemoteVolumeState.Uploading, -1, null).ConfigureAwait(false);
-                await db.CommitTransactionAsync("CommitUpdateRemoteVolume").ConfigureAwait(false);
+                await db.CommitTransactionAsync("CommitAfterUploads").ConfigureAwait(false);
 
+                // Upload the dlist file and flush messages
                 await backendManager.PutAsync(filesetvolume, null, null, false, taskreader.ProgressToken).ConfigureAwait(false);
+                await db.FlushBackend(backendManager, taskreader.ProgressToken).ConfigureAwait(false);
             }
         }
         else

--- a/Duplicati/Library/Main/Operation/Common/DatabaseCommon.cs
+++ b/Duplicati/Library/Main/Operation/Common/DatabaseCommon.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Main.Database;
 
@@ -65,6 +66,9 @@ namespace Duplicati.Library.Main.Operation.Common
         {
             return RunOnMain(() => m_db.UpdateRemoteVolume(name, state, size, hash, suppressCleanup, deleteGraceTime, GetTransaction()));
         }
+
+        public Task FlushBackend(IBackendManager backendManager, CancellationToken token)
+            => RunOnMain(() => backendManager.WaitForEmptyAsync(m_db, null, token).ConfigureAwait(false));
 
         public Task CommitTransactionAsync(string message, bool restart = true)
         {


### PR DESCRIPTION
If any of the uploads fail, do not upload the dlist in parallel with the failing upload.

Previously, it was possible to upload the dlist if the very last dblock was slow in failing.

This also fixes some logic around getting the size of the last uploaded volume, which is used for compating decisions.

There are still some quirks with the transactions. Flushing the queue with a transaction active causes partial updates to the database.