### PR TITLE
Support Azure Access Tier

### DIFF
--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -92,7 +92,10 @@ namespace Duplicati.Library.Backend.AzureBlob
 
             var archiveClasses = ParseStorageClasses(options.GetValueOrDefault(AZURE_ARCHIVE_CLASSES_OPTION));
             var accessTierValue = options.GetValueOrDefault(AZURE_ACCESS_TIER_OPTION);
-            var accessTier = string.IsNullOrWhiteSpace(accessTierValue) ? null : new AccessTier(accessTierValue);
+            var accessTier = string.IsNullOrWhiteSpace(accessTierValue)
+                ? null
+                // Warning: The cast here is required to avoid implicit casting null to AccessTier
+                : (AccessTier?)new AccessTier(accessTierValue);
             _azureBlob = new AzureBlobWrapper(auth.Username!, auth.Password, sasToken, containerName, accessTier, archiveClasses, timeouts);
         }
 

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -22,6 +22,7 @@
 using Azure;
 using Azure.Storage.Blobs.Models;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 
 namespace Duplicati.Library.Backend.AzureBlob
@@ -63,6 +64,15 @@ namespace Duplicati.Library.Backend.AzureBlob
             AccessTier.Cool, AccessTier.Cold, AccessTier.Archive
         ]);
 
+        /// <summary>
+        /// List of access tiers
+        /// </summary>
+        private static readonly IEnumerable<AccessTier> ACCESS_TIERS =
+            typeof(AccessTier).GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                .Where(x => x.PropertyType == typeof(AccessTier))
+                .Select(x => x.GetValue(null) as AccessTier?)
+                .WhereNotNull()
+                .ToArray();
 
         // ReSharper disable once UnusedMember.Global
         // This constructor is needed by the BackendLoader.
@@ -176,17 +186,14 @@ namespace Duplicati.Library.Backend.AzureBlob
                         Strings.AzureBlobBackend.ArchiveClassesDescriptionLong,
                         string.Join(",", DEFAULT_ARCHIVE_CLASSES.Select(x => x.ToString())),
                         null,
-                        DEFAULT_ARCHIVE_CLASSES.Select(x => x.ToString()).ToArray()),
+                        ACCESS_TIERS.Select(x => x.ToString()).ToArray()),
                     new CommandLineArgument(AZURE_ACCESS_TIER_OPTION,
                         CommandLineArgument.ArgumentType.String,
                         Strings.AzureBlobBackend.AccessTierDescriptionShort,
                         Strings.AzureBlobBackend.AccessTierDescriptionLong,
                         "",
                         null,
-                        typeof(AccessTier).GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-                            .Where(x => x.PropertyType == typeof(AccessTier))
-                            .Select(x => x.Name)
-                            .ToArray()),
+                        ACCESS_TIERS.Select(x => x.ToString()).ToArray()),
                     .. TimeoutOptionsHelper.GetOptions()
                 ];
             }

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -61,7 +61,7 @@ namespace Duplicati.Library.Backend.AzureBlob
         /// The default storage classes that are considered archive classes
         /// </summary>
         private static readonly IReadOnlySet<AccessTier> DEFAULT_ARCHIVE_CLASSES = new HashSet<AccessTier>([
-            AccessTier.Cool, AccessTier.Cold, AccessTier.Archive
+            AccessTier.Cold, AccessTier.Archive
         ]);
 
         /// <summary>

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -30,7 +30,39 @@ namespace Duplicati.Library.Backend.AzureBlob
     // This class is instantiated dynamically in the BackendLoader.
     public class AzureBlobBackend : IStreamingBackend
     {
+        /// <summary>
+        /// The access to Azure blob storage
+        /// </summary>
         private readonly AzureBlobWrapper _azureBlob;
+
+        /// <summary>
+        /// The option to specify the Azure storage account name
+        /// </summary>
+        private const string AZURE_ACCOUNT_NAME_OPTION = "azure-account-name";
+        /// <summary>
+        /// The option to specify the Azure access key
+        /// </summary>
+        private const string AZURE_ACCESS_KEY_OPTION = "azure-access-key";
+        /// <summary>
+        /// The option to specify the Azure access SAS token
+        /// </summary>
+        private const string AZURE_ACCESS_SAS_TOKEN_OPTION = "azure-access-sas-token";
+        /// <summary>
+        /// The option to specify the archive classes
+        /// </summary>
+        private const string AZURE_ARCHIVE_CLASSES_OPTION = "azure-archive-classes";
+        /// <summary>
+        /// The option to specify the Azure access tier
+        /// </summary>
+        private const string AZURE_ACCESS_TIER_OPTION = "azure-access-tier";
+
+        /// <summary>
+        /// The default storage classes that are considered archive classes
+        /// </summary>
+        private static readonly IReadOnlySet<AccessTier> DEFAULT_ARCHIVE_CLASSES = new HashSet<AccessTier>([
+            AccessTier.Cool, AccessTier.Cold, AccessTier.Archive
+        ]);
+
 
         // ReSharper disable once UnusedMember.Global
         // This constructor is needed by the BackendLoader.
@@ -48,17 +80,33 @@ namespace Duplicati.Library.Backend.AzureBlob
 
             var containerName = uri.Host.ToLowerInvariant();
 
-            var auth = AuthOptionsHelper.ParseWithAlias(options, uri, "azure-account-name", "azure-access-key");
+            var auth = AuthOptionsHelper.ParseWithAlias(options, uri, AZURE_ACCOUNT_NAME_OPTION, AZURE_ACCESS_KEY_OPTION);
             var timeouts = TimeoutOptionsHelper.Parse(options);
 
-            var sasToken = options.GetValueOrDefault("azure-access-sas-token");
+            var sasToken = options.GetValueOrDefault(AZURE_ACCESS_SAS_TOKEN_OPTION);
             if (!auth.HasUsername)
                 throw new UserInformationException(Strings.AzureBlobBackend.NoStorageAccountName, "AzureNoAccountName");
 
             if (!auth.HasPassword && string.IsNullOrWhiteSpace(sasToken))
                 throw new UserInformationException(Strings.AzureBlobBackend.NoAccessKeyOrSasToken, "AzureNoAccessKeyOrSasToken");
 
-            _azureBlob = new AzureBlobWrapper(auth.Username!, auth.Password, sasToken, containerName, timeouts);
+            var archiveClasses = ParseStorageClasses(options.GetValueOrDefault(AZURE_ARCHIVE_CLASSES_OPTION));
+            var accessTierValue = options.GetValueOrDefault(AZURE_ACCESS_TIER_OPTION);
+            var accessTier = string.IsNullOrWhiteSpace(accessTierValue) ? null : new AccessTier(accessTierValue);
+            _azureBlob = new AzureBlobWrapper(auth.Username!, auth.Password, sasToken, containerName, accessTier, archiveClasses, timeouts);
+        }
+
+        /// <summary>
+        /// Parses the storage classes from the string
+        /// </summary>
+        /// <param name="storageClass">The storage class string</param>
+        /// <returns>The storage classes</returns>
+        private static IReadOnlySet<AccessTier> ParseStorageClasses(string? storageClass)
+        {
+            if (string.IsNullOrWhiteSpace(storageClass))
+                return DEFAULT_ARCHIVE_CLASSES;
+
+            return new HashSet<AccessTier>(storageClass.Split([','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(x => new AccessTier(x)));
         }
 
         public string DisplayName => Strings.AzureBlobBackend.DisplayName;
@@ -103,22 +151,39 @@ namespace Duplicati.Library.Backend.AzureBlob
             get
             {
                 return [
-                    new CommandLineArgument("azure-account-name",
+                    new CommandLineArgument(AZURE_ACCOUNT_NAME_OPTION,
                         CommandLineArgument.ArgumentType.String,
                         Strings.AzureBlobBackend.StorageAccountNameDescriptionShort,
                         Strings.AzureBlobBackend.StorageAccountNameDescriptionLong,
                         null,
                         [AuthOptionsHelper.AuthUsernameOption]),
-                    new CommandLineArgument("azure-access-key",
+                    new CommandLineArgument(AZURE_ACCESS_KEY_OPTION,
                         CommandLineArgument.ArgumentType.Password,
                         Strings.AzureBlobBackend.AccessKeyDescriptionShort,
                         Strings.AzureBlobBackend.AccessKeyDescriptionLong,
                         null,
                         [AuthOptionsHelper.AuthPasswordOption]),
-                    new CommandLineArgument("azure-access-sas-token",
+                    new CommandLineArgument(AZURE_ACCESS_SAS_TOKEN_OPTION,
                         CommandLineArgument.ArgumentType.Password,
                         Strings.AzureBlobBackend.SasTokenDescriptionShort,
                         Strings.AzureBlobBackend.SasTokenDescriptionLong),
+                    new CommandLineArgument(AZURE_ARCHIVE_CLASSES_OPTION,
+                        CommandLineArgument.ArgumentType.Flags,
+                        Strings.AzureBlobBackend.ArchiveClassesDescriptionShort,
+                        Strings.AzureBlobBackend.ArchiveClassesDescriptionLong,
+                        string.Join(",", DEFAULT_ARCHIVE_CLASSES.Select(x => x.ToString())),
+                        null,
+                        DEFAULT_ARCHIVE_CLASSES.Select(x => x.ToString()).ToArray()),
+                    new CommandLineArgument(AZURE_ACCESS_TIER_OPTION,
+                        CommandLineArgument.ArgumentType.String,
+                        Strings.AzureBlobBackend.AccessTierDescriptionShort,
+                        Strings.AzureBlobBackend.AccessTierDescriptionLong,
+                        "",
+                        null,
+                        typeof(AccessTier).GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                            .Where(x => x.PropertyType == typeof(AccessTier))
+                            .Select(x => x.Name)
+                            .ToArray()),
                     .. TimeoutOptionsHelper.GetOptions()
                 ];
             }

--- a/Duplicati/Library/Backend/AzureBlob/Strings.cs
+++ b/Duplicati/Library/Backend/AzureBlob/Strings.cs
@@ -37,4 +37,8 @@ internal static class AzureBlobBackend
     public static string SasTokenDescriptionLong => LC.L(@"The Azure shared access signature (SAS) token which can be obtained by selecting the ""Shared access signature"" blade on the storage account dashboard, or inside a container blade.");
     public static string SasTokenDescriptionShort => LC.L(@"The SAS token");
     public static string NoAccessKeyOrSasToken => LC.L(@"No Azure access key or SAS token given");
+    public static string AccessTierDescriptionShort => LC.L(@"Specify the access tier");
+    public static string AccessTierDescriptionLong => LC.L(@"Use this option to specify the access tier. If this option is not used, the server will choose a default access tier.");
+    public static string ArchiveClassesDescriptionShort => LC.L(@"The storage classes that are considered archive classes");
+    public static string ArchiveClassesDescriptionLong => LC.L(@"Use this option to specify what storage classes are considered archive storage classes. With this option it is possible to allow lifecycle policies to move data to cheaper storage classes and prevent Duplicati from accessing archived data.");
 }

--- a/Duplicati/Library/Utility/EnumerableExtensions.cs
+++ b/Duplicati/Library/Utility/EnumerableExtensions.cs
@@ -41,6 +41,15 @@ public static class EnumerableExtensions
                 .Select(x => x!);
 
     /// <summary>
+    /// Filters a sequence of values to exclude null elements.
+    /// </summary>
+    /// <param name="source">The sequence to filter.</param>
+    /// <returns>A sequence that contains only the non-null elements from the input sequence.</returns>
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : struct
+        => source.Where(x => x != null)
+                .Select(x => x.Value);
+
+    /// <summary>
     /// Filters a sequence of values to exclude null or whitespace elements.
     /// </summary>
     /// <param name="source">The sequence to filter.</param>


### PR DESCRIPTION
This adds support for Azure Access Tiers, similar to AWS Storage Class.

This update adds the option to set a custom storage class, as well as the option to define which storage classes are considered archive classes.