### PR TITLE
Remove fixed index files from output

### DIFF
--- a/Duplicati/Library/Main/Operation/TestHandler.cs
+++ b/Duplicati/Library/Main/Operation/TestHandler.cs
@@ -373,6 +373,7 @@ namespace Duplicati.Library.Main.Operation
                         await backendManager.DeleteAsync(vol.Name, vol.Size, true, m_results.TaskControl.ProgressToken).ConfigureAwait(false);
                         await backendManager.WaitForEmptyAsync(repairdb, rtr.Transaction, m_results.TaskControl.ProgressToken).ConfigureAwait(false);
                         rtr.Commit("ReplaceFaultyIndexFileCommit");
+                        m_results.RemoveResult(vol.Name);
                     }
                 }
                 catch (Exception ex)

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -877,6 +877,13 @@ namespace Duplicati.Library.Main
             m_verifications.Add(res);
             return res;
         }
+
+        public void RemoveResult(string volume)
+        {
+            var item = m_verifications.FirstOrDefault(x => x.Key == volume);
+            if (item.Key == volume)
+                m_verifications.Remove(item);
+        }
     }
 
     internal class TestFilterResults : BasicResults, ITestFilterResults

--- a/Duplicati/UnitTest/Issue6296.cs
+++ b/Duplicati/UnitTest/Issue6296.cs
@@ -137,10 +137,16 @@ namespace Duplicati.UnitTest
                 dont_replace_faulty_index_files = false,
             });
 
+            var brokenIndexFileNames = brokenIndexFiles.Select(Path.GetFileName).ToHashSet();
+
             using (var c = new Controller("file://" + TARGETFOLDER, repairopts, null))
             {
                 var res = c.Test(short.MaxValue);
                 Assert.That(res.Warnings, Is.Not.Empty, "Expected warnings during test with broken index files");
+                var faultyResults = res.Verifications
+                    .Where(x => x.Value.Any())
+                    .Where(x => brokenIndexFileNames.Contains(x.Key)).ToList();
+                Assert.That(faultyResults, Is.Empty, "Expected no faulty index files reported after repair");
             }
 
             var indexFilesAfter = Directory.GetFiles(TARGETFOLDER, "*.dindex.zip", SearchOption.TopDirectoryOnly).ToHashSet();


### PR DESCRIPTION
This removes index files that were succesfully repaired from the output, so the now-missing files are not reported as failures.

This fixes #6336