### PR TITLE
Fix spelling of supplementary groups

### DIFF
--- a/ReleaseBuilder/Resources/debian/systemd/duplicati-agent.default
+++ b/ReleaseBuilder/Resources/debian/systemd/duplicati-agent.default
@@ -9,5 +9,5 @@
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
 
-# Supplemantary groups to inherit if not running as root
-SUPPLIMENTARY_GROUPS=
+# Supplementary groups to inherit if not running as root
+SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/debian/systemd/duplicati.default
+++ b/ReleaseBuilder/Resources/debian/systemd/duplicati.default
@@ -9,5 +9,5 @@
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
 
-# Supplemantary groups to inherit if not running as root
-SUPPLIMENTARY_GROUPS=
+# Supplementary groups to inherit if not running as root
+SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/debian/systemd/duplicati.service
+++ b/ReleaseBuilder/Resources/debian/systemd/duplicati.service
@@ -9,7 +9,7 @@ IOSchedulingPriority=7
 EnvironmentFile=-/etc/default/duplicati
 ExecStart=/usr/bin/duplicati-server $DAEMON_OPTS
 Restart=always
-SupplimentaryGroups=$SUPPLIMENTARY_GROUPS
+SupplementaryGroups=$SUPPLEMENTARY_GROUPS
 
 [Install]
 WantedBy=multi-user.target

--- a/ReleaseBuilder/Resources/fedora/systemd/duplicati-agent.default
+++ b/ReleaseBuilder/Resources/fedora/systemd/duplicati-agent.default
@@ -10,5 +10,5 @@
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
 
-# Supplemantary groups to inherit if not running as root
-SUPPLIMENTARY_GROUPS=
+# Supplementary groups to inherit if not running as root
+SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/fedora/systemd/duplicati.default
+++ b/ReleaseBuilder/Resources/fedora/systemd/duplicati.default
@@ -10,5 +10,5 @@
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
 
-# Supplemantary groups to inherit if not running as root
-SUPPLIMENTARY_GROUPS=
+# Supplementary groups to inherit if not running as root
+SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/fedora/systemd/duplicati.service
+++ b/ReleaseBuilder/Resources/fedora/systemd/duplicati.service
@@ -9,7 +9,7 @@ IOSchedulingPriority=7
 EnvironmentFile=-/etc/sysconfig/duplicati
 ExecStart=/usr/bin/duplicati-server $DAEMON_OPTS
 Restart=on-failure
-SupplimentaryGroups=$SUPPLIMENTARY_GROUPS
+SupplementaryGroups=$SUPPLEMENTARY_GROUPS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR fixes a mis-spelling of supplementary groups used in Linux installs with systemd agents.

This closes #6699