### PR TITLE
Handle expired links

### DIFF
--- a/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
+++ b/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
@@ -470,7 +470,7 @@ public class KeepRemoteConnection : IDisposable
     /// </summary>
     /// <returns>An awaitable task</returns>
     private Task InvokeReKey()
-        => _onReKey(new ClaimedClientData(_token, _serverUrl, _certificateUrl, _serverKeys, null));
+        => _onReKey(new ClaimedClientData(_token, _serverUrl, _certificateUrl, _serverKeys, null, null));
 
     /// <summary>
     /// Creates a new connection to the remote server

--- a/Duplicati/Library/RemoteControl/RegisterForRemote.cs
+++ b/Duplicati/Library/RemoteControl/RegisterForRemote.cs
@@ -273,11 +273,13 @@ public class RegisterForRemote : IDisposable
         var doc = JsonDocument.Parse(raw);
         if (doc.RootElement.TryGetProperty("jwt", out var _) && doc.RootElement.TryGetProperty("serverUrl", out var _))
         {
-            return JsonSerializer.Deserialize<ClaimedClientData>(raw, JsonOptions) switch
-            {
-                { } data => (null, data),
-                null => throw new Exception("Failed to read client claimed data")
-            };
+            var res = JsonSerializer.Deserialize<ClaimedClientData>(raw, JsonOptions)
+                ?? throw new Exception("Failed to read client claimed data");
+
+            if (string.IsNullOrWhiteSpace(res.JWT) || string.IsNullOrWhiteSpace(res.ServerUrl))
+                throw new Exception($"Failed to obtain registration data, status message: {res.StatusMessage}");
+
+            return (null, res);
         }
 
         if (doc.RootElement.TryGetProperty("claimLink", out var _) && doc.RootElement.TryGetProperty("statusLink", out var _))
@@ -340,7 +342,14 @@ public class RegisterForRemote : IDisposable
         if (!result.Success)
             throw new Exception($"Failed to claim machine: {result.StatusMessage}");
 
-        return new ClaimedClientData(result.JWT, result.ServerUrl, result.CertificateUrl, result.ServerCertificates, result.LocalEncryptionKey, result.Settings);
+        return new ClaimedClientData(
+            result.JWT,
+            result.ServerUrl,
+            result.CertificateUrl,
+            result.ServerCertificates,
+            result.LocalEncryptionKey,
+            result.StatusMessage,
+            result.Settings);
     }
 
     /// </inheritdoc>

--- a/Duplicati/Library/RemoteControl/SharedTypes.cs
+++ b/Duplicati/Library/RemoteControl/SharedTypes.cs
@@ -54,6 +54,7 @@ public sealed record ClaimedClientData(
     string CertificateUrl,
     IEnumerable<MiniServerCertificate> ServerCertificates,
     string? LocalEncryptionKey,
+    string? StatusMessage,
     Dictionary<string, string?>? Settings = null
 );
 


### PR DESCRIPTION
This PR updates the code that handles remote connections to detect server emitted error messages and log them.

Prior to this PR an expired link would make the UI appear to be sort-of connected with no indication of why it would not fully connect.