### PR TITLE
fix(S3): validate endpoint does not contain path

### DIFF
--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -247,6 +247,10 @@ namespace Duplicati.Library.Backend
             if (!options.ContainsKey("s3-ext-forcepathstyle") && !hostname.EndsWith(".amazonaws.com", StringComparison.OrdinalIgnoreCase))
                 options["s3-ext-forcepathstyle"] = "true";
 
+            // Validate that hostname doesn't contain a path
+            if (hostname.Contains('/') || hostname.Contains('\\'))
+                throw new UserInformationException(Strings.S3Backend.NoPathAllowedInEndpointError, "S3NoPathInEndpoint");
+
 
             var s3ClientOptionValue = options.GetValueOrDefault(S3_CLIENT_OPTION);
 

--- a/Duplicati/Library/Backend/S3/Strings.cs
+++ b/Duplicati/Library/Backend/S3/Strings.cs
@@ -58,6 +58,7 @@ namespace Duplicati.Library.Backend.Strings
         public static string DescriptionRecursiveListShort { get { return LC.L(@"Use this option to list all files in the bucket"); } }
         public static string DescriptionRecursiveListLong { get { return LC.L(@"To reduce the number of objects listed, the default is to only list the first level of objects. Use this option to list all objects in the bucket."); } }
         public static string UnknownS3ClientError(string client) { return LC.L(@"Unknown S3 client: {0}", client); }
+        public static string NoPathAllowedInEndpointError { get { return LC.L(@"No path allowed in endpoint"); } }
     }
 
     internal static class S3Config


### PR DESCRIPTION
Add validation to ensure custom S3 endpoint URLs like r2 from cloudflare don't contain paths and throw appropriate error message. This prevents potential issues with malformed endpoint configurations. Previously, all it said for the AWS SDK was "Name or service not known (https:80)" which was confusing, i believe this would make it clearer.