### PR TITLE
Don't push Docker with naked version

### DIFF
--- a/ReleaseBuilder/Build/Command.CreatePackage.cs
+++ b/ReleaseBuilder/Build/Command.CreatePackage.cs
@@ -1588,9 +1588,12 @@ public static partial class Command
             // Copy in the run-as-user.sh script
             File.Copy(Path.Combine(resourcesDir, "run-as-user.sh"), Path.Combine(tmpbuild, "run-as-user.sh"), true);
 
-            var tags = new List<string> { rtcfg.ReleaseInfo.Channel.ToString(), rtcfg.ReleaseInfo.Version.ToString(), $"{rtcfg.ReleaseInfo.Version}-{rtcfg.ReleaseInfo.Channel}" };
+            var tags = new List<string> { rtcfg.ReleaseInfo.Channel.ToString(), $"{rtcfg.ReleaseInfo.Version}-{rtcfg.ReleaseInfo.Channel}" };
             if (rtcfg.ReleaseInfo.Channel == ReleaseChannel.Stable)
+            {
+                tags.Add(rtcfg.ReleaseInfo.Version.ToString());
                 tags.Add("latest");
+            }
 
             if (!dockerArchs.Any())
                 continue;


### PR DESCRIPTION
This PR updates the build process to not push Docker tags with naked version numbers, unless they are stable releases.

For a canary version, it will be tagged `canary` and `2.2.0.105-canary`.

For a stable version, it will be tagged with  `stable`, `2.2.0.0-stable`, `2.2.0.0`, and `latest`

This is done to make Duplicati releases more compatible with how other tools use version number tags.

This fixes #6797
This fixes #6797