### PR TITLE
Performance/List roots takes long time

### DIFF
--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -1106,60 +1106,37 @@ namespace Duplicati.Library.Main.Database
         {
             await using var cmd = m_connection.CreateCommand();
             cmd.SetCommandAndParameters(@"
-                WITH AllPaths AS (
-                    SELECT
-                        fl.""ID"" AS ""FileID"",
-                        pp.""Prefix"" || fl.""Path"" AS ""FullPath"",
-                        fl.""BlocksetID"",
-                        b.""Length"",
-                        fe.""Lastmodified""
-                    FROM ""FilesetEntry"" fe
-                    JOIN ""FileLookup"" fl
-                        ON fe.""FileID"" = fl.""ID""
-                    JOIN ""PathPrefix"" pp
-                        ON fl.""PrefixID"" = pp.""ID""
-                    LEFT JOIN ""Blockset"" b
-                        ON fl.""BlocksetID"" = b.""ID""
-                    WHERE fe.""FilesetID"" = @FilesetId
-                ),
-                RootCandidates AS (
-                    SELECT a1.*
-                    FROM AllPaths a1
-                    WHERE NOT EXISTS (
-                        SELECT 1
-                        FROM AllPaths a2
-                        WHERE
-                            a2.""FullPath"" != a1.""FullPath""
-                            AND a1.""FullPath"" LIKE a2.""FullPath"" || '%'
-                    )
-                )
-                SELECT ""FullPath"", ""Length"",
-                    CASE
-                        WHEN ""BlocksetID"" = -100
-                        THEN 1
-                        ELSE 0
-                    END AS ""IsDirectory"",
-                    CASE
-                        WHEN ""BlocksetID"" = -200
-                        THEN 1
-                        ELSE 0
-                    END AS ""IsSymlink"",
-                    ""Lastmodified""
-                FROM RootCandidates
-                ORDER BY ""FullPath""
+                SELECT
+                    pp.""Prefix"" || fl.""Path"" AS ""FullPath"",
+                    b.""Length"",
+                    CASE WHEN fl.""BlocksetID"" = -100 THEN 1 ELSE 0 END AS ""IsDirectory"",
+                    CASE WHEN fl.""BlocksetID"" = -200 THEN 1 ELSE 0 END AS ""IsSymlink"",
+                    fe.""Lastmodified""
+                FROM ""FilesetEntry"" fe
+                JOIN ""FileLookup"" fl ON fe.""FileID"" = fl.""ID""
+                JOIN ""PathPrefix"" pp ON fl.""PrefixID"" = pp.""ID""
+                LEFT JOIN ""Blockset"" b ON fl.""BlocksetID"" = b.""ID""
+                WHERE fe.""FilesetID"" = @FilesetId
+                ORDER BY ""FullPath"";
             ")
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@FilesetId", filesetId);
 
+            string? lastRoot = null;
+
             await foreach (var rd in cmd.ExecuteReaderEnumerableAsync(token))
             {
                 var path = rd.ConvertValueToString(0) ?? string.Empty;
-                var size = rd.ConvertValueToInt64(1, -1);
-                var isDir = rd.GetInt32(2) != 0;
-                var isSymlink = rd.GetInt32(3) != 0;
-                var lastModified = new DateTime(rd.ConvertValueToInt64(4, 0), DateTimeKind.Utc);
+                if (lastRoot == null || !path.StartsWith(lastRoot, StringComparison.Ordinal))
+                {
+                    lastRoot = path;
+                    var size = rd.ConvertValueToInt64(1, -1);
+                    var isDir = rd.GetInt32(2) != 0;
+                    var isSymlink = rd.GetInt32(3) != 0;
+                    var lastModified = new DateTime(rd.ConvertValueToInt64(4, 0), DateTimeKind.Utc);
 
-                yield return new FolderEntry(path, size, isDir, isSymlink, lastModified);
+                    yield return new FolderEntry(path, size, isDir, isSymlink, lastModified);
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes [issue 1715](https://github.com/duplicati/duplicati/issues/1715
).

Essentially, the fix moves the root comparison from SQL to C#, converting a `O(n^2)` comparison to an `O(n)` one. 

This is done by exploiting the fact that the paths returned from the query are sorted, so we don't have to look at all of the entries, when comparing to whether each new path contains a potential new root. 