### PR TITLE
Fixed no custom editors in ngax

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
@@ -7,7 +7,7 @@ backupApp.directive('backupEditUri', function(gettextCatalog) {
         setBuilduriFn: '&'
     },
     templateUrl: 'templates/edituri.html',
-    controller: function($scope, AppService, AppUtils, SystemInfo, EditUriBackendConfig, DialogService) {
+    controller: function($scope, AppService, AppUtils, SystemInfo, EditUriBackendConfig, DialogService, EditUriBuiltins) {
 
         var scope = $scope;
         scope.AppUtils = AppUtils;


### PR DESCRIPTION
This reverts a removed injection parameter that caused all custom dialogs for destination editors to be missing.