### PR TITLE
Return full certificate chains

### DIFF
--- a/Duplicati/WebserverCore/DuplicatiWebserver.cs
+++ b/Duplicati/WebserverCore/DuplicatiWebserver.cs
@@ -19,8 +19,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System.Collections.Concurrent;
 using System.Net;
-using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+using System.Security.Authentication;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Duplicati.Library.Interface;
@@ -434,29 +436,30 @@ public class DuplicatiWebserver
     /// <param name="connection">The connection</param>
     private static void ConfigureHttps(Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions listenOptions, Connection connection)
     {
-        listenOptions.UseHttps(new HttpsConnectionAdapterOptions()
-        {
-            // Use ServerCertificateSelector for dynamic certificate loading
-            // This allows the certificate to be renewed without server restart
-            ServerCertificateSelector = (connectionContext, hostName) =>
-            {
-                try
-                {
-                    var cert = connection.ApplicationSettings.ServerSSLCertificate;
-                    if (cert == null || cert.Count == 0)
-                    {
-                        Library.Logging.Log.WriteWarningMessage(LOGTAG, "NoCertificateAvailable", null, "No SSL certificate available for HTTPS connection.");
-                        return null;
-                    }
+        var _contextCache = new ConcurrentDictionary<string, SslStreamCertificateContext>();
 
-                    // Return the certificate with private key
-                    return cert.FirstOrDefault(x => x.HasPrivateKey);
-                }
-                catch (Exception ex)
+        listenOptions.UseHttps(new TlsHandshakeCallbackOptions
+        {
+            OnConnection = context =>
+            {
+                var collection = connection.ApplicationSettings.ServerSSLCertificate;
+                var leafCert = collection?.FirstOrDefault(x => x.HasPrivateKey);
+                if (leafCert == null || collection == null)
                 {
-                    Library.Logging.Log.WriteErrorMessage(LOGTAG, "CertificateLoadFailed", ex, "Failed to load SSL certificate for connection.");
-                    return null;
+                    Library.Logging.Log.WriteWarningMessage(LOGTAG, "NoCertificateAvailable", null, "No SSL certificate available for HTTPS connection.");
+                    throw new AuthenticationException("No certificates found");
                 }
+
+                // We only expect a single active certificate
+                if (_contextCache.Count > 2)
+                    _contextCache.Clear();
+
+                // Reuse cert context across connections
+                var certContext = _contextCache.GetOrAdd(leafCert.Thumbprint, _ => SslStreamCertificateContext.Create(leafCert, collection));
+                return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                {
+                    ServerCertificateContext = certContext
+                });
             }
         });
     }


### PR DESCRIPTION
Rewrote the certificate selector to use the TlsHandshakeCallbackOptions  as the HttpsConnectionAdapterOptions did not support returning the full chain, but only returned the leaf certificate.

This fixes #6807