### PR TITLE
Add null checks to send-mail

### DIFF
--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -226,6 +226,7 @@ namespace Duplicati.Library.Modules.Builtin
         /// <param name="commandlineOptions">A set of commandline options passed to Duplicati</param>
         public void Configure(IDictionary<string, string> commandlineOptions)
         {
+            m_isConfigured = false;
             if (!ConfigureModule(commandlineOptions))
                 return;
 

--- a/Duplicati/Library/Modules/Builtin/Strings.cs
+++ b/Duplicati/Library/Modules/Builtin/Strings.cs
@@ -122,6 +122,8 @@ To enable SMTP over SSL, use the format smtps://example.com. To enable SMTP STAR
         public static string SendMailSuccess(string server) { return LC.L(@"Email sent successfully using server: {0}", server); }
         public static string SendmailextraparametersLong { get { return LC.L(@"Use this option to set extra parameters for the message body. This parameter can either be a querystring (e.g. 'parameter1=value1&parameter2=value2') or a JSON key/value object."); } }
         public static string SendmailextraparametersShort { get { return LC.L(@"Extra parameters for the message sent"); } }
+        public static string InvalidRecipient(string recipient) => LC.L(@"The recipient ""{0}"" is not a valid email address. Please use the format ""Name <user@example.com>"" or just ""user@example.com""", recipient);
+        public static string NoRecipientsSpecified(string optionname) => LC.L(@"No recipients specified. Please use the option --{0} to specify the recipients.", optionname);
     }
     internal static class SendJabberMessage
     {


### PR DESCRIPTION
This PR adds null checks to the email module to prevent crashes when sending email.

It also guards against improper reuse of the modules. This is related to #6343.

This fixes #6315