### PR TITLE
Fix block initialization bug in IssueTests

### DIFF
--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -836,15 +836,9 @@ namespace Duplicati.UnitTest
             string target = "file://" + TARGETFOLDER;
 
             byte[] block1 = new byte[10 * 1024];
-            for (int i = 0; i < block1.Length; ++i)
-            {
-                block1[i] = 1;
-            }
+            block1.AsSpan().Fill(1);
             byte[] block2 = new byte[10 * 1024];
-            for (int i = 0; i < block1.Length; ++i)
-            {
-                block1[i] = 2;
-            }
+            block2.AsSpan().Fill(2);
 
             HashAlgorithm blockhasher = Library.Utility.HashFactory.CreateHasher(new Options(testopts).BlockHashAlgorithm);
 


### PR DESCRIPTION
## Summary
- fix block2 initialization
- use Span.Fill instead of loops

## Testing
- `dotnet test Duplicati/UnitTest/Duplicati.UnitTest.csproj --no-build --verbosity minimal` *(fails: The argument Duplicati.UnitTest.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_b_684137641d688329b32f21f410b23ac7