### PR TITLE
Bugfix/Dollar sign in filename breaks regex

### DIFF
--- a/Duplicati/Library/Main/Database/ExtensionMethods.cs
+++ b/Duplicati/Library/Main/Database/ExtensionMethods.cs
@@ -780,8 +780,11 @@ public static partial class ExtensionMethods
             else
                 v = Library.Utility.Utility.FormatInvariantValue(p.Value);
 
+            paramName = Regex.Escape(paramName);
+            v = v.Replace("$", "$$");
+
             // Replace all occurrences of the parameter (with word boundary)
-            txt = Regex.Replace(txt, $@"\B{Regex.Escape(paramName)}\b", v, RegexOptions.IgnoreCase);
+            txt = Regex.Replace(txt, $@"\B{paramName}\b", v, RegexOptions.IgnoreCase);
         }
 
         return txt;

--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -971,7 +971,7 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void DollarSignNumberInFilenameBreaksRegex()
+        public void Issue6817DollarSignNumberInFilenameBreaksRegex()
         {
             var filename = "~$1234567891011121314151617181920.txt";
             var content = RandomNumberGenerator.GetBytes(1024);

--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -969,5 +969,23 @@ namespace Duplicati.UnitTest
                     "Blocklist download pass was required");
             }
         }
+
+        [Test]
+        public void DollarSignNumberInFilenameBreaksRegex()
+        {
+            var filename = "~$1234567891011121314151617181920.txt";
+            var content = RandomNumberGenerator.GetBytes(1024);
+            TestUtils.WriteFile(Path.Combine(DATAFOLDER, filename), content);
+
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, TestOptions, null))
+                TestUtils.AssertResults(c.Backup([DATAFOLDER]));
+
+            // Delete the database
+            File.Delete(DBFILE);
+
+            // Recreate the database, which would fail if the filename is not handled correctly
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, TestOptions, null))
+                TestUtils.AssertResults(c.Repair());
+        }
     }
 }


### PR DESCRIPTION
If the replacement string passed to `Regex.Replace()` contains a dollar sign followed by an integer, it's interpreted as a regex backreference. This could happen since filenames are allowed to contain dollar signs. 

This PR fixes this by escaping `$` through `.Replace("$", "$$")` before passing the string to `Regex.Replace()`. This PR also adds a test, which previously failed prior to this fix during recreating the database. 

Escaping only `$` is sufficient, as that's the character the substitution engine triggers on: https://learn.microsoft.com/en-us/dotnet/standard/base-types/substitutions-in-regular-expressions . The rest of the characters haven't been escaped (e.g. through `Regex.Escape()`) as that bloats the output string with literal escapes, e.g. `\\` becomes `\\\\`. 