### PR TITLE
Prevent thread leak in TrayIcon

### DIFF
--- a/Duplicati/Agent/Program.cs
+++ b/Duplicati/Agent/Program.cs
@@ -369,7 +369,7 @@ public static class Program
     {
         cancellationToken.Register(() =>
         {
-            applicationSettings.ApplicationExitEvent.Set();
+            applicationSettings.SignalApplicationExit();
         });
 
         var lastRestart = DateTime.Now;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HostedInstanceKeeper.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HostedInstanceKeeper.cs
@@ -31,11 +31,11 @@ namespace Duplicati.GUI.TrayIcon
     /// </summary>
     internal class HostedInstanceKeeper : IDisposable
     {
-        private readonly System.Threading.Thread m_runner;
+        private readonly Thread m_runner;
         private Exception m_runnerException = null;
         public Action InstanceShutdown;
         private int _InstanceShutdownInvoked = 0;
-          
+
         public readonly IApplicationSettings applicationSettings;
 
         public HostedInstanceKeeper(IApplicationSettings applicationSettings, string[] args)
@@ -56,7 +56,7 @@ namespace Duplicati.GUI.TrayIcon
                 {
                     m_runnerException = ex;
                     Server.Program.ServerStartedEvent?.Set();
-                    applicationSettings.ApplicationExitEvent?.Set();
+                    applicationSettings.SignalApplicationExit();
                 }
                 finally
                 {
@@ -94,7 +94,7 @@ namespace Duplicati.GUI.TrayIcon
         {
             try
             {
-                applicationSettings.ApplicationExitEvent.Set();
+                applicationSettings.SignalApplicationExit();
                 if (!m_runner.Join(TimeSpan.FromSeconds(10)))
                 {
                     m_runner.Interrupt();

--- a/Duplicati/Library/RestAPI/Abstractions/IApplicationSettings.cs
+++ b/Duplicati/Library/RestAPI/Abstractions/IApplicationSettings.cs
@@ -49,7 +49,12 @@ public interface IApplicationSettings
     /// <summary>
     /// The application exit event
     /// </summary>
-    ManualResetEvent ApplicationExitEvent { get; }
+    CancellationToken ApplicationExit { get; }
+
+    /// <summary>
+    /// Signal the application exit event to notify that the application is exiting
+    /// </summary>
+    void SignalApplicationExit();
 
     /// <summary>
     /// The shared secret provider from the server invocation

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -266,7 +266,7 @@ namespace Duplicati.Server
                     }
 
                     terminated = true;
-                    applicationSettings.ApplicationExitEvent.Set();
+                    applicationSettings.SignalApplicationExit();
                 });
 
                 var stopCounter = 0;
@@ -288,7 +288,7 @@ namespace Duplicati.Server
                 };
 
                 ServerStartedEvent.Set();
-                applicationSettings.ApplicationExitEvent.WaitOne();
+                applicationSettings.ApplicationExit.WaitHandle.WaitOne();
             }
             catch (SingleInstance.MultipleInstanceException mex)
             {
@@ -891,7 +891,7 @@ namespace Duplicati.Server
                 {
                     // TODO: All calls to ApplicationExitEvent and TrayIcon->Quit
                     // should check if we are running something
-                    applicationSettings.ApplicationExitEvent.Set();
+                    applicationSettings.SignalApplicationExit();
                 }
                 else
                 {

--- a/Duplicati/WebserverCore/DuplicatiWebserver.cs
+++ b/Duplicati/WebserverCore/DuplicatiWebserver.cs
@@ -408,10 +408,7 @@ public class DuplicatiWebserver
         var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
 
         // Register SIGTERM handler
-        lifetime.ApplicationStopping.Register(() =>
-        {
-            applicationSettings.ApplicationExitEvent.Set();
-        });
+        lifetime.ApplicationStopping.Register(() => applicationSettings.SignalApplicationExit());
 
         return new DuplicatiWebserver()
         {

--- a/Duplicati/WebserverCore/Services/ApplicationSettings.cs
+++ b/Duplicati/WebserverCore/Services/ApplicationSettings.cs
@@ -12,7 +12,7 @@ public class ApplicationSettings : IApplicationSettings
     /// <summary>
     /// The application exit event
     /// </summary>
-    private readonly ManualResetEvent _applicationExitEvent = new ManualResetEvent(false);
+    private readonly CancellationTokenSource _applicationExitEvent = new();
     /// <summary>
     /// The folder where Duplicati data is stored
     /// </summary>
@@ -39,7 +39,10 @@ public class ApplicationSettings : IApplicationSettings
     public string Origin { get; set; } = "Server";
 
     /// <inheritdoc />
-    public ManualResetEvent ApplicationExitEvent => _applicationExitEvent;
+    public CancellationToken ApplicationExit => _applicationExitEvent.Token;
+
+    /// <inheritdoc />
+    public void SignalApplicationExit() => _applicationExitEvent.Cancel();
 
     /// <inheritdoc />
     public ISecretProvider? SecretProvider { get; set; }


### PR DESCRIPTION
This PR changes the termination signal to a `CancellationToken` instead of a `ManualResetEvent` as the former works better with async code.

With this change there is no longer a thread being captured during each long poll operation.

This fixes #6452