### PR TITLE
Fix ngax support --use-ssl

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
@@ -232,6 +232,8 @@ backupApp.directive('backupEditUri', function(gettextCatalog) {
                 if (scope.Backend.Options[n].Name == 'use-ssl')
                     scope.SupportsSSL = true;
 
+            console.log('Backend changed to: ' + scope.Backend.Key, scope.SupportsSSL);
+
             scope.TemplateUrl = EditUriBackendConfig.templates[scope.Backend.Key];
             if (scope.TemplateUrl == null)
                 scope.TemplateUrl = EditUriBackendConfig.defaulttemplate;
@@ -266,16 +268,15 @@ backupApp.directive('backupEditUri', function(gettextCatalog) {
 
                     if (hasssl) {
                         scope.Backend = bk;
-                        parts['--use-ssl'] = true;
+                        parts['--use-ssl'] = 'true';
                         break;
                     }
                 }
             }
 
-
             scope.Username = parts['--auth-username'];
             scope.Password = parts['--auth-password'];
-            scope.UseSSL = parts['--use-ssl'];
+            scope.UseSSL = AppUtils.parseBoolString(parts['--use-ssl']);
             scope.Port = parts['server-port'];
             scope.Server = parts['server-name'];
             scope.Path = parts['server-path'];

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBackendConfig.js
@@ -26,9 +26,8 @@ backupApp.service('EditUriBackendConfig', function(AppService, AppUtils, SystemI
         var opts = {};
         self.merge_in_advanced_options(scope, opts, true);
 
-        var url = AppUtils.format('{0}{1}://{2}{3}/{4}{5}',
+        var url = AppUtils.format('{0}://{1}{2}/{3}{4}',
             scope.Backend.Key,
-            (scope.SupportsSSL && scope.UseSSL) ? 's' : '',
             scope.Server || '',
             (scope.Port || '') == '' ? '' : ':' + scope.Port,
             scope.Path || '',
@@ -50,6 +49,8 @@ backupApp.service('EditUriBackendConfig', function(AppService, AppUtils, SystemI
             dict['auth-username'] = scope.Username;
         if (includeUserPassword && scope.Password != null && scope.Password != '')
             dict['auth-password'] = scope.Password;
+        if (scope.UseSSL)
+            dict['use-ssl'] = 'true';
 
         if (!AppUtils.parse_extra_options(scope.AdvancedOptions, dict))
             return false;

--- a/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/EditUriBuiltins.js
@@ -668,9 +668,8 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         
         EditUriBackendConfig.merge_in_advanced_options(scope, opts, true);
 
-        var url = AppUtils.format('{0}{1}://{2}/{3}{4}',
+        var url = AppUtils.format('{0}://{1}/{2}{3}',
             scope.Backend.Key,
-            scope.UseSSL ? 's' : '',
             scope.Server || '',
             scope.Path || '',
             AppUtils.encodeDictAsUrl(opts)
@@ -697,9 +696,8 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
         }
         EditUriBackendConfig.merge_in_advanced_options(scope, opts, false);
 
-        var url = AppUtils.format('{0}{1}://{2}{3}',
+        var url = AppUtils.format('{0}://{1}{2}',
             scope.Backend.Key,
-            (scope.SupportsSSL && scope.UseSSL) ? 's' : '',
             scope.Path || '',
             AppUtils.encodeDictAsUrl(opts)
         );
@@ -1104,7 +1102,6 @@ backupApp.service('EditUriBuiltins', function (AppService, AppUtils, SystemInfo,
             });
     };
 
-    EditUriBackendConfig.validaters['webdav'] = EditUriBackendConfig.validaters['webdav'];
     EditUriBackendConfig.validaters['tahoe'] = EditUriBackendConfig.validaters['ssh'];
 
     EditUriBackendConfig.validaters['pcloud'] = function (scope, continuation) {


### PR DESCRIPTION
This fixes ngax to not use the `s` postfix on destinations, but instead rely on `--use-ssl`.

There is still support for inputting strings with the postfix, but the generated url will be without it.

This fixes #6417