### PR TITLE
Feature/S3 pre-computed hashes

### DIFF
--- a/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
+++ b/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
@@ -282,6 +282,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
 
         using var request = new HttpRequestMessage(HttpMethod.Post, $"/put/{remotename}");
         request.Content = new StreamContent(timeoutStream);
+        request.Content.Headers.ContentLength = source.Length;
         request.Headers.Add("X-Content-MD5", md5 ?? string.Empty);
         request.Headers.Add("X-Content-SHA256", sha256 ?? string.Empty);
 

--- a/Duplicati/Library/Backend/S3/S3AwsClient.cs
+++ b/Duplicati/Library/Backend/S3/S3AwsClient.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2026, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 
@@ -247,6 +247,17 @@ namespace Duplicati.Library.Backend
             // Precalculate the hashes to avoid calculating them in the PutObjectAsync call where the stream could be throttled
             var md5 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[0]));
             var sha256 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[1]));
+
+            await AddFileStreamAsync(bucketName, keyName, source, [md5, sha256], cancelToken).ConfigureAwait(false);
+        }
+
+        public virtual async Task AddFileStreamAsync(string bucketName, string keyName, Stream source, string[] hashes, CancellationToken cancelToken)
+        {
+            if (hashes.Length != 2)
+                throw new ArgumentException("Hashes array must contain exactly two elements: MD5 and SHA256", nameof(hashes));
+
+            var md5 = hashes[0];
+            var sha256 = hashes[1];
 
             using var ts = source.ObserveReadTimeout(m_timeouts.ReadWriteTimeout, false);
             var objectAddRequest = new PutObjectRequest

--- a/Duplicati/Library/Backend/S3/S3AwsClient.cs
+++ b/Duplicati/Library/Backend/S3/S3AwsClient.cs
@@ -248,10 +248,20 @@ namespace Duplicati.Library.Backend
             var md5 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[0]));
             var sha256 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[1]));
 
-            await AddFileStreamAsync(bucketName, keyName, source, [md5, sha256], cancelToken).ConfigureAwait(false);
+            await AddFileStreamAsync(bucketName, keyName, source, [md5, sha256], source.Length, cancelToken).ConfigureAwait(false);
         }
 
-        public virtual async Task AddFileStreamAsync(string bucketName, string keyName, Stream source, string[] hashes, CancellationToken cancelToken)
+        /// <summary>
+        /// Adds a file stream to the bucket with the specified hashes and content length
+        /// </summary>
+        /// <param name="bucketName">The name of the bucket</param>
+        /// <param name="keyName">The name of the object to create</param>
+        /// <param name="source">The source stream to upload</param>
+        /// <param name="hashes">The hashes of the content, in the order of MD5 and SHA256 as hex strings</param>
+        /// <param name="contentLength">The content length of the stream</param>
+        /// <param name="cancelToken">The cancellation token</param>
+        /// <returns>>A task representing the asynchronous operation</returns>
+        public virtual async Task AddFileStreamAsync(string bucketName, string keyName, Stream source, string[] hashes, long contentLength, CancellationToken cancelToken)
         {
             if (hashes.Length != 2)
                 throw new ArgumentException("Hashes array must contain exactly two elements: MD5 and SHA256", nameof(hashes));
@@ -271,6 +281,8 @@ namespace Duplicati.Library.Backend
                 ChecksumSHA256 = sha256,
                 DisablePayloadSigning = m_disablePayloadSigning
             };
+            objectAddRequest.Headers["Content-Length"] = contentLength.ToString();
+
             if (!string.IsNullOrWhiteSpace(m_storageClass))
                 objectAddRequest.StorageClass = new S3StorageClass(m_storageClass);
 

--- a/Duplicati/Library/Backend/S3/S3AwsClient.cs
+++ b/Duplicati/Library/Backend/S3/S3AwsClient.cs
@@ -248,7 +248,7 @@ namespace Duplicati.Library.Backend
             var md5 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[0]));
             var sha256 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[1]));
 
-            await AddFileStreamAsync(bucketName, keyName, source, [md5, sha256], source.Length, cancelToken).ConfigureAwait(false);
+            await AddFileStreamAsync(bucketName, keyName, source, md5, sha256, source.Length, cancelToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -257,18 +257,13 @@ namespace Duplicati.Library.Backend
         /// <param name="bucketName">The name of the bucket</param>
         /// <param name="keyName">The name of the object to create</param>
         /// <param name="source">The source stream to upload</param>
-        /// <param name="hashes">The hashes of the content, in the order of MD5 and SHA256 as hex strings</param>
+        /// <param name="md5">The MD5 hash of the content as a hex string</param>
+        /// <param name="sha256">The SHA256 hash of the content as a hex string</param>
         /// <param name="contentLength">The content length of the stream</param>
         /// <param name="cancelToken">The cancellation token</param>
         /// <returns>>A task representing the asynchronous operation</returns>
-        public virtual async Task AddFileStreamAsync(string bucketName, string keyName, Stream source, string[] hashes, long contentLength, CancellationToken cancelToken)
+        public virtual async Task AddFileStreamAsync(string bucketName, string keyName, Stream source, string md5, string sha256, long contentLength, CancellationToken cancelToken)
         {
-            if (hashes.Length != 2)
-                throw new ArgumentException("Hashes array must contain exactly two elements: MD5 and SHA256", nameof(hashes));
-
-            var md5 = hashes[0];
-            var sha256 = hashes[1];
-
             using var ts = source.ObserveReadTimeout(m_timeouts.ReadWriteTimeout, false);
             var objectAddRequest = new PutObjectRequest
             {
@@ -290,7 +285,7 @@ namespace Duplicati.Library.Backend
             // - If chunked streaming is ON, the SDK uses the streaming literal.
             // - If payload signing is disabled, the SDK uses the UNSIGNED-PAYLOAD literal.
             if (!m_useChunkEncoding && !m_disablePayloadSigning)
-                objectAddRequest.Headers["x-amz-content-sha256"] = hashes[1].ToLowerInvariant();
+                objectAddRequest.Headers["x-amz-content-sha256"] = sha256.ToLowerInvariant();
 
             try
             {

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -1,22 +1,22 @@
 // Copyright (C) 2026, The Duplicati Team
 // https://duplicati.com, hello@duplicati.com
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in 
+//
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 using Duplicati.Library.Common.IO;

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -356,14 +356,15 @@ namespace Duplicati.Library.Backend
         /// </summary>
         /// <param name="remotename">The remote filename, relative to the URL.</param>
         /// <param name="input">The stream to read from.</param>
-        /// <param name="hashes">The precomputed hashes of the file.</param>
+        /// <param name="md5">The precomputed MD5 hash of the file.</param>
+        /// <param name="sha256">The precomputed SHA256 hash of the file.</param>
         /// <param name="length">The length of the file.</param>
         /// <param name="cancelToken">Token to cancel the operation.</param>
         /// <returns></returns>
-        public async Task PutWithHashAsync(string remotename, Stream input, string[] hashes, long length, CancellationToken cancelToken)
+        public async Task PutWithHashAsync(string remotename, Stream input, string md5, string sha256, long length, CancellationToken cancelToken)
         {
             if (Connection is S3AwsClient awsClient)
-                await awsClient.AddFileStreamAsync(m_bucket, GetFullKey(remotename), input, hashes, length, cancelToken).ConfigureAwait(false);
+                await awsClient.AddFileStreamAsync(m_bucket, GetFullKey(remotename), input, md5, sha256, length, cancelToken).ConfigureAwait(false);
             else
                 await PutAsync(remotename, input, cancelToken).ConfigureAwait(false);
         }

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -351,6 +351,23 @@ namespace Duplicati.Library.Backend
             await Connection.AddFileStreamAsync(m_bucket, GetFullKey(remotename), input, cancelToken);
         }
 
+        /// <summary>
+        /// Puts a file with the provided hashes and content length, if supported by the client. This allows for optimized uploads where the hashes are already known and for put'ing files with non-seekable streams. If the client does not support this method, it will fall back to a normal PutAsync without the hashes and length.
+        /// </summary>
+        /// <param name="remotename">The remote filename, relative to the URL.</param>
+        /// <param name="input">The stream to read from.</param>
+        /// <param name="hashes">The precomputed hashes of the file.</param>
+        /// <param name="length">The length of the file.</param>
+        /// <param name="cancelToken">Token to cancel the operation.</param>
+        /// <returns></returns>
+        public async Task PutWithHashAsync(string remotename, Stream input, string[] hashes, long length, CancellationToken cancelToken)
+        {
+            if (Connection is S3AwsClient awsClient)
+                await awsClient.AddFileStreamAsync(m_bucket, GetFullKey(remotename), input, hashes, length, cancelToken).ConfigureAwait(false);
+            else
+                await PutAsync(remotename, input, cancelToken).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         public async Task GetAsync(string remotename, string localname, CancellationToken cancelToken)
         {

--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Duplicati.Library.Backend;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 
@@ -248,14 +249,23 @@ namespace Duplicati.Library.Main.Backend
         /// <param name="remotename">The name of the remote file to put.</param>
         /// <param name="stream">The stream containing the file data to put.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <param name="hashes">Optional array of precomputed hashes to forward to the backend.</param>
         /// <returns>A task representing the asynchronous put operation.</returns>
-        public Task PutAsync(string remotename, Stream stream, CancellationToken token)
+        public Task PutAsync(string remotename, Stream stream, CancellationToken token, string[]? hashes = null)
         {
             return RetryWithDelay(
                 $"Put {remotename}",
                 async () =>
                 {
-                    await _streamingBackend!.PutAsync(remotename, stream, token).ConfigureAwait(false);
+                    if (hashes is not null && _streamingBackend is S3AwsClient s3client)
+                    {
+                        var bucketname = Directory.GetParent(remotename)!.Name;
+                        var keyname = Path.GetFileName(remotename);
+                        await s3client.AddFileStreamAsync(bucketname, keyname, stream, hashes, token).ConfigureAwait(false);
+                    }
+                    else
+                        await _streamingBackend!.PutAsync(remotename, stream, token).ConfigureAwait(false);
+
                     _anyUploaded = true;
                 },
                 stream,

--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -249,17 +249,19 @@ namespace Duplicati.Library.Main.Backend
         /// <param name="remotename">The name of the remote file to put.</param>
         /// <param name="stream">The stream containing the file data to put.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
-        /// <param name="hashes">Optional array of precomputed hashes to forward to the backend.</param>
+        /// <param name="md5">Optional precomputed MD5 hash of the file.</param>
+        /// <param name="sha256">Optional precomputed SHA256 hash of the file.</param>
         /// <param name="length">The length of the stream data. Required if hashes are provided.</param>
         /// <returns>A task representing the asynchronous put operation.</returns>
-        public Task PutAsync(string remotename, Stream stream, CancellationToken token, string[]? hashes = null, long? length = null)
+        public Task PutAsync(string remotename, Stream stream, CancellationToken token, string? md5 = null, string? sha256 = null, long? length = null)
         {
             return RetryWithDelay(
                 $"Put {remotename}",
                 async () =>
                 {
-                    if (hashes is not null && length is not null && _streamingBackend is Duplicati.Library.Backend.S3 s3backend)
-                        await s3backend.PutWithHashAsync(remotename, stream, hashes, length!.Value, token).ConfigureAwait(false);
+                    var hashes_length_not_null = md5 is not null && sha256 is not null && length is not null;
+                    if (hashes_length_not_null && _streamingBackend is Duplicati.Library.Backend.S3 s3backend)
+                        await s3backend.PutWithHashAsync(remotename, stream, md5!, sha256!, length!.Value, token).ConfigureAwait(false);
                     else
                         await _streamingBackend!.PutAsync(remotename, stream, token).ConfigureAwait(false);
 

--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -150,23 +150,15 @@ namespace Duplicati.Library.Main.Backend
 
             try
             {
-                await RetryWithDelay(
-                    $"Get {remotename} to TempFile",
-                    async () =>
+                using var fileStream = System.IO.File.OpenWrite(temp);
+                using var progressStream = new ProgressReportingStream(fileStream, pg =>
                     {
-                        using var fileStream = System.IO.File.OpenWrite(temp);
-                        using var progressStream = new ProgressReportingStream(fileStream, pg =>
-                            {
-                                _backendProgressUpdater?.UpdateProgress(remotename, pg);
-                                _progressUpdater?.UpdateFileProgress(pg);
-                            });
-                        await _streamingBackend!.GetAsync(remotename, progressStream, token).ConfigureAwait(false);
-                        _anyDownloaded = true;
-                    },
-                    null,
-                    false,
-                    token
-                ).ConfigureAwait(false);
+                        _backendProgressUpdater?.UpdateProgress(remotename, pg);
+                        _progressUpdater?.UpdateFileProgress(pg);
+                    });
+
+                await GetAsync(remotename, progressStream, token)
+                    .ConfigureAwait(false);
 
                 return temp;
             }
@@ -280,25 +272,17 @@ namespace Duplicati.Library.Main.Backend
         /// <param name="temp">The temporary file containing the data to upload.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <returns>A task representing the asynchronous put operation.</returns>
-        public Task PutAsync(string remotename, TempFile temp, CancellationToken token)
+        public async Task PutAsync(string remotename, TempFile temp, CancellationToken token)
         {
-            return RetryWithDelay(
-                $"Put {remotename}",
-                async () =>
+            using var fileStream = System.IO.File.OpenRead(temp);
+            using var progressStream = new ProgressReportingStream(fileStream, pg =>
                 {
-                    using var fileStream = System.IO.File.OpenRead(temp);
-                    using var progressStream = new ProgressReportingStream(fileStream, pg =>
-                        {
-                            _backendProgressUpdater?.UpdateProgress(remotename, pg);
-                            _progressUpdater?.UpdateFileProgress(pg);
-                        });
-                    await _streamingBackend!.PutAsync(remotename, progressStream, token).ConfigureAwait(false);
-                    _anyUploaded = true;
-                },
-                null,
-                false,
-                token
-            );
+                    _backendProgressUpdater?.UpdateProgress(remotename, pg);
+                    _progressUpdater?.UpdateFileProgress(pg);
+                });
+
+            await PutAsync(remotename, progressStream, token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -250,19 +250,16 @@ namespace Duplicati.Library.Main.Backend
         /// <param name="stream">The stream containing the file data to put.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <param name="hashes">Optional array of precomputed hashes to forward to the backend.</param>
+        /// <param name="length">The length of the stream data. Required if hashes are provided.</param>
         /// <returns>A task representing the asynchronous put operation.</returns>
-        public Task PutAsync(string remotename, Stream stream, CancellationToken token, string[]? hashes = null)
+        public Task PutAsync(string remotename, Stream stream, CancellationToken token, string[]? hashes = null, long? length = null)
         {
             return RetryWithDelay(
                 $"Put {remotename}",
                 async () =>
                 {
-                    if (hashes is not null && _streamingBackend is S3AwsClient s3client)
-                    {
-                        var bucketname = Directory.GetParent(remotename)!.Name;
-                        var keyname = Path.GetFileName(remotename);
-                        await s3client.AddFileStreamAsync(bucketname, keyname, stream, hashes, token).ConfigureAwait(false);
-                    }
+                    if (hashes is not null && length is not null && _streamingBackend is Duplicati.Library.Backend.S3 s3backend)
+                        await s3backend.PutWithHashAsync(remotename, stream, hashes, length!.Value, token).ConfigureAwait(false);
                     else
                         await _streamingBackend!.PutAsync(remotename, stream, token).ConfigureAwait(false);
 


### PR DESCRIPTION
This PR adapts the S3 backend to allow providing precomputed hashes and content length. Before, the backend automatically computed these based of the given stream. However, when passing a stream that doesn't support seeking and doesn't provide a length (such as forwarding a stream from a web application POST request), the S3 backend would fail.

Additionally, the PR also consolidates the `GetAsync()` and `PutAsync()` methods of the `LightweightBackendManager` to ensure the overloads are calling the same core implementation. 