### PR TITLE
Update ServerUtil probing

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -192,7 +192,7 @@ namespace Duplicati.GUI.TrayIcon
                 if (File.Exists(Path.Combine(DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ReadWritePermissionSet), DataFolderManager.SERVER_DATABASE_FILENAME)))
                 {
                     passwordSource = PasswordSource.Database;
-                    databaseConnection = Server.Program.GetDatabaseConnection(new ApplicationSettings(), options, true);
+                    databaseConnection = Server.Program.GetDatabaseConnection(new ApplicationSettings(), options, true, false);
 
                     if (databaseConnection != null)
                     {

--- a/Duplicati/UnitTest/ImportExportTests.cs
+++ b/Duplicati/UnitTest/ImportExportTests.cs
@@ -109,7 +109,7 @@ namespace Duplicati.UnitTest
             }
 
             byte[] jsonByteArray;
-            using (var con = Program.GetDatabaseConnection(new ApplicationSettings(), advancedOptions, true))
+            using (var con = Program.GetDatabaseConnection(new ApplicationSettings(), advancedOptions, true, false))
                 jsonByteArray = BackupImportExportHandler.ExportToJSON(con, backup, null);
 
             // The username should not have the '%40' converted to '@' since the import code


### PR DESCRIPTION
This PR updates the probing logic to not try the database if a password is supplied on the commandline.

It also fixes a crash that could happen at an unwanted place, if the user does not have write access to the supplied data folder. After this, the application will still crash due to not having  a place to write information, but it does not crash in the preloader logic. This also prevents creating the folder while probing for the database.

This PR also fixes a case where the database could become encrypted, if the ServerUtil was providing an encryption key to an unencrypted database. Before this fix, the database would be encrypted with the key provided to ServerUtil, which would most likely cause the Server/TrayIcon to fail starting and perhaps crash.

This fixes #6377