### PR TITLE
Add verify and cleanup to database tool

### DIFF
--- a/Duplicati/CommandLine/DatabaseTool/Commands/Cleanup.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Commands/Cleanup.cs
@@ -1,0 +1,135 @@
+
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using Duplicati.Library.AutoUpdater;
+using Duplicati.Library.Utility;
+
+namespace Duplicati.CommandLine.DatabaseTool.Commands;
+
+/// <summary>
+/// The cleanup command - removes orphaned database files
+/// </summary>
+public static class Cleanup
+{
+    /// <summary>
+    /// Creates the cleanup command
+    /// </summary>
+    /// <returns>The cleanup command</returns>
+    public static Command Create() =>
+        new Command("cleanup", "Removes orphaned database files that are not referenced in dbconfig.json or the server database")
+        {
+            new Option<DirectoryInfo>("--datafolder", description: "The folder with databases", getDefaultValue: () => new DirectoryInfo(DataFolderLocator.GetDefaultStorageFolder(DataFolderManager.SERVER_DATABASE_FILENAME, false, true))),
+            new Option<bool>("--dry-run", description: "Show what would be deleted without actually deleting", getDefaultValue: () => false),
+            new Option<bool>("--force", description: "Delete without prompting for confirmation", getDefaultValue: () => false),
+        }
+        .WithHandler(CommandHandler.Create<DirectoryInfo, bool, bool>(async (datafolder, dryrun, force) =>
+        {
+            var datafolderPath = datafolder.FullName;
+
+            // Get orphaned databases using the same logic as verify
+            var orphanedDbs = await Verify.GetOrphanedDatabasesAsync(datafolderPath);
+
+            if (orphanedDbs.Count == 0)
+            {
+                Console.WriteLine("No orphaned databases found.");
+                return;
+            }
+
+            Console.WriteLine($"Found {orphanedDbs.Count} orphaned database(s):");
+            Console.WriteLine();
+
+            long totalSize = 0;
+            foreach (var db in orphanedDbs)
+            {
+                var fileInfo = new FileInfo(db.Path);
+                if (fileInfo.Exists)
+                {
+                    totalSize += fileInfo.Length;
+                    Console.WriteLine($"  {db.Path}");
+                    Console.WriteLine($"    Size: {Utility.FormatSizeString(fileInfo.Length)}");
+                    Console.WriteLine($"    Last modified: {fileInfo.LastWriteTime}");
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Total size: {Utility.FormatSizeString(totalSize)}");
+            Console.WriteLine();
+
+            if (dryrun)
+            {
+                Console.WriteLine("Dry run mode - no files were deleted.");
+                return;
+            }
+
+            // Confirm deletion unless --force is used
+            if (!force)
+            {
+                Console.Write("Do you want to delete these orphaned databases? [y/N]: ");
+                var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+                if (response != "y" && response != "yes")
+                {
+                    Console.WriteLine("Operation cancelled.");
+                    return;
+                }
+                Console.WriteLine();
+            }
+
+            // Delete orphaned databases
+            int deleted = 0;
+            int failed = 0;
+            long freedSpace = 0;
+
+            foreach (var db in orphanedDbs)
+            {
+                try
+                {
+                    if (File.Exists(db.Path))
+                    {
+                        var fileInfo = new FileInfo(db.Path);
+                        var size = fileInfo.Length;
+
+                        File.Delete(db.Path);
+
+                        freedSpace += size;
+                        deleted++;
+                        Console.WriteLine($"Deleted: {db.Path}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Already deleted: {db.Path}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    Console.WriteLine($"Failed to delete {db.Path}: {ex.Message}");
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Cleanup complete:");
+            Console.WriteLine($"  Deleted: {deleted} file(s)");
+            Console.WriteLine($"  Failed: {failed} file(s)");
+            Console.WriteLine($"  Space freed: {Utility.FormatSizeString(freedSpace)}");
+        }));
+}

--- a/Duplicati/CommandLine/DatabaseTool/Commands/Verify.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Commands/Verify.cs
@@ -1,0 +1,299 @@
+
+// Copyright (C) 2025, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Text.Json;
+using Duplicati.Library.AutoUpdater;
+using Duplicati.Library.Main;
+using Duplicati.Library.Main.Database;
+using Duplicati.Library.SQLiteHelper;
+
+namespace Duplicati.CommandLine.DatabaseTool.Commands;
+
+/// <summary>
+/// Database status information
+/// </summary>
+public class DatabaseStatus
+{
+    /// <summary>
+    /// The path to the database
+    /// </summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>
+    /// The status of the database: Found, Missing, or Orphaned
+    /// </summary>
+    public string Status { get; set; } = "";
+
+    /// <summary>
+    /// Source of the reference (dbconfig.json, server database, or filesystem)
+    /// </summary>
+    public string Source { get; set; } = "";
+
+    /// <summary>
+    /// Whether the database file exists on disk
+    /// </summary>
+    public bool FileExists { get; set; }
+
+    /// <summary>
+    /// Whether the database is referenced in dbconfig.json
+    /// </summary>
+    public bool InDbConfig { get; set; }
+
+    /// <summary>
+    /// Whether the database is referenced in the server database
+    /// </summary>
+    public bool InServerDb { get; set; }
+}
+
+/// <summary>
+/// The verify command - lists all databases with their status
+/// </summary>
+public static class Verify
+{
+    /// <summary>
+    /// The filename of the file with database configurations
+    /// </summary>
+    private const string CONFIG_FILE = "dbconfig.json";
+
+    /// <summary>
+    /// Creates the verify command
+    /// </summary>
+    /// <returns>The verify command</returns>
+    public static Command Create() =>
+        new Command("verify", "Verifies database files and shows their status (Found, Missing, Orphaned)")
+        {
+            new Option<DirectoryInfo>("--datafolder", description: "The folder with databases", getDefaultValue: () => new DirectoryInfo(DataFolderLocator.GetDefaultStorageFolder(DataFolderManager.SERVER_DATABASE_FILENAME, false, true))),
+            new Option<bool>("--output-json", description: "Output as JSON", getDefaultValue: () => false),
+            new Option<bool>("--include-server", description: "Include server database in the list", getDefaultValue: () => true),
+        }
+        .WithHandler(CommandHandler.Create<DirectoryInfo, bool, bool>(async (datafolder, outputjson, includeserver) =>
+        {
+            var datafolderPath = datafolder.FullName;
+            var results = await AnalyzeDatabasesAsync(datafolderPath, includeserver);
+
+            if (outputjson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(results, new JsonSerializerOptions { WriteIndented = true }));
+            }
+            else
+            {
+                PrintResults(results, includeserver);
+            }
+        }));
+
+    /// <summary>
+    /// Analyzes all databases and returns their status
+    /// </summary>
+    public static async Task<List<DatabaseStatus>> AnalyzeDatabasesAsync(string datafolder, bool includeServer)
+    {
+        var results = new List<DatabaseStatus>();
+        var serverDbPath = Path.Combine(datafolder, DataFolderManager.SERVER_DATABASE_FILENAME);
+
+        // Get databases referenced in dbconfig.json
+        var dbConfigPath = Path.Combine(datafolder, CONFIG_FILE);
+        var dbConfigPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (File.Exists(dbConfigPath))
+        {
+            try
+            {
+                var configs = Newtonsoft.Json.JsonConvert.DeserializeObject<List<CLIDatabaseLocator.BackendEntry>>(
+                    await File.ReadAllTextAsync(dbConfigPath));
+                if (configs != null)
+                {
+                    foreach (var config in configs)
+                    {
+                        if (!string.IsNullOrEmpty(config.Databasepath))
+                            dbConfigPaths.Add(Path.GetFullPath(config.Databasepath));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Could not parse {CONFIG_FILE}: {ex.Message}");
+            }
+        }
+
+        // Get databases referenced in server database
+        var serverDbPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (File.Exists(serverDbPath))
+        {
+            try
+            {
+                await using var con = await SQLiteLoader.LoadConnectionAsync(serverDbPath);
+                await using var cmd = con.CreateCommand(@"
+                    SELECT ""DBPath""
+                    FROM ""Backup""
+                ");
+                await foreach (var rd in cmd.ExecuteReaderEnumerableAsync(CancellationToken.None))
+                {
+                    var path = rd.ConvertValueToString(0);
+                    if (!string.IsNullOrEmpty(path))
+                        serverDbPaths.Add(Path.GetFullPath(path));
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Could not read server database: {ex.Message}");
+            }
+        }
+
+        // Get all sqlite files in the datafolder
+        var fileSystemPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (Directory.Exists(datafolder))
+        {
+            foreach (var file in Directory.EnumerateFiles(datafolder, "*.sqlite", SearchOption.AllDirectories))
+            {
+                fileSystemPaths.Add(Path.GetFullPath(file));
+            }
+        }
+
+        // Combine all unique paths
+        var allPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        allPaths.UnionWith(dbConfigPaths);
+        allPaths.UnionWith(serverDbPaths);
+        allPaths.UnionWith(fileSystemPaths);
+
+        // Analyze each path
+        foreach (var path in allPaths)
+        {
+            // Skip server database unless included
+            if (!includeServer && Path.GetFileName(path).Equals(DataFolderManager.SERVER_DATABASE_FILENAME, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var fileExists = File.Exists(path);
+            var inDbConfig = dbConfigPaths.Contains(path);
+            var inServerDb = serverDbPaths.Contains(path);
+
+            string status;
+            string source;
+
+            if (fileExists && (inDbConfig || inServerDb))
+            {
+                status = "Found";
+                var sources = new List<string>();
+                if (inDbConfig) sources.Add("dbconfig.json");
+                if (inServerDb) sources.Add("server");
+                source = string.Join(", ", sources);
+            }
+            else if (!fileExists && (inDbConfig || inServerDb))
+            {
+                status = "Missing";
+                var sources = new List<string>();
+                if (inDbConfig) sources.Add("dbconfig.json");
+                if (inServerDb) sources.Add("server");
+                source = string.Join(", ", sources);
+            }
+            else if (fileExists && !inDbConfig && !inServerDb)
+            {
+                status = "Orphaned";
+                source = "filesystem only";
+            }
+            else
+            {
+                continue; // Should not happen
+            }
+
+            results.Add(new DatabaseStatus
+            {
+                Path = path,
+                Status = status,
+                Source = source,
+                FileExists = fileExists,
+                InDbConfig = inDbConfig,
+                InServerDb = inServerDb
+            });
+        }
+
+        return results.OrderBy(r => r.Status).ThenBy(r => r.Path).ToList();
+    }
+
+    /// <summary>
+    /// Gets orphaned databases only
+    /// </summary>
+    public static async Task<List<DatabaseStatus>> GetOrphanedDatabasesAsync(string datafolder)
+    {
+        var all = await AnalyzeDatabasesAsync(datafolder, true);
+        return all.Where(d => d.Status == "Orphaned").ToList();
+    }
+
+    /// <summary>
+    /// Prints the results to the console
+    /// </summary>
+    private static void PrintResults(List<DatabaseStatus> results, bool includeServer)
+    {
+        if (results.Count == 0)
+        {
+            Console.WriteLine("No databases found.");
+            return;
+        }
+
+        // Group by status
+        var found = results.Where(r => r.Status == "Found").ToList();
+        var missing = results.Where(r => r.Status == "Missing").ToList();
+        var orphaned = results.Where(r => r.Status == "Orphaned").ToList();
+
+        Console.WriteLine($"Database Verification Results");
+        Console.WriteLine($"==============================");
+        Console.WriteLine($"Total: {results.Count} databases");
+        Console.WriteLine($"  Found: {found.Count}");
+        Console.WriteLine($"  Missing: {missing.Count}");
+        Console.WriteLine($"  Orphaned: {orphaned.Count}");
+        Console.WriteLine();
+
+        if (found.Count > 0)
+        {
+            Console.WriteLine($"Found ({found.Count}):");
+            Console.WriteLine(new string('-', 80));
+            foreach (var db in found)
+            {
+                Console.WriteLine($"  {db.Path}");
+                Console.WriteLine($"    Source: {db.Source}");
+            }
+            Console.WriteLine();
+        }
+
+        if (missing.Count > 0)
+        {
+            Console.WriteLine($"Missing ({missing.Count}):");
+            Console.WriteLine(new string('-', 80));
+            foreach (var db in missing)
+            {
+                Console.WriteLine($"  {db.Path}");
+                Console.WriteLine($"    Expected in: {db.Source}");
+            }
+            Console.WriteLine();
+        }
+
+        if (orphaned.Count > 0)
+        {
+            Console.WriteLine($"Orphaned ({orphaned.Count}):");
+            Console.WriteLine(new string('-', 80));
+            foreach (var db in orphaned)
+            {
+                Console.WriteLine($"  {db.Path}");
+                Console.WriteLine($"    Not referenced in dbconfig.json or server database");
+            }
+            Console.WriteLine();
+        }
+    }
+}

--- a/Duplicati/CommandLine/DatabaseTool/Program.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Program.cs
@@ -46,6 +46,8 @@ public static class Program
                 Commands.Upgrade.Create(),
                 Commands.List.Create(),
                 Commands.Execute.Create(),
+                Commands.Verify.Create(),
+                Commands.Cleanup.Create(),
             };
 
         return new CommandLineBuilder(rootCmd)

--- a/Duplicati/UnitTest/DatabaseToolTests.cs
+++ b/Duplicati/UnitTest/DatabaseToolTests.cs
@@ -18,6 +18,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Duplicati.CommandLine.DatabaseTool;
 using Duplicati.Library.SQLiteHelper;
@@ -336,5 +339,211 @@ CREATE TABLE ""ChangeJournalData"" (
 INSERT INTO ""Version"" (""Version"") VALUES (12);
 
 ";
+
+        [Test]
+        [Category("DatabaseTool")]
+        public async Task TestVerifyCommand()
+        {
+            using var tempFolder = new Library.Utility.TempFolder();
+            string tempDir = tempFolder;
+
+            var serverDb = Path.Combine(tempDir, "server.sqlite");
+            var localDb1 = Path.Combine(tempDir, "local1.sqlite");
+            var localDb2 = Path.Combine(tempDir, "local2.sqlite"); // Referenced but won't exist = Missing
+            var orphanDb = Path.Combine(tempDir, "ABCDEFGHIJ.sqlite"); // Random name = Orphaned
+
+            // Create server database
+            using (var db = SQLiteLoader.LoadConnection(serverDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = ServerSchemaV6;
+                cmd.ExecuteNonQuery();
+
+                // Insert a backup referencing localDb1
+                cmd.CommandText = $@"
+                    INSERT INTO ""Backup"" (""Name"", ""Tags"", ""TargetURL"", ""DBPath"")
+                    VALUES ('Test Backup', '', 'file:///test', '{localDb1.Replace("'", "''")}');
+                ";
+                cmd.ExecuteNonQuery();
+            }
+
+            // Create local database
+            using (var db = SQLiteLoader.LoadConnection(localDb1))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                cmd.ExecuteNonQuery();
+            }
+
+            // Create orphan database (exists but not referenced)
+            using (var db = SQLiteLoader.LoadConnection(orphanDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                cmd.ExecuteNonQuery();
+            }
+
+            // Copy server database to expected location
+            var serverTargetPath = Path.Combine(tempDir, "Duplicati-server.sqlite");
+            File.Copy(serverDb, serverTargetPath);
+
+            // Create dbconfig.json with localDb2 (which won't exist)
+            var dbConfigPath = Path.Combine(tempDir, "dbconfig.json");
+            var dbConfig = new List<Duplicati.Library.Main.CLIDatabaseLocator.BackendEntry>
+            {
+                new()
+                {
+                    Type = "file",
+                    Server = "localhost",
+                    Path = "/backup1",
+                    Prefix = "dup",
+                    Username = "user",
+                    Port = 0,
+                    Databasepath = localDb2, // This file won't exist = Missing
+                    ParameterFile = null
+                },
+                new()
+                {
+                    Type = "file",
+                    Server = "localhost",
+                    Path = "/backup2",
+                    Prefix = "dup",
+                    Username = "user",
+                    Port = 0,
+                    Databasepath = localDb1, // This file exists = Found
+                    ParameterFile = null
+                }
+            };
+            await File.WriteAllTextAsync(dbConfigPath, Newtonsoft.Json.JsonConvert.SerializeObject(dbConfig));
+
+            // Test verify command with JSON output
+            var output = new StringWriter();
+            var originalOut = Console.Out;
+            Console.SetOut(output);
+
+            try
+            {
+                Assert.AreEqual(0, await Program.Main(["verify", "--datafolder", tempDir, "--output-json"]));
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            var result = output.ToString();
+
+            // Should report localDb1 as Found (in both server and dbconfig)
+            Assert.That(result, Does.Contain("\"Status\": \"Found\""));
+            // Should report localDb2 as Missing (referenced in dbconfig but file doesn't exist)
+            Assert.That(result, Does.Contain("\"Status\": \"Missing\""));
+            // Should report orphanDb as Orphaned (exists but not referenced)
+            Assert.That(result, Does.Contain("\"Status\": \"Orphaned\""));
+        }
+
+        [Test]
+        [Category("DatabaseTool")]
+        [TestCase(true)]  // Dry run - no files should be deleted
+        [TestCase(false)] // Force - only orphaned files should be deleted
+        public async Task TestCleanupCommand(bool dryRun)
+        {
+            using var tempFolder = new Library.Utility.TempFolder();
+            var tempDir = (string)tempFolder;
+
+            // Create three types of databases:
+            // 1. FOUND: Referenced in server DB and exists
+            var foundDb = Path.Combine(tempDir, "FOUNDDB.sqlite");
+            // 2. MISSING: Referenced in dbconfig but doesn't exist
+            var missingDb = Path.Combine(tempDir, "MISSINGDB.sqlite");
+            // 3. ORPHANED: Exists but not referenced anywhere
+            var orphanDb = Path.Combine(tempDir, "ORPHANXYZ.sqlite");
+
+            var serverDb = Path.Combine(tempDir, "Duplicati-server.sqlite");
+
+            // Create server database with a backup referencing foundDb
+            using (var db = SQLiteLoader.LoadConnection(serverDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = ServerSchemaV6;
+                cmd.ExecuteNonQuery();
+
+                cmd.CommandText = $@"
+                    INSERT INTO ""Backup"" (""Name"", ""Tags"", ""TargetURL"", ""DBPath"")
+                    VALUES ('Test Backup', '', 'file:///test', '{foundDb.Replace("'", "''")}');
+                ";
+                cmd.ExecuteNonQuery();
+            }
+
+            // Create "Found" database (referenced in server DB and exists)
+            using (var db = SQLiteLoader.LoadConnection(foundDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                cmd.ExecuteNonQuery();
+            }
+
+            // Create "Orphaned" database (exists but not referenced)
+            using (var db = SQLiteLoader.LoadConnection(orphanDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                cmd.ExecuteNonQuery();
+            }
+
+            // Create dbconfig.json with missingDb reference (file won't exist = Missing)
+            var dbConfigPath = Path.Combine(tempDir, "dbconfig.json");
+            var dbConfig = new List<Duplicati.Library.Main.CLIDatabaseLocator.BackendEntry>
+            {
+                new()
+                {
+                    Type = "file",
+                    Server = "localhost",
+                    Path = "/backup1",
+                    Prefix = "dup",
+                    Username = "user",
+                    Port = 0,
+                    Databasepath = missingDb, // This file won't exist = Missing
+                    ParameterFile = null
+                },
+                new()
+                {
+                    Type = "file",
+                    Server = "localhost",
+                    Path = "/backup2",
+                    Prefix = "dup",
+                    Username = "user",
+                    Port = 0,
+                    Databasepath = foundDb, // This file exists = Found
+                    ParameterFile = null
+                }
+            };
+            await File.WriteAllTextAsync(dbConfigPath, Newtonsoft.Json.JsonConvert.SerializeObject(dbConfig));
+
+            // Verify pre-cleanup state
+            Assert.That(File.Exists(foundDb), Is.True, "Found DB should exist before cleanup");
+            Assert.That(File.Exists(orphanDb), Is.True, "Orphan DB should exist before cleanup");
+            Assert.That(File.Exists(missingDb), Is.False, "Missing DB should not exist before cleanup");
+
+            // Run cleanup with appropriate flag
+            string[] args = dryRun
+                ? ["cleanup", "--datafolder", tempDir, "--dry-run"]
+                : ["cleanup", "--datafolder", tempDir, "--force"];
+
+            Assert.AreEqual(0, await Program.Main(args));
+
+            if (dryRun)
+            {
+                // Dry run: No files should be deleted
+                Assert.That(File.Exists(foundDb), Is.True, "Found DB should still exist after dry-run");
+                Assert.That(File.Exists(orphanDb), Is.True, "Orphan DB should still exist after dry-run");
+                Assert.That(File.Exists(missingDb), Is.False, "Missing DB should still not exist after dry-run");
+            }
+            else
+            {
+                // Force cleanup: Only orphaned file should be deleted
+                Assert.That(File.Exists(foundDb), Is.True, "Found DB should still exist after cleanup");
+                Assert.That(File.Exists(orphanDb), Is.False, "Orphan DB should be deleted after cleanup");
+                Assert.That(File.Exists(missingDb), Is.False, "Missing DB should still not exist after cleanup");
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds two new commands to the database CLI tool:

- verify: Lists all databases with their status (Found, Missing, Orphaned) across dbconfig.json, server database, and filesystem

- cleanup: Removes orphaned database files not referenced in dbconfig.json or server database, with --dry-run and --force options

Includes unit tests for both commands.