### PR TITLE
Fixed logic for release builder

### DIFF
--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -447,6 +447,9 @@ public static partial class Command
 
     static async Task DoBuild(CommandInput input)
     {
+        if (input.ResumeFromUpload)
+            input = input with { KeepBuilds = true };
+
         Console.WriteLine($"Building {input.Channel} release ...");
         var configuration = Configuration.Create(input.Channel);
 


### PR DESCRIPTION
If the user supplies --resume-from-upload, this now implies that the build folder should not be deleted