### PR TITLE
Add option to limit modules

### DIFF
--- a/Duplicati/CommandLine/CLI/Program.cs
+++ b/Duplicati/CommandLine/CLI/Program.cs
@@ -193,6 +193,16 @@ namespace Duplicati.CommandLine
             options.Remove(Library.AutoUpdater.DataFolderManager.SERVER_DATAFOLDER_OPTION);
             options.Remove(Library.AutoUpdater.DataFolderManager.PORTABLE_MODE_OPTION);
 
+            // Unload any modules that are not allowed
+            Library.DynamicLoader.BackendLoader.OnlyAllowBackends(options.GetValueOrDefault("allowed-backend-modules"));
+            Library.DynamicLoader.EncryptionLoader.OnlyAllowModules(options.GetValueOrDefault("allowed-encryption-modules"));
+            Library.DynamicLoader.CompressionLoader.OnlyAllowModules(options.GetValueOrDefault("allowed-compression-modules"));
+
+            // These options are only used by the command line tool
+            options.Remove("allowed-backend-modules");
+            options.Remove("allowed-encryption-modules");
+            options.Remove("allowed-compression-modules");
+
             if (!options.ContainsKey("passphrase"))
                 if (!string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("PASSPHRASE")))
                     options["passphrase"] = System.Environment.GetEnvironmentVariable("PASSPHRASE");
@@ -304,6 +314,9 @@ namespace Duplicati.CommandLine
             new CommandLineArgument("auto-update", CommandLineArgument.ArgumentType.Boolean, Strings.Program.AutoUpdateOptionShort, Strings.Program.AutoUpdateOptionLong, "false"),
             new CommandLineArgument(DataFolderManager.PORTABLE_MODE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.PortableModeOptionShort, Strings.Program.PortableModeOptionLong, DataFolderManager.PORTABLE_MODE.ToString().ToLowerInvariant()),
             new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.DataFolderOptionShort, Strings.Program.DataFolderOptionLong, DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)),
+            new CommandLineArgument("allowed-backend-modules", CommandLineArgument.ArgumentType.String, Strings.Program.AllowedBackendModulesShort, Strings.Program.AllowedBackendModulesLong),
+            new CommandLineArgument("allowed-encryption-modules", CommandLineArgument.ArgumentType.String, Strings.Program.AllowedEncryptionModulesShort, Strings.Program.AllowedEncryptionModulesLong),
+            new CommandLineArgument("allowed-compression-modules", CommandLineArgument.ArgumentType.String, Strings.Program.AllowedCompressionModulesShort, Strings.Program.AllowedCompressionModulesLong),
         ];
 
         private static bool ReadOptionsFromFile(TextWriter outwriter, string filename, ref Library.Utility.IFilter filter, List<string> cargs, Dictionary<string, string> options)

--- a/Duplicati/CommandLine/CLI/Strings.cs
+++ b/Duplicati/CommandLine/CLI/Strings.cs
@@ -60,6 +60,12 @@ namespace Duplicati.CommandLine.Strings
         public static string PortableModeOptionLong { get { return LC.L(@"If this option is set, the configuration files will be stored in a data subfolder of the Duplicati installation folder. This is useful for running from a USB stick or other portable media."); } }
         public static string DataFolderOptionShort { get { return LC.L(@"Data folder"); } }
         public static string DataFolderOptionLong { get { return LC.L(@"The folder where data is stored. This is the folder where the database and other files are stored."); } }
+        public static string AllowedBackendModulesShort { get { return LC.L(@"Allowed backends"); } }
+        public static string AllowedBackendModulesLong { get { return LC.L(@"Comma-separated list of backend protocol keys that are allowed to be used. If this option is not specified, all available backends are allowed. Use this option to restrict the backends that can be used, for example in a managed environment. Example: --allowed-backend-modules=file,ftp,s3"); } }
+        public static string AllowedEncryptionModulesShort { get { return LC.L(@"Allowed encryption modules"); } }
+        public static string AllowedEncryptionModulesLong { get { return LC.L(@"Comma-separated list of encryption module file extensions that are allowed to be used. If this option is not specified, all available encryption modules are allowed. Use this option to restrict the encryption modules that can be used, for example in a managed environment. Example: --allowed-encryption-modules=aes,gpg"); } }
+        public static string AllowedCompressionModulesShort { get { return LC.L(@"Allowed compression modules"); } }
+        public static string AllowedCompressionModulesLong { get { return LC.L(@"Comma-separated list of compression module file extensions that are allowed to be used. If this option is not specified, all available compression modules are allowed. Use this option to restrict the compression modules that can be used, for example in a managed environment. Example: --allowed-compression-modules=zip"); } }
 
         // ReSharper disable once UnusedMember.Global
         // This is a placeholder message that is intended to be used with the code

--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -192,5 +192,12 @@ namespace Duplicati.Library.DynamicLoader
         {
             _backendLoader.AddModule(backend);
         }
+
+        /// <summary>
+        /// Removes all backends except the specified ones
+        /// </summary>
+        /// <param name="protocolKeys">The protocol keys to keep, comma-separated</param>
+        public static void OnlyAllowBackends(string protocolKeys)
+            => _backendLoader.RemoveAllModulesExcept(protocolKeys);
     }
 }

--- a/Duplicati/Library/DynamicLoader/CompressionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/CompressionLoader.cs
@@ -146,5 +146,11 @@ namespace Duplicati.Library.DynamicLoader
         }
         #endregion
 
+        /// <summary>
+        /// Removes all compression modules except the specified ones
+        /// </summary>
+        /// <param name="allowedModules">The module keys to keep, comma-separated</param>
+        public static void OnlyAllowModules(string allowedModules)
+            => _compressionLoader.RemoveAllModulesExcept(allowedModules);
     }
 }

--- a/Duplicati/Library/DynamicLoader/DynamicLoader.cs
+++ b/Duplicati/Library/DynamicLoader/DynamicLoader.cs
@@ -244,5 +244,37 @@ namespace Duplicati.Library.DynamicLoader
             lock (m_lock)
                 m_interfaces[GetInterfaceKey(module)] = module;
         }
+
+        /// <summary>
+        /// Helper method to unregister a module
+        /// </summary>
+        public void RemoveModule(string key)
+        {
+            LoadInterfaces();
+            lock (m_lock)
+                m_interfaces.Remove(key);
+        }
+
+        /// <summary>
+        /// Helper method to unregister all modules except the ones in the provided list
+        /// </summary>
+        /// <param name="keysToKeep">The keys to keep, comma-separated</param>
+        public void RemoveAllModulesExcept(string keysToKeep)
+        {
+            var keysToKeepSet = (keysToKeep ?? "")
+                .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            if (keysToKeepSet.Count > 0)
+            {
+                LoadInterfaces();
+                lock (m_lock)
+                {
+                    var keysToRemove = m_interfaces.Keys.Where(k => !keysToKeepSet.Contains(k)).ToList();
+                    foreach (var key in keysToRemove)
+                        m_interfaces.Remove(key);
+                }
+            }
+        }
     }
 }

--- a/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
+++ b/Duplicati/Library/DynamicLoader/EncryptionLoader.cs
@@ -144,5 +144,12 @@ namespace Duplicati.Library.DynamicLoader
         }
         #endregion
 
+        /// <summary>
+        /// Removes all encryption modules except the specified ones
+        /// </summary>
+        /// <param name="allowedModules">The module keys to keep, comma-separated</param>
+        public static void OnlyAllowModules(string allowedModules)
+            => _encryptionLoader.RemoveAllModulesExcept(allowedModules);
+
     }
 }

--- a/Duplicati/Library/RestAPI/Strings.cs
+++ b/Duplicati/Library/RestAPI/Strings.cs
@@ -24,103 +24,109 @@ using System.Linq;
 
 namespace Duplicati.Server.Strings
 {
-        public static class Program
-        {
-                public static string AnotherInstanceDetected { get { return LC.L(@"Another instance is running, and was notified"); } }
-                public static string DatabaseOpenError(string message) { return LC.L(@"Failed to create, open or upgrade the database.
+    public static class Program
+    {
+        public static string AnotherInstanceDetected { get { return LC.L(@"Another instance is running, and was notified"); } }
+        public static string DatabaseOpenError(string message) { return LC.L(@"Failed to create, open or upgrade the database.
 Error message: {0}", message); }
-                public static string HelpCommandDescription { get { return LC.L(@"Display this help"); } }
-                public static string HelpDisplayDialog { get { return LC.L(@"Supported commandline arguments:
+        public static string HelpCommandDescription { get { return LC.L(@"Display this help"); } }
+        public static string HelpDisplayDialog { get { return LC.L(@"Supported commandline arguments:
 
 "); } }
-                public static string HelpDisplayFormat(string optionname, string optiontext) { return LC.L(@"--{0}: {1}", optionname, optiontext); }
-                public static string ParametersFileOptionLong { get { return LC.L(@"Use this option to store some or all of the options given to the commandline client. The file must be a plain text file, and UTF-8 encoding is preferred. Each line in the file should be of the format --option=value. Use the special options --{0} and --{1} to override the localpath and the remote destination uri, respectively. The options in this file take precedence over the options provided on the commandline. You cannot specify filters in both the file and on the commandline. Instead, you can use the special --{2}, --{3}, or --{4} options to specify filters inside the parameter file. Each filter must be prefixed with either a + or a -, and multiple filters must be joined with {5} ", "source", "target", "replace-filter", "append-filter", "prepend-filter", System.IO.Path.PathSeparator); } }
-                public static string ParametersFileOptionShort { get { return LC.L(@"Path to a file with parameters"); } }
-                public static string FiltersCannotBeUsedWithFileError2 { get { return LC.L(@"Filters cannot be specified on the commandline if filters are also present in the parameter file. Use the special --{0}, --{1}, or --{2} options to specify filters inside the parameter file. Each filter must be prefixed with either a + or a -, and multiple filters must be joined with {3}", "replace-filter", "append-filter", "prepend-filter", System.IO.Path.PathSeparator); } }
-                public static string FailedToParseParametersFileError(string path, string message) { return LC.L(@"Unable to read the parameters file ""{0}"", reason: {1}", path, message); }
-                public static string SkippingSourceArgumentsOnNonBackupOperation { get { return @"The --source argument was specified in the parameter file, but the current operation is not a backup operation, so the argument is ignored"; } }
-                public static string LogfileCommandDescription { get { return LC.L(@"Output log information to the file given"); } }
-                public static string LoglevelCommandDescription { get { return LC.L(@"Determine the amount of information written in the log file"); } }
-                public static string LogConsoleDescription { get { return LC.L(@"Output log information to the console"); } }
-                public static string PortablemodeCommandDescription { get { return LC.L(@"Activate portable mode where the database is placed below the program executable"); } }
-                public static string SeriousError(string message) { return LC.L(@"A serious error occurred in Duplicati: {0}", message); }
-                public static string TearDownError(string message) { return LC.L(@"An error occurred on server tear down: {0}", message); }
-                public static string StartupFailure(System.Exception error) { return LC.L(@"Unable to start up. Perhaps another process is already running?
+        public static string HelpDisplayFormat(string optionname, string optiontext) { return LC.L(@"--{0}: {1}", optionname, optiontext); }
+        public static string ParametersFileOptionLong { get { return LC.L(@"Use this option to store some or all of the options given to the commandline client. The file must be a plain text file, and UTF-8 encoding is preferred. Each line in the file should be of the format --option=value. Use the special options --{0} and --{1} to override the localpath and the remote destination uri, respectively. The options in this file take precedence over the options provided on the commandline. You cannot specify filters in both the file and on the commandline. Instead, you can use the special --{2}, --{3}, or --{4} options to specify filters inside the parameter file. Each filter must be prefixed with either a + or a -, and multiple filters must be joined with {5} ", "source", "target", "replace-filter", "append-filter", "prepend-filter", System.IO.Path.PathSeparator); } }
+        public static string ParametersFileOptionShort { get { return LC.L(@"Path to a file with parameters"); } }
+        public static string FiltersCannotBeUsedWithFileError2 { get { return LC.L(@"Filters cannot be specified on the commandline if filters are also present in the parameter file. Use the special --{0}, --{1}, or --{2} options to specify filters inside the parameter file. Each filter must be prefixed with either a + or a -, and multiple filters must be joined with {3}", "replace-filter", "append-filter", "prepend-filter", System.IO.Path.PathSeparator); } }
+        public static string FailedToParseParametersFileError(string path, string message) { return LC.L(@"Unable to read the parameters file ""{0}"", reason: {1}", path, message); }
+        public static string SkippingSourceArgumentsOnNonBackupOperation { get { return @"The --source argument was specified in the parameter file, but the current operation is not a backup operation, so the argument is ignored"; } }
+        public static string LogfileCommandDescription { get { return LC.L(@"Output log information to the file given"); } }
+        public static string LoglevelCommandDescription { get { return LC.L(@"Determine the amount of information written in the log file"); } }
+        public static string LogConsoleDescription { get { return LC.L(@"Output log information to the console"); } }
+        public static string PortablemodeCommandDescription { get { return LC.L(@"Activate portable mode where the database is placed below the program executable"); } }
+        public static string SeriousError(string message) { return LC.L(@"A serious error occurred in Duplicati: {0}", message); }
+        public static string TearDownError(string message) { return LC.L(@"An error occurred on server tear down: {0}", message); }
+        public static string StartupFailure(System.Exception error) { return LC.L(@"Unable to start up. Perhaps another process is already running?
 Error message: {0}", error); }
-                public static string UnencrypteddatabaseCommandDescription { get { return LC.L(@"Disable database encryption"); } }
-                public static string WrongSQLiteVersion(System.Version actualversion, string expectedversion) { return LC.L(@"Unsupported version of SQLite detected ({0}), must be {1} or higher", actualversion, expectedversion); }
-                public static string WebserverWebrootDescription { get { return LC.L(@"The path to the folder where the static files for the webserver is present. The folder must be located beneath the installation folder."); } }
-                public static string WebserverPortDescription { get { return LC.L(@"The port the webserver listens on. Multiple values may be supplied with a comma in between."); } }
-                public static string WebserverDisableHTTPSDescription { get { return LC.L(@"Deactivates the use of HTTPS even if a certificate is stored in the database or provided on the commandline."); } }
-                public static string WebserverRemoveCertificateDescription { get { return LC.L(@"Removes any existing certificate from the database. This option also disables HTTPS."); } }
-                public static string WebserverCertificateFileDescription { get { return LC.L(@"The certificate and key file in PKCS #12 format the webserver use for SSL."); } }
-                public static string WebserverCertificatePasswordDescription { get { return LC.L(@"The password for decryption of the provided certificate PKCS #12 file."); } }
-                public static string WebserverInterfaceDescription { get { return LC.L(@"The interface the webserver listens on. The special values ""*"" and ""any"" means any interface. The special value ""loopback"" means the loopback adapter."); } }
-                public static string WebserverPasswordDescription { get { return LC.L(@"The password required to access the webserver. This option is saved so you do not need to set it on each run. An access password is mandatory."); } }
-                public static string WebserverAllowedhostnamesDescription { get { return LC.L(@"The hostnames that are accepted, separated with semicolons. If any of the hostnames are ""*"", all hostnames are allowed and the hostname checking is disabled."); } }
-                public static string PingpongkeepaliveLong { get { return LC.L(@"When running as a server, the service daemon must verify that the process is responding. If this option is enabled, the server reads stdin and writes a reply to each line read."); } }
-                public static string PingpongkeepaliveShort { get { return LC.L(@"Enable the ping-pong responder"); } }
-                public static string DisableupdatecheckShort { get { return LC.L(@"Disable the automatic update check"); } }
-                public static string DisableupdatecheckLong { get { return LC.L(@"Use this option to disable the automatic update check. Manual update checks can still be performed."); } }
-                public static string LogretentionLong { get { return LC.L(@"Set the time after which log data will be purged from the database."); } }
-                public static string LogretentionShort { get { return LC.L(@"Clean up old log data"); } }
-                public static string ServerdatafolderLong(string envname) { return LC.L(@"Duplicati needs to store a small database with all settings. Use this option to choose where the settings are stored. This option can also be set with the environment variable {0}.", envname); }
-                public static string ServerdatafolderShort { get { return LC.L(@"Set the folder where settings are stored"); } }
-                public static string ServerencryptionkeyLong(string envname, string decryptionoption) { return LC.L(@"This option sets the encryption key used to scramble the local settings database. This option can also be set with the environment variable {0}. Use the option --{1} to disable the database scrambling.", envname, decryptionoption); }
-                public static string ServerencryptionkeyShort { get { return LC.L(@"Set the database encryption key"); } }
-                public static string TempdirLong { get { return LC.L(@"Use this option to supply an alternative folder for temporary storage. By default the system default temporary folder is used. Note that also SQLite will put temporary files in this temporary folder."); } }
-                public static string TempdirShort { get { return LC.L(@"Temporary storage folder"); } }
-                public static string WebserverResetJwtConfigDescription { get { return LC.L(@"Reset the JWT configuration, invalidating any issued login tokens"); } }
-                public static string WebserverEnableForeverTokenDescription { get { return LC.L(@"Enable the use of long-lived access tokens"); } }
-                public static string WebserverApiOnlyDescription { get { return LC.L(@"Disable the web interface and only allow API access"); } }
-                public static string WebserverDisableSigninTokensDescription { get { return LC.L(@"Disable the use of signin tokens"); } }
-                public static string WebserverSpaPathsDescription { get { return LC.L(@"The relative paths that should be served as single page applications, separated with semicolons."); } }
-                public static string WebserverCorsOriginsDescription { get { return LC.L(@"A list of CORS origins to allow, separated with semicolons. Each origin must be a valid URL."); } }
-                public static string WebserverTimezoneDescription { get { return LC.L(@"The timezone to use for the webserver. The timezone must be a valid timezone identifier, such as ""America/New_York"" or ""UTC"". Common three-letter abbreviations like ""CET"" are supported, but ambiguous in some cases."); } }
-                public static string WebserverPreAuthTokensDescription { get { return LC.L(@"A list of pre-authenticated tokens, separated with semicolons. These can be used in cases where the authentication is provided by a proxy. Each token must be at least 10 characters and not contain extended characters. The token must be provided by setting the header on each request to contain: Authentication: PreAuth <token>"); } }
-                public static string WebserverDisableApiExtensionsDescription { get { return LC.L(@"Disable the API extensions reported by the server. This will not disable the functionality, but will not report the extensions in the API responses. Use this option to degrade the server to a more basic API."); } }
-                public static string WebserverTokenDurationDescription { get { return LC.L(@"The duration of the refresh tokens issued by the server. This value indicates how much time can pass without activity before the user is asked to log in again. The value must be greater than zero and is capped at 30 days."); } }
-                public static string DisabledbencryptionLong { get { return LC.L(@"Use this option to disable database encryption of sensitive fields"); } }
-                public static string DisabledbencryptionShort { get { return LC.L(@"Disable database encryption"); } }
-                public static string LogwindowseventlogLong { get { return LC.L(@"Use this option to log to the Windows event log. The provided name is in the format Log:Source. If no log name is provided, Duplicati is used."); } }
-                public static string LogwindowseventlogShort { get { return LC.L(@"Log to the Windows event log"); } }
-                public static string LogwindowseventloglevelLong { get { return LC.L(@"Use this option to set the log level for the Windows event log."); } }
-                public static string LogwindowseventloglevelShort { get { return LC.L(@"Set the log level for the Windows event log"); } }
-                public static string WindowsEventLogSourceNotFound(string source) { return LC.L(@"The Windows event log source {0} was not found. Attempting to create.", source); }
-                public static string WindowsEventLogSourceNotCreated(string source) { return LC.L(@"The Windows Event Log was not created for: {0}, not logging to eventlog.", source); }
-                public static string WindowsEventLogNotSupported { get { return LC.L(@"The Windows event log is not supported on this platform"); } }
-                public static string ServerStarted(string @interface, int port) { return LC.L(@"Server has started and is listening on {0}, port {1}", @interface, port); }
-                public static string ServerStartedSignin(string url) { return LC.L(@"Use the following link to sign in: {0}", url); }
-                public static string ServerCrashed(string message) { return LC.L(@"The server crashed: {0}", message); }
-                public static string ServerStopping { get { return LC.L(@"Server is stopping, tearing down handlers"); } }
-                public static string ServerStopped { get { return LC.L(@"Server has stopped"); } }
-                public static string RequiredbencryptionLong { get { return LC.L(@"Use this option to require a custom provided key for database encryption of sensitive fields and not rely on the serial number."); } }
-                public static string RequiredbencryptionShort { get { return LC.L(@"Require database encryption"); } }
-                public static string DatabaseEncryptionKeyRequired(string envkey, string disableoptionname) { return LC.L(@"Database encryption key is required. Supply an encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
-                public static string BlacklistedEncryptionKey(string envkey, string disableoptionname) { return LC.L(@"The database encryption key is blacklisted and cannot be used. The database has been decrypted. Supply a new encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
-                public static string NoEncryptionKeySpecified(string envkey, string disableoptionname) { return LC.L(@"No database encryption key was found. The database will be stored unencrypted. Supply an encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
-                public static string EncryptionKeyMissing(string envkey) { return LC.L(@"The database appears to be encrypted, but no key was specified. Opening the database will likely fail. Use the environment variable {0} to specify the key.", envkey); }
-                public static string InvalidTimezone(string timezone) { return LC.L(@"The timezone {0} is not valid", timezone); }
-                public static string SettingsencryptionkeyShort { get { return LC.L(@"Set the encryption key for the settings database"); } }
-                public static string SettingsencryptionkeyLong(string envname) { return LC.L(@"Use this option to set the encryption key for the settings database. This option can also be set with the environment variable {0}.", envname); }
-                public static string InvalidPauseResumeState(LiveControls.LiveControlState state) { return LC.L(@"Invalid pause/resume state: {0}", state); }
-                public static string RegisterRemoteControlShort { get { return LC.L(@"Register for remote control"); } }
-                public static string RegisterRemoteControlLong { get { return LC.L(@"Register for remote control using the pre-authenticated url. If the server is already registered, this option has no effect"); } }
-                public static string RegisterRemoteControlReregisterShort { get { return LC.L(@"Force register for remote control"); } }
-                public static string RegisterRemoteControlReregisterLong { get { return LC.L(@"Forces a re-registration if the server is already registered. If the server is not already registered, this option has no effect."); } }
-                public static string RemoteControlAlreadyRegistered { get { return LC.L(@"The server is already registered for remote control, ignoring registration request"); } }
-                public static string RemoteControlRegistrationUrl(string url) { return LC.L(@"The server is registered, use the following link to claim it: {0}", url); }
-                public static string RemoteControlRegistrationFailed(string message) { return LC.L(@"The server registration failed: {0}", message); }
-        }
-        internal static class Scheduler
-        {
-                public static string InvalidTimeSetupError(System.DateTime startdate, string interval, string alloweddays) { return LC.L(@"Unable to find a valid date, given the start date {0}, the repetition interval {1} and the allowed days {2}", startdate, interval, alloweddays); }
-        }
-        public static class Server
-        {
-                public static string StartedServer(string ip, int port) { return LC.L(@"Server has started and is listening on {0}, port {1}", ip, port); }
-                public static string SSLCertificateFileMissingOption { get { return LC.L(@"SSL certificate password option has no meaning when provided without SSL certificate file option!"); } }
-                public static string ServerStartFailure(IEnumerable<int> portstried) { return LC.L(@"Unable to open a socket for listening, tried ports: {0}", string.Join(",", from n in (portstried ?? new int[0]) select n.ToString())); }
-        }
+        public static string UnencrypteddatabaseCommandDescription { get { return LC.L(@"Disable database encryption"); } }
+        public static string WrongSQLiteVersion(System.Version actualversion, string expectedversion) { return LC.L(@"Unsupported version of SQLite detected ({0}), must be {1} or higher", actualversion, expectedversion); }
+        public static string WebserverWebrootDescription { get { return LC.L(@"The path to the folder where the static files for the webserver is present. The folder must be located beneath the installation folder."); } }
+        public static string WebserverPortDescription { get { return LC.L(@"The port the webserver listens on. Multiple values may be supplied with a comma in between."); } }
+        public static string WebserverDisableHTTPSDescription { get { return LC.L(@"Deactivates the use of HTTPS even if a certificate is stored in the database or provided on the commandline."); } }
+        public static string WebserverRemoveCertificateDescription { get { return LC.L(@"Removes any existing certificate from the database. This option also disables HTTPS."); } }
+        public static string WebserverCertificateFileDescription { get { return LC.L(@"The certificate and key file in PKCS #12 format the webserver use for SSL."); } }
+        public static string WebserverCertificatePasswordDescription { get { return LC.L(@"The password for decryption of the provided certificate PKCS #12 file."); } }
+        public static string WebserverInterfaceDescription { get { return LC.L(@"The interface the webserver listens on. The special values ""*"" and ""any"" means any interface. The special value ""loopback"" means the loopback adapter."); } }
+        public static string WebserverPasswordDescription { get { return LC.L(@"The password required to access the webserver. This option is saved so you do not need to set it on each run. An access password is mandatory."); } }
+        public static string WebserverAllowedhostnamesDescription { get { return LC.L(@"The hostnames that are accepted, separated with semicolons. If any of the hostnames are ""*"", all hostnames are allowed and the hostname checking is disabled."); } }
+        public static string PingpongkeepaliveLong { get { return LC.L(@"When running as a server, the service daemon must verify that the process is responding. If this option is enabled, the server reads stdin and writes a reply to each line read."); } }
+        public static string PingpongkeepaliveShort { get { return LC.L(@"Enable the ping-pong responder"); } }
+        public static string DisableupdatecheckShort { get { return LC.L(@"Disable the automatic update check"); } }
+        public static string DisableupdatecheckLong { get { return LC.L(@"Use this option to disable the automatic update check. Manual update checks can still be performed."); } }
+        public static string LogretentionLong { get { return LC.L(@"Set the time after which log data will be purged from the database."); } }
+        public static string LogretentionShort { get { return LC.L(@"Clean up old log data"); } }
+        public static string ServerdatafolderLong(string envname) { return LC.L(@"Duplicati needs to store a small database with all settings. Use this option to choose where the settings are stored. This option can also be set with the environment variable {0}.", envname); }
+        public static string ServerdatafolderShort { get { return LC.L(@"Set the folder where settings are stored"); } }
+        public static string ServerencryptionkeyLong(string envname, string decryptionoption) { return LC.L(@"This option sets the encryption key used to scramble the local settings database. This option can also be set with the environment variable {0}. Use the option --{1} to disable the database scrambling.", envname, decryptionoption); }
+        public static string ServerencryptionkeyShort { get { return LC.L(@"Set the database encryption key"); } }
+        public static string TempdirLong { get { return LC.L(@"Use this option to supply an alternative folder for temporary storage. By default the system default temporary folder is used. Note that also SQLite will put temporary files in this temporary folder."); } }
+        public static string TempdirShort { get { return LC.L(@"Temporary storage folder"); } }
+        public static string WebserverResetJwtConfigDescription { get { return LC.L(@"Reset the JWT configuration, invalidating any issued login tokens"); } }
+        public static string WebserverEnableForeverTokenDescription { get { return LC.L(@"Enable the use of long-lived access tokens"); } }
+        public static string WebserverApiOnlyDescription { get { return LC.L(@"Disable the web interface and only allow API access"); } }
+        public static string WebserverDisableSigninTokensDescription { get { return LC.L(@"Disable the use of signin tokens"); } }
+        public static string WebserverSpaPathsDescription { get { return LC.L(@"The relative paths that should be served as single page applications, separated with semicolons."); } }
+        public static string WebserverCorsOriginsDescription { get { return LC.L(@"A list of CORS origins to allow, separated with semicolons. Each origin must be a valid URL."); } }
+        public static string WebserverTimezoneDescription { get { return LC.L(@"The timezone to use for the webserver. The timezone must be a valid timezone identifier, such as ""America/New_York"" or ""UTC"". Common three-letter abbreviations like ""CET"" are supported, but ambiguous in some cases."); } }
+        public static string WebserverPreAuthTokensDescription { get { return LC.L(@"A list of pre-authenticated tokens, separated with semicolons. These can be used in cases where the authentication is provided by a proxy. Each token must be at least 10 characters and not contain extended characters. The token must be provided by setting the header on each request to contain: Authentication: PreAuth <token>"); } }
+        public static string WebserverDisableApiExtensionsDescription { get { return LC.L(@"Disable the API extensions reported by the server. This will not disable the functionality, but will not report the extensions in the API responses. Use this option to degrade the server to a more basic API."); } }
+        public static string WebserverTokenDurationDescription { get { return LC.L(@"The duration of the refresh tokens issued by the server. This value indicates how much time can pass without activity before the user is asked to log in again. The value must be greater than zero and is capped at 30 days."); } }
+        public static string DisabledbencryptionLong { get { return LC.L(@"Use this option to disable database encryption of sensitive fields"); } }
+        public static string DisabledbencryptionShort { get { return LC.L(@"Disable database encryption"); } }
+        public static string LogwindowseventlogLong { get { return LC.L(@"Use this option to log to the Windows event log. The provided name is in the format Log:Source. If no log name is provided, Duplicati is used."); } }
+        public static string LogwindowseventlogShort { get { return LC.L(@"Log to the Windows event log"); } }
+        public static string LogwindowseventloglevelLong { get { return LC.L(@"Use this option to set the log level for the Windows event log."); } }
+        public static string LogwindowseventloglevelShort { get { return LC.L(@"Set the log level for the Windows event log"); } }
+        public static string WindowsEventLogSourceNotFound(string source) { return LC.L(@"The Windows event log source {0} was not found. Attempting to create.", source); }
+        public static string WindowsEventLogSourceNotCreated(string source) { return LC.L(@"The Windows Event Log was not created for: {0}, not logging to eventlog.", source); }
+        public static string WindowsEventLogNotSupported { get { return LC.L(@"The Windows event log is not supported on this platform"); } }
+        public static string ServerStarted(string @interface, int port) { return LC.L(@"Server has started and is listening on {0}, port {1}", @interface, port); }
+        public static string ServerStartedSignin(string url) { return LC.L(@"Use the following link to sign in: {0}", url); }
+        public static string ServerCrashed(string message) { return LC.L(@"The server crashed: {0}", message); }
+        public static string ServerStopping { get { return LC.L(@"Server is stopping, tearing down handlers"); } }
+        public static string ServerStopped { get { return LC.L(@"Server has stopped"); } }
+        public static string RequiredbencryptionLong { get { return LC.L(@"Use this option to require a custom provided key for database encryption of sensitive fields and not rely on the serial number."); } }
+        public static string RequiredbencryptionShort { get { return LC.L(@"Require database encryption"); } }
+        public static string DatabaseEncryptionKeyRequired(string envkey, string disableoptionname) { return LC.L(@"Database encryption key is required. Supply an encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
+        public static string BlacklistedEncryptionKey(string envkey, string disableoptionname) { return LC.L(@"The database encryption key is blacklisted and cannot be used. The database has been decrypted. Supply a new encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
+        public static string NoEncryptionKeySpecified(string envkey, string disableoptionname) { return LC.L(@"No database encryption key was found. The database will be stored unencrypted. Supply an encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
+        public static string EncryptionKeyMissing(string envkey) { return LC.L(@"The database appears to be encrypted, but no key was specified. Opening the database will likely fail. Use the environment variable {0} to specify the key.", envkey); }
+        public static string InvalidTimezone(string timezone) { return LC.L(@"The timezone {0} is not valid", timezone); }
+        public static string SettingsencryptionkeyShort { get { return LC.L(@"Set the encryption key for the settings database"); } }
+        public static string SettingsencryptionkeyLong(string envname) { return LC.L(@"Use this option to set the encryption key for the settings database. This option can also be set with the environment variable {0}.", envname); }
+        public static string InvalidPauseResumeState(LiveControls.LiveControlState state) { return LC.L(@"Invalid pause/resume state: {0}", state); }
+        public static string RegisterRemoteControlShort { get { return LC.L(@"Register for remote control"); } }
+        public static string RegisterRemoteControlLong { get { return LC.L(@"Register for remote control using the pre-authenticated url. If the server is already registered, this option has no effect"); } }
+        public static string RegisterRemoteControlReregisterShort { get { return LC.L(@"Force register for remote control"); } }
+        public static string RegisterRemoteControlReregisterLong { get { return LC.L(@"Forces a re-registration if the server is already registered. If the server is not already registered, this option has no effect."); } }
+        public static string RemoteControlAlreadyRegistered { get { return LC.L(@"The server is already registered for remote control, ignoring registration request"); } }
+        public static string RemoteControlRegistrationUrl(string url) { return LC.L(@"The server is registered, use the following link to claim it: {0}", url); }
+        public static string RemoteControlRegistrationFailed(string message) { return LC.L(@"The server registration failed: {0}", message); }
+        public static string AllowedBackendModulesShort { get { return LC.L(@"Set the allowed backends for remote control"); } }
+        public static string AllowedBackendModulesLong { get { return LC.L(@"Set the allowed backends for remote control. The value is a comma-separated list of backend names. If this option is not set, all backends are allowed. Use this option to restrict the backends that can be used to store data."); } }
+        public static string AllowedEncryptionModulesShort { get { return LC.L(@"Set the allowed encryption modules for remote control"); } }
+        public static string AllowedEncryptionModulesLong { get { return LC.L(@"Set the allowed encryption modules for remote control. The value is a comma-separated list of encryption module names. If this option is not set, all encryption modules are allowed. Use this option to restrict the encryption modules that can be used to encrypt data."); } }
+        public static string AllowedCompressionModulesShort { get { return LC.L(@"Set the allowed compression modules for remote control"); } }
+        public static string AllowedCompressionModulesLong { get { return LC.L(@"Set the allowed compression modules for remote control. The value is a comma-separated list of compression module names. If this option is not set, all compression modules are allowed. Use this option to restrict the compression modules that can be used to compress data."); } }
+    }
+    internal static class Scheduler
+    {
+        public static string InvalidTimeSetupError(System.DateTime startdate, string interval, string alloweddays) { return LC.L(@"Unable to find a valid date, given the start date {0}, the repetition interval {1} and the allowed days {2}", startdate, interval, alloweddays); }
+    }
+    public static class Server
+    {
+        public static string StartedServer(string ip, int port) { return LC.L(@"Server has started and is listening on {0}, port {1}", ip, port); }
+        public static string SSLCertificateFileMissingOption { get { return LC.L(@"SSL certificate password option has no meaning when provided without SSL certificate file option!"); } }
+        public static string ServerStartFailure(IEnumerable<int> portstried) { return LC.L(@"Unable to open a socket for listening, tried ports: {0}", string.Join(",", from n in (portstried ?? new int[0]) select n.ToString())); }
+    }
 
 }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -54,6 +54,9 @@ namespace Duplicati.Server
         private const string DISABLE_UPDATE_CHECK_OPTION = "disable-update-check";
         private const string REGISTER_REMOTE_CONTROL_OPTION = "register-remote-control";
         private const string REGISTER_REMOTE_CONTROL_REREGISTER_OPTION = "register-remote-control-force";
+        private const string ALLOWED_BACKEND_MODULES = "allowed-backend-modules";
+        private const string ALLOWED_ENCRYPTION_MODULES = "allowed-encryption-modules";
+        private const string ALLOWED_COMPRESSION_MODULES = "allowed-compression-modules";
         private const string LOG_FILE_OPTION = "log-file";
         private const string LOG_LEVEL_OPTION = "log-level";
         private const string LOG_CONSOLE_OPTION = "log-console";
@@ -188,6 +191,12 @@ namespace Duplicati.Server
 
             // Validate after logging is configured
             CommandLineArgumentValidator.ValidateArguments(SupportedCommands, commandlineOptions, KnownDuplicateOptions, ValidationIgnoredOptions);
+
+            // Unload any modules that are not allowed
+            Library.DynamicLoader.BackendLoader.OnlyAllowBackends(commandlineOptions.GetValueOrDefault(ALLOWED_BACKEND_MODULES));
+            Library.DynamicLoader.EncryptionLoader.OnlyAllowModules(commandlineOptions.GetValueOrDefault(ALLOWED_ENCRYPTION_MODULES));
+            Library.DynamicLoader.CompressionLoader.OnlyAllowModules(commandlineOptions.GetValueOrDefault(ALLOWED_COMPRESSION_MODULES));
+
 
             var crashed = false;
             var terminated = false;
@@ -962,6 +971,9 @@ namespace Duplicati.Server
             new CommandLineArgument(SETTINGS_ENCRYPTION_KEY_OPTION, CommandLineArgument.ArgumentType.Password, Strings.Program.SettingsencryptionkeyShort, Strings.Program.SettingsencryptionkeyLong(EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME)),
             new CommandLineArgument(REGISTER_REMOTE_CONTROL_OPTION, CommandLineArgument.ArgumentType.String, Strings.Program.RegisterRemoteControlShort, Strings.Program.RegisterRemoteControlLong),
             new CommandLineArgument(REGISTER_REMOTE_CONTROL_REREGISTER_OPTION, CommandLineArgument.ArgumentType.String, Strings.Program.RegisterRemoteControlReregisterShort, Strings.Program.RegisterRemoteControlReregisterLong),
+            new CommandLineArgument(ALLOWED_BACKEND_MODULES, CommandLineArgument.ArgumentType.String, Strings.Program.AllowedBackendModulesShort, Strings.Program.AllowedBackendModulesLong),
+            new CommandLineArgument(ALLOWED_ENCRYPTION_MODULES, CommandLineArgument.ArgumentType.String, Strings.Program.AllowedEncryptionModulesShort, Strings.Program.AllowedEncryptionModulesLong),
+            new CommandLineArgument(ALLOWED_COMPRESSION_MODULES, CommandLineArgument.ArgumentType.String, Strings.Program.AllowedCompressionModulesShort, Strings.Program.AllowedCompressionModulesLong),
             .. SECRET_PROVIDER_OPTIONS
         ];
 


### PR DESCRIPTION
This PR adds the option to limit the available modules to just the set of specified choices.

If no option is set, all modules are available (default). If the option is set, only those in the list are available (whitelisting).

The options are:
- `--allowed-backend-modules`
- `--allowed-encryption-modules`
- `--allowed-compression-modules`