### PR TITLE
Improve API for getting registration status.

### DIFF
--- a/Duplicati/WebserverCore/Dto/StartRegistrationInput.cs
+++ b/Duplicati/WebserverCore/Dto/StartRegistrationInput.cs
@@ -24,4 +24,4 @@ namespace Duplicati.WebserverCore.Dto;
 /// The required data for starting a registration
 /// </summary>
 /// <param name="RegistrationUrl">The URL to register the machine with</param>
-public sealed record StartRegistrationInput(string RegistrationUrl);
+public sealed record StartRegistrationInput(string? RegistrationUrl);


### PR DESCRIPTION
This PR adds a new endpoint to explicitly wait for registration instead of reusing the registration endpoint for both starting and continuing registration wait.