### PR TITLE
Sets infinite timeout for HTTP clients

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -231,7 +231,10 @@ namespace Duplicati.Library.AutoUpdater
                         using var timeoutToken = new CancellationTokenSource();
                         timeoutToken.CancelAfter(TimeSpan.FromSeconds(SHORT_OPERATION_TIMEOUT_SECONDS));
                         using (var client = HttpClientHelper.CreateClient())
+                        {
+                            client.Timeout = Timeout.InfiniteTimeSpan;
                             client.DownloadFile(request, tmpfile, null, timeoutToken.Token).Await();
+                        }
 
                         using (var fs = File.OpenRead(tmpfile))
                         {
@@ -372,7 +375,10 @@ namespace Duplicati.Library.AutoUpdater
                             timeoutToken.CancelAfter(TimeSpan.FromSeconds(DOWNLOAD_OPERATION_TIMEOUT_SECONDS));
 
                             using (var client = HttpClientHelper.CreateClient())
+                            {
+                                client.Timeout = Timeout.InfiniteTimeSpan;
                                 client.DownloadFile(request, tempfile, cb, timeoutToken.Token).Await();
+                            }
 
                             var sha256 = System.Security.Cryptography.SHA256.Create();
                             var md5 = System.Security.Cryptography.MD5.Create();

--- a/Duplicati/Library/Backend/Filejump/Filejump.cs
+++ b/Duplicati/Library/Backend/Filejump/Filejump.cs
@@ -148,7 +148,8 @@ namespace Duplicati.Library.Backend
             m_pageSize = Utility.Utility.ParseIntOption(options, PAGE_SIZE_OPTION, DEFAULT_PAGE_SIZE);
             m_softDelete = Utility.Utility.ParseBoolOption(options, SOFT_DELETE_OPTION);
 
-            m_client = new HttpClient();
+            m_client = HttpClientHelper.CreateClient();
+            m_client.Timeout = Timeout.InfiniteTimeSpan;
             m_client.BaseAddress = new System.Uri(DEFAULT_API_URL);
         }
 

--- a/Duplicati/Library/Backend/Filen/FilenBackend.cs
+++ b/Duplicati/Library/Backend/Filen/FilenBackend.cs
@@ -107,7 +107,11 @@ public class FilenBackend : IStreamingBackend
         {
             _client?.Dispose();
             _client = null;
-            _client = await FilenClient.CreateClientAsync(HttpClientHelper.CreateClient(), _auth.Username!, _auth.Password!, _twoFactorCode, cancellationToken).ConfigureAwait(false);
+            _client = await FilenClient.CreateClientAsync(((Func<HttpClient>)(() => {
+                var httpClient = HttpClientHelper.CreateClient();
+                httpClient.Timeout = Timeout.InfiniteTimeSpan;
+                return httpClient;
+            }))(), _auth.Username!, _auth.Password!, _twoFactorCode, cancellationToken).ConfigureAwait(false);
         }
 
         return _client;

--- a/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
@@ -52,8 +52,13 @@ namespace Duplicati.Library.Backend
         /// <summary>
         /// Lazy cached HttpClient
         /// </summary>
-        private readonly Lazy<HttpClient> _httpClient = new(HttpClientHelper.CreateClient);
-
+        private readonly Lazy<HttpClient> _httpClient = new(() =>
+        {
+            var client = HttpClientHelper.CreateClient();
+            client.Timeout = Timeout.InfiniteTimeSpan;
+            return client;
+        });
+        
         /// <summary>
         /// The timeout options
         /// </summary>

--- a/Duplicati/Library/Backend/Jottacloud/JottacloudAuthHelper.cs
+++ b/Duplicati/Library/Backend/Jottacloud/JottacloudAuthHelper.cs
@@ -40,6 +40,7 @@ public class JottacloudAuthHelper : OAuthHelperHttpClient, IDisposable
     public static async Task<JottacloudAuthHelper> CreateAsync(string accessToken, CancellationToken cancellationToken = default)
     {
         var httpClient = HttpClientHelper.CreateClient();
+        httpClient.Timeout = Timeout.InfiniteTimeSpan;
         try
         {
             var inst = new JottacloudAuthHelper(httpClient, accessToken);

--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHelperHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHelperHttpClient.cs
@@ -95,8 +95,15 @@ public class OAuthHelperHttpClient : JsonWebHelperHttpClient
     /// </summary>
     public bool AutoV2 { get; set; } = true;
 
+    private static HttpClient CreateHttpClientWithInfiniteTimeout()
+    {
+        var client = HttpClientHelper.CreateClient();
+        client.Timeout = Timeout.InfiniteTimeSpan;
+        return client;
+    }
+    
     public OAuthHelperHttpClient(string authid, string servicename, HttpClient httpClient = null, string useragent = null)
-        : base(httpClient ?? HttpClientHelper.CreateClient())
+        : base(httpClient ?? CreateHttpClientWithInfiniteTimeout())
     {
         _Authid = authid;
         OAuthLoginUrl = OAUTH_LOGIN_URL(servicename);

--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -161,6 +161,7 @@ public class OpenStackStorage : IStreamingBackend
         }
 
         m_httpClient = HttpClientHelper.CreateClient();
+        m_httpClient.Timeout = Timeout.InfiniteTimeSpan;
         m_helper = new OpenStackWebHelper(this, m_httpClient);
     }
 

--- a/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
@@ -393,7 +393,7 @@ namespace Duplicati.Library.Modules.Builtin
             using HttpClientHandler httpHandler = new HttpClientHandler();
             HttpClientHelper.ConfigureHandlerCertificateValidator(httpHandler, m_acceptAnyCertificate, m_acceptSpecificCertificates);
 
-            using var client = new HttpClient(httpHandler);
+            using var client = HttpClientHelper.CreateClient(httpHandler);
 
             Exception ex = null;
 

--- a/Duplicati/Library/Modules/Builtin/SendTelegramMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendTelegramMessage.cs
@@ -278,6 +278,7 @@ public class SendTelegramMessage : ReportHelper
             timeoutToken.CancelAfter(REQUEST_TIMEOUT);
 
             using var client = HttpClientHelper.CreateClient();
+            client.Timeout = Timeout.InfiniteTimeSpan;
             var response = await client.GetAsync(url, timeoutToken.Token).ConfigureAwait(false);
             var responseContent = await response.Content.ReadAsStringAsync(timeoutToken.Token).ConfigureAwait(false);
 

--- a/Duplicati/Library/RemoteControl/RegisterForRemote.cs
+++ b/Duplicati/Library/RemoteControl/RegisterForRemote.cs
@@ -165,7 +165,8 @@ public class RegisterForRemote : IDisposable
         _state = States.NotStarted;
         _registrationUrl = registrationUrl;
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _httpClient = httpClient ?? new HttpClient();
+        _httpClient = httpClient ?? HttpClientHelper.CreateClient();
+        // Timeout for _httpClient will be kept at default 100s (Which is already a long one for registration)
     }
 
     /// <summary>

--- a/Duplicati/Library/SecretProvider/HCVaultSecretProvider.cs
+++ b/Duplicati/Library/SecretProvider/HCVaultSecretProvider.cs
@@ -215,7 +215,8 @@ public class HCVaultSecretProvider : ISecretProvider
         if (_client is null || _secrets is null)
             throw new InvalidOperationException("The secret provider has not been initialized");
 
-        using var client = new HttpClient();
+        using var client = HttpClientHelper.CreateClient();
+        // We will not set the timeout here, keeping the 100s default one
         var result = new Dictionary<string, string>();
         var missing = new HashSet<string>(keys);
 

--- a/Duplicati/Library/UsageReporter/ReportSetUploader.cs
+++ b/Duplicati/Library/UsageReporter/ReportSetUploader.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Net.Http;
 using Duplicati.Library.Utility;
 using System.Threading;
+using Timeout = System.Threading.Timeout;
 
 namespace Duplicati.Library.UsageReporter
 {
@@ -89,6 +90,7 @@ namespace Duplicati.Library.UsageReporter
                                         timeoutToken.CancelAfter(TimeSpan.FromSeconds(UPLOAD_OPERATION_TIMEOUT_SECONDS));
 
                                         using var client = HttpClientHelper.CreateClient();
+                                        client.Timeout = Timeout.InfiniteTimeSpan;
                                         using var response = await client.UploadStream(request, timeoutToken.Token);
                                         rc = (int)response.StatusCode;
                                     }

--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -85,7 +85,7 @@ namespace Duplicati.UnitTest
             {
                 try
                 {
-                    using var httpClient = new HttpClient();
+                    using var httpClient = new HttpClient(); // Because it's a test unit, will use a new instance created via default constructor.
                     using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
                     if (systemIO.FileExists(destinationFilePath))

--- a/Duplicati/WebserverCore/Middlewares/StaticFilesMiddleware.Debug.cs
+++ b/Duplicati/WebserverCore/Middlewares/StaticFilesMiddleware.Debug.cs
@@ -59,8 +59,9 @@ internal static class NpmSpaHelper
 
             var tgzFile = Path.Combine(tempPath, "package.tgz");
             var tarFile = Path.ChangeExtension(tgzFile, ".tar");
-            using (var client = new HttpClient())
+            using (var client = HttpClientHelper.CreateClient())
             {
+                // Explicitly leaving the 100s default timeout
                 var response = client.GetAsync(packageUrl).Await();
                 response.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
Ensures that long-running HTTP requests, such as downloads and uploads, do not timeout prematurely.

This change configures specific HttpClient instances with an infinite timeout to accommodate operations that may take an extended period. The default 100s timeout is retained for some operations like registration, where a long delay may indicate a problem.

Response to issue #6340