### PR TITLE
Improve WebDAV SSL certs

### DIFF
--- a/Duplicati/Library/Utility/SslCertificateValidator.cs
+++ b/Duplicati/Library/Utility/SslCertificateValidator.cs
@@ -67,6 +67,9 @@ public class SslCertificateValidator(bool acceptAll, string[]? validHashes)
                         return true;
             }
 
+            if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch) || sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateChainErrors))
+                throw new InvalidCertificateException(certificate.GetCertHashString(), sslPolicyErrors);
+
             // If no hash is found, perform the standard validations
             return sslPolicyErrors == SslPolicyErrors.None && certificate.Verify();
         }

--- a/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
@@ -45,13 +45,15 @@ public class DestinationVerify : IEndpointV2
 
         try
         {
-
             if (destinationType == RemoteDestinationType.SourceProvider)
             {
                 using var wrapper = await SharedRemoteOperation.GetSourceProviderForTesting(connection, applicationSettings, input.DestinationUrl, input.BackupId, cancelToken);
+                await wrapper.SourceProvider.Test(cancelToken);
+                // Technically we also count folders as files here, but really we just want to know if there is data to backup
+                var anyFiles = await wrapper.SourceProvider.Enumerate(cancelToken).AnyAsync(cancelToken);
 
                 return DestinationTestResponseDto.Create(
-                    anyFiles: true,
+                    anyFiles: anyFiles,
                     anyBackups: false,
                     anyEncryptedFiles: false
                 );
@@ -59,6 +61,7 @@ public class DestinationVerify : IEndpointV2
             else if (destinationType == RemoteDestinationType.RestoreDestinationProvider)
             {
                 using var wrapper = await SharedRemoteOperation.GetRestoreDestinationProviderForTesting(connection, applicationSettings, input.DestinationUrl, input.BackupId, cancelToken);
+                await wrapper.RestoreDestinationProvider.Test(cancelToken);
 
                 return DestinationTestResponseDto.Create(
                     anyFiles: true,


### PR DESCRIPTION
This PR now checks for the SSL certificate and the UI will offer to pin the certificate if this is not a trusted certificate.

Also, the sourceproviders and restoredestinationproviders now actually invoke the `Test` method when being tested.