### PR TITLE
Fix incorrect quota size reported

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -2104,7 +2104,7 @@ namespace Duplicati.Library.Utility
                 }
                 else if (!OperatingSystem.IsWindows())
                 {
-                    var driveInfo = new DriveInfo(root);
+                    var driveInfo = new DriveInfo(path);
                     if (driveInfo.TotalSize > 0)
                         return (driveInfo.AvailableFreeSpace, driveInfo.TotalSize);
                 }


### PR DESCRIPTION
The code before this would incorrectly always return the free space of `/` on non-Windows, instead of the actual mounted path's free space.