### PR TITLE
Fix full result option mismatch by adding alias support and updating tests

### DIFF
--- a/Duplicati/CommandLine/CLI/ConsoleOutput.cs
+++ b/Duplicati/CommandLine/CLI/ConsoleOutput.cs
@@ -40,7 +40,8 @@ namespace Duplicati.CommandLine
             this.Output = output;
             this.QuietConsole = Library.Utility.Utility.ParseBoolOption(options, "quiet-console");
             this.VerboseErrors = Library.Utility.Utility.ParseBoolOption(options, "debug-output");
-            this.FullResults = Library.Utility.Utility.ParseBoolOption(options, "full-results");
+            this.FullResults = Library.Utility.Utility.ParseBoolOption(options, "full-result")
+                || Library.Utility.Utility.ParseBoolOption(options, "full-results");
         }
 
         #region IMessageSink implementation

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -490,7 +490,7 @@ namespace Duplicati.Library.Main
             new CommandLineArgument("next-scheduled-run", CommandLineArgument.ArgumentType.String, Strings.Options.NextscheduledrunShort, Strings.Options.NextscheduledrunLong),
 
             new CommandLineArgument("verbose", CommandLineArgument.ArgumentType.Boolean, Strings.Options.VerboseShort, Strings.Options.VerboseLong, "false", null, null, Strings.Options.VerboseDeprecated),
-            new CommandLineArgument("full-result", CommandLineArgument.ArgumentType.Boolean, Strings.Options.FullresultShort, Strings.Options.FullresultLong, "false"),
+            new CommandLineArgument("full-result", CommandLineArgument.ArgumentType.Boolean, Strings.Options.FullresultShort, Strings.Options.FullresultLong, "false", new string[] { "full-results" }),
 
             new CommandLineArgument("overwrite", CommandLineArgument.ArgumentType.Boolean, Strings.Options.OverwriteShort, Strings.Options.OverwriteLong, "false"),
 

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -155,6 +155,22 @@ namespace Duplicati.UnitTest
             }
         }
 
+        [Test]
+        public void TestFullResultOptionSupportsAliasAndConsoleOutput()
+        {
+            var option = new Options(new Dictionary<string, string?>()).SupportedCommands.FirstOrDefault(x => x.Name == "full-result");
+
+            Assert.IsNotNull(option, "The full-result option was not registered.");
+            Assert.IsTrue(option!.Aliases.Contains("full-results"), "The full-results alias was not registered.");
+
+            using var writer = new StringWriter();
+            using var singularConsole = new CommandLine.ConsoleOutput(writer, new Dictionary<string, string> { ["full-result"] = "true" });
+            using var pluralConsole = new CommandLine.ConsoleOutput(writer, new Dictionary<string, string> { ["full-results"] = "true" });
+
+            Assert.IsTrue(singularConsole.FullResults, "Console output did not honor the full-result option.");
+            Assert.IsTrue(pluralConsole.FullResults, "Console output did not honor the full-results alias.");
+        }
+
         /// <summary>
         /// Tests passing all arguments to the main method of the remote synchronization tool.
         /// </summary>


### PR DESCRIPTION
This fixes a mismatch between the registered CLI option name and the console output path that enables full result serialization.

Before this change:

* `full-result` was the registered and documented option.
* `full-results` was not a supported option and produced a warning.
* The console output code only checked `full-results`, so `full-result` could be accepted but still not enable full result output in that path.

After this change:
* The console output path honors both `full-result` and `full-results`.
* `full-results` is registered as an alias for `full-result`.
* A regression test covers both spellings and verifies the alias is registered.

This keeps the documented option working as expected while preserving compatibility with the plural form that had been checked in the CLI output code.