### PR TITLE
Flush messages after backup stop

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
@@ -310,18 +310,13 @@ partial class BackendManager
                 // Terminate any active uploads and downloads. Exceptions thrown by the downloads should be captured by the callers.
                 tcs.Cancel();
 
-                if (activeUploads.Count > 0)
-                {
-                    Logging.Log.WriteWarningMessage(LOGTAG, "BackendManagerDisposeWhileActive", null, "Terminating {0} active uploads", activeUploads.Count);
+                await WaitForPendingItems("upload", activeUploads).ConfigureAwait(false);
+                await WaitForPendingItems("download", activeDownloads).ConfigureAwait(false);
 
-                    await WaitForPendingItems("upload", activeUploads).ConfigureAwait(false);
-                    await WaitForPendingItems("download", activeDownloads).ConfigureAwait(false);
-
-                    // Dispose of any remaining backends
-                    while (backendPool.TryDequeue(out var backend))
-                        try { backend.Dispose(); }
-                        catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, "BackendManagerDisposeError", ex, "Failed to dispose backend instance: {0}", ex.Message); }
-                }
+                // Dispose of any remaining backends
+                while (backendPool.TryDequeue(out var backend))
+                    try { backend.Dispose(); }
+                    catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, "BackendManagerDisposeError", ex, "Failed to dispose backend instance: {0}", ex.Message); }
             }
         }
 

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -506,25 +506,25 @@ namespace Duplicati.Library.Main
                         finally
                         {
                             m_currentBackendManager = null;
-                        }
 
-                        // TODO: Should also have a single shared database connection for all operations
-                        // The transactions should be managed inside the connection, and not passed around
+                            // TODO: Should also have a single shared database connection for all operations
+                            // The transactions should be managed inside the connection, and not passed around
 
-                        // This would allow us to pass the database instance to the backend manager
-                        // And safeguard against remote operations not being logged in the database
+                            // This would allow us to pass the database instance to the backend manager
+                            // And safeguard against remote operations not being logged in the database
 
-                        // This would also allow us to control the unclean shutdown flag,
-                        // by toggling this on start and completion of transfers in the manager,
-                        // instead of relying on the operations to correctly toggle the flag
-                        if (LocalDatabase.Exists(m_options.Dbpath))
-                        {
-                            using (var db = new LocalDatabase(m_options.Dbpath, result.MainOperation.ToString(), true, m_options.SqlitePageCache))
-                                backend.StopRunnerAndFlushMessages(db, null).Await();
-                        }
-                        else
-                        {
-                            backend.StopRunnerAndDiscardMessages();
+                            // This would also allow us to control the unclean shutdown flag,
+                            // by toggling this on start and completion of transfers in the manager,
+                            // instead of relying on the operations to correctly toggle the flag
+                            if (LocalDatabase.Exists(m_options.Dbpath) && !m_options.NoLocalDb)
+                            {
+                                using (var db = new LocalDatabase(m_options.Dbpath, result.MainOperation.ToString(), true, m_options.SqlitePageCache))
+                                    backend.StopRunnerAndFlushMessages(db, null).Await();
+                            }
+                            else
+                            {
+                                backend.StopRunnerAndDiscardMessages();
+                            }
                         }
                     }
 


### PR DESCRIPTION
This change now flushes all pending messages from the backendmanager to the database, even if the main operation crashes (or is stopped).

This ensures that the database and remote storage are more in sync.

Also removed a redundant warning from the backendmanager during shutdown, and simplified a check for active operations.

This fixes #6200