### PR TITLE
Expose pCloud options

### DIFF
--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -166,6 +166,7 @@ public class pCloudBackend : IStreamingBackend
             CommandLineArgument.ArgumentType.Password,
             Strings.pCloudBackend.AuthPasswordDescriptionShort,
             Strings.pCloudBackend.AuthPasswordDescriptionLong(TOKEN_URL)),
+        .. TimeoutOptionsHelper.GetOptions()
     ];
 
     /// <summary>


### PR DESCRIPTION
This PR fixes an issue with pCloud where the timeout options were not shown as supported even though they are parsed.