### PR TITLE
Prevent serialization from throwing

### DIFF
--- a/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
@@ -158,6 +158,7 @@ namespace Duplicati.Library.Main.Operation
 
         private class MockList<T> : IList<T>
         {
+            private readonly List<T> _dummy = new List<T>();
             public MockList(int count)
             {
                 Count = count;
@@ -174,54 +175,26 @@ namespace Duplicati.Library.Main.Operation
             public bool IsReadOnly => true;
 
             public void Add(T item)
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             public void Clear()
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             public bool Contains(T item)
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             public void CopyTo(T[] array, int arrayIndex)
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             public IEnumerator<T> GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
+                => _dummy.GetEnumerator();
 
             public int IndexOf(T item)
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             public void Insert(int index, T item)
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             public bool Remove(T item)
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             public void RemoveAt(int index)
-            {
-                throw new NotImplementedException();
-            }
-
+                => throw new NotImplementedException();
             IEnumerator IEnumerable.GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
+                => _dummy.GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
When serializing the mock list, it needs to access the enumerators.