### PR TITLE
Added option to disable console control

### DIFF
--- a/Duplicati/Library/RestAPI/Database/ServerSettings.cs
+++ b/Duplicati/Library/RestAPI/Database/ServerSettings.cs
@@ -79,6 +79,7 @@ namespace Duplicati.Server.Database
             public const string BACKUP_LIST_SORT_ORDER = "backup-list-sort-order";
             public const string DISABLE_API_EXTENSIONS = "disable-api-extensions";
             public const string POWER_MODE_PROVIDER = "power-mode-provider";
+            public const string DISABLE_CONSOLE_CONTROL = "disable-console-control";
         }
 
         private readonly Dictionary<string, string?> settings;
@@ -652,6 +653,21 @@ namespace Duplicati.Server.Database
                 return !DisableHTTPS && !string.IsNullOrWhiteSpace(settings[CONST.SERVER_SSL_CERTIFICATE]);
             }
         }
+
+        public bool DisableConsoleControl
+        {
+            get
+            {
+                return Utility.ParseBool(settings[CONST.DISABLE_CONSOLE_CONTROL], false);
+            }
+            set
+            {
+                lock (databaseConnection.m_lock)
+                    settings[CONST.DISABLE_CONSOLE_CONTROL] = value.ToString();
+                SaveSettings();
+            }
+        }
+
 
         public X509Certificate2Collection? ServerSSLCertificate
         {

--- a/Duplicati/WebserverCore/Services/RemoteControllerHandler.cs
+++ b/Duplicati/WebserverCore/Services/RemoteControllerHandler.cs
@@ -144,6 +144,12 @@ public class RemoteControllerHandler(Connection connection, IHttpClientFactory h
     /// <inheritdoc/>
     public async Task OnMessage(KeepRemoteConnection.CommandMessage commandMessage)
     {
+        if (connection.ApplicationSettings.DisableConsoleControl)
+        {
+            commandMessage.Respond(new CommandResponseMessage(501, "Remote control is disabled.", null));
+            return;
+        }
+
         using var httpClient = httpClientFactory.CreateClient();
         var token = jwtTokenProvider.CreateAccessToken("remote-control", jwtTokenProvider.TemporaryFamilyId, TimeSpan.FromMinutes(2));
 


### PR DESCRIPTION
This PR adds an option to disable control from the console. With this option it is possible to keep a connection to the console, but not allow remote administration.