### PR TITLE
Update Docker images

### DIFF
--- a/ReleaseBuilder/Resources/Docker/Dockerfile
+++ b/ReleaseBuilder/Resources/Docker/Dockerfile
@@ -1,23 +1,31 @@
 FROM debian:latest
 
-RUN apt update && apt install tini
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+RUN apt update -y && \
+    apt install -y libssl3 ca-certificates libicu72 rclone gnupg tini
 
-RUN apt update -y && apt install -y libssl3 ca-certificates gnupg libicu72 rclone
+ENTRYPOINT [ "/usr/bin/tini", "--", "/run-as-user.sh" ]
 
 ENV XDG_CONFIG_HOME=/data
 VOLUME /data
 
+# Pass Duplicati version/channel as build arguments (not used by Duplicati itself)
 ARG CHANNEL=
 ARG VERSION=
 ENV DUPLICATI_CHANNEL=${CHANNEL}
 ENV DUPLICATI_VERSION=${VERSION}
 
+# Configure web interface and port
 ENV DUPLICATI__WEBSERVICE_PORT=8200
 ENV DUPLICATI__WEBSERVICE_INTERFACE=any
 
+# Copy in the Duplicati binaries for the target architecture
 ARG TARGETARCH
 COPY ./${TARGETARCH} /opt/duplicati
+COPY run-as-user.sh /run-as-user.sh
+RUN chmod +x /run-as-user.sh
+
+# Set the PATH to include the Duplicati binaries
+ENV PATH="/opt/duplicati:${PATH}"
 
 EXPOSE 8200
-CMD ["/opt/duplicati/duplicati-server"]
+CMD ["duplicati-server"]

--- a/ReleaseBuilder/Resources/Docker/Dockerfile-agent
+++ b/ReleaseBuilder/Resources/Docker/Dockerfile-agent
@@ -1,19 +1,26 @@
 FROM debian:latest
 
-RUN apt update && apt install tini
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+RUN apt update -y && \
+    apt install -y libssl3 ca-certificates libicu72 rclone gnupg tini
 
-RUN apt update -y && apt install -y libssl3 ca-certificates gnupg libicu72 
+ENTRYPOINT [ "/usr/bin/tini", "--", "/run-as-user.sh" ]
 
 ENV XDG_CONFIG_HOME=/data
 VOLUME /data
 
+# Pass Duplicati version/channel as build arguments (not used by Duplicati itself)
 ARG CHANNEL=
 ARG VERSION=
 ENV DUPLICATI_CHANNEL=${CHANNEL}
 ENV DUPLICATI_VERSION=${VERSION}
 
+# Copy in the Duplicati binaries for the target architecture
 ARG TARGETARCH
 COPY ./${TARGETARCH} /opt/duplicati
+COPY run-as-user.sh /run-as-user.sh
+RUN chmod +x /run-as-user.sh
 
-CMD ["/opt/duplicati/duplicati-agent"]
+# Set the PATH to include the Duplicati binaries
+ENV PATH="/opt/duplicati:${PATH}"
+
+CMD ["duplicati-agent"]

--- a/ReleaseBuilder/Resources/Docker/run-as-user.sh
+++ b/ReleaseBuilder/Resources/Docker/run-as-user.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# Extract the command to run
+CMD="$@"
+
+if [ -z "$CMD" ]; then
+    echo "ERROR: No command specified to run."
+    exit 1
+fi
+
+# Create user/group and drop privileges if UID/GID are provided
+if [[ -n "$UID" && -n "$GID" ]]; then
+    # Create group if it doesn't already exist
+    if ! getent group "$GID" >/dev/null; then
+        groupadd -g "$GID" duplicati
+    fi
+
+    # Create user if it doesn't already exist
+    if ! id -u "$UID" >/dev/null 2>&1; then
+        useradd -u "$UID" -g "$GID" -m -s /bin/bash duplicati
+    fi
+
+    # Set ownership on required paths
+    chown -R "$UID:$GID" /opt/duplicati /data || true
+
+    exec su duplicati -c "$(printf "%q " "$@")"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
This updates Docker images to support UID/GID overrides, faling back to running as root.

This also fixes the images to actually allow executing the binaries as described in the README by adding them to the PATH environment variable.

The README file was overhauled to fix some outdated content and include the new UID/GID override feature.