### PR TITLE
Expand envvars for UI commandline

### DIFF
--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -671,11 +671,10 @@ namespace Duplicati.Server
                         case DuplicatiOperation.Backup:
                             {
                                 var filter = ApplyFilter(backup, GetCommonFilter(databaseConnection));
-                                var sources =
-                                    (from n in backup.Sources
-                                     let p = SpecialFolders.ExpandEnvironmentVariables(n)
-                                     where !string.IsNullOrWhiteSpace(p)
-                                     select p).ToArray();
+                                var sources = backup.Sources
+                                    .Select(n => SpecialFolders.ExpandEnvironmentVariables(n))
+                                    .WhereNotNullOrWhiteSpace()
+                                    .ToArray();
 
                                 var r = controller.Backup(sources, filter);
                                 UpdateMetadataBase(databaseConnection, eventPollNotify, notificationUpdateService, backup, r);


### PR DESCRIPTION
This PR adds expansion of the UI "commandline" feature when running a backup, similar to what the regular runner does when running the backup.