### PR TITLE
Improved ownership calculation for RPM

### DIFF
--- a/ReleaseBuilder/Build/Command.cs
+++ b/ReleaseBuilder/Build/Command.cs
@@ -146,7 +146,7 @@ public static partial class Command
     /// <summary>
     /// The packages that are required for GUI builds
     /// </summary>
-    private static readonly IReadOnlyList<string> FedoraGUIDepends = ["libICE", "libSM", "fontconfig", "libicu", "desktop-file-utils"];
+    private static readonly IReadOnlyList<string> FedoraGUIDepends = ["fontconfig", "libicu", "desktop-file-utils"];
     /// <summary>
     /// The packages that are required for CLI builds
     /// </summary>

--- a/ReleaseBuilder/Resources/fedora/duplicati.spec.template.txt
+++ b/ReleaseBuilder/Resources/fedora/duplicati.spec.template.txt
@@ -38,6 +38,13 @@ Source4:	%{installname}.default
 BuildRequires:  systemd
 
 Requires:	bash
+#GUI_ONLY#%ifarch x86_64 aarch64
+#GUI_ONLY#Requires: libICE.so.6()(64bit)
+#GUI_ONLY#Requires: libSM.so.6()(64bit)
+#GUI_ONLY#%else
+#GUI_ONLY#Requires: libICE.so.6
+#GUI_ONLY#Requires: libSM.so.6
+#GUI_ONLY#%endif
 %DEPENDS%
 
 %PROVIDES%
@@ -125,6 +132,7 @@ install -p -D -m 644 %{_topdir}/SOURCES/%{namer}%SERVICENAME%.default %{buildroo
 %changelog
 * Mon Feb 9 2026 Kenneth Skovhede <kenneth@duplicati.com> - 2.0.0-0.20260209.git
 - Changed ownership logic for files to avoid accidentially owning base folders
+- Changed logic for finding libICE and libSM so it is compatible with OpenSUSE and Fedora
 
 * Mon May 19 2025 Kenneth Skovhede <kenneth@duplicati.com> - 2.0.0-0.20250519.git
 - Fixed config files not being overwritten


### PR DESCRIPTION
This PR narrows the files that are captured as being provided/owned by Duplicati, to avoid cases where it would match something overly broad.

This fixes #2540

However, it looks like issue #2540 was resolved in Fedora at some point as it was no longer an issue in Fedora 43.

Also changed spec to look for `libICE.so.6` instead of relying on the package names that differ on Fedora/OpenSUSE (`libICE` vs `libICE6`).

This fixes #6166 