### PR TITLE
Throw exception on error

### DIFF
--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -815,10 +815,7 @@ namespace Duplicati.Server
                     UpdateMetadataError(databaseConnection, notificationUpdateService, data.Backup, ex);
                 Library.UsageReporter.Reporter.Report(ex);
 
-                if (!fromQueue)
-                    throw;
-
-                return null;
+                throw;
             }
             finally
             {


### PR DESCRIPTION
This PR changs the logic for queued tasks, so they throw if they fail. Without this fix, some tasks may look like the succeeded, when they actually failed.