### PR TITLE
Fixed startup delay not working

### DIFF
--- a/Duplicati/Library/RestAPI/Scheduler.cs
+++ b/Duplicati/Library/RestAPI/Scheduler.cs
@@ -100,7 +100,6 @@ namespace Duplicati.Server
             m_updateTasks = new Dictionary<Runner.IRunnerData, Tuple<ISchedule, DateTime, DateTime>>();
             m_thread.IsBackground = true;
             m_thread.Name = "TaskScheduler";
-            m_thread.Start();
         }
 
         public IList<Tuple<string, DateTime>> GetProposedSchedule()
@@ -121,6 +120,8 @@ namespace Duplicati.Server
         /// </summary>
         public void Reschedule()
         {
+            if (!m_thread.IsAlive && !m_terminate)
+                m_thread.Start();
             m_event.Set();
         }
 

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -257,6 +257,14 @@ namespace Duplicati.Server
 
                 LiveControl.StateChanged = (e) => { LiveControl_StateChanged(queueRunner, connection, eventPollNotify, scheduler, e); };
 
+                // Invoke it once to set initial state
+                LiveControl_StateChanged(queueRunner, connection, eventPollNotify, scheduler, new LiveControls.LiveControlEvent
+                {
+                    State = LiveControl.State,
+                    TransfersPaused = LiveControl.TransfersPaused,
+                    WaitTimeExpiration = LiveControl.EstimatedPauseEnd
+                });
+
                 if (Library.Utility.Utility.ParseBoolOption(commandlineOptions, PING_PONG_KEEPALIVE_OPTION))
                 {
                     PingPongThread = new Thread(() => PingPongMethod(applicationSettings)) { IsBackground = true };


### PR DESCRIPTION
This PR fixes a race during startup, where it was possible for the scheduler to start before the runner was paused, such that tasks could be started, even if the server was supposed to be paused.

This also fixes a more direct issue where the state was not updated during startup, so the UI could look paused, but the runner was active and accepting tasks.

This fixes #6634