### PR TITLE
Report remote filename on hash errors

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.GetOperation.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.GetOperation.cs
@@ -92,7 +92,7 @@ partial class BackendManager
                         throw new Exception(Strings.Controller.DownloadedFileSizeError(RemoteFilename, dataSizeDownloaded, Size));
 
                     if (!string.IsNullOrEmpty(Hash) && fileHash != Hash)
-                        throw new HashMismatchException(Strings.Controller.HashMismatchError(tmpfile, Hash, fileHash));
+                        throw new HashMismatchException(Strings.Controller.HashMismatchError(RemoteFilename, Hash, fileHash));
                 }
 
                 // Perform decryption after hash validation, if needed


### PR DESCRIPTION
This PR changes the reported filename to use the remote filename instead of the random temporary filename that has little value to the user as the file is deleted immediately after the error is raised.