### PR TITLE
Improve dependency on libicu

### DIFF
--- a/ReleaseBuilder/Build/Command.CreatePackage.cs
+++ b/ReleaseBuilder/Build/Command.CreatePackage.cs
@@ -860,6 +860,7 @@ public static partial class Command
                     .Replace("%VERSION%", rtcfg.ReleaseInfo.Version.ToString())
                     .Replace("%ARCH%", debArchString)
                     .Replace("%PACKAGE_TYPE%", packageType)
+                    .Replace("%RECOMMENDS%", string.Join(", ", DebianRecommends))
                     .Replace("%DEPENDS%", string.Join(", ", target.Interface == InterfaceType.GUI
                         ? DebianGUIDepends
                         : DebianCLIDepends))
@@ -935,6 +936,25 @@ public static partial class Command
                 string.Join("\n", conffiles)
             );
 
+            File.Copy(
+                Path.Combine(resourcesDir, $"preinst"),
+                Path.Combine(pkgroot, "DEBIAN", "preinst"),
+                true
+            );
+
+            var filemode777 = UnixFileMode.UserRead
+                | UnixFileMode.UserWrite
+                | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead
+                | UnixFileMode.GroupWrite
+                | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead
+                | UnixFileMode.OtherWrite
+                | UnixFileMode.OtherExecute;
+
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(Path.Combine(pkgroot, "DEBIAN", "preinst"), filemode777);
+
             if (target.Interface == InterfaceType.Agent)
             {
                 // Write a custom postinst script
@@ -953,16 +973,8 @@ public static partial class Command
 
                 if (!OperatingSystem.IsWindows())
                 {
-                    var filemode = UnixFileMode.UserRead
-                        | UnixFileMode.UserWrite
-                        | UnixFileMode.UserExecute
-                        | UnixFileMode.GroupRead
-                        | UnixFileMode.GroupExecute
-                        | UnixFileMode.OtherRead
-                        | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(Path.Combine(pkgroot, "DEBIAN", "prerm"), filemode);
-                    File.SetUnixFileMode(Path.Combine(pkgroot, "DEBIAN", "postinst"), filemode);
+                    File.SetUnixFileMode(Path.Combine(pkgroot, "DEBIAN", "prerm"), filemode777);
+                    File.SetUnixFileMode(Path.Combine(pkgroot, "DEBIAN", "postinst"), filemode777);
                 }
             }
 

--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -123,11 +123,15 @@ public static partial class Command
     /// <summary>
     /// The packages that are required for GUI builds
     /// </summary>
-    private static readonly IReadOnlyList<string> DebianGUIDepends = ["libice6", "libsm6", "libfontconfig1", DebianLibIcuVersions, DebianLibSslVersions];
+    private static readonly IReadOnlyList<string> DebianGUIDepends = ["libice6", "libsm6", "libfontconfig1", DebianLibSslVersions];
     /// <summary>
     /// The packages that are required for CLI builds
     /// </summary>
-    private static readonly IReadOnlyList<string> DebianCLIDepends = [DebianLibIcuVersions, DebianLibSslVersions];
+    private static readonly IReadOnlyList<string> DebianCLIDepends = [DebianLibSslVersions];
+    /// <summary>
+    /// The packages that are recommended for Debian builds
+    /// </summary>
+    private static readonly IReadOnlyList<string> DebianRecommends = [DebianLibIcuVersions];
 
     /// <summary>
     /// The packages that are required for GUI builds

--- a/ReleaseBuilder/Resources/debian/control.template.txt
+++ b/ReleaseBuilder/Resources/debian/control.template.txt
@@ -6,6 +6,7 @@ Homepage: https://duplicati.com
 Package: duplicati%PACKAGE_TYPE%
 Architecture: %ARCH%
 Depends: %DEPENDS%
+Recommends: %RECOMMENDS%
 Version: %VERSION%
 Description: Backup client for encrypted online backups
  Duplicati is a free open-source backup client that securely stores encrypted, incremental,

--- a/ReleaseBuilder/Resources/debian/preinst
+++ b/ReleaseBuilder/Resources/debian/preinst
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+if ! ldconfig -p 2>/dev/null | grep -qE 'libicuuc\.so\.[0-9]+'; then
+    echo
+    echo "************************************************************"
+    echo "WARNING: No system ICU library (libicuNN) detected."
+    echo
+    echo "Duplicati relies on ICU for globalization."
+    echo "Without ICU, Duplicati will likely fail at runtime with"
+    echo "errors like: 'Couldn't find a valid ICU package installed'."
+    echo
+    echo "To fix this, either:"
+    echo "  1. Install a system ICU package (e.g. libicu75, libicu74, ...)"
+    echo "     Example: sudo apt install libicu75"
+    echo "  2. Or run with invariant globalization enabled:"
+    echo "     export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1"
+    echo "************************************************************"
+    echo
+fi
+
+exit 0


### PR DESCRIPTION
Since .NET dynamically loads libicu, it is not prone to ABI breakage and can load virtually any version.

However, there is no `Depends: libicu*` option in Debian packages, so we need the explicit package version. This is prone to breaking as new Debian version bump the version number.

This PR changes the `Depends:` to `Recommends:` so `libicu` is installed if possible, but does not prevent installation.

For cases where the is no `libicu` on the system, there is now a `preinst` script which will warn if the library is missing, but not prevent installation.

The warning should only show in Docker images or similar slim contexts, as `libicu` is otherwise installed with the base system.