### PR TITLE
Mask passwords to avoid leaking them in the UI

### DIFF
--- a/Duplicati/Library/RestAPI/BackupImportExportHandler.cs
+++ b/Duplicati/Library/RestAPI/BackupImportExportHandler.cs
@@ -31,8 +31,7 @@ public static class BackupImportExportHandler
 {
     public static void RemovePasswords(IBackup backup)
     {
-        backup.SanitizeSettings();
-        backup.SanitizeTargetUrl();
+        backup.RemoveSensitiveInformation();
     }
 
     public static byte[] ExportToJSON(Connection connection, IBackup backup, string passphrase)
@@ -78,11 +77,9 @@ public static class BackupImportExportHandler
             throw new InvalidOperationException($"A backup with the name {importedStructure.Backup.Name} already exists.");
         }
 
-        string error = connection.ValidateBackup(importedStructure.Backup, importedStructure.Schedule);
+        var error = connection.ValidateBackup(importedStructure.Backup, importedStructure.Schedule);
         if (!string.IsNullOrWhiteSpace(error))
-        {
             throw new InvalidOperationException(error);
-        }
 
         // This creates a new ID and DBPath.
         connection.AddOrUpdateBackupAndSchedule(importedStructure.Backup, importedStructure.Schedule);

--- a/Duplicati/Library/RestAPI/Database/Connection.cs
+++ b/Duplicati/Library/RestAPI/Database/Connection.cs
@@ -43,7 +43,7 @@ namespace Duplicati.Server.Database
         /// <summary>
         /// The placeholder for passwords in the UI
         /// </summary>
-        public const string PASSWORD_PLACEHOLDER = "**********";
+        public const string PASSWORD_PLACEHOLDER = "***************";
 
         private readonly IDbConnection m_connection;
         private readonly IDbCommand m_errorcmd;
@@ -76,6 +76,8 @@ namespace Duplicati.Server.Database
                     ServerSettings.CONST.SERVER_SSL_CERTIFICATEPASSWORD
                 ])
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        public static IReadOnlySet<string> PasswordFieldNames => _encryptedFields;
 
         public Connection(IDbConnection connection, bool disableFieldEncryption, EncryptedFieldHelper.KeyInstance? key, string dataFolder, Action startOrStopUsageReporter)
         {
@@ -540,6 +542,11 @@ namespace Duplicati.Server.Database
 
             if (string.IsNullOrWhiteSpace(item.TargetURL))
                 return "Missing a target";
+
+            if (item.TargetURL.Contains(PASSWORD_PLACEHOLDER))
+                return "TargetURL contains password placeholder value";
+            if (item.Settings != null && item.Settings.Any(x => PASSWORD_PLACEHOLDER.Equals(x.Value)))
+                return "Settings contains password placeholder value";
 
             if (item.Sources == null || item.Sources.Any(x => string.IsNullOrWhiteSpace(x)) || item.Sources.Length == 0)
                 return "Invalid source list";

--- a/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
+++ b/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
@@ -1,0 +1,137 @@
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Duplicati.Server.Database;
+
+#nullable enable
+
+namespace Duplicati.Server;
+
+/// <summary>
+/// Helper class to mask and unmask sensitive query parameters in backup configs.
+/// </summary>
+public static class QuerystringMasking
+{
+    /// <summary>
+    /// Masks the values in the given URL for any properties listed in protectedProperties.
+    /// </summary>
+    /// <param name="url">The URL to mask.</param>
+    /// <param name="protectedProperties">The set of property names to mask (case-insensitive).</param>
+    /// <returns>>The URL with sensitive properties masked.</returns>
+    public static string Mask(string urlstring, IReadOnlySet<string> protectedProperties)
+    {
+        if (string.IsNullOrEmpty(urlstring))
+            return urlstring;
+
+        var url = new Library.Utility.Uri(urlstring);
+        if (string.IsNullOrWhiteSpace(url.Query))
+            return urlstring;
+
+        var modified = false;
+        var query = Library.Utility.Uri.ParseQueryString(url.Query, false);
+        foreach (var k in query.AllKeys)
+        {
+            if (k is null) continue;
+            if (protectedProperties.Contains(k, StringComparer.OrdinalIgnoreCase))
+            {
+                query[k] = Connection.PASSWORD_PLACEHOLDER;
+                modified = true;
+            }
+        }
+
+        if (!modified) return urlstring;
+
+        url = url.SetQuery(Library.Utility.Uri.BuildUriQuery(query));
+        return url.ToString();
+    }
+
+    /// <summary>
+    /// Unmasks sensitive properties in the <paramref name="newUrl"/> by copying values from the <paramref name="previousUrl"/>
+    /// </summary>
+    /// <param name="newUrl">The new URL which may contain masked properties.</param>
+    /// <param name="previousUrl">The previous URL to copy unmasked values from.</param>
+    /// <returns>The unmasked URL.</returns>
+    public static string Unmask(string newUrl, string previousUrl)
+    {
+        if (string.IsNullOrEmpty(newUrl))
+            throw new ArgumentException("newUrl is null or empty");
+        if (string.IsNullOrEmpty(previousUrl))
+            throw new ArgumentException("previousUrl is null or empty");
+
+        var newUb = new Library.Utility.Uri(newUrl);
+        if (string.IsNullOrWhiteSpace(newUb.Query))
+            return newUrl;
+        var prevUb = new Library.Utility.Uri(previousUrl);
+
+        var newQuery = Library.Utility.Uri.ParseQueryString(newUb.Query, false);
+        var prevQuery = Library.Utility.Uri.ParseQueryString(prevUb.Query ?? "", false);
+
+        var modified = false;
+        foreach (var key in newQuery.AllKeys)
+        {
+            if (key is null) continue;
+
+            // Read values from the new URL for this key
+            var newValues = GetValuesCaseInsensitive(newQuery, key);
+            if (newValues is null || newValues.Length == 0) continue;
+
+            // If any value is the mask, replace the entire set for that key from the previous URL
+            if (newValues.Any(v => string.Equals(v, Connection.PASSWORD_PLACEHOLDER, StringComparison.Ordinal)))
+            {
+                var prevValues = GetValuesCaseInsensitive(prevQuery, key);
+                if (prevValues is null || prevValues.Length == 0)
+                    throw new InvalidOperationException($"Missing previous value for protected parameter '{key}'.");
+
+                // Remove existing entries for this key (case-insensitive) and add prior values
+                RemoveCaseInsensitive(newQuery, key);
+                foreach (var pv in prevValues)
+                    newQuery.Add(key, pv);
+
+                modified = true;
+            }
+        }
+
+        if (!modified)
+            return newUrl;
+
+        newUb = newUb.SetQuery(Library.Utility.Uri.BuildUriQuery(newQuery));
+
+        return newUb.ToString();
+
+        static string[]? GetValuesCaseInsensitive(NameValueCollection nvc, string key)
+        {
+            foreach (var k in nvc.AllKeys)
+                if (k != null && string.Equals(k, key, StringComparison.OrdinalIgnoreCase))
+                    return nvc.GetValues(k);
+            return null;
+        }
+
+        static void RemoveCaseInsensitive(NameValueCollection nvc, string key)
+        {
+            string? match = nvc.AllKeys?.FirstOrDefault(k => k != null && string.Equals(k, key, StringComparison.OrdinalIgnoreCase));
+            if (match != null) nvc.Remove(match);
+        }
+    }
+}

--- a/Duplicati/Server/Duplicati.Server.Serialization/Interface/IBackup.cs
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Interface/IBackup.cs
@@ -78,9 +78,15 @@ namespace Duplicati.Server.Serialization.Interface
         /// </summary>
         bool IsTemporary { get; }
 
-        void SanitizeTargetUrl();
+        /// <summary>
+        /// Removes sensitive information from the backup settings and target URL
+        /// </summary>
+        void RemoveSensitiveInformation();
 
-        void SanitizeSettings();
+        /// <summary>
+        /// Masks sensitive information in the backup settings and target URL
+        /// </summary>
+        void MaskSensitiveInformation();
     }
 }
 

--- a/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
+++ b/Duplicati/Server/webroot/ngax/scripts/controllers/EditBackupController.js
@@ -73,6 +73,10 @@ backupApp.controller('EditBackupController', function ($rootScope, $scope, $rout
         return this.ExtendedOptions.includes('--gpg-encryption-command=--encrypt');
     }
 
+    $scope.isMaskedPassphrase = function() {
+        return this.Options && this.Options['passphrase'] && this.Options['passphrase'] == $scope.SystemInfo.PasswordPlaceholder;
+    };
+
     $scope.generatePassphrase = function() {
         this.Options["passphrase"] = this.RepeatPasshrase = AppUtils.generatePassphrase();
         this.ShowPassphrase = true;

--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -72,8 +72,8 @@
                                 <li>
                                     <a href ng-click="generatePassphrase()" translate>Generate</a>
                                 </li>
-                                <li ng-show="PassphraseScoreString">|</li>
-                                <li class="strength score-{{PassphraseScore}}" ng-show="PassphraseScoreString">{{PassphraseScore != 'x' ? 'Strength: ' : ''}} {{PassphraseScoreString}}</li>
+                                <li ng-show="PassphraseScoreString && !isMaskedPassphrase()">|</li>
+                                <li class="strength score-{{PassphraseScore}}" ng-show="PassphraseScoreString && !isMaskedPassphrase()">{{PassphraseScore != 'x' ? 'Strength: ' : ''}} {{PassphraseScoreString}}</li>
                             </ul>
                         </div>
                     </div>

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
@@ -98,8 +98,7 @@ public class BackupGet : IEndpointV1
         var scheduleId = connection.GetScheduleIDsFromTags(new string[] { "ID=" + bk.ID });
         var schedule = scheduleId.Any() ? connection.GetSchedule(scheduleId.First()) : null;
         var sourcenames = SpecialFolders.GetSourceNames(bk);
-
-        //TODO: Filter out the password in both settings and the target url
+        bk.MaskSensitiveInformation();
 
         return new GetBackupResultDto(
             schedule == null ? null : new Dto.ScheduleDto()
@@ -236,8 +235,7 @@ public class BackupGet : IEndpointV1
 
     public static void RemovePasswords(IBackup backup)
     {
-        backup.SanitizeSettings();
-        backup.SanitizeTargetUrl();
+        backup.RemoveSensitiveInformation();
     }
 
     private static Dto.ExportCommandlineDto ExecuteGetExportCmdline(Connection connection, IBackup backup, bool exportPasswords)

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPutDelete.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPutDelete.cs
@@ -113,11 +113,11 @@ public class BackupPutDelete : IEndpointV1
                 if (connection.Backups.Any(x => x.Name.Equals(backup.Name, StringComparison.OrdinalIgnoreCase) && x.ID != backup.ID))
                     throw new ConflictException($"There already exists a backup with the name: {backup.Name}");
 
+                backup.UnmaskSensitiveInformation(existing);
                 var err = connection.ValidateBackup(backup, schedule);
                 if (!string.IsNullOrWhiteSpace(err))
                     throw new BadRequestException(err);
 
-                //TODO: Merge in real passwords where the placeholder is found
                 connection.AddOrUpdateBackupAndSchedule(backup, schedule);
             }
         }


### PR DESCRIPTION
This PR adds a masking function that replaces sensitive parameters with a masking string, such that the passwords are never submitted to the client during edits.

For now, the export feature (both as JSON and as commandline) do not mask the sensitive parameters.

This fixes #2024