### PR TITLE
Fix base href replacement in StaticFilesMiddleware

### DIFF
--- a/Duplicati/WebserverCore/Middlewares/StaticFilesMiddleware.cs
+++ b/Duplicati/WebserverCore/Middlewares/StaticFilesMiddleware.cs
@@ -59,7 +59,7 @@ public static class StaticFilesExtensions
         if (!prefix.EndsWith("/"))
             prefix += "/";
 
-        return fileContent.Replace("<base href=\"/\" \/>", $"<base href=\"{prefix}\" \/>");
+        return fileContent.Replace("<base href=\"/\" />", $"<base href=\"{prefix}\" />");
     }
 
     public static IApplicationBuilder UseDefaultStaticFiles(this WebApplication app, string webroot, IEnumerable<string> spaPaths)


### PR DESCRIPTION
ngclient index.html base tag contains extra space / closing slash which breaks replace and X-Forwarded-Prefix support: https://github.com/duplicati/ngclient/blob/866be6d5ffc504a46b40c5aa728b56b11ef9e691/projects/ngclient/src/index.html#L6
