### PR TITLE
Add ssh-agent support for SSH backend

### DIFF
--- a/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
+++ b/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SSH.NET" Version="2024.2.0" />
+    <PackageReference Include="SSH.NET" Version="2025.0.0" />
     <PackageReference Include="SshNet.Agent" Version="2024.2.0" />
   </ItemGroup>
 

--- a/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
+++ b/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2024.2.0" />
+    <PackageReference Include="SSH.NET.Agent" Version="2024.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
+++ b/Duplicati/Library/Backend/SSHv2/Duplicati.Library.Backend.SSHv2.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2024.2.0" />
-    <PackageReference Include="SSH.NET.Agent" Version="2024.2.0" />
+    <PackageReference Include="SshNet.Agent" Version="2024.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/Backend/SSHv2/Strings.cs
+++ b/Duplicati/Library/Backend/SSHv2/Strings.cs
@@ -60,7 +60,11 @@ namespace Duplicati.Library.Backend.Strings
         public static string DescriptionSshkeepaliveLong => LC.L(@"Use this option to enable the keep-alive interval for the SSH connection. If the connection is idle, aggressive firewalls might close the connection. Using keep-alive will keep the connection open in this scenario. If this value is set to zero, the keep-alive is disabled.");
         public static string DescriptionSshkeepaliveShort => LC.L(@"Set a keepalive value");
         public static string DescriptionDisableAgentShort => LC.L(@"Disable ssh-agent authentication");
-        public static string DescriptionDisableAgentLong => LC.L(@"Prevent using ssh-agent for authentication. When not set and no password or keyfile is supplied, the agent will be used.");
+        private static string MacOSAgentNotes => OperatingSystem.IsMacOS()
+            ? LC.L(@"On macOS, the ssh-agent is used, and an attempt is made to use the keychain to load private key passphrases. If the private key itself is stored in the keychain, it will not be available.")
+            : string.Empty;
+
+        public static string DescriptionDisableAgentLong => LC.L(@$"Prevent using ssh-agent for authentication. When not set and no password or keyfile is supplied, the agent will be used. {MacOSAgentNotes}");
         public static string DescriptionRelativePathShort => LC.L(@"Treat source path as relative to the initial path");
         public static string DescriptionRelativePathLong => LC.L(@"Use this option to treat the source path as relative to the initial path. This is useful when the full path of the system is not known.");
         public static string FolderNotFoundManagedError(string foldername, string message) { return LC.L(@"Unable to set folder to {0}, error message: {1}", foldername, message); }

--- a/Duplicati/Library/Backend/SSHv2/Strings.cs
+++ b/Duplicati/Library/Backend/SSHv2/Strings.cs
@@ -59,6 +59,8 @@ namespace Duplicati.Library.Backend.Strings
         public static string DescriptionSshtimeoutShort => LC.L(@"Set the operation timeout value");
         public static string DescriptionSshkeepaliveLong => LC.L(@"Use this option to enable the keep-alive interval for the SSH connection. If the connection is idle, aggressive firewalls might close the connection. Using keep-alive will keep the connection open in this scenario. If this value is set to zero, the keep-alive is disabled.");
         public static string DescriptionSshkeepaliveShort => LC.L(@"Set a keepalive value");
+        public static string DescriptionDisableAgentShort => LC.L(@"Disable ssh-agent authentication");
+        public static string DescriptionDisableAgentLong => LC.L(@"Prevent using ssh-agent for authentication. When not set and no password or keyfile is supplied, the agent will be used.");
         public static string DescriptionRelativePathShort => LC.L(@"Treat source path as relative to the initial path");
         public static string DescriptionRelativePathLong => LC.L(@"Use this option to treat the source path as relative to the initial path. This is useful when the full path of the system is not known.");
         public static string FolderNotFoundManagedError(string foldername, string message) { return LC.L(@"Unable to set folder to {0}, error message: {1}", foldername, message); }


### PR DESCRIPTION
This adds the `SshNet.Agent` library to support Pageant on Windows and `ssh-agent` on Windows/Linux/MacOS.

For MacOS, this has some integration to the Keychain where on-disk private keys are added if their password is available through Keychain. If the private key itself is stored in Keychain (or on a hardware token), it will not be added as there is no API to extract such keys.

This fixes #1557
