### PR TITLE
Ignore any error on pragma optimize.

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1673,7 +1673,7 @@ AND oldVersion.FilesetID = (SELECT ID FROM Fileset WHERE ID != @FilesetId ORDER 
                         {
                             transaction.Commit();
                         }
-                        catch (SQLite.SQLiteException ex)
+                        catch (Exception ex)
                         {
                             Logging.Log.WriteVerboseMessage(LOGTAG, "FailedToCommitTransaction", ex, "Failed to commit transaction after pragma optimize, usually caused by the a no-op transaction");
                         }


### PR DESCRIPTION
Previous logic would only catch SQLite exceptions, but it is just a performance thing, so we can ignore any errors (they are still logged)