### PR TITLE
Bugfix/Remote Synchronization tool seek on non-seekable stream

### DIFF
--- a/Tools/RemoteSynchronization/LightWeightBackendManager.cs
+++ b/Tools/RemoteSynchronization/LightWeightBackendManager.cs
@@ -271,9 +271,12 @@ namespace RemoteSynchronization
                     Dispose(); // Dispose current backend and streaming backend.
 
                     // Reset the stream, as it's in a potentially faulty state.
-                    stream?.Seek(0, SeekOrigin.Begin);
-                    if (resetStream)
-                        stream?.SetLength(0);
+                    if (stream != null && stream.CanSeek)
+                    {
+                        stream.Seek(0, SeekOrigin.Begin);
+                        if (resetStream)
+                            stream.SetLength(0);
+                    }
 
                     // Try to see if we can recover from the error.
                     await TryRecoverFromException(ex, token).ConfigureAwait(false);


### PR DESCRIPTION
This PR handles the remote synchronization tool throwing an exception when it tries to seek on a stream that does not support seeking during exception handling. E.g. this could occur when the destination folder did not exist, in which case nothing has happened to the stream and it should be left untouched while the folder is being created during retry. 