### PR TITLE
Added support for importing a backup as temporary

### DIFF
--- a/Duplicati/WebserverCore/Abstractions/IBackupListService.cs
+++ b/Duplicati/WebserverCore/Abstractions/IBackupListService.cs
@@ -28,7 +28,7 @@ public interface IBackupListService
 {
     IEnumerable<Dto.BackupAndScheduleOutputDto> List(string? orderBy);
 
-    Dto.ImportBackupOutputDto Import(bool cmdline, bool import_metadata, bool direct, string passphrase, string tempfile);
+    Dto.ImportBackupOutputDto Import(bool cmdline, bool import_metadata, bool direct, bool temporary, string passphrase, string tempfile);
 
     Dto.CreateBackupDto Add(Dto.BackupAndScheduleInputDto data, bool temporary, bool existingDb);
 }

--- a/Duplicati/WebserverCore/Dto/ImportBackupInputDto.cs
+++ b/Duplicati/WebserverCore/Dto/ImportBackupInputDto.cs
@@ -28,11 +28,13 @@ namespace Duplicati.WebserverCore.Dto;
 /// <param name="import_metadata">Whether the metadata should be imported</param>
 /// <param name="direct">Whether the backup should be imported and created directly</param>
 /// <param name="passphrase">The passphrase to use for the backup configuration</param>
+/// <param name="temporary">Whether the backup should be created as temporary</param>
 public sealed record ImportBackupInputDto
 (
     string config,
     bool? cmdline,
     bool? import_metadata,
     bool? direct,
-    string? passphrase
+    string? passphrase,
+    bool? temporary
 );

--- a/Duplicati/WebserverCore/Endpoints/V1/Backups.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backups.cs
@@ -40,7 +40,7 @@ public class Backups : IEndpointV1
             using var tempfile = new Library.Utility.TempFile();
             File.WriteAllBytes(tempfile, Convert.FromBase64String(input.config));
 
-            return backupListService.Import(input.cmdline ?? false, input.import_metadata ?? false, input.direct ?? false, input.passphrase ?? "", tempfile);
+            return backupListService.Import(input.cmdline ?? false, input.import_metadata ?? false, input.direct ?? false, input.temporary ?? false, input.passphrase ?? "", tempfile);
 
         }).RequireAuthorization();
     }

--- a/Duplicati/WebserverCore/Services/BackupListService.cs
+++ b/Duplicati/WebserverCore/Services/BackupListService.cs
@@ -121,7 +121,7 @@ public class BackupListService(Connection connection) : IBackupListService
     }
 
     /// <inheritdoc/>
-    public ImportBackupOutputDto Import(bool cmdline, bool import_metadata, bool direct, string passphrase, string tempfile)
+    public ImportBackupOutputDto Import(bool cmdline, bool import_metadata, bool direct, bool temporary, string passphrase, string tempfile)
     {
         try
         {
@@ -145,7 +145,10 @@ public class BackupListService(Connection connection) : IBackupListService
                     if (!string.IsNullOrWhiteSpace(err))
                         throw new BadRequestException(err);
 
-                    connection.AddOrUpdateBackupAndSchedule(ipx.Backup, ipx.Schedule);
+                    if (temporary)
+                        connection.RegisterTemporaryBackup(ipx.Backup);
+                    else
+                        connection.AddOrUpdateBackupAndSchedule(ipx.Backup, ipx.Schedule);
                 }
 
                 return new ImportBackupOutputDto(ipx.Backup.ID, null);


### PR DESCRIPTION
This allows the FE to call the import with both `direct` and `temporary` set to `true` to import from a config without needing a second step.

Once the FE is updated to support this, we can keep the unencrypted passwords out of the FE during import-from-config