### PR TITLE
Show assembly version

### DIFF
--- a/Duplicati/License/VersionNumbers.cs
+++ b/Duplicati/License/VersionNumbers.cs
@@ -59,7 +59,7 @@ namespace Duplicati.License
             if (!string.IsNullOrWhiteSpace(TAG))
                 v += " - " + TAG;
 #if DEBUG
-            v = " - debug";
+            v += " - debug";
 #endif
             VERSION_NAME = v;
 


### PR DESCRIPTION
This PR fixes a long-standing issue where the reported version number is just the tag with a `-` prefix.

This was caused by the logic dropping the assembly version number if a tag exists, but prefixing it with a dash.

The fix is to now show both the assembly version and the tag.