### PR TITLE
Roll back supplementary groups

### DIFF
--- a/ReleaseBuilder/Resources/debian/systemd/duplicati-agent.default
+++ b/ReleaseBuilder/Resources/debian/systemd/duplicati-agent.default
@@ -8,6 +8,3 @@
 
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
-
-# Supplementary groups to inherit if not running as root
-SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/debian/systemd/duplicati.default
+++ b/ReleaseBuilder/Resources/debian/systemd/duplicati.default
@@ -8,6 +8,3 @@
 
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
-
-# Supplementary groups to inherit if not running as root
-SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/debian/systemd/duplicati.service
+++ b/ReleaseBuilder/Resources/debian/systemd/duplicati.service
@@ -9,7 +9,6 @@ IOSchedulingPriority=7
 EnvironmentFile=-/etc/default/duplicati
 ExecStart=/usr/bin/duplicati-server $DAEMON_OPTS
 Restart=always
-SupplementaryGroups=$SUPPLEMENTARY_GROUPS
 
 [Install]
 WantedBy=multi-user.target

--- a/ReleaseBuilder/Resources/fedora/systemd/duplicati-agent.default
+++ b/ReleaseBuilder/Resources/fedora/systemd/duplicati-agent.default
@@ -9,6 +9,3 @@
 
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
-
-# Supplementary groups to inherit if not running as root
-SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/fedora/systemd/duplicati.default
+++ b/ReleaseBuilder/Resources/fedora/systemd/duplicati.default
@@ -9,6 +9,3 @@
 
 # Additional options that are passed to the Daemon.
 DAEMON_OPTS=""
-
-# Supplementary groups to inherit if not running as root
-SUPPLEMENTARY_GROUPS=

--- a/ReleaseBuilder/Resources/fedora/systemd/duplicati.service
+++ b/ReleaseBuilder/Resources/fedora/systemd/duplicati.service
@@ -9,7 +9,6 @@ IOSchedulingPriority=7
 EnvironmentFile=-/etc/sysconfig/duplicati
 ExecStart=/usr/bin/duplicati-server $DAEMON_OPTS
 Restart=on-failure
-SupplementaryGroups=$SUPPLEMENTARY_GROUPS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR removes the supplementary groups addition to the service files on Linux.

Turns out that the override does not support variables, so it is not possible to supply the groups this way.

The right way to do this is to run something like:
```
sudo systemctl edit duplicati.service
```

Then add the directive:
```
[Service]
SupplementaryGroups=media backup
```

When saving, an override file will be created, likely in:
```
/etc/systemd/system/duplicati.service.d/override.conf
```

You can now reload the daemon, and the override will persist even on package upgrades.


This fixes ##6556