### PR TITLE
Implemented remotely managed backup configurations

### DIFF
--- a/Duplicati/CommandLine/DatabaseTool/Scripts/Server/9. Remove ExternalID from backup.sql
+++ b/Duplicati/CommandLine/DatabaseTool/Scripts/Server/9. Remove ExternalID from backup.sql
@@ -1,0 +1,16 @@
+﻿ALTER TABLE Backup RENAME TO BackupTemp;
+
+CREATE TABLE "Backup" (
+    "ID" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "Name" TEXT NOT NULL,
+    "Description" TEXT NOT NULL DEFAULT '',
+    "Tags" TEXT NOT NULL,
+    "TargetURL" TEXT NOT NULL,
+    "DBPath" TEXT NOT NULL,
+);
+
+INSERT INTO "Backup"("ID", "Name", "Description", "Tags", "TargetURL", "DBPath")
+SELECT "ID", "Name", "Description", "Tags", "TargetURL", "DBPath"
+FROM "BackupTemp";
+
+DROP TABLE "BackupTemp";

--- a/Duplicati/Library/RemoteControl/ExchangeDataTypes.cs
+++ b/Duplicati/Library/RemoteControl/ExchangeDataTypes.cs
@@ -89,17 +89,21 @@ public sealed record WelcomeMessage(string PublicKeyHash, string MachineName, st
 public sealed record ControlRequestMessage(string Command, Dictionary<string, string?> Parameters)
 {
     /// <summary>
-    /// The configure report url command
+    /// The command to update settings
     /// </summary>
-    public const string ConfigureReportUrlSet = "configure-report-url:set";
+    public const string UpdateSettingsCommand = "updatesettings";
     /// <summary>
-    /// A control message to return if the report url is configured
+    /// The key that contains the reporting URL
     /// </summary>
-    public const string ConfigureReportUrlGet = "configure-report-url:get";
+    public const string ReportUrlKey = "reportingurl";
     /// <summary>
-    /// The url parameter for the configure report url command
+    /// The prefix used for backup config keys
     /// </summary>
-    public const string ConfigureReportUrlParameter = "url";
+    public const string BackupConfigKeyPrefix = "backupconfig:";
+    /// <summary>
+    /// The key that contains the applied settings version
+    /// </summary>
+    public const string SettingsVersionKey = "settingsversion";
 
 }
 /// <summary>
@@ -108,7 +112,13 @@ public sealed record ControlRequestMessage(string Command, Dictionary<string, st
 /// <param name="Success">Whether the command was successful</param>
 /// <param name="Output">The output of the command</param>
 /// <param name="ErrorMessage">The error message if the command failed</param>
-public sealed record ControlResponseMessage(bool Success, Dictionary<string, string?>? Output, string? ErrorMessage);
+public sealed record ControlResponseMessage(bool Success, Dictionary<string, string?>? Output, string? ErrorMessage)
+{
+    /// <summary>
+    /// The key used for reporting the applied settings version
+    /// </summary>
+    public const string SettingsVersionKey = "settingsversion";
+}
 
 /// <summary>
 /// A message to send a command

--- a/Duplicati/Library/RestAPI/Database/Backup.cs
+++ b/Duplicati/Library/RestAPI/Database/Backup.cs
@@ -53,12 +53,16 @@ namespace Duplicati.Server.Database
             }
         }
 
-        protected void SetDBPath(string path) => this.DBPath = path;
+        public void SetDBPath(string path) => this.DBPath = path;
 
         /// <summary>
         /// The backup ID
         /// </summary>
         public string ID { get; set; }
+        /// <summary>
+        /// The external ID for tracking the backup, or null if not set
+        /// </summary>
+        public string ExternalID { get; set; }
         /// <summary>
         /// The backup name
         /// </summary>

--- a/Duplicati/Library/RestAPI/Database/Connection.cs
+++ b/Duplicati/Library/RestAPI/Database/Connection.cs
@@ -695,7 +695,7 @@ namespace Duplicati.Server.Database
                             if (update)
                                 cmd.SetCommandAndParameters(@"UPDATE ""Backup"" SET ""Name""=@Name, ""Description""=@Description, ""Tags""=@Tags, ""TargetURL""=@TargetUrl WHERE ""ID""=@Id");
                             else
-                                cmd.SetCommandAndParameters(@"INSERT INTO ""Backup"" (""Name"", ""Description"", ""Tags"", ""TargetURL"", ""DBPath"") VALUES (@Name,@Description,@Tags,@TargetUrl,@DbPath)");
+                                cmd.SetCommandAndParameters(@"INSERT INTO ""Backup"" (""Name"", ""ExternalID"", ""Description"", ""Tags"", ""TargetURL"", ""DBPath"") VALUES (@Name,@ExternalID,@Description,@Tags,@TargetUrl,@DbPath)");
                         },
                         (cmd, n) =>
                         {
@@ -712,7 +712,9 @@ namespace Duplicati.Server.Database
                             if (update)
                                 cmd.SetParameterValue("@Id", item.ID);
                             else
-                                cmd.SetParameterValue("@DbPath", n.DBPath);
+                                cmd.SetParameterValue("@DbPath", n.DBPath)
+                                    .SetParameterValue("@ExternalID", n.ExternalID ?? "");
+
                         });
 
                     if (!update)
@@ -890,12 +892,13 @@ namespace Duplicati.Server.Database
                         {
                             ID = ConvertToInt64(rd, 0).ToString(),
                             Name = ConvertToString(rd, 1),
-                            Description = ConvertToString(rd, 2),
-                            Tags = (ConvertToString(rd, 3) ?? "").Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
-                            TargetURL = EncryptedFieldHelper.Decrypt(ConvertToString(rd, 4), m_key),
-                            DBPath = ConvertToString(rd, 5),
+                            ExternalID = ConvertToString(rd, 2),
+                            Description = ConvertToString(rd, 3),
+                            Tags = (ConvertToString(rd, 4) ?? "").Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
+                            TargetURL = EncryptedFieldHelper.Decrypt(ConvertToString(rd, 5), m_key),
+                            DBPath = ConvertToString(rd, 6),
                         },
-                        cmd => cmd.SetCommandAndParameters(@"SELECT ""ID"", ""Name"", ""Description"", ""Tags"", ""TargetURL"", ""DBPath"" FROM ""Backup"" "))
+                        cmd => cmd.SetCommandAndParameters(@"SELECT ""ID"", ""Name"", ""ExternalID"", ""Description"", ""Tags"", ""TargetURL"", ""DBPath"" FROM ""Backup"" "))
                         .ToArray();
 
                     foreach (var n in lst)

--- a/Duplicati/Library/RestAPI/Database/Database schema/9. Add External Id to backup.sql
+++ b/Duplicati/Library/RestAPI/Database/Database schema/9. Add External Id to backup.sql
@@ -1,0 +1,2 @@
+﻿ALTER TABLE "Backup" ADD COLUMN "ExternalID" TEXT NULL;
+

--- a/Duplicati/Library/RestAPI/Database/Database schema/Schema.sql
+++ b/Duplicati/Library/RestAPI/Database/Database schema/Schema.sql
@@ -12,7 +12,8 @@ CREATE TABLE "Backup" (
     "Description" TEXT NOT NULL DEFAULT '',
     "Tags" TEXT NOT NULL,
     "TargetURL" TEXT NOT NULL,
-    "DBPath" TEXT NOT NULL
+    "DBPath" TEXT NOT NULL,
+    "ExternalID" TEXT NULL
 );
 
 /*
@@ -164,5 +165,5 @@ CREATE TABLE "TokenFamily" (
     "LastUpdated" INTEGER NOT NULL
 );
 
-INSERT INTO "Version" ("Version") VALUES (8);
+INSERT INTO "Version" ("Version") VALUES (9);
 

--- a/Duplicati/Server/Duplicati.Server.Serialization/Interface/IBackup.cs
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Interface/IBackup.cs
@@ -33,6 +33,10 @@ namespace Duplicati.Server.Serialization.Interface
         /// </summary>
         string ID { get; set; }
         /// <summary>
+        /// An external ID for tracking the backup, or null if not set
+        /// </summary>
+        string ExternalID { get; set; }
+        /// <summary>
         /// The backup name
         /// </summary>
         string Name { get; set; }

--- a/Duplicati/WebserverCore/Dto/BackupDto.cs
+++ b/Duplicati/WebserverCore/Dto/BackupDto.cs
@@ -30,6 +30,10 @@ public sealed record BackupDto
     /// </summary>
     public required string ID { get; init; }
     /// <summary>
+    /// An external ID for tracking the backup, or null if not set
+    /// </summary>
+    public required string? ExternalID { get; init; }
+    /// <summary>
     /// The backup name
     /// </summary>
     public required string Name { get; init; }

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
@@ -114,6 +114,7 @@ public class BackupGet : IEndpointV1
             new Dto.BackupDto()
             {
                 ID = bk.ID,
+                ExternalID = bk.ExternalID,
                 Name = bk.Name,
                 Sources = bk.Sources,
                 Settings = bk.Settings?.Select(x => new Dto.SettingDto()

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
@@ -186,21 +186,12 @@ public class BackupPost : IEndpointV1
         return new Dto.TaskStartedDto("OK", queueRunnerService.AddTask(Runner.CreateTask(DuplicatiOperation.Backup, backup), skipQueue));
     }
 
-    private class WrappedBackup : Server.Database.Backup
-    {
-        public string? DBPathSetter
-        {
-            get => DBPath;
-            set => SetDBPath(value);
-        }
-    }
-
     private static Dto.CreateBackupDto ExecuteCopyToTemp(IBackup backup, Connection connection)
     {
-        var ipx = Serializer.Deserialize<WrappedBackup>(new StringReader(Newtonsoft.Json.JsonConvert.SerializeObject(backup)));
+        var ipx = Serializer.Deserialize<Server.Database.Backup>(new StringReader(Newtonsoft.Json.JsonConvert.SerializeObject(backup)));
 
         using (var tf = new Library.Utility.TempFile())
-            ipx.DBPathSetter = tf;
+            ipx.SetDBPath(tf);
         ipx.ID = null;
 
         connection.RegisterTemporaryBackup(ipx);

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPutDelete.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPutDelete.cs
@@ -49,15 +49,6 @@ public class BackupPutDelete : IEndpointV1
     private static IBackup GetBackup(Connection connection, string id)
         => connection.GetBackup(id) ?? throw new NotFoundException("Backup not found");
 
-    private class WrappedBackup : Server.Database.Backup
-    {
-        public string? DBPathSetter
-        {
-            get => DBPath;
-            set => SetDBPath(value);
-        }
-    }
-
     private static void ExecutePut(IBackup existing, Connection connection, Dto.BackupAndScheduleInputDto input)
     {
         // TODO: This method and "POST /backups" are 99% identical
@@ -70,14 +61,13 @@ public class BackupPutDelete : IEndpointV1
 
         try
         {
-            var backup = new WrappedBackup()
+            var backup = new Server.Database.Backup()
             {
                 ID = existing.ID,
                 Name = input.Backup.Name,
                 Description = input.Backup.Description,
                 Tags = input.Backup.Tags,
                 TargetURL = input.Backup.TargetURL,
-                DBPathSetter = null,
                 Sources = input.Backup.Sources,
                 Settings = settings.Select(x => new Setting()
                 {

--- a/Duplicati/WebserverCore/Services/RemoteControllerService.cs
+++ b/Duplicati/WebserverCore/Services/RemoteControllerService.cs
@@ -102,5 +102,6 @@ public class RemoteControllerService(Connection connection, IRemoteControllerHan
     {
         Disable();
         connection.ApplicationSettings.RemoteControlConfig = string.Empty;
+        connection.ApplicationSettings.AdditionalReportUrl = string.Empty;
     }
 }

--- a/Duplicati/WebserverCore/Services/Settings/SettingsService.cs
+++ b/Duplicati/WebserverCore/Services/Settings/SettingsService.cs
@@ -55,6 +55,7 @@ public class SettingsService(Connection connection) : ISettingsService
         Server.Database.ServerSettings.CONST.ENCRYPTED_FIELDS,
         Server.Database.ServerSettings.CONST.REMOTE_CONTROL_CONFIG,
         Server.Database.ServerSettings.CONST.SERVER_SSL_CERTIFICATEPASSWORD,
+        Server.Database.ServerSettings.CONST.ADDITIONAL_REPORT_URL,
         "ServerSSLCertificate",
         "server-passphrase-trayicon-hash",
         "server-passphrase-trayicon-salt"


### PR DESCRIPTION
This PR adds the ability to manage backup configurations outside of the the client.

The implementation ensures that locally created configurations cannot be affected by the remotely managed backups.

If the instance is not connected to a remote console, this has no effect.

This PR updates the local database to add the column `ExternalID` that tracks backups that are managed remotely.