### PR TITLE
Add completed-task event to websocket

### DIFF
--- a/Duplicati/Library/RestAPI/EventPollNotify.cs
+++ b/Duplicati/Library/RestAPI/EventPollNotify.cs
@@ -61,6 +61,11 @@ namespace Duplicati.Server
         public event EventHandler<EventArgs?>? TaskQueueUpdate;
 
         /// <summary>
+        /// An eventhandler for subscribing to task completion without blocking
+        /// </summary>
+        public event EventHandler<long>? TaskCompleted;
+
+        /// <summary>
         /// An eventhandler for subscribing backup list updates without blocking
         /// </summary>
         public event EventHandler<EventArgs?>? BackupListUpdate;
@@ -126,6 +131,9 @@ namespace Duplicati.Server
 
         public void SignalTaskQueueUpdate()
             => TaskQueueUpdate?.Invoke(this, null);
+
+        public void SignalTaskCompleted(long taskId)
+            => TaskCompleted?.Invoke(this, taskId);
 
         public void SignalServerSettingsUpdated()
             => ServerSettingsUpdate?.Invoke(this, null!);

--- a/Duplicati/WebserverCore/Abstractions/Notifications/IWebsocketAccessor.cs
+++ b/Duplicati/WebserverCore/Abstractions/Notifications/IWebsocketAccessor.cs
@@ -48,6 +48,10 @@ public enum SubscriptionService
     /// </summary>
     TaskQueue,
     /// <summary>
+    /// Completed tasks updates, such as when a task finishes or fails.
+    /// </summary>
+    TaskCompleted,
+    /// <summary>
     /// Notification messages
     /// </summary>
     Notifications,

--- a/Duplicati/WebserverCore/Services/QueueRunnerService.cs
+++ b/Duplicati/WebserverCore/Services/QueueRunnerService.cs
@@ -165,6 +165,7 @@ public class QueueRunnerService(
                 _current = (null, null);
             eventPollNotify.SignalNewEvent();
             eventPollNotify.SignalTaskQueueUpdate();
+            eventPollNotify.SignalTaskCompleted(task.TaskID);
             StartNextTask();
         }
     }

--- a/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
+++ b/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
@@ -53,6 +53,7 @@ public class SystemInfoProvider(IApplicationSettings applicationSettings, Connec
         "v1:subscribe:serversettings",
         "v1:subscribe:progress",
         "v1:subscribe:taskqueue",
+        "v1:subscribe:taskcompleted",
         "v1:subscribe:notifications",
 
         // "v1:subscribe:scheduler",


### PR DESCRIPTION
This adds support for subscribing to a "completed task" event, that is triggered when a task completes.

Using this subscription removes the need to poll for task state.