### PR TITLE
Bugfix/cross OS restore

### DIFF
--- a/Duplicati/UnitTest/Issue6705.cs
+++ b/Duplicati/UnitTest/Issue6705.cs
@@ -142,16 +142,16 @@ public class Issue6705 : BasicSetupHelper
     [OneTimeSetUp]
     public void DownloadAndExtractBackups()
     {
-        bool remote = false; // Set to false to use local files instead of downloading from S3
+        bool remote = true; // Set to false to use local files instead of downloading from S3
         var localZipPath = "D:\\git\\duplicati-carl";
-        var zipPostfix = "_large"; // Set to "" for small backup, "_large" for large backup
+        var zipPostfix = ""; // Set to "" for small backup, "_large" for large backup
         foreach (var os in new[] { "Windows", "Linux", "MacOS" })
         {
             string zipFilepath = Path.Combine(localZipPath, $"{os}{zipPostfix}.zip");
             if (remote)
             {
                 zipFilepath = ZipPath(os);
-                var url = $"https://testfiles.duplicati.com/issue6705/{os}{zipPostfix}.zip";
+                var url = $"https://testfiles.duplicati.com/cross-os-backups/{os}{zipPostfix}.zip";
                 DownloadS3FileIfNewerAsync(zipFilepath, url).GetAwaiter().GetResult();
             }
             var extractedPath = ExtractedBasePath(os);


### PR DESCRIPTION
This PR adds tests to cover issue #6705, which highlights that there may be a problem with restoring files from a backup created on a different operating system that the one being restored on. 

While the tests pass with the current implementation, the test still provides value in covering this scenario. 

The tests works by downloading a zip folder containing:
1. The database that was created during the backup. 
2. The original files. 
3. The backup created using [the master branch at the time of writing](https://github.com/duplicati/duplicati/commit/6d6168c2962f54e57fa12b8e4c582c04859d3dc5).

There exists a zip file for each of the major operating systems (Linux, MacOS, and Windows). The tests then downloads and extracts each of these zip folders, followed by a restore from each of them with all combinations of the following configurations:
1. With and without using the packed database.
2. With and without using the legacy restore flow. 
3. With and without skipping metadata during the restore. 
resulting in 8 combinations for each of the 3 operating systems, totaling 24 restores. 