### PR TITLE
Fix ngax auth refresh infinite loop and handle terminal refresh failures (fixes #6832)

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/services/AppService.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/AppService.js
@@ -2,6 +2,7 @@ backupApp.service('AppService', function ($http, $cookies, $q, $cookies, DialogS
     this.apiurl = '../api/v1';
     this.access_token = null;
     this.access_token_promise = null;
+    this.redirecting_to_login = false;
 
     const self = this;
 
@@ -10,6 +11,50 @@ backupApp.service('AppService', function ($http, $cookies, $q, $cookies, DialogS
         DialogService.accept('Not logged in', function () {
             window.location = appConfig.login_url;
         });
+    }
+
+    function isRefreshStatusCode(status) {
+        return status === 400 || status === 401 || status === 415;
+    }
+
+    function isRefreshUrl(url) {
+        if (!url)
+            return false;
+
+        if (url.indexOf('/auth/refresh/logout') >= 0)
+            return false;
+
+        if (url.indexOf('/api/v1/auth/refresh') >= 0 || url.indexOf('/auth/refresh') >= 0)
+            return true;
+
+        return false;
+    }
+
+    this.isRefreshFailureResponse = function(response) {
+        return response != null
+            && isRefreshStatusCode(response.status)
+            && isRefreshUrl(response.config && response.config.url);
+    };
+
+    function clearAuthState() {
+        self.clearAccessToken();
+        localStorage.removeItem('v1:persist:duplicati:refreshNonce');
+    }
+
+    function redirectToLogin() {
+        if (self.redirecting_to_login)
+            return;
+
+        self.redirecting_to_login = true;
+        window.location.href = '/login.html';
+    }
+
+    function handleRefreshFailure(response) {
+        if (response != null)
+            response.refreshAuthFailure = true;
+
+        clearAuthState();
+        redirectToLogin();
     }
 
 
@@ -66,9 +111,15 @@ backupApp.service('AppService', function ($http, $cookies, $q, $cookies, DialogS
                                 }
                             ); 
                         }, 
-                        () => { 
-                            // Fail, but report the original failed response, not the refresh response
-                            deferred.reject(response);
+                        refreshResponse => {
+                            // If the refresh endpoint itself failed in a terminal auth state,
+                            // do not hide it behind the original response.
+                            if (self.isRefreshFailureResponse(refreshResponse)) {
+                                deferred.reject(refreshResponse);
+                            } else {
+                                // Fail, but report the original failed response, not the refresh response
+                                deferred.reject(response);
+                            }
                         }
                     );
 
@@ -101,9 +152,11 @@ backupApp.service('AppService', function ($http, $cookies, $q, $cookies, DialogS
             self.access_token_promise = deferred.promise;
 
             const storedNonce = localStorage.getItem('v1:persist:duplicati:refreshNonce');
-            const body = storedNonce ? { Nonce: storedNonce } : undefined;
+            const body = storedNonce ? { Nonce: storedNonce } : {};
+            const refreshUrl = self.apiurl + '/auth/refresh';
+            const refreshConfig = setupConfig('POST', {}, body, refreshUrl);
 
-            $http.post(self.apiurl + '/auth/refresh', body)
+            $http.post(refreshUrl, body, refreshConfig)
                 .then(function (response) {
                     self.access_token = response.data.AccessToken;
                     self.access_token_promise = null;
@@ -115,8 +168,12 @@ backupApp.service('AppService', function ($http, $cookies, $q, $cookies, DialogS
                     self.access_token = null;
                     self.access_token_promise = null;
                     
+                    // Explicit terminal auth failures for /auth/refresh should not be retried.
+                    if (self.isRefreshFailureResponse(response)) {
+                        handleRefreshFailure(response);
+                    }
                     // Auth error, refresh token invalid
-                    if (response.status == 401)
+                    else if (response.status == 401)
                         loginRequired();
 
                     deferred.reject(response);

--- a/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
@@ -315,7 +315,24 @@ backupApp.service('ServerStatus', function ($rootScope, $timeout, AppService, Ap
     const webSocketUnauthorizedCode = 4401;
     const unauthorizedCode = 401;
 
+    function isTerminalRefreshFailure(response) {
+        return (response && response.refreshAuthFailure === true)
+            || (AppService.isRefreshFailureResponse && AppService.isRefreshFailureResponse(response));
+    }
+
     function handleConnectionError(response) {
+        if (isTerminalRefreshFailure(response)) {
+            if (websocketReconnectTimer != null) {
+                window.clearInterval(websocketReconnectTimer);
+                websocketReconnectTimer = null;
+            }
+
+            state.failedAuthAttempts++;
+            state.connectionState = 'unauthorized';
+            $rootScope.$broadcast('serverstatechanged');
+            return;
+        }
+
         state.failedConnectionAttempts++;
         if (response.status === webSocketUnauthorizedCode || response.status === unauthorizedCode)
         {

--- a/playwright-tests/ngaxAuthRefresh.spec.ts
+++ b/playwright-tests/ngaxAuthRefresh.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+const NGAX_URL = process.env.NGAX_URL || "http://localhost:8200/ngax/index.html";
+
+test("ngax redirects to login on terminal refresh failures", async ({ page }) => {
+  let refreshCalls = 0;
+
+  await page.route("**/api/v1/auth/refresh", async (route) => {
+    refreshCalls++;
+    await route.fulfill({
+      status: 415,
+      contentType: "application/json",
+      body: JSON.stringify({ Error: "Unsupported Media Type" }),
+    });
+  });
+
+  await page.goto(NGAX_URL, { waitUntil: "domcontentloaded" });
+
+  // The app should immediately abandon refresh retries and go to login.
+  await page.waitForURL(/\/login\.html(\?.*)?$/, { timeout: 15000 });
+
+  // Give it a short window and ensure no runaway retry loop occurs.
+  await page.waitForTimeout(1500);
+  expect(refreshCalls).toBeLessThanOrEqual(3);
+});
+
+test("ngax keeps retry behavior for transient refresh failures", async ({ page }) => {
+  let refreshCalls = 0;
+
+  await page.route("**/api/v1/auth/refresh", async (route) => {
+    refreshCalls++;
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ Error: "Service Unavailable" }),
+    });
+  });
+
+  await page.goto(NGAX_URL, { waitUntil: "domcontentloaded" });
+
+  // For transient failures, the app should not force a login redirect.
+  await page.waitForTimeout(2500);
+  await expect(page).not.toHaveURL(/\/login\.html(\?.*)?$/);
+
+  // The reconnect flow should attempt refresh again rather than terminating.
+  expect(refreshCalls).toBeGreaterThanOrEqual(2);
+});


### PR DESCRIPTION
Fixes #6832 

Summary
This PR fixes a critical ngax authentication flow issue where failed refresh calls could trigger repeated reconnect attempts and leave the UI stuck on Connecting.

Root cause
When the client attempted POST /api/v1/auth/refresh with an invalid or missing session, terminal auth failures (especially 415, and also 400/401) were not handled as stop conditions in the client reconnect flow. The app could continue retrying instead of exiting to login.

What changed
1. Added explicit terminal refresh failure detection for refresh endpoint responses with status 400, 401, or 415.
2. On terminal refresh failure, the client now:
- clears stale auth state
- clears stored refresh nonce
- redirects immediately to /login.html
3. Updated reconnect handling to stop retry/countdown behavior for terminal refresh failures.
4. Preserved existing retry behavior for transient backend/network failures such as 502/503/504.
5. Added Playwright regression coverage for both terminal and transient refresh failure paths.

Behavior after fix
- Refresh returns 400/401/415: no retry loop, immediate redirect to login.
- Refresh returns transient error (for example 503): no forced login redirect; retry behavior remains intact.

Validation
Playwright regression tests were added and executed for:
1. terminal refresh failure redirects to login and avoids runaway retries
2. transient refresh failure keeps retry behavior and does not force login redirect