### PR TITLE
Minor polish to the new restore flow

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -377,9 +377,8 @@ namespace Duplicati.Library.Main.Operation.Restore
                                         sw_resp?.Start();
                                         using var datablock = await (await block_response.ReadAsync().ConfigureAwait(false)).ConfigureAwait(false);
                                         if (datablock.Data == null)
-                                        {
-                                            throw new Exception($"Received null data block from request {missing_blocks[i].BlockID} for file {file.TargetPath}");
-                                        }
+                                            throw new Exception($"Received null data block from request {missing_blocks[j].BlockID} for file {file.TargetPath}");
+
                                         sw_resp?.Stop();
 
                                         sw_req?.Start();

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -368,13 +368,22 @@ namespace Duplicati.Library.Main.Operation
         /// <param name="filter">The filter of which files to restore.</param>
         /// <param name="restoreDestination">The destination to restore to.</param>
         /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
-        private async Task DoRunNewAsync(IBackendManager backendManager, LocalRestoreDatabase database, Library.Utility.IFilter filter, IRestoreDestinationProvider restoreDestination, CancellationToken cancellationToken)
+        private async Task DoRunNewAsync(IBackendManager backendManager, LocalRestoreDatabase database, IFilter filter, IRestoreDestinationProvider restoreDestination, CancellationToken cancellationToken)
         {
             // Perform initial setup
             await Utility.UpdateOptionsFromDb(database, m_options, cancellationToken)
                 .ConfigureAwait(false);
             await Utility.VerifyOptionsAndUpdateDatabase(database, m_options, cancellationToken)
                 .ConfigureAwait(false);
+
+            if (m_options.RestoreChannelBufferSize < 0)
+                throw new UserInformationException("Restore channel buffer size must be greater than or equal to 0", "RestoreChannelBufferSizeTooSmall");
+            if (m_options.RestoreVolumeDecryptors <= 0)
+                throw new UserInformationException("Restore volume decryptors must be greater than 0", "RestoreVolumeDecryptorsTooSmall");
+            if (m_options.RestoreVolumeDecompressors <= 0)
+                throw new UserInformationException("Restore volume decompressors must be greater than 0", "RestoreVolumeDecompressorsTooSmall");
+            if (m_options.RestoreVolumeDownloaders <= 0)
+                throw new UserInformationException("Restore volume downloaders must be greater than 0", "RestoreVolumeDownloadersTooSmall");
 
             // Verify the backend if necessary
             if (!m_options.NoBackendverification)


### PR DESCRIPTION
This PR adds explicit validation to the size parameters so we ensure that we throw a meaningful error message instead of fail on some later step.

This also fixes an error in an exception message. Should the error scenario ever trigger, it would previously show incorrect data or cause out-of-bounds error instead of the intended error message.