### PR TITLE
Feature/Remote synchronization destination quota check

### DIFF
--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2026, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using Duplicati.Library.Common.IO;

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -241,7 +241,7 @@ namespace Duplicati.Library.Backend
         public string DisplayName => Strings.FileBackend.DisplayName;
 
         /// <inheritdoc />
-        public string ProtocolKey => "file";
+        public virtual string ProtocolKey => "file";
 
         public bool SupportsStreaming => !m_moveFile;
 
@@ -450,7 +450,7 @@ namespace Duplicati.Library.Backend
         }
 
         /// <inheritdoc />
-        public Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
+        public virtual Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
         {
             var spaceInfo = Utility.Utility.GetFreeSpaceForPath(m_path);
             if (spaceInfo != null)

--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -194,7 +194,8 @@ namespace Duplicati.Library.Main.Backend
                 return;
             }
 
-            _backend = DynamicLoader.BackendLoader.GetBackend(_backendUrl, _options);
+            _backend = DynamicLoader.BackendLoader.GetBackend(_backendUrl, _options)
+                ?? throw new InvalidOperationException("Failed to instantiate backend.");
             _streamingBackend = _backend as IStreamingBackend;
             if (_streamingBackend == null || !_streamingBackend.SupportsStreaming)
             {

--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -158,6 +158,28 @@ namespace Duplicati.Library.Main.Backend
         }
 
         /// <summary>
+        /// Gets quota information from the backend if it supports quota operations.
+        /// </summary>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task representing the asynchronous operation. The task result is the quota information, or null if the backend does not support quota operations or an error occurs.</returns>
+        public async Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken token)
+        {
+            if (_backend is IQuotaEnabledBackend qeb)
+            {
+                try
+                {
+                    return await qeb.GetQuotaInfoAsync(token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Duplicati.Library.Logging.Log.WriteErrorMessage(LOGTAG, "rsync", ex, "Error getting quota info", null);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Instantiates the backend if it has not been instantiated yet.
         /// If the backend is already instantiated, it simply returns.
         /// If the maximum number of retries has been reached, it throws an InvalidOperationException.

--- a/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
@@ -198,6 +198,22 @@ public static class RemoteSynchronizationRunner
         // Prepare the operations
         var (to_copy, to_delete, to_verify) = await PrepareFileLists(b1m, b2m, config, token).ConfigureAwait(false);
 
+        // Check if we have enough free space in the destination to perform the synchronization.
+        var dst_quota = await b2m.GetQuotaInfoAsync(token).ConfigureAwait(false);
+        if (dst_quota is not null)
+        {
+            var total_delete_size = to_delete.Sum(x => Math.Max(x.Size, 0));
+            var total_copy_size = to_copy.Sum(x => Math.Max(x.Size, 0));
+            if (dst_quota.FreeQuotaSpace < total_copy_size - total_delete_size)
+            {
+                Duplicati.Library.Logging.Log.WriteErrorMessage(LOGTAG, "rsync", null,
+                    "Not enough free space in destination to perform the synchronization. Required: {0}, Available: {1}. Aborting.",
+                    Duplicati.Library.Utility.Utility.FormatSizeString(total_copy_size - total_delete_size),
+                    Duplicati.Library.Utility.Utility.FormatSizeString(dst_quota.FreeQuotaSpace));
+                throw new Exception("Not enough free space in destination to perform the synchronization.");
+            }
+        }
+
         // Verify the files if requested. If the files are not verified, they will be deleted and copied again.
         long verified = 0, failed_verify = 0;
         if (config.VerifyContents)

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -24,8 +24,10 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -641,6 +643,80 @@ namespace Duplicati.UnitTest
             var data = new byte[size];
             rnd.NextBytes(data);
             await File.WriteAllBytesAsync(file, data);
+        }
+
+        /// <summary>
+        /// A test backend that simulates a quota of 1KB for testing quota checks in the remote synchronization tool.
+        /// </summary>
+        public class FileBackendWith1Kb : Library.Backend.File
+        {
+            public FileBackendWith1Kb() { }
+
+            public FileBackendWith1Kb(string url, Dictionary<string, string?> options) : base(url.Replace("quotatest://", "file://"), options) { }
+
+            public override string ProtocolKey => "quotatest";
+
+            public override Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken token)
+            {
+                return Task.FromResult<IQuotaInfo?>(new QuotaInfo(1024 * 1024, 1024));
+            }
+        }
+
+        /// <summary>
+        /// Tests that the remote synchronization tool checks quota and fails if insufficient.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public void TestRemoteSynchronizationQuotaCheckFails()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "quota_src");
+            var l2 = Path.Combine(TARGETFOLDER, "quota_dst");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            // Generate test data: 5 files of ~1KB each, total ~5KB
+            GenerateTestData(l1, 5, 0, 0, 2048).Wait();
+
+            // Register the test backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new FileBackendWith1Kb());
+
+            // Use the test backend for destination with only 1KB free quota
+            var args = new string[] { $"file://{l1}", $"quotatest://{l2}", "--confirm" };
+
+            var async_call = RemoteSynchronization.Program.Main(args);
+            var return_code = async_call.ConfigureAwait(false).GetAwaiter().GetResult();
+
+            Assert.AreNotEqual(0, return_code, "Remote synchronization should fail due to insufficient quota.");
+        }
+
+        /// <summary>
+        /// Tests that the remote synchronization tool succeeds when quota is sufficient.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public void TestRemoteSynchronizationQuotaCheckSucceeds()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "quota_src2");
+            var l2 = Path.Combine(TARGETFOLDER, "quota_dst2");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            // Generate small test data: 1 file of ~500B
+            GenerateTestData(l1, 1, 0, 0, 512).Wait();
+
+            // Register the test backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new FileBackendWith1Kb());
+
+            // Use the test backend for destination with 1KB free quota (sufficient)
+            var args = new string[] { $"file://{l1}", $"quotatest://{l2}", "--confirm", "--dst-options", "freequota=1024" };
+
+            var async_call = RemoteSynchronization.Program.Main(args);
+            var return_code = async_call.ConfigureAwait(false).GetAwaiter().GetResult();
+
+            Assert.AreEqual(0, return_code, "Remote synchronization should succeed with sufficient quota.");
+            Assert.IsTrue(DirectoriesAndContentsAreEqual(l1, l2), "Directories should be synchronized.");
         }
 
     }


### PR DESCRIPTION
This PR adds a check to the remote synchronization tool to ensure that the destination has enough space at the start of running the tool to complete the operation. If there is not enough space, the tool logs it as an error and fails. This should prevent some cases of partial synchronization from happening. 

The PR also provides tests for whether the remote synchronization tool checks the destination quotas, and improves error handling when the `LightweightBackendManager` fails to instantiate a backend. 