### PR TITLE
Fixed bug with scheme detection

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1664,10 +1664,10 @@ namespace Duplicati.Library.Utility
                 return null;
 
             var idx = url.IndexOf("://");
-            if (idx < 0 && idx < 15 && idx + "://".Length < url.Length)
+            if (idx < 0 || idx > 15)
                 return null;
 
-            return url.Substring(0, idx);
+            return url[..idx];
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes a reported issue with strings that are less than 3 characters.

This is unlikely, but happens if the code tries to get the scheme of a path, like `/a` or `/`.

The updated logic returns the scheme if one exists, and it is less than 15 characters (to avoid leaking sensitive information).