### PR TITLE
Bugfix/RemoteVolume hash null

### DIFF
--- a/Duplicati/Library/Main/Database/LocalTestDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalTestDatabase.cs
@@ -130,7 +130,7 @@ namespace Duplicati.Library.Main.Database
                 ID = rd.ConvertValueToInt64(0);
                 Name = rd.ConvertValueToString(1) ?? "";
                 Size = rd.ConvertValueToInt64(2);
-                Hash = rd.ConvertValueToString(3) ?? throw new ArgumentNullException("Hash cannot be null");
+                Hash = rd.ConvertValueToString(3) ?? "";
                 VerificationCount = rd.ConvertValueToInt64(4);
             }
         }

--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -488,7 +488,7 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Test"), Category("Bug")]
-        public void IssueXHashNullInTest()
+        public void Issue6459HashNullInTest()
         {
             // Reproduction of the issue outlined in https://forum.duplicati.com/t/value-cannot-be-null-parameter-hash-cannot-be-null/20958
             // This test is to ensure that a null hash in the database does not cause issues during backup and repair operations.


### PR DESCRIPTION
This PR fixes the issue outlined in [this forum post](https://forum.duplicati.com/t/value-cannot-be-null-parameter-hash-cannot-be-null/20958), where a hash being `null` in the `RemoteVolume` table caused the post verification test step of a backup to fail.

Rather than throwing an exception in the constructor, the hash is set to be empty. If the database is recreated later, the hash should be set to a correct value once again.

The PR also adds a test to capture this issue. 