### PR TITLE
Resillient box error parsing

### DIFF
--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -71,8 +71,11 @@ namespace Duplicati.Library.Backend.Box
                 await using var stream = await responseContext.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 using var reader = new StreamReader(stream);
                 var rawData = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancellationToken, ct => reader.ReadToEndAsync(ct)).ConfigureAwait(false);
-                var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(rawData)
-                    ?? new ErrorResponse { Status = (int)responseContext.StatusCode, Code = "Unknown", Message = rawData };
+                ErrorResponse? errorResponse = null;
+                try { errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(rawData); }
+                catch { }
+
+                errorResponse ??= new ErrorResponse { Status = (int)responseContext.StatusCode, Code = "Unknown", Message = rawData };
                 throw new UserInformationException($"Box.com ErrorResponse: {errorResponse.Status} - {errorResponse.Code}: {errorResponse.Message}", "box.com");
             }
         }


### PR DESCRIPTION
When an error is thrown from box.com, it is sometimes not formatted according to the API documentation (most likely html/xml output).

This commit handles an invalid JSON response and returns the body contents in the error message.

This fixes #4283