### PR TITLE
Adding repair for index files

### DIFF
--- a/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalRepairDatabase.cs
@@ -43,7 +43,15 @@ namespace Duplicati.Library.Main.Database
         public LocalRepairDatabase(string path, long pagecachesize)
             : base(path, "Repair", true, pagecachesize)
         {
+        }
 
+        /// <summary>
+        /// Creates a new local repair database from an existing local database
+        /// </summary>
+        /// <param name="db">The existing local database</param>
+        public LocalRepairDatabase(LocalDatabase db)
+            : base(db)
+        {
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -231,19 +231,29 @@ namespace Duplicati.Library.Main
         public enum RemoteTestStrategy
         {
             /// <summary>
-            /// test the remote volumes
+            /// Test the remote volumes
             /// </summary>
-            True,
+            True = 0,
 
             /// <summary>
-            /// do not test the remote volumes
+            /// Do not test the remote volumes
             /// </summary>
-            False,
+            False = 1,
 
             /// <summary>
-            /// test only the list and index volumes
+            /// Test only the list and index volumes
             /// </summary>
-            ListAndIndexes
+            ListAndIndexes = 2,
+
+            /// <summary>
+            /// Test only the index files
+            /// </summary>
+            IndexesOnly = 3,
+
+            /// <summary>
+            /// Alias for IndexesOnly
+            /// </summary>
+            IndexOnly = 3
         }
 
         /// <summary>
@@ -458,6 +468,7 @@ namespace Duplicati.Library.Main
             new CommandLineArgument("backup-test-samples", CommandLineArgument.ArgumentType.Integer, Strings.Options.BackendtestsamplesShort, Strings.Options.BackendtestsamplesLong("no-backend-verification"), DEFAULT_BACKUP_TEST_SAMPLES.ToString()),
             new CommandLineArgument("backup-test-percentage", CommandLineArgument.ArgumentType.Decimal, Strings.Options.BackendtestpercentageShort, Strings.Options.BackendtestpercentageLong, "0.1"),
             new CommandLineArgument("full-remote-verification", CommandLineArgument.ArgumentType.Enumeration, Strings.Options.FullremoteverificationShort, Strings.Options.FullremoteverificationLong("no-backend-verification"), Enum.GetName(typeof(RemoteTestStrategy), RemoteTestStrategy.False), null, Enum.GetNames(typeof(RemoteTestStrategy))),
+            new CommandLineArgument("replace-faulty-index-files", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ReplaceFaultyIndexFilesShort, Strings.Options.ReplaceFaultyIndexFilesLong, "true"),
 
             new CommandLineArgument("dry-run", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DryrunShort, Strings.Options.DryrunLong, "false", new string[] { "dryrun" }),
 
@@ -1334,6 +1345,11 @@ namespace Duplicati.Library.Main
         /// Gets a value indicating if the remote verification is deep
         /// </summary>
         public RemoteTestStrategy FullRemoteVerification => GetEnum("full-remote-verification", RemoteTestStrategy.True);
+
+        /// <summary>
+        /// Gets a value indicating if defective index files should be replaced
+        /// </summary>
+        public bool ReplaceFaultyIndexFiles => GetBool("replace-faulty-index-files");
 
         /// <summary>
         /// The block hash algorithm to use

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -232,6 +232,8 @@ namespace Duplicati.Library.Main.Strings
         public static string BackendtestpercentageShort { get { return LC.L(@"The percentage of samples to test after a backup"); } }
         public static string FullremoteverificationLong(string optionname) { return LC.L(@"After a backup is completed, some (dblock, dindex, dlist) files from the remote backend are selected for verification. Use this option to turn on full verification, which will decrypt the files and examine the insides of each volume, instead of simply verifying the external hash. If the option --{0} is set, no remote files are verified. This option is automatically set when then verification is performed directly. ListAndIndexes is like True but only dlist and index volumes are handled.", optionname); }
         public static string FullremoteverificationShort { get { return LC.L(@"Activate in-depth verification of files"); } }
+        public static string ReplaceFaultyIndexFilesLong { get { return LC.L(@"Use this option to replace index files that are missing content during the testing phase. This takes slightly longer, but will prevent very slow database recreates"); } }
+        public static string ReplaceFaultyIndexFilesShort { get { return LC.L(@"Replace defective index files"); } }
         public static string FilereadbuffersizeLong { get { return LC.L(@"Use this size to control how many bytes are read from a file before processing."); } }
         public static string FilereadbuffersizeShort { get { return LC.L(@"Size of the file read buffer"); } }
         public static string FilereadbuffersizeDeprecated { get { return LC.L(@"The option --{0} is no longer used and has been deprecated.", "file-read-buffer-size"); } }

--- a/Duplicati/UnitTest/Issue6296.cs
+++ b/Duplicati/UnitTest/Issue6296.cs
@@ -1,0 +1,166 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System.IO;
+using NUnit.Framework;
+using System.Linq;
+using System;
+using NUnit.Framework.Internal;
+using System.IO.Compression;
+using Duplicati.Library.DynamicLoader;
+using Duplicati.Library.Main;
+using System.Collections.Generic;
+
+namespace Duplicati.UnitTest
+{
+    public class Issue6296 : BasicSetupHelper
+    {
+        [Test]
+        [Category("Targeted")]
+        public void TestRepairIndexFilesWorks([Values(1, 2, 3)] int fileDistribution)
+        {
+            var testopts = TestOptions.Expand(new
+            {
+                no_encryption = true,
+                number_of_retries = 0,
+                zip_compression_level = 0,
+                blocksize = "10kb",
+                dblock_size = "4mb"
+            });
+
+            var rnd = Random.Shared; // new Random(42);
+
+            // Create some files
+            if (fileDistribution == 1)
+            {
+                var data1 = new byte[1024 * 1024 * 10];
+                rnd.NextBytes(data1);
+
+                for (var i = 0; i < 10; i++)
+                    File.WriteAllBytes(Path.Combine(DATAFOLDER, $"a{i}"), data1.AsSpan().Slice(i, 1024 * 1024 * 2).ToArray());
+            }
+            else if (fileDistribution == 2)
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    var data1 = new byte[rnd.Next(0, 1024 * 1024 * 11)];
+                    rnd.NextBytes(data1);
+                    File.WriteAllBytes(Path.Combine(DATAFOLDER, $"a{i}"), data1);
+                }
+            }
+            else if (fileDistribution == 3)
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    var data1 = new byte[rnd.Next(0, 1024 * 1024 * 11)];
+                    File.WriteAllBytes(Path.Combine(DATAFOLDER, $"a{i}"), data1);
+                }
+            }
+
+            // Make a backup
+            using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Backup(new string[] { DATAFOLDER }));
+
+            // Make sure the tests succeed
+            var verifyopts = testopts.Expand(new
+            {
+                full_remote_verification = nameof(Options.RemoteTestStrategy.IndexOnly),
+                replace_faulty_index_files = false,
+            });
+            using (var c = new Controller("file://" + TARGETFOLDER, verifyopts, null))
+                TestUtils.AssertResults(c.Test(short.MaxValue));
+
+            // Manipulate the index files to remove the blocklist hashes
+            var brokenIndexFiles = new HashSet<string>();
+            foreach (var indexFile in Directory.GetFiles(TARGETFOLDER, "*.dindex.zip", SearchOption.AllDirectories))
+            {
+                List<string> entriesToRemove;
+                using (var zip = ZipFile.Open(indexFile, ZipArchiveMode.Read))
+                    entriesToRemove = zip.Entries
+                        .Where(e => e.FullName.StartsWith("list/", StringComparison.OrdinalIgnoreCase))
+                        .Select(e => e.FullName)
+                        .ToList();
+
+                using (var zip = ZipFile.Open(indexFile, ZipArchiveMode.Update))
+                {
+                    foreach (var entryName in entriesToRemove)
+                    {
+                        var entry = zip.GetEntry(entryName);
+                        if (entry != null)
+                        {
+                            entry.Delete();
+                            brokenIndexFiles.Add(indexFile);
+                        }
+                    }
+                }
+            }
+
+            // Setup for repair with broken index files
+            BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var anyblockfiles = false;
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action.IsGetOperation && remotename.Contains(".dblock."))
+                    anyblockfiles = true;
+                return false;
+            };
+
+            File.Delete(DBFILE);
+            using (var c = new Controller(new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Repair());
+
+            // Check that the backup is valid, but missing data in the index files
+            Assert.That(anyblockfiles, Is.True, "No dblock files were loaded during repair");
+
+            // Run the test+repair index operation
+            var repairopts = testopts.Expand(new
+            {
+                full_remote_verification = nameof(Options.RemoteTestStrategy.IndexOnly),
+                replace_faulty_index_files = true,
+            });
+
+            using (var c = new Controller("file://" + TARGETFOLDER, repairopts, null))
+            {
+                var res = c.Test(short.MaxValue);
+                Assert.That(res.Warnings, Is.Not.Empty, "Expected warnings during test with broken index files");
+            }
+
+            var indexFilesAfter = Directory.GetFiles(TARGETFOLDER, "*.dindex.zip", SearchOption.TopDirectoryOnly).ToHashSet();
+            Assert.That(brokenIndexFiles.Any(x => !indexFilesAfter.Contains(x)), Is.True, "Some index files were not repaired");
+            Assert.That(indexFilesAfter.Any(x => !brokenIndexFiles.Contains(x)), Is.True, "Some index files were replaced?");
+
+            // Prepare for repair that does not need to download dblock files
+            File.Delete(DBFILE);
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action.IsGetOperation && remotename.Contains(".dblock."))
+                    return true;
+                return false;
+            };
+
+
+            // Check that the recreate operation works without downloading dblock files
+            using (var c = new Controller(new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(c.Repair());
+        }
+    }
+}
+


### PR DESCRIPTION
Since index files only contains information related to recreating the database, they can be recreated directly from a working database.

This PR adds an automatic repair feature that replaces index files if they are missing content. This will gradually repair remote index files if they are affected by the compact bug that re-wrote index files without the blocklists.

To fully repair, it is possible to run the `Test` command with the option `--full-remote-verification=indexonly` and a large number of samples. Since the new option `--replace-faulty-index-files` is default set to `true` this will repair any defective index files and ignore all others.

This update uncovered that the Test method would previously not verify the presence of blocklists in the index files. This is likely a very old bug, caused by the fact that the original implementation did not place blocklisthashes in the index files. The omission of this check is the reason the extent of the compact issue was not discovered earlier.

With this PR it is now also visible that there is ample room for error in creating the index files during the backup process. This is caused by the parallel processing and carry-over, where the index files are created on-the-go, so they are ready to upload once the blocks are filled.

While this is likely good for performance, it has some drawbacks.
- A failed block upload will cause a rewrite of the index file
- An elaborate callback system is needed to update the index file
- It is possible to race against the database and create extra blocklist hashes, bloating the index files (causes problems on verification)

A subsequent task is to rewrite the logic to not touch the index files outside the backend manager, so the backend manager will just use the database to create the index file. This means the same code will be invoked for both the create, the recreate, and the replacement.

For now, extra content in index files is logged with the verbose log level.

This fixes #6296