### PR TITLE
Fixed masked passwords breaking test function

### DIFF
--- a/Duplicati/Library/RestAPI/Database/Backup.cs
+++ b/Duplicati/Library/RestAPI/Database/Backup.cs
@@ -166,7 +166,7 @@ namespace Duplicati.Server.Database
             var prevSettings = previous.Settings.ToDictionary(x => x.Name, x => x.Value, StringComparer.OrdinalIgnoreCase);
             foreach (var setting in this.Settings)
             {
-                if (setting.Value == Connection.PASSWORD_PLACEHOLDER)
+                if (Connection.IsPasswordPlaceholder(setting.Value))
                 {
                     if (prevSettings.TryGetValue(setting.Name, out var prevValue))
                         setting.Value = prevValue;

--- a/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
+++ b/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
@@ -97,8 +97,8 @@ public static class QuerystringMasking
             var newValues = GetValuesCaseInsensitive(newQuery, key);
             if (newValues is null || newValues.Length == 0) continue;
 
-            // If any value is the mask, replace the entire set for that key from the previous URL
-            if (newValues.Any(v => string.Equals(v, Connection.PASSWORD_PLACEHOLDER, StringComparison.Ordinal)))
+            // If any value contains the mask, replace the entire set for that key from the previous URL
+            if (newValues.Any(v => Connection.IsPasswordPlaceholder(v)))
             {
                 var prevValues = GetValuesCaseInsensitive(prevQuery, key);
                 if (prevValues is null || prevValues.Length == 0)

--- a/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
@@ -3,10 +3,11 @@ backupApp.directive('backupEditUri', function(gettextCatalog) {
     restrict: 'E',
     scope: {
         uri: '=uri',
+        backupId: '=backupId',
         setBuilduriFn: '&'
     },
     templateUrl: 'templates/edituri.html',
-    controller: function($scope, AppService, AppUtils, SystemInfo, EditUriBackendConfig, DialogService, EditUriBuiltins) {
+    controller: function($scope, AppService, AppUtils, SystemInfo, EditUriBackendConfig, DialogService) {
 
         var scope = $scope;
         scope.AppUtils = AppUtils;
@@ -41,7 +42,7 @@ backupApp.directive('backupEditUri', function(gettextCatalog) {
                     dlg.dismiss();
 
                 dlg = DialogService.dialog(gettextCatalog.getString('Testing …'), gettextCatalog.getString('Testing connection …'), [], null, function() {
-                    AppService.postJson('/remoteoperation/test', { path: uri }).then(function() {
+                    AppService.postJson('/remoteoperation/test', { path: uri, backupId: scope.backupId }).then(function() {
                         scope.Testing = false;
                         dlg.dismiss();
 
@@ -202,6 +203,7 @@ backupApp.directive('backupEditUri', function(gettextCatalog) {
         }
 
         $scope.testConnection = function() {
+            console.log(scope);
             builduri(performConnectionTest);
         };
 

--- a/Duplicati/Server/webroot/ngax/templates/addoredit.html
+++ b/Duplicati/Server/webroot/ngax/templates/addoredit.html
@@ -107,7 +107,7 @@
                     </div>
                 </div>
 
-                <backup-edit-uri uri="Backup.TargetURL" set-builduri-fn="setBuilduriFn(builduriFn)"></backup-edit-uri>
+                <backup-edit-uri uri="Backup.TargetURL" backup-id="Backup.ID" set-builduri-fn="setBuilduriFn(builduriFn)"></backup-edit-uri>
 
                 <div class="buttons">
                     <input class="submit next" type="button" id="nextStep2" ng-click="nextPage()" value="{{'Next' | translate}} &gt;" />

--- a/Duplicati/UnitTest/MaskingUnmaskingTest.cs
+++ b/Duplicati/UnitTest/MaskingUnmaskingTest.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.Serialization;
 using System.Web;
 using Duplicati.Server.Database;
@@ -146,9 +145,15 @@ public class BackupConfigMaskingTests
     }
 
     [Test]
-    public void ValidateBackupDetectsPlaceholder()
+    public void ValidateBackupDetectsPlaceholder([Values(0, 1, 2)] int type)
     {
-        var placeholder = Connection.PASSWORD_PLACEHOLDER;
+        var placeholder = type switch
+        {
+            0 => Connection.PASSWORD_PLACEHOLDER,
+            1 => "***",
+            2 => "%2A%2a%2A",
+            _ => throw new ArgumentOutOfRangeException(nameof(type))
+        };
 
         var backup = new Backup
         {

--- a/Duplicati/WebserverCore/Dto/V2/DestinationTestRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/DestinationTestRequestDto.cs
@@ -31,6 +31,11 @@ public sealed record DestinationTestRequestDto
     public required string DestinationUrl { get; init; }
 
     /// <summary>
+    /// The backup ID, if known
+    /// </summary>
+    public string? BackupId { get; init; }
+
+    /// <summary>
     /// Any additional options to pass to the destination
     /// </summary>
     public required Dictionary<string, string> Options { get; init; } = new();


### PR DESCRIPTION
This updates the masked password feature to be better at detecting variations of the password mask, such as removing one or more asterisks from the string.

This also updates the "Test destination" endpoints to support a backupId so the call can unmask the target urls.