### PR TITLE
Fix for case where empty filesets can be removed

### DIFF
--- a/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
@@ -89,19 +89,6 @@ namespace Duplicati.Library.Main.Database
         }
 
         /// <summary>
-        /// Deletes a fileset from the database
-        /// </summary>
-        /// <param name="filesetid">The fileset ID</param>
-        /// <param name="transaction">The transaction</param>
-        public void DeleteFileset(long filesetid, IDbTransaction transaction)
-        {
-            using var cmd = m_connection.CreateCommand(transaction);
-            cmd.SetCommandAndParameters(@"DELETE FROM ""Fileset"" WHERE ""ID"" = @FilesetId")
-                .SetParameterValue("@FilesetId", filesetid)
-                .ExecuteNonQuery();
-        }
-
-        /// <summary>
         /// Gets the list of index files that reference a given block file
         /// </summary>
         /// <param name="blockfileid">The block file ID</param>

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -347,6 +347,25 @@ namespace Duplicati.Library.Main.Operation
                         else
                         {
                             await FilelistProcessor.VerifyRemoteList(backendManager, options, database, null, result.BackendWriter, [lastTempFilelist.Name], [], logErrors: false, verifyMode: FilelistProcessor.VerifyMode.VerifyAndClean).ConfigureAwait(false);
+                            var updatedLastTemp = string.IsNullOrWhiteSpace(lastTempFilelist.Name) ? default : database.GetRemoteVolume(lastTempFilelist.Name, null);
+                            if (!string.IsNullOrWhiteSpace(updatedLastTemp.Name) && updatedLastTemp.State == RemoteVolumeState.Deleting)
+                            {
+                                // The last temporary filelist was emptied, and scheduled for deletion, so we need to delete it
+                                try
+                                {
+                                    await backendManager.DeleteAsync(updatedLastTemp.Name, updatedLastTemp.Size, true, result.TaskControl.ProgressToken).ConfigureAwait(false);
+                                }
+                                catch (Exception ex)
+                                {
+                                    Log.WriteMessage(LogMessageType.Information, LOGTAG, "BackendDeleteFailed", ex, "Backend delete failed: {0}", ex.Message);
+                                }
+
+                                await backendManager.WaitForEmptyAsync(database, null, result.TaskControl.ProgressToken).ConfigureAwait(false);
+                                // In case the backend delete failed, manually set the state to deleted
+                                database.UpdateRemoteVolume(updatedLastTemp.Name, RemoteVolumeState.Deleted, updatedLastTemp.Size, updatedLastTemp.Hash, false, TimeSpan.FromHours(2), null, null);
+                                // The last temporary filelist is no more
+                                lastTempFilelist = default;
+                            }
                         }
                     }
                     catch (RemoteListVerificationException ex)

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -330,15 +330,12 @@ namespace Duplicati.Library.Main.Operation
                     if (database.RepairInProgress)
                         throw new UserInformationException("The database was attempted repaired, but the repair did not complete. This database may be incomplete and the backup process cannot continue. You may delete the local database and attempt to repair it again.", "DatabaseRepairInProgress");
 
-                    using (var db = new Backup.BackupDatabase(database, options))
-                    {
-                        // Make sure the database is sane
-                        await db.VerifyConsistencyAsync(options.Blocksize, options.BlockhashSize, !options.DisableFilelistConsistencyChecks);
+                    // Make sure the database is sane
+                    database.VerifyConsistency(options.Blocksize, options.BlockhashSize, !options.DisableFilelistConsistencyChecks, null);
 
-                        // Guard the last filelist
-                        if (!options.DisableSyntheticFilelist)
-                            lastTempFilelist = database.GetLastIncompleteFilesetVolume(null);
-                    }
+                    // Guard the last filelist
+                    if (!options.DisableSyntheticFilelist)
+                        lastTempFilelist = database.GetLastIncompleteFilesetVolume(null);
 
                     try
                     {

--- a/Duplicati/UnitTest/Issue5862.cs
+++ b/Duplicati/UnitTest/Issue5862.cs
@@ -1,0 +1,105 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System.IO;
+using NUnit.Framework;
+using System.Linq;
+using Duplicati.Library.Interface;
+using Duplicati.Library.DynamicLoader;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Duplicati.UnitTest
+{
+    public class Issue5862 : BasicSetupHelper
+    {
+        private class PreventingBackend : IStreamingBackend
+        {
+            public const string Key = "test-backend-5862";
+            public string DisplayName => "Test backend";
+            public string ProtocolKey => Key;
+            public string Description => "Test backend";
+            public IList<ICommandLineArgument> SupportedCommands => backend.SupportedCommands;
+            private readonly IStreamingBackend backend;
+
+            public static string RealKey { get; set; } = "file";
+            public PreventingBackend()
+            {
+                backend = (IStreamingBackend)BackendLoader.Backends.First(x => x.ProtocolKey == RealKey);
+            }
+
+            public PreventingBackend(string url, Dictionary<string, string> opts)
+            {
+                backend = (IStreamingBackend)BackendLoader.GetBackend(RealKey + url.Substring(ProtocolKey.Length), opts);
+            }
+
+            public Task CreateFolderAsync(CancellationToken cancellationToken)
+                => backend.CreateFolderAsync(cancellationToken);
+
+            public Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+                => backend.DeleteAsync(remotename, cancellationToken);
+            public void Dispose()
+                => backend.Dispose();
+            public Task GetAsync(string remotename, Stream stream, CancellationToken cancelToken)
+                => backend.GetAsync(remotename, stream, cancelToken);
+            public Task GetAsync(string remotename, string filename, CancellationToken cancellationToken)
+                => backend.GetAsync(remotename, filename, cancellationToken);
+            public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken)
+                => GetDNSNamesAsync(cancelToken);
+            public IAsyncEnumerable<IFileEntry> ListAsync(CancellationToken cancellationToken)
+                => backend.ListAsync(cancellationToken);
+
+            public Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken)
+                => throw new DeterministicErrorBackend.DeterministicErrorBackendException("Prevent");
+
+            public Task PutAsync(string remotename, string filename, CancellationToken cancellationToken)
+                => throw new DeterministicErrorBackend.DeterministicErrorBackendException("Prevent");
+
+            public Task TestAsync(CancellationToken cancellationToken)
+                => backend.TestAsync(cancellationToken);
+        }
+
+        [Test]
+        [Category("Targeted")]
+        public void TestUploadFailureWithResume()
+        {
+            var testopts = TestOptions.Expand(new
+            {
+                no_encryption = true,
+                number_of_retries = 0,
+            });
+
+            BackendLoader.AddBackend(new PreventingBackend());
+            var data = new byte[1024 * 1024 * 10];
+            File.WriteAllBytes(Path.Combine(DATAFOLDER, "a"), data);
+
+            // Make a failing backup
+            using (var c = new Library.Main.Controller(PreventingBackend.Key + "://" + TARGETFOLDER, testopts, null))
+                Assert.Throws<DeterministicErrorBackend.DeterministicErrorBackendException>(() => c.Backup(new string[] { DATAFOLDER }));
+
+            // Make a working backup, should not give any errors
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Backup(new string[] { DATAFOLDER }));
+        }
+    }
+}
+


### PR DESCRIPTION
If the fileset is fully empty, removing the `dblock` files will eventually cause the fileset to be deleted.
This delete did not correctly handle the updating of the attached remote volume, which caused validation errors.

This PR updates the remote volume table, and also deletes the unused remote file to stop validation issues.

This PR also fixes a case where the transaction dispose was not properly synchronized, making it possible to get races during error shutdowns. These shutdown errors would then cause the real problem to be hidden.