### PR TITLE
Added redundant secret provider check

### DIFF
--- a/Duplicati/Library/Main/SecretProviderHelper.cs
+++ b/Duplicati/Library/Main/SecretProviderHelper.cs
@@ -223,6 +223,10 @@ public static class SecretProviderHelper
         if (translated.Any(x => string.IsNullOrWhiteSpace(x.Value)))
             throw new InvalidOperationException("The secret provider returned an empty key");
 
+        // Sanity check the results to guard against faulty providers
+        if (secrets.Any(x => !translated.ContainsKey(x)))
+            throw new InvalidOperationException("The secret provider did not return all values");
+
         // Update options by replacing values
         foreach (var v in optionsMap)
             foreach (var k in v.Value)


### PR DESCRIPTION
This check only verifies that the secret provider is not faulty, as each provider *should* fail if the values cannot be translated.

With this commit it is explicit, so future modules are ensured to function as expected.