### PR TITLE
Added support for settings override in imports

### DIFF
--- a/Duplicati/CommandLine/ServerUtil/Connection.cs
+++ b/Duplicati/CommandLine/ServerUtil/Connection.cs
@@ -562,15 +562,17 @@ public class Connection
     /// <param name="file">The file to import</param>
     /// <param name="password">The password to use</param>
     /// <param name="importMetadata">Whether to import metadata</param>
+    /// <param name="extraSettings">Extra settings to apply to the imported backup</param>
     /// <returns>The backup</returns>
-    public async Task<BackupEntry> ImportBackup(string file, string? password, bool importMetadata)
+    public async Task<BackupEntry> ImportBackup(string file, string? password, bool importMetadata, Dictionary<string, string> extraSettings)
     {
         var payload = JsonContent.Create(new
         {
             config = Convert.ToBase64String(await File.ReadAllBytesAsync(file)),
             import_metadata = importMetadata,
             passphrase = password,
-            direct = true
+            direct = true,
+            replace_settings = extraSettings
         });
         var response = await client.PostAsync("backups/import", payload);
         await EnsureSuccessStatusCodeWithParsing(response);

--- a/Duplicati/WebserverCore/Abstractions/IBackupListService.cs
+++ b/Duplicati/WebserverCore/Abstractions/IBackupListService.cs
@@ -28,7 +28,7 @@ public interface IBackupListService
 {
     IEnumerable<Dto.BackupAndScheduleOutputDto> List(string? orderBy);
 
-    Dto.ImportBackupOutputDto Import(bool cmdline, bool import_metadata, bool direct, bool temporary, string passphrase, string tempfile);
+    Dto.ImportBackupOutputDto Import(bool cmdline, bool import_metadata, bool direct, bool temporary, string passphrase, string tempfile, Dictionary<string, string>? replace_settings);
 
     Dto.CreateBackupDto Add(Dto.BackupAndScheduleInputDto data, bool temporary, bool existingDb);
 }

--- a/Duplicati/WebserverCore/Dto/ImportBackupInputDto.cs
+++ b/Duplicati/WebserverCore/Dto/ImportBackupInputDto.cs
@@ -29,6 +29,7 @@ namespace Duplicati.WebserverCore.Dto;
 /// <param name="direct">Whether the backup should be imported and created directly</param>
 /// <param name="passphrase">The passphrase to use for the backup configuration</param>
 /// <param name="temporary">Whether the backup should be created as temporary</param>
+/// <param name="replace_settings">Settings to replace in the imported backup configuration</param>
 public sealed record ImportBackupInputDto
 (
     string config,
@@ -36,5 +37,6 @@ public sealed record ImportBackupInputDto
     bool? import_metadata,
     bool? direct,
     string? passphrase,
-    bool? temporary
+    bool? temporary,
+    Dictionary<string, string>? replace_settings
 );

--- a/Duplicati/WebserverCore/Endpoints/V1/Backups.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backups.cs
@@ -40,7 +40,7 @@ public class Backups : IEndpointV1
             using var tempfile = new Library.Utility.TempFile();
             File.WriteAllBytes(tempfile, Convert.FromBase64String(input.config));
 
-            return backupListService.Import(input.cmdline ?? false, input.import_metadata ?? false, input.direct ?? false, input.temporary ?? false, input.passphrase ?? "", tempfile);
+            return backupListService.Import(input.cmdline ?? false, input.import_metadata ?? false, input.direct ?? false, input.temporary ?? false, input.passphrase ?? "", tempfile, input.replace_settings);
 
         }).RequireAuthorization();
     }


### PR DESCRIPTION
This PR adds the option to provide additional settings when importing a backup.

The ServerUtil has been expanded to support passing in the target url and backup passphrase when importing a backup.

Also clarified wording around the import passphrase as there are (at least) two passphrases related to imports.

This fixes #6640