### PR TITLE
Added support for retries in backend tester

### DIFF
--- a/LiveTests/Duplicati.Backend.Tests/Parameters.cs
+++ b/LiveTests/Duplicati.Backend.Tests/Parameters.cs
@@ -33,6 +33,7 @@ public static class Parameters
         "--auto-create-folder",
         "--extended-chars=_-",
         "--force",
+        "--failure-retries=3",
         $"--max-file-size={Environment.GetEnvironmentVariable("MAX_FILE_SIZE") ?? "1000kb"}",
         $"--number-of-files={Environment.GetEnvironmentVariable("NUMBER_OF_FILES") ?? "20"}"
     ];


### PR DESCRIPTION
This PR adds support for retries in the backend tester.

The CI tests have been updated to retry operations 3 times, which will hopefully make the CI tests more stable.