### PR TITLE
Bugfix/RemoteSynchronization reset stream during rename. 

### DIFF
--- a/Tools/RemoteSynchronization/LightWeightBackendManager.cs
+++ b/Tools/RemoteSynchronization/LightWeightBackendManager.cs
@@ -208,6 +208,7 @@ namespace RemoteSynchronization
                             // Download the file, rename it, and delete the old one
                             using var downloaded = new MemoryStream();
                             await sb.GetAsync(oldname, downloaded, token).ConfigureAwait(false);
+                            downloaded.Seek(0, SeekOrigin.Begin);
                             await sb.PutAsync(newname, downloaded, token).ConfigureAwait(false);
                             await sb.DeleteAsync(oldname, token).ConfigureAwait(false);
                             _anyUploaded = true;


### PR DESCRIPTION
This PR fixes the issue of handing of a stream where position != 0 to `PutAsync()`, which results in faulty uploads where digests doesn't match (such as to S3). 