### PR TITLE
Guard against sending extra header.

### DIFF
--- a/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
+++ b/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
@@ -645,8 +645,11 @@ public class KeepRemoteConnection : IDisposable
                 {
                     foreach (var header in CommandRequestMessage.Headers)
                     {
-                        if (header.Key == "Content-Type" && request.Content != null)
-                            request.Content.Headers.ContentType = new MediaTypeHeaderValue(header.Value);
+                        if (header.Key == "Content-Type")
+                        {
+                            if (request.Content != null)
+                                request.Content.Headers.ContentType = new MediaTypeHeaderValue(header.Value);
+                        }
                         else
                             request.Headers.Add(header.Key, header.Value);
                     }


### PR DESCRIPTION
If the remote client is sending an extra unwanted header, just ignore it.