### PR TITLE
Auto-correct S3 hostname

### DIFF
--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -249,6 +249,7 @@ namespace Duplicati.Library.Backend
                 options["s3-ext-forcepathstyle"] = "true";
 
             // Validate that hostname doesn't contain a path
+            hostname = hostname.Trim('/').Trim('\\');
             if (hostname.Contains('/') || hostname.Contains('\\'))
                 throw new UserInformationException(Strings.S3Backend.NoPathAllowedInEndpointError, "S3NoPathInEndpoint");
 


### PR DESCRIPTION
This PR updates the S3 backend to automatically remove leading and trailing `/` characters so upgrades are less likely to encounter the error, as the previous version did not fail on such hostnames.

The check still captures cases where the user attempts to input a path or URL into the hostname field.