### PR TITLE
Add explicit status code check for B2 upload

### DIFF
--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -324,6 +324,8 @@ public class B2 : IStreamingBackend
             request.Content.Headers.Add("Content-Length", timeoutStream.Length.ToString());
 
             var response = await _httpClient.UploadStream(request, cancelToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
             var rdata = await response.Content.ReadAsStreamAsync(cancelToken).ConfigureAwait(false);
 
             UploadFileResponse fileinfo;


### PR DESCRIPTION
This PR adds an explicit check for the status code for a B2 upload to ensure that non-success status codes are treated as failures.

Prior to this PR an upload would be considered a success if it has a failed status code but returns a valid JSON document with a `contentLength` property.