### PR TITLE
Handle loading and unloading of modules

### DIFF
--- a/Duplicati/Library/DynamicLoader/GenericLoader.cs
+++ b/Duplicati/Library/DynamicLoader/GenericLoader.cs
@@ -19,8 +19,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Modules.Builtin;
 
@@ -55,6 +58,21 @@ namespace Duplicati.Library.DynamicLoader
             /// </summary>
             protected override IEnumerable<IGenericModule> BuiltInModules
                 => GenericModules.BuiltInGenericModules;
+
+            /// <summary>
+            /// Creates a new instance of the module based on the key
+            /// </summary>
+            /// <param name="key">The key to create the instance for</param>
+            /// <returns>The instanciated module or null if the key is not supported</returns>
+            public IGenericModule? GetModule(string key)
+            {
+                LoadInterfaces();
+                var entry = Interfaces.FirstOrDefault(m => m.Key.Equals(key, StringComparison.OrdinalIgnoreCase));
+                if (entry == null)
+                    return null;
+
+                return (IGenericModule?)Activator.CreateInstance(entry.GetType());
+            }
         }
 
         #region Public static API
@@ -72,6 +90,13 @@ namespace Duplicati.Library.DynamicLoader
         /// Gets a list of keys supported
         /// </summary>
         public static string[] Keys => _loader.Value.Keys;
+
+        /// <summary>
+        /// Instanciates a specific module
+        /// </summary>
+        /// <param name="key">The key to create the instance for</param>
+        /// <returns>The instanciated backend or null if the key is not supported</returns>
+        public static IGenericModule? GetModule(string key) => _loader.Value.GetModule(key);
 
         #endregion
 

--- a/Duplicati/Library/Interface/IGenericPriorityModule.cs
+++ b/Duplicati/Library/Interface/IGenericPriorityModule.cs
@@ -1,0 +1,36 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+namespace Duplicati.Library.Interface
+{
+    /// <summary>
+    /// Interface for implementing a generic module with a priority
+    /// </summary>
+    public interface IGenericPriorityModule : IGenericModule
+    {
+        /// <summary>
+        /// The priority of the module, higher values are executed first.
+        /// Negative values places the module at the end of the queue.
+        /// A value of 0 means the module is executed in the default order.
+        /// </summary>
+        int Priority { get; }
+    }
+}

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -626,19 +626,19 @@ namespace Duplicati.Library.Main
 
         private void OperationComplete(IBasicResults result, Exception exception)
         {
-            if (m_options != null && m_options.LoadedModules != null)
+            if (m_options?.LoadedModules != null)
             {
-                foreach (KeyValuePair<bool, IGenericModule> mx in m_options.LoadedModules)
-                    if (mx.Key && mx.Value is IGenericCallbackModule module)
+                foreach (var mx in m_options.LoadedModules)
+                    if (mx is IGenericCallbackModule module)
                         try { module.OnFinish(result, exception); }
                         catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, $"OnFinishError{mx.Key}", ex, "OnFinish callback {0} failed: {1}", mx.Key, ex.Message); }
 
-                foreach (KeyValuePair<bool, IGenericModule> mx in m_options.LoadedModules)
-                    if (mx.Key && mx.Value is IDisposable disposable)
+                foreach (var mx in m_options.LoadedModules)
+                    if (mx is IDisposable disposable)
                         try { disposable.Dispose(); }
                         catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, $"DisposeError{mx.Key}", ex, "Dispose for {0} failed: {1}", mx.Key, ex.Message); }
 
-                m_options.LoadedModules.Clear();
+                m_options.ClearLoadedModules();
             }
 
             if (m_localeChange != null)
@@ -666,11 +666,17 @@ namespace Duplicati.Library.Main
                     break;
             }
 
-            //Load all generic modules
-            m_options.LoadedModules.Clear();
+            //Load generic modules
+            m_options.ClearLoadedModules();
 
-            foreach (IGenericModule m in DynamicLoader.GenericLoader.Modules)
-                m_options.LoadedModules.Add(new KeyValuePair<bool, IGenericModule>(!m_options.DisableModules.Contains(m.Key, StringComparer.OrdinalIgnoreCase) && (m.LoadAsDefault || m_options.EnableModules.Contains(m.Key, StringComparer.OrdinalIgnoreCase)), m));
+            foreach (var m in DynamicLoader.GenericLoader.Modules)
+            {
+                var active = !m_options.DisableModules.Contains(m.Key, StringComparer.OrdinalIgnoreCase) && (m.LoadAsDefault || m_options.EnableModules.Contains(m.Key, StringComparer.OrdinalIgnoreCase));
+                if (!active)
+                    continue;
+
+                m_options.AddLoadedModule(DynamicLoader.GenericLoader.GetModule(m.Key));
+            }
 
             // Make the filter read-n-write able in the generic modules
             var pristinefilter = string.Join(Path.PathSeparator.ToString(), FilterExpression.Serialize(filter));
@@ -682,40 +688,27 @@ namespace Duplicati.Library.Main
             foreach (var k in qp.Keys)
                 conopts[(string)k] = qp[(string)k];
 
-            //// Since Configure in RunScript can alter the RawOptions, make sure it is first in the list for Configure
-            var LoadedModules = new List<KeyValuePair<bool, Interface.IGenericModule>>();
             foreach (var mx in m_options.LoadedModules)
-                if (mx.Value.ToString().IndexOf("runscript", StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    LoadedModules.Insert(0, mx);
-                }
+            {
+                if (mx is IConnectionModule)
+                    mx.Configure(conopts);
                 else
-                {
-                    LoadedModules.Add(mx);
-                }
+                    mx.Configure(m_options.RawOptions);
 
-            foreach (var mx in LoadedModules)
-                if (mx.Key)
+                if (mx is IGenericSourceModule sourcemodule)
                 {
-                    if (mx.Value is IConnectionModule)
-                        mx.Value.Configure(conopts);
-                    else
-                        mx.Value.Configure(m_options.RawOptions);
-
-                    if (mx.Value is IGenericSourceModule sourcemodule)
+                    if (sourcemodule.ContainFilesForBackup(paths))
                     {
-                        if (sourcemodule.ContainFilesForBackup(paths))
-                        {
-                            var sourceoptions = sourcemodule.ParseSourcePaths(ref paths, ref pristinefilter, m_options.RawOptions);
+                        var sourceoptions = sourcemodule.ParseSourcePaths(ref paths, ref pristinefilter, m_options.RawOptions);
 
-                            foreach (var sourceoption in sourceoptions)
-                                m_options.RawOptions[sourceoption.Key] = sourceoption.Value;
-                        }
+                        foreach (var sourceoption in sourceoptions)
+                            m_options.RawOptions[sourceoption.Key] = sourceoption.Value;
                     }
-
-                    if (mx.Value is IGenericCallbackModule module)
-                        module.OnStart(result.MainOperation.ToString(), ref m_backendUrl, ref paths);
                 }
+
+                if (mx is IGenericCallbackModule module)
+                    module.OnStart(result.MainOperation.ToString(), ref m_backendUrl, ref paths);
+            }
 
             // If the filters were changed by a module, read them back in
             if (pristinefilter != m_options.RawOptions["filter"])
@@ -829,26 +822,31 @@ namespace Duplicati.Library.Main
             var supportedOptions = new Dictionary<string, ICommandLineArgument>();
 
             //There are a few internal options that are not accessible from outside, and thus not listed
-            foreach (string s in Options.InternalOptions)
+            foreach (var s in Options.InternalOptions)
                 supportedOptions[s] = null;
 
             //Figure out what module options are supported in the current setup
             var moduleOptions = new List<ICommandLineArgument>();
             var disabledModuleOptions = new Dictionary<string, string>();
+            var loadedModuleKeys = m_options.LoadedModules.Select(k => k.Key).ToHashSet();
 
-            foreach (var m in m_options.LoadedModules)
-                if (m.Value.SupportedCommands != null)
-                    if (m.Key)
-                        moduleOptions.AddRange(m.Value.SupportedCommands);
-                    else
-                        foreach (ICommandLineArgument c in m.Value.SupportedCommands)
-                        {
-                            disabledModuleOptions[c.Name] = m.Value.DisplayName + " (" + m.Value.Key + ")";
+            foreach (var m in DynamicLoader.GenericLoader.Modules)
+            {
+                if (m.SupportedCommands == null)
+                    continue;
 
-                            if (c.Aliases != null)
-                                foreach (string s in c.Aliases)
-                                    disabledModuleOptions[s] = disabledModuleOptions[c.Name];
-                        }
+                if (loadedModuleKeys.Contains(m.Key))
+                    moduleOptions.AddRange(m.SupportedCommands);
+                else
+                    foreach (var c in m.SupportedCommands)
+                    {
+                        disabledModuleOptions[c.Name] = m.DisplayName + " (" + m.Key + ")";
+
+                        if (c.Aliases != null)
+                            foreach (string s in c.Aliases)
+                                disabledModuleOptions[s] = disabledModuleOptions[c.Name];
+                    }
+            }
 
             // Throw url-encoded options into the mix
             //TODO: This can hide values if both commandline and url-parameters supply the same key

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1531,22 +1531,7 @@ namespace Duplicati.Library.Main
         /// Gets a list of loaded modules, in their activation order
         /// </summary>
         public IEnumerable<IGenericModule> LoadedModules => m_loadedModules
-            .Select(module => (Priority: module is IGenericPriorityModule pm ? pm.Priority : 0, Module: module))
-            .Select(x => (x.Priority, x.Module, Group: x.Priority switch
-            {
-                > 0 => 1,
-                < 0 => -1,
-                _ => 0
-            }))
-            .GroupBy(x => x.Group)
-            .OrderByDescending(g => g.Key)
-            .SelectMany(g =>
-            {
-                // Keep the order of modules with priority 0 as is, but sort the others
-                if (g.Key == 0)
-                    return g.AsEnumerable();
-                return g.OrderByDescending(x => x.Priority);
-            }).Select(x => x.Module);
+            .OrderByDescending(x => (x as IGenericPriorityModule)?.Priority ?? 0);
 
         /// <summary>
         /// Adds a loaded module to the list of loaded modules.

--- a/Duplicati/Library/Modules/Builtin/RunScript.cs
+++ b/Duplicati/Library/Modules/Builtin/RunScript.cs
@@ -32,7 +32,7 @@ using Duplicati.Library.Logging;
 
 namespace Duplicati.Library.Modules.Builtin
 {
-    public class RunScript : IGenericCallbackModule
+    public class RunScript : IGenericCallbackModule, IGenericPriorityModule
     {
         /// <summary>
         /// The tag used for logging
@@ -91,6 +91,10 @@ namespace Duplicati.Library.Modules.Builtin
         /// </summary>
         private FileBackedStringList m_logstorage;
 
+        /// <summary>
+        /// The priority of the module, used to determine the order in which modules are executed.
+        /// </summary>
+        public int Priority => 100;
 
         #region IGenericModule implementation
         public void Configure(IDictionary<string, string> commandlineOptions)

--- a/Duplicati/WebserverCore/Endpoints/V1/RemoteOperation.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/RemoteOperation.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
+using Duplicati.Library.Utility;
 using Duplicati.Server;
 using Duplicati.Server.Database;
 using Duplicati.WebserverCore.Abstractions;
@@ -67,11 +68,11 @@ namespace Duplicati.WebserverCore.Endpoints.V1
 
         private static IEnumerable<IGenericModule> ConfigureModules(IDictionary<string, string?> opts)
         {
-            // TODO: This works because the generic modules are implemented
-            // with pre .NetCore logic, using static methods
-            // The modules are created to allow multipe dispose,
-            // which violates the .Net patterns
-            var modules = Library.DynamicLoader.GenericLoader.Modules.OfType<IConnectionModule>().ToArray();
+            var modules = Library.DynamicLoader.GenericLoader.Modules.OfType<IConnectionModule>()
+                .Select(x => Library.DynamicLoader.GenericLoader.GetModule(x.Key))
+                .WhereNotNull()
+                .ToArray();
+
             foreach (var n in modules)
                 n.Configure(opts);
 

--- a/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
@@ -22,6 +22,7 @@
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using Duplicati.Library.Main.Volumes;
+using Duplicati.Library.Utility;
 using Duplicati.Server;
 using Duplicati.Server.Database;
 using Duplicati.WebserverCore.Abstractions;
@@ -64,11 +65,11 @@ public class DestinationVerify : IEndpointV2
 
     private static IEnumerable<IGenericModule> ConfigureModules(IDictionary<string, string?> opts)
     {
-        // TODO: This works because the generic modules are implemented
-        // with pre .NetCore logic, using static methods
-        // The modules are created to allow multipe dispose,
-        // which violates the .Net patterns
-        var modules = Library.DynamicLoader.GenericLoader.Modules.OfType<IConnectionModule>().ToArray();
+        var modules = Library.DynamicLoader.GenericLoader.Modules.OfType<IConnectionModule>()
+            .Select(x => Library.DynamicLoader.GenericLoader.GetModule(x.Key))
+            .WhereNotNull()
+            .ToArray();
+
         foreach (var n in modules)
             n.Configure(opts);
 


### PR DESCRIPTION
This PR fixes the issues with not correctly loading and disposing modules.

Prior to this PR, there would be only a single instance of each module loaded, which would be configured and later disposed, meaning that the same instance would be used after being disposed, and disposed multiple times.

This mostly worked, but it could carry configuration details over between unrelated runs.

This fixes #6314