### PR TITLE
Fix logic issue with purge-broken-files

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -816,7 +816,7 @@ AND ""Fileset"".""ID"" NOT IN
         /// <param name="hashsize">The hash size in byts</param>
         /// <param name="verifyfilelists">Also verify filelists (can be slow)</param>
         /// <param name="transaction">The transaction to run in</param>
-        public void VerifyConsistency(long blocksize, long hashsize, bool verifyfilelists, IDbTransaction transaction)
+        public void VerifyConsistency(long blocksize, long hashsize, bool verifyfilelists, IDbTransaction? transaction)
             => VerifyConsistencyInner(blocksize, hashsize, verifyfilelists, false, transaction);
 
         /// <summary>
@@ -826,7 +826,7 @@ AND ""Fileset"".""ID"" NOT IN
         /// <param name="hashsize">The hash size in byts</param>
         /// <param name="verifyfilelists">Also verify filelists (can be slow)</param>
         /// <param name="transaction">The transaction to run in</param>
-        public void VerifyConsistencyForRepair(long blocksize, long hashsize, bool verifyfilelists, IDbTransaction transaction)
+        public void VerifyConsistencyForRepair(long blocksize, long hashsize, bool verifyfilelists, IDbTransaction? transaction)
             => VerifyConsistencyInner(blocksize, hashsize, verifyfilelists, true, transaction);
 
         /// <summary>
@@ -837,7 +837,7 @@ AND ""Fileset"".""ID"" NOT IN
         /// <param name="verifyfilelists">Also verify filelists (can be slow)</param>
         /// <param name="laxVerifyForRepair">Disable verify for errors that will be fixed by repair</param>
         /// <param name="transaction">The transaction to run in</param>
-        private void VerifyConsistencyInner(long blocksize, long hashsize, bool verifyfilelists, bool laxVerifyForRepair, IDbTransaction transaction)
+        private void VerifyConsistencyInner(long blocksize, long hashsize, bool verifyfilelists, bool laxVerifyForRepair, IDbTransaction? transaction)
         {
             using (var cmd = m_connection.CreateCommand(transaction))
             {

--- a/Duplicati/Library/Main/Database/LocalListBrokenFilesDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListBrokenFilesDatabase.cs
@@ -126,7 +126,7 @@ WHERE ""BlocksetID"" IS NULL OR ""BlocksetID"" IN
         /// <param name="tablename">The name of the table to insert into</param>
         /// <param name="IDfieldname">The name of the ID field in the table</param>
         /// <param name="transaction">The transaction to use for the query</param>
-        public void InsertBrokenFileIDsIntoTable(long filesetid, string tablename, string IDfieldname, IDbTransaction transaction)
+        public void InsertBrokenFileIDsIntoTable(long filesetid, string tablename, string IDfieldname, IDbTransaction? transaction)
         {
             using var cmd = Connection.CreateCommand(transaction, INSERT_BROKEN_IDS(tablename, IDfieldname))
               .SetParameterValue("@FilesetId", filesetid);
@@ -142,7 +142,7 @@ WHERE ""BlocksetID"" IS NULL OR ""BlocksetID"" IN
         /// <param name="emptyHashSize">The size of the empty blockset</param>
         /// <param name="transaction">The transaction to use for the query</param>
         /// <returns>The ID of the empty metadata blockset, or -1 if no suitable blockset is found</returns>
-        public long GetEmptyMetadataBlocksetId(IEnumerable<long> blockVolumeIds, string emptyHash, long emptyHashSize, IDbTransaction transaction)
+        public long GetEmptyMetadataBlocksetId(IEnumerable<long> blockVolumeIds, string emptyHash, long emptyHashSize, IDbTransaction? transaction)
         {
             using var cmd = Connection.CreateCommand(transaction, @"SELECT ""ID"" FROM ""Blockset"" WHERE ""FullHash"" = @EmptyHash AND ""Length"" == @EmptyHashSize AND ""ID"" NOT IN (SELECT ""BlocksetID"" FROM ""BlocksetEntry"", ""Block"" WHERE ""BlocksetEntry"".""BlockID"" = ""Block"".""ID"" AND ""Block"".""VolumeID"" NOT IN (@BlockVolumeIds))")
               .ExpandInClauseParameter("@BlockVolumeIds", blockVolumeIds)
@@ -175,7 +175,7 @@ WHERE ""BlocksetID"" IS NULL OR ""BlocksetID"" IN
         /// <param name="emptyBlocksetId">The empty blockset ID to replace with</param>
         /// <param name="transaction">The transaction to use for the query</param>
         /// <returns>The number of rows affected</returns>
-        public int ReplaceMetadata(long filesetId, long emptyBlocksetId, IDbTransaction transaction)
+        public int ReplaceMetadata(long filesetId, long emptyBlocksetId, IDbTransaction? transaction)
         {
             using var cmd = m_connection.CreateCommand(transaction, @"
 UPDATE ""Metadataset"" 

--- a/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
@@ -19,6 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -45,7 +47,7 @@ namespace Duplicati.Library.Main.Operation
             m_result = result;
         }
 
-        public async Task RunAsync(IBackendManager backendManager, IFilter filter, Func<long, DateTime, long, string, long, bool> callbackhandler = null)
+        public async Task RunAsync(IBackendManager backendManager, IFilter filter, Func<long, DateTime, long, string, long, bool>? callbackhandler = null)
         {
             if (!File.Exists(m_options.Dbpath))
                 throw new UserInformationException(string.Format("Database file does not exist: {0}", m_options.Dbpath), "DatabaseDoesNotExist");
@@ -55,9 +57,9 @@ namespace Duplicati.Library.Main.Operation
                 await DoRunAsync(backendManager, db, tr, filter, callbackhandler).ConfigureAwait(false);
         }
 
-        public static async Task<((DateTime FilesetTime, long FilesetID, long RemoveCount)[], List<Database.RemoteVolumeEntry> Missing)> GetBrokenFilesetsFromRemote(IBackendManager backendManager, BasicResults result, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, Options options)
+        public static async Task<((DateTime FilesetTime, long FilesetID, long RemoveCount)[]?, List<Database.RemoteVolumeEntry>? Missing)> GetBrokenFilesetsFromRemote(IBackendManager backendManager, BasicResults result, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, Options options)
         {
-            List<Database.RemoteVolumeEntry> missing = null;
+            List<Database.RemoteVolumeEntry>? missing = null;
             var brokensets = db.GetBrokenFilesets(options.Time, options.Version, transaction).ToArray();
 
             if (brokensets.Length == 0)
@@ -97,7 +99,7 @@ namespace Duplicati.Library.Main.Operation
             return (brokensets, missing);
         }
 
-        private async Task DoRunAsync(IBackendManager backendManager, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, IFilter filter, Func<long, DateTime, long, string, long, bool> callbackhandler)
+        private async Task DoRunAsync(IBackendManager backendManager, Database.LocalListBrokenFilesDatabase db, System.Data.IDbTransaction transaction, IFilter filter, Func<long, DateTime, long, string, long, bool>? callbackhandler)
         {
             if (filter != null && !filter.Empty)
                 throw new UserInformationException("Filters are not supported for this operation", "FiltersAreNotSupportedForListBrokenFiles");

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -19,6 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -72,7 +74,7 @@ namespace Duplicati.Library.Main.Operation
                 }
                 else
                 {
-                    Logging.Log.WriteInformationMessage(LOGTAG, "FoundBrokenFilesets", "Found {0} broken filesets with {1} affected files, purging files", sets.Length, sets.Sum(x => x.Item3));
+                    Logging.Log.WriteInformationMessage(LOGTAG, "FoundBrokenFilesets", "Found {0} broken filesets with {1} affected files, purging files", sets.Length, sets.Sum(x => x.RemoveCount));
 
                     var pgoffset = 0.0f;
                     var pgspan = 0.95f / sets.Length;

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -88,12 +88,12 @@ namespace Duplicati.Library.Main.Operation
                         SetCount = db.GetFilesetFileCount(x.Item2, tr)
                     }).ToArray();
 
-                    var emptyBlocksetId = -1L;
+                    var replacementMetadataBlocksetId = -1L;
                     if (!m_options.DisableReplaceMissingMetadata)
                     {
                         var emptymetadata = Utility.WrapMetadata(new Dictionary<string, string>(), m_options);
-                        emptyBlocksetId = db.GetEmptyMetadataBlocksetId(missing.Select(x => x.ID), emptymetadata.FileHash, emptymetadata.Blob.Length, null);
-                        if (emptyBlocksetId < 0)
+                        replacementMetadataBlocksetId = db.GetEmptyMetadataBlocksetId((missing ?? []).Select(x => x.ID), emptymetadata.FileHash, emptymetadata.Blob.Length, null);
+                        if (replacementMetadataBlocksetId < 0)
                             throw new UserInformationException($"Failed to locate an empty metadata blockset to replace missing metadata. Set the option --disable-replace-missing-metadata=true to ignore this and drop files with missing metadata.", "FailedToLocateEmptyMetadataBlockset");
                     }
 
@@ -163,7 +163,7 @@ namespace Duplicati.Library.Main.Operation
                                     // Update entries that would be removed because of missing metadata
                                     var updatedEntries = 0;
                                     if (!m_options.DisableReplaceMissingMetadata)
-                                        updatedEntries = db.ReplaceMetadata(filesetid, emptyBlocksetId, cmd.Transaction);
+                                        updatedEntries = db.ReplaceMetadata(filesetid, replacementMetadataBlocksetId, cmd.Transaction);
 
                                     db.InsertBrokenFileIDsIntoTable(filesetid, tablename, "FileID", cmd.Transaction);
                                     return updatedEntries;


### PR DESCRIPTION
In the case where no a fileset was detected broken but no files are missing, the `purge-broken-files` command would fail.