### PR TITLE
Added more guards on MSGraph errors

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -740,8 +740,20 @@ namespace Duplicati.Library.Backend
             using (var request = new HttpRequestMessage(HttpMethod.Delete, uploadSession.UploadUrl))
             using (var response = await this.m_client.SendAsync(request, false, cancelToken).ConfigureAwait(false))
             {
-                // Note that the response body should always be empty in this case.
-                await this.ParseResponseAsync<UploadSession>(response, cancelToken).ConfigureAwait(false);
+                try
+                {
+                    // Note that the response body should always be empty in this case.
+                    if (response.StatusCode != HttpStatusCode.NoContent)
+                        await this.ParseResponseAsync<UploadSession>(response, cancelToken).ConfigureAwait(false);
+                }
+                catch (Exception parseEx)
+                {
+                    Log.WriteErrorMessage(
+                        LOGTAG,
+                        "MicrosoftGraphUploadSessionCancelError",
+                        parseEx,
+                        "Error canceling upload session after fragment upload failure");
+                }
             }
 
             throw new UploadSessionException(createSessionResponse, fragment, fragmentCount, ex);


### PR DESCRIPTION
This PR handles empty responses with the status code 204 - No Content.

Prior to this PR a 204 response when cancelling an upload session would cause an error due to not being able to parse the empty body.

This should get us one step closer to figuring out what is triggering the errors.