### PR TITLE
Default disable throttle for local destinations

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.PendingOperation.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.PendingOperation.cs
@@ -21,6 +21,7 @@ partial class BackendManager
     /// <param name="UploadThrottleManager">The upload throttle manager</param>
     /// <param name="DownloadThrottleManager">The download throttle manager</param>
     /// <param name="TaskReader">The task reader</param>
+    /// <param name="IsThrottleDisabled">Whether throttling is disabled</param>
     /// <param name="Options">The options</param>
     private sealed record ExecuteContext(
         ProgressHandler ProgressHandler,
@@ -29,6 +30,7 @@ partial class BackendManager
         ThrottleManager UploadThrottleManager,
         ThrottleManager DownloadThrottleManager,
         ITaskReader TaskReader,
+        bool IsThrottleDisabled,
         Options Options);
 
     /// <summary>

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -59,14 +59,17 @@ internal partial class BackendManager : IBackendManager
         if (string.IsNullOrWhiteSpace(backendUrl))
             throw new ArgumentNullException(nameof(backendUrl));
 
+        var isThrottleDisabled = options.DisableThrottle || options.ThrottleDisabledBackends.Contains(Library.Utility.Utility.GuessScheme(backendUrl) ?? string.Empty);
+
         // To avoid excessive parameter passing, the context is captured here
         context = new ExecuteContext(
             new ProgressHandler(backendWriter, taskReader),
             backendWriter ?? throw new ArgumentNullException(nameof(backendWriter)),
             new DatabaseCollector(),
-            new ThrottleManager() { Limit = options.MaxUploadPrSecond },
-            new ThrottleManager() { Limit = options.MaxDownloadPrSecond },
+            new ThrottleManager() { Limit = isThrottleDisabled ? 0 : options.MaxUploadPrSecond },
+            new ThrottleManager() { Limit = isThrottleDisabled ? 0 : options.MaxDownloadPrSecond },
             taskReader ?? throw new ArgumentNullException(nameof(taskReader)),
+            isThrottleDisabled,
             options ?? throw new ArgumentNullException(nameof(options))
         );
 
@@ -393,6 +396,9 @@ internal partial class BackendManager : IBackendManager
     /// <param name="maxDownloadPrSecond">The maximum download speed in bytes per second</param>
     public void UpdateThrottleValues(long maxUploadPrSecond, long maxDownloadPrSecond)
     {
+        if (context.IsThrottleDisabled)
+            return;
+
         context.UploadThrottleManager.Limit = maxUploadPrSecond;
         context.DownloadThrottleManager.Limit = maxDownloadPrSecond;
     }

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -95,6 +95,11 @@ namespace Duplicati.Library.Main
         private const int DEFAULT_ASYNCHRONOUS_CONCURRENT_UPLOAD_LIMIT = 4;
 
         /// <summary>
+        /// The backends where throttling is disabled by default
+        /// </summary>
+        private const string DEFAULT_THROTTLE_DISABLED_BACKENDS = "file";
+
+        /// <summary>
         /// The default retry delay
         /// </summary>
         private const string DEFAULT_RETRY_DELAY = "10s";
@@ -368,6 +373,8 @@ namespace Duplicati.Library.Main
 
             new CommandLineArgument("throttle-upload", CommandLineArgument.ArgumentType.Size, Strings.Options.ThrottleuploadShort, Strings.Options.ThrottleuploadLong, "0kb"),
             new CommandLineArgument("throttle-download", CommandLineArgument.ArgumentType.Size, Strings.Options.ThrottledownloadShort, Strings.Options.ThrottledownloadLong, "0kb"),
+            new CommandLineArgument("throttle-disabled", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisablethrottleShort, Strings.Options.DisablethrottleLong, "false"),
+            new CommandLineArgument("throttle-disabled-backends", CommandLineArgument.ArgumentType.String, Strings.Options.DisablethrottlebackendsShort, Strings.Options.DisablethrottlebackendsLong("disable-throttle"), DEFAULT_THROTTLE_DISABLED_BACKENDS),
             new CommandLineArgument("skip-files-larger-than", CommandLineArgument.ArgumentType.Size, Strings.Options.SkipfileslargerthanShort, Strings.Options.SkipfileslargerthanLong),
 
             new CommandLineArgument("upload-unchanged-backups", CommandLineArgument.ArgumentType.Boolean, Strings.Options.UploadUnchangedBackupsShort, Strings.Options.UploadUnchangedBackupsLong, "false"),
@@ -863,6 +870,17 @@ namespace Duplicati.Library.Main
                     m_options["throttle-download"] = value <= 0 ? "" : $"{value}b";
             }
         }
+
+        /// <summary>
+        /// A value indicating if the throttling is disabled
+        /// </summary>
+        public bool DisableThrottle => GetBool("throttle-disabled");
+
+        /// <summary>
+        /// The backends where the throttling is disabled
+        /// </summary>
+        public HashSet<string> ThrottleDisabledBackends
+            => GetString("throttle-disabled-backends", DEFAULT_THROTTLE_DISABLED_BACKENDS)?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)?.ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>();
 
         /// <summary>
         /// A value indicating if the backup is a full backup

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -59,6 +59,10 @@ namespace Duplicati.Library.Main.Strings
         public static string ThrottledownloadShort { get { return LC.L(@"Max number of kilobytes to download pr. second"); } }
         public static string ThrottleuploadLong { get { return LC.L(@"By setting this value you can limit how much bandwidth Duplicati consumes for uploads. Setting this limit can make the backups take longer, but will make Duplicati less intrusive."); } }
         public static string ThrottleuploadShort { get { return LC.L(@"Max number of kilobytes to upload pr. second"); } }
+        public static string DisablethrottleLong { get { return LC.L(@"Disable the throttling of upload and download speeds for this task. If there is a throttle set, it will be ignored when running this task."); } }
+        public static string DisablethrottleShort { get { return LC.L(@"Disable throttling"); } }
+        public static string DisablethrottlebackendsLong(string option) { return LC.L(@"Disable the throttling of upload and download speeds for specific backends. If there is a throttle set, it will be ignore when running this task, if the backend is one of the specified backends. Multiple backends can be specified with a comma separator. This option has no effect if there is no throttle or if --{0} is set", option); }
+        public static string DisablethrottlebackendsShort { get { return LC.L(@"Disable throttling for specific backends"); } }
         public static string NoencryptionLong { get { return LC.L(@"If you store the backups on a local disk, and prefer that they are kept unencrypted, you can turn of encryption completely by using this switch."); } }
         public static string NoencryptionShort { get { return LC.L(@"Disable encryption"); } }
         public static string NumberofretriesLong { get { return LC.L(@"If an upload or download fails, Duplicati will retry a number of times before failing. Use this to handle unstable network connections better."); } }


### PR DESCRIPTION
This PR adds the option to disable throttle on a backup, so it will ignore throttle settings both from the server and the job.

Additionally, a list of backend keys can be provided, where backups will disable throttling. This can be used to set advanced options with a set of backends that should not be throttled.

By default, the `file` backend is now exempt from throttling by default. 

This fixes #2685