### PR TITLE
Fixed timestamp drift causing validation errors

### DIFF
--- a/Duplicati/Library/Main/Database/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalDatabase.cs
@@ -1486,7 +1486,11 @@ AND oldVersion.FilesetID = (SELECT ID FROM Fileset WHERE ID != @FilesetId ORDER 
 
                 //Create a fake new entry with the old name and mark as deleting
                 // as this ensures we will remove it, if it shows up in some later listing
-                RegisterRemoteVolume(oldname, type, RemoteVolumeState.Deleting, tr.Parent);
+                var newvolId = RegisterRemoteVolume(oldname, type, RemoteVolumeState.Deleting, tr.Parent);
+
+                // IF needed, also create an empty fileset, so the validation works
+                if (type == RemoteVolumeType.Files)
+                    CreateFileset(newvolId, DateTime.UnixEpoch, tr.Parent);
 
                 tr.Commit();
             }

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -157,9 +157,11 @@ namespace Duplicati.Library.Main.Operation
                 var progress = 0;
                 var targetProgess = tp.ExtraVolumes.Count() + tp.MissingVolumes.Count() + tp.VerificationRequiredVolumes.Count() + missingRemoteFilesets.Count + missingLocalFilesets.Count + emptyIndexFiles.Count;
 
+                // Find the most recent timestamp from either a fileset or a remote volume
                 var mostRecentLocal = db.GetRemoteVolumes(rtr.Transaction)
-                    .Where(x => x.Type == RemoteVolumeType.Files && x.State != RemoteVolumeState.Deleted)
+                    .Where(x => x.Type == RemoteVolumeType.Files)
                     .Select(x => VolumeBase.ParseFilename(x.Name).Time.ToLocalTime())
+                    .Concat(db.FilesetTimes.Select(x => x.Value.ToLocalTime()))
                     .Append(DateTime.MinValue).Max();
 
                 var mostRecentRemote = tp.ParsedVolumes.Select(x => x.Time.ToLocalTime()).Append(DateTime.MinValue).Max();

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -157,7 +157,11 @@ namespace Duplicati.Library.Main.Operation
                 var progress = 0;
                 var targetProgess = tp.ExtraVolumes.Count() + tp.MissingVolumes.Count() + tp.VerificationRequiredVolumes.Count() + missingRemoteFilesets.Count + missingLocalFilesets.Count + emptyIndexFiles.Count;
 
-                var mostRecentLocal = db.FilesetTimes.Select(x => x.Value.ToLocalTime()).Append(DateTime.MinValue).Max();
+                var mostRecentLocal = db.GetRemoteVolumes(rtr.Transaction)
+                    .Where(x => x.Type == RemoteVolumeType.Files && x.State != RemoteVolumeState.Deleted)
+                    .Select(x => VolumeBase.ParseFilename(x.Name).Time.ToLocalTime())
+                    .Append(DateTime.MinValue).Max();
+
                 var mostRecentRemote = tp.ParsedVolumes.Select(x => x.Time.ToLocalTime()).Append(DateTime.MinValue).Max();
                 if (mostRecentLocal < DateTime.UnixEpoch)
                     throw new UserInformationException("The local database has no fileset times. Consider deleting the local database and run the repair operation again.", "LocalDatabaseHasNoFilesetTimes");

--- a/Duplicati/UnitTest/Issue6235.cs
+++ b/Duplicati/UnitTest/Issue6235.cs
@@ -52,10 +52,10 @@ namespace Duplicati.UnitTest
             var count = 0;
             DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
             {
-                if (action.IsPutOperation && remotename.Contains(".dlist."))
+                if (action == DeterministicErrorBackend.BackendAction.PutBefore && remotename.Contains(".dlist."))
                 {
                     count++;
-                    if (count < 2)
+                    if (count <= 2)
                         return true;
                 }
                 return false;
@@ -68,7 +68,7 @@ namespace Duplicati.UnitTest
             Assert.That(count, Is.EqualTo(3), "Did not retry the dlist upload");
 
             // Check that repair works
-            using (var c = new Library.Main.Controller(new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER, testopts, null))
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
                 TestUtils.AssertResults(c.Repair());
 
             // Check that recreate works

--- a/Duplicati/UnitTest/Issue6235.cs
+++ b/Duplicati/UnitTest/Issue6235.cs
@@ -30,7 +30,7 @@ namespace Duplicati.UnitTest
     {
         [Test]
         [Category("Targeted")]
-        public void RepairWithDlistRetries([Values(2)] int keepVersions)
+        public void RepairWithDlistRetries([Values(1, 2)] int keepVersions)
         {
             var testopts = TestOptions.Expand(new
             {

--- a/Duplicati/UnitTest/Issue6235.cs
+++ b/Duplicati/UnitTest/Issue6235.cs
@@ -1,0 +1,88 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System.IO;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Duplicati.Library.DynamicLoader;
+
+namespace Duplicati.UnitTest
+{
+    public class Issue6235 : BasicSetupHelper
+    {
+        [Test]
+        [Category("Targeted")]
+        public void RepairWithDlistRetries([Values(2)] int keepVersions)
+        {
+            var testopts = TestOptions.Expand(new
+            {
+                no_encryption = true,
+                number_of_retries = 5,
+                retry_delay = "0s",
+                keep_versions = keepVersions,
+                upload_unchanged_backups = true,
+            });
+
+            // Create a file 
+            File.WriteAllText(Path.Combine(DATAFOLDER, "a.txt"), "Hello world");
+
+            // Make a backup
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Backup(new string[] { DATAFOLDER }));
+
+            BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var count = 0;
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action.IsPutOperation && remotename.Contains(".dlist."))
+                {
+                    count++;
+                    if (count < 2)
+                        return true;
+                }
+                return false;
+            };
+
+            // Make a backup where two attemps to upload the dlist file fails
+            using (var c = new Library.Main.Controller(new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Backup(new string[] { DATAFOLDER }));
+
+            Assert.That(count, Is.EqualTo(3), "Did not retry the dlist upload");
+
+            // Check that repair works
+            using (var c = new Library.Main.Controller(new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Repair());
+
+            // Check that recreate works
+            File.Delete(DBFILE);
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action.IsGetOperation && remotename.Contains(".dblock."))
+                    return true;
+                return false;
+            };
+
+            using (var c = new Library.Main.Controller(new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Repair());
+        }
+    }
+}
+


### PR DESCRIPTION
If the upload of the dlist fails, the filename will be incremented with one second. This causes validation errors when running repair, because it compares the fileset times (when the backup actually started) with the timestamp in the filename.

This PR updates the check to look only at the filename timestamp so the comparison is accurate even in the failure scenario.

This fixes #6235
This fixes #5996