### PR TITLE
Invert `--allow-empty-source`

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -1059,8 +1059,8 @@ namespace Duplicati.Library.Main
                             // If the directory exists, but is empty, and we are not allowed to have empty sources, throw an error
                             try
                             {
-                                if (!m_options.AllowEmptySource && di.Exists && !di.EnumerateFileSystemInfos().Any())
-                                    throw new UserInformationException(Strings.Controller.SourceFolderEmptyError(inputsource, "allow-empty-source"), "SourceFolderEmpty");
+                                if (m_options.PreventEmptySource && di.Exists && !di.EnumerateFileSystemInfos().Any())
+                                    throw new UserInformationException(Strings.Controller.SourceFolderEmptyError(inputsource), "SourceFolderEmpty");
                             }
                             catch (UnauthorizedAccessException ex)
                             {

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -389,7 +389,7 @@ namespace Duplicati.Library.Main
             new CommandLineArgument("list-sets-only", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ListsetsonlyShort, Strings.Options.ListsetsonlyLong, "false"),
             new CommandLineArgument("disable-autocreate-folder", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisableautocreatefolderShort, Strings.Options.DisableautocreatefolderLong, "false"),
             new CommandLineArgument("allow-missing-source", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AllowmissingsourceShort, Strings.Options.AllowmissingsourceLong, "false"),
-            new CommandLineArgument("allow-empty-source", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AllowemptysourceShort, Strings.Options.AllowemptysourceLong, "false"),
+            new CommandLineArgument("prevent-empty-source", CommandLineArgument.ArgumentType.Boolean, Strings.Options.PreventemptysourceShort, Strings.Options.PreventemptysourceLong, "false"),
 
             new CommandLineArgument("disable-filetime-check", CommandLineArgument.ArgumentType.Boolean, Strings.Options.DisablefiletimecheckShort, Strings.Options.DisablefiletimecheckLong, "false"),
             new CommandLineArgument("check-filetime-only", CommandLineArgument.ArgumentType.Boolean, Strings.Options.CheckfiletimeonlyShort, Strings.Options.CheckfiletimeonlyLong, "false"),
@@ -1364,7 +1364,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// Gets a flag indicating if empty source elements should cause backups to fail
         /// </summary>
-        public bool AllowEmptySource => GetBool("allow-empty-source");
+        public bool PreventEmptySource => GetBool("prevent-empty-source");
 
         /// <summary>
         /// Gets a value indicating if a verification file should be uploaded after changing the remote store

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -39,7 +39,7 @@ namespace Duplicati.Library.Main.Strings
         public static string CompletedOperationMessage(OperationMode operationname) { return LC.L(@"The operation {0} has completed", operationname); }
         public static string FailedOperationMessage(OperationMode operationname) { return LC.L(@"The operation {0} has failed", operationname); }
         public static string InvalidPathError(string path, string message) { return LC.L(@"Invalid path: ""{0}"" ({1})", path, message); }
-        public static string SourceFolderEmptyError(string foldername, string optionname) { return LC.L(@"The source folder {0} is empty, aborting backup. If this is expected, consider using the --{1} option.", foldername, optionname); }
+        public static string SourceFolderEmptyError(string foldername) { return LC.L(@"The source folder {0} is empty, aborting backup", foldername); }
         public static string FailedForceLocaleError(string exMsg) { return LC.L(@"Failed to apply 'force-locale' setting. Please try to update .NET-Framework. Exception was: ""{0}"" ", exMsg); }
         public static string SourceVolumeNameInvalidError(string filename) { return LC.L(@"The source {0} uses an invalid volume name, aborting backup", filename); }
         public static string SourceVolumeNameNotFoundError(string filename, Guid volumeGuid) { return LC.L(@"The source {0} is on volume {1}, which could not be found, aborting backup", filename, volumeGuid); }
@@ -227,8 +227,8 @@ namespace Duplicati.Library.Main.Strings
         public static string RetentionPolicyShort { get { return LC.L(@"Reduce number of versions by deleting old intermediate backups"); } }
         public static string AllowmissingsourceLong { get { return LC.L(@"Use this option to continue even if some source entries are missing."); } }
         public static string AllowmissingsourceShort { get { return LC.L(@"Ignore missing source elements"); } }
-        public static string AllowemptysourceLong { get { return LC.L(@"Use this option to allow backups to run if one or more source folders are empty. Usually an empty source folder is an indication that something like a USB drive is not mounted correctly. This check only works for filesystem source paths."); } }
-        public static string AllowemptysourceShort { get { return LC.L(@"Allow backups to run if source folders are empty"); } }
+        public static string PreventemptysourceLong { get { return LC.L(@"Use this option to prevent backups from running if one or more source folders are empty. This is useful to prevent backups from running when the source is not available, such as when a USB drive is not mounted. This only works for filesystem source paths."); } }
+        public static string PreventemptysourceShort { get { return LC.L(@"Prevent backups from running if source folders are empty"); } }
         public static string OverwriteLong { get { return LC.L(@"Use this option to overwrite target files when restoring. If this option is not set, the files will be restored with a timestamp and a number appended."); } }
         public static string OverwriteShort { get { return LC.L(@"Overwrite files when restoring"); } }
         public static string VerboseLong { get { return LC.L(@"Use this option to increase the amount of output generated when running an option. Generally this option will produce a line for each file processed."); } }

--- a/Duplicati/UnitTest/DirectListHandlerTests.cs
+++ b/Duplicati/UnitTest/DirectListHandlerTests.cs
@@ -19,8 +19,7 @@ namespace Duplicati.UnitTest
         {
             var options = new Dictionary<string, string>(this.TestOptions)
             {
-                ["upload-unchanged-backups"] = "true",
-                ["allow-empty-source"] = "true"
+                ["upload-unchanged-backups"] = "true"
             };
 
             for (var i = 0; i < 3; i++)
@@ -39,8 +38,7 @@ namespace Duplicati.UnitTest
         {
             var options = new Dictionary<string, string>(this.TestOptions)
             {
-                ["upload-unchanged-backups"] = "true",
-                ["allow-empty-source"] = "true"
+                ["upload-unchanged-backups"] = "true"
             };
 
             var initial = new[] {

--- a/Duplicati/UnitTest/Issue4988.cs
+++ b/Duplicati/UnitTest/Issue4988.cs
@@ -47,7 +47,7 @@ public class Issue4988 : BasicSetupHelper
     [Category("ManualTamper")]
     public void TestManualDindexTamperAndRecreate()
     {
-        var testopts = TestOptions.Expand(new { no_encryption = "true", allow_empty_source = "true" });
+        var testopts = TestOptions.Expand(new { no_encryption = "true" });
         var opts = new Options(testopts);
 
         // Step 1: Create an empty folder

--- a/Duplicati/UnitTest/PreventEmptySourceTest.cs
+++ b/Duplicati/UnitTest/PreventEmptySourceTest.cs
@@ -24,13 +24,13 @@ using NUnit.Framework;
 
 namespace Duplicati.UnitTest
 {
-    public class AllowEmptySourceTest : BasicSetupHelper
+    public class PreventEmptySourceTest : BasicSetupHelper
     {
         [Test]
         [Category("Targeted")]
         public void BackupFailsWhenSourceFolderIsEmpty()
         {
-            var testopts = TestOptions.Expand(new { });
+            var testopts = TestOptions.Expand(new { prevent_empty_source = true });
 
             using var controller = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null);
             var ex = Assert.Throws<UserInformationException>(() => controller.Backup(new[] { DATAFOLDER }));
@@ -41,7 +41,7 @@ namespace Duplicati.UnitTest
         [Category("Targeted")]
         public void BackupWorksWhenSourceFolderIsEmpty()
         {
-            var testopts = TestOptions.Expand(new { allow_empty_source = true });
+            var testopts = TestOptions.Expand(new { });
 
             using var controller = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null);
             var result = controller.Backup(new[] { DATAFOLDER });


### PR DESCRIPTION
This inverts the `--allow-empty-source` to `--prevent-empty-source` so the user has to opt-in to using the check.