### PR TITLE
Added post-backup script

### DIFF
--- a/Duplicati/Library/Interface/IBackupCallbackModule.cs
+++ b/Duplicati/Library/Interface/IBackupCallbackModule.cs
@@ -1,0 +1,43 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+
+namespace Duplicati.Library.Interface
+{
+    /// <summary>
+    /// Interface for implementing backup-specific callback modules
+    /// </summary>
+    public interface IBackupCallbackModule : IGenericModule
+    {
+        /// <summary>
+        /// Called when the backup operation has completed uploading data,
+        /// but before the remote verification is performed.
+        /// This allows scripts to run after the backup data is written
+        /// and source resources (like VSS snapshots) are released,
+        /// but before the potentially lengthy verification or synchronization
+        /// processes run.
+        /// </summary>
+        /// <param name="result">The result object containing backup operation results</param>
+        /// <param name="exception">Any exception that occurred during backup, or null</param>
+        void OnFinishBackup(IBasicResults result, Exception exception);
+    }
+}

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -893,6 +893,18 @@ namespace Duplicati.Library.Main.Operation
                     await db.RemoveDuplicatePathsFromFilesetAsync(filesetid, m_taskReader.ProgressToken)
                         .ConfigureAwait(false);
 
+
+                    // Invoke the after-backup callback, after the backup is complete
+                    // and sources are disposed, but before verification
+                    if (await m_result.TaskControl.ProgressRendevouz().ConfigureAwait(false) && m_options.LoadedModules != null)
+                    {
+                        foreach (var mx in m_options.LoadedModules)
+                            if (mx is IBackupCallbackModule module)
+                                try { module.OnFinishBackup(m_result, null); }
+                                catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, $"OnFinishBackupError{mx.Key}", ex, "OnFinishBackup callback {0} failed: {1}", mx.Key, ex.Message); }
+                    }
+
+
                     // If this throws, we should roll back the transaction
                     if (await m_result.TaskControl.ProgressRendevouz().ConfigureAwait(false))
                     {

--- a/Duplicati/Library/Modules/Builtin/RunScript.cs
+++ b/Duplicati/Library/Modules/Builtin/RunScript.cs
@@ -35,7 +35,7 @@ namespace Duplicati.Library.Modules.Builtin
     /// <summary>
     /// Module for running scripts before and after operations.
     /// </summary>
-    public class RunScript : IGenericCallbackModule, IGenericPriorityModule
+    public class RunScript : IGenericCallbackModule, IBackupCallbackModule, IGenericPriorityModule
     {
         /// <summary>
         /// The tag used for logging
@@ -57,6 +57,7 @@ namespace Duplicati.Library.Modules.Builtin
 
         private const string STARTUP_OPTION = "run-script-before";
         private const string FINISH_OPTION = "run-script-after";
+        private const string FINISH_BACKUP_OPTION = "run-script-post-backup";
         private const string REQUIRED_OPTION = "run-script-before-required";
         private const string TIMEOUT_OPTION = "run-script-timeout";
         private const string ENABLE_ARGUMENTS_OPTION = "run-script-with-arguments";
@@ -76,6 +77,7 @@ namespace Duplicati.Library.Modules.Builtin
         private string m_requiredScript = null;
         private string m_startScript = null;
         private string m_finishScript = null;
+        private string m_finishBackupScript = null;
         private int m_timeout = 0;
         private bool m_enableArguments = false;
 
@@ -109,6 +111,7 @@ namespace Duplicati.Library.Modules.Builtin
             commandlineOptions.TryGetValue(STARTUP_OPTION, out m_startScript);
             commandlineOptions.TryGetValue(REQUIRED_OPTION, out m_requiredScript);
             commandlineOptions.TryGetValue(FINISH_OPTION, out m_finishScript);
+            commandlineOptions.TryGetValue(FINISH_BACKUP_OPTION, out m_finishBackupScript);
             m_enableArguments = Utility.Utility.ParseBoolOption(commandlineOptions.AsReadOnly(), ENABLE_ARGUMENTS_OPTION);
 
             ResultExportFormat resultFormat;
@@ -175,6 +178,7 @@ namespace Duplicati.Library.Modules.Builtin
                 return new List<ICommandLineArgument>([
                     new CommandLineArgument(STARTUP_OPTION, CommandLineArgument.ArgumentType.Path, Strings.RunScript.StartupoptionShort, Strings.RunScript.StartupoptionLong),
                     new CommandLineArgument(FINISH_OPTION, CommandLineArgument.ArgumentType.Path, Strings.RunScript.FinishoptionShort, Strings.RunScript.FinishoptionLong),
+                    new CommandLineArgument(FINISH_BACKUP_OPTION, CommandLineArgument.ArgumentType.Path, Strings.RunScript.FinishBackupOptionShort, Strings.RunScript.FinishBackupOptionLong),
                     new CommandLineArgument(REQUIRED_OPTION, CommandLineArgument.ArgumentType.Path, Strings.RunScript.RequiredoptionShort, Strings.RunScript.RequiredoptionLong),
                     new CommandLineArgument(ENABLE_ARGUMENTS_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.RunScript.EnableArgumentsShort, Strings.RunScript.EnableArgumentsLong),
                     new CommandLineArgument(RESULT_FORMAT_OPTION,
@@ -268,6 +272,50 @@ namespace Duplicati.Library.Modules.Builtin
 
                 Execute(m_finishScript, "AFTER", m_operationName, ref m_remoteurl, ref m_localpath, m_timeout, false, m_enableArguments, m_options, tmpfile, level);
             }
+        }
+
+        /// <summary>
+        /// Called when the backup operation has completed uploading data,
+        /// but before the remote verification is performed.
+        /// </summary>
+        /// <param name="result">The result object containing backup operation results</param>
+        /// <param name="exception">Any exception that occurred during backup, or null</param>
+        public void OnFinishBackup(IBasicResults result, Exception exception)
+        {
+            if (string.IsNullOrEmpty(m_finishBackupScript))
+                return;
+
+            ParsedResultType level;
+            if (exception is OperationAbortException oae)
+            {
+                switch (oae.AbortReason)
+                {
+                    case OperationAbortReason.Error:
+                        level = ParsedResultType.Error;
+                        break;
+                    case OperationAbortReason.Normal:
+                        level = ParsedResultType.Success;
+                        break;
+                    case OperationAbortReason.Warning:
+                        level = ParsedResultType.Warning;
+                        break;
+                    default:
+                        level = ParsedResultType.Unknown;
+                        break;
+                }
+            }
+            else if (exception != null)
+                level = ParsedResultType.Fatal;
+            else if (result != null)
+                level = result.ParsedResult;
+            else
+                level = ParsedResultType.Error;
+
+            using var tmpfile = new TempFile();
+            using (var streamWriter = new StreamWriter(tmpfile))
+                streamWriter.Write(resultFormatSerializer.Serialize(result, exception, m_logstorage, null));
+
+            Execute(m_finishBackupScript, "POST-BACKUP", m_operationName, ref m_remoteurl, ref m_localpath, m_timeout, false, m_enableArguments, m_options, tmpfile, level);
         }
         #endregion
 

--- a/Duplicati/Library/Modules/Builtin/Strings.cs
+++ b/Duplicati/Library/Modules/Builtin/Strings.cs
@@ -112,6 +112,8 @@ namespace Duplicati.Library.Modules.Builtin.Strings
         public static string DisplayName { get { return LC.L(@"Run script"); } }
         public static string FinishoptionLong { get { return LC.L(@"Execute a script after performing an operation. The script will receive the operation results written to stdout."); } }
         public static string FinishoptionShort { get { return LC.L(@"Run a script on exit"); } }
+        public static string FinishBackupOptionLong { get { return LC.L(@"Execute a script after the backup data has been written and source resources (like VSS snapshots) have been released, but before the remote verification is performed. This allows scripts to run at the earliest point where the backup is complete but verification has not yet started. The script will receive the operation results written to stdout."); } }
+        public static string FinishBackupOptionShort { get { return LC.L(@"Run a script post-backup, before verification"); } }
         public static string InvalidExitCodeError(string script, int exitcode) { return LC.L(@"The script ""{0}"" returned with exit code {1}", script, exitcode); }
         public static string ExitCodeError(string script, int exitcode, string message) { return LC.L(@"The script ""{0}"" returned with exit code {1}{2}", script, exitcode, string.IsNullOrWhiteSpace(message) ? string.Empty : string.Format(": {0}", message)); }
         public static string RequiredoptionLong { get { return LC.L(@"Execute a script before performing an operation. The operation will block until the script has completed or timed out. If the script returns a non-zero error code or times out, the operation will be aborted."); } }

--- a/Duplicati/Library/Modules/Builtin/run-script-example.bat
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.bat
@@ -11,6 +11,7 @@ REM --run-script-before = <filename>
 REM --run-script-before-required = <filename>
 REM --run-script-timeout = <time>
 REM --run-script-after = <filename>
+REM --run-script-post-backup = <filename>
 REM --run-script-with-arguments = <boolean>
 REM
 REM --run-script-before-required = <filename>
@@ -46,6 +47,17 @@ REM warning is logged.
 REM The same exit codes as in --run-script-before are supported, but
 REM the operation will always continue (i.e. 1 => 0, 3 => 2, 5 => 4)
 REM as it has already completed so stopping it during stop is useless.
+REM
+REM --run-script-post-backup = <filename>
+REM Duplicati will run the script after the backup data has been written and
+REM source resources (like VSS snapshots) have been released, but before the
+REM remote verification is performed. This allows scripts to run at the earliest
+REM point where the backup is complete but verification has not yet started.
+REM This is useful for scenarios where you want to minimize the time that
+REM operations are suspended or paused. The script will wait for its completion
+REM for 60 seconds (default timeout value). After a timeout a warning is logged.
+REM The same exit codes as in --run-script-before are supported, but
+REM the operation will always continue.
 REM
 REM --run-script-with-arguments = <boolean>
 REM If set to true, the script path will be parsed as a command line, and the
@@ -103,8 +115,9 @@ REM Special Environment Variables
 REM ###############################################################################
 
 REM DUPLICATI__EVENTNAME
-REM Eventname is BEFORE if invoked as --run-script-before, and AFTER if 
-REM invoked as --run-script-after. This value cannot be changed by writing
+REM Eventname is BEFORE if invoked as --run-script-before, AFTER if 
+REM invoked as --run-script-after, and POST-BACKUP if invoked as
+REM --run-script-post-backup. This value cannot be changed by writing
 REM it back!
 
 REM DUPLICATI__OPERATIONNAME
@@ -145,6 +158,7 @@ SET "LOCALPATH=%DUPLICATI__LOCALPATH%"
 REM Basic setup, we use the same file for both before and after,
 REM so we need to figure out which event has happened
 if "%EVENTNAME%" == "BEFORE" GOTO ON_BEFORE
+if "%EVENTNAME%" == "POST-BACKUP" GOTO ON_POST_BACKUP
 if "%EVENTNAME%" == "AFTER" GOTO ON_AFTER
 
 REM This should never happen, but there may be new operations
@@ -177,6 +191,24 @@ GOTO end
 :SET_VOLSIZE
 REM Write the option to stdout to change it
 echo --dblock-size=25mb
+GOTO end
+
+
+:ON_POST_BACKUP
+
+REM This event is triggered after the backup data has been written and
+REM source resources (like VSS snapshots) have been released, but before
+REM the remote verification is performed. This is the earliest point where
+REM you can safely resume operations that were suspended for the backup.
+
+IF "%OPERATIONNAME%" == "Backup" GOTO ON_POST_BACKUP_BACKUP
+REM This will be ignored
+echo Got operation "%OPERATIONNAME%", ignoring
+GOTO end
+
+:ON_POST_BACKUP_BACKUP
+echo Backup data written, resuming normal operations before verification
+REM Add your post-backup logic here, e.g., resuming services
 GOTO end
 
 

--- a/Duplicati/Library/Modules/Builtin/run-script-example.sh
+++ b/Duplicati/Library/Modules/Builtin/run-script-example.sh
@@ -11,6 +11,7 @@
 # --run-script-before-required = <filename>
 # --run-script-timeout = <time>
 # --run-script-after = <filename>
+# --run-script-post-backup = <filename>
 # --run-script-with-arguments = <boolean>
 #
 # --run-script-before-required = <filename>
@@ -43,6 +44,16 @@
 # Duplicati will run the script after the backup job and wait for its 
 # completion for 60 seconds (default timeout value). After a timeout a 
 # warning is logged.
+# Any other exit code than 0 will be logged as a warning.
+#
+# --run-script-post-backup = <filename>
+# Duplicati will run the script after the backup data has been written and
+# source resources (like VSS snapshots) have been released, but before the
+# remote verification is performed. This allows scripts to run at the earliest
+# point where the backup is complete but verification has not yet started.
+# This is useful for scenarios where you want to minimize the time that
+# operations are suspended or paused. The script will wait for its completion
+# for 60 seconds (default timeout value). After a timeout a warning is logged.
 # Any other exit code than 0 will be logged as a warning.
 #
 # --run-script-with-arguments = <boolean>
@@ -99,8 +110,9 @@
 ###############################################################################
 
 # DUPLICATI__EVENTNAME
-# Eventname is BEFORE if invoked as --run-script-before, and AFTER if 
-# invoked as --run-script-after. This value cannot be changed by writing
+# Eventname is BEFORE if invoked as --run-script-before, AFTER if 
+# invoked as --run-script-after, and POST-BACKUP if invoked as
+# --run-script-post-backup. This value cannot be changed by writing
 # it back!
 
 # DUPLICATI__OPERATIONNAME
@@ -161,6 +173,19 @@ then
 	else
 		# This will be ignored
 		echo "Got operation \"OPERATIONNAME\", ignoring"	
+	fi
+
+elif [ "$EVENTNAME" == "POST-BACKUP" ]
+then
+	# This event is triggered after the backup data has been written and
+	# source resources (like VSS snapshots) have been released, but before
+	# the remote verification is performed. This is the earliest point where
+	# you can safely resume operations that were suspended for the backup.
+
+	if [ "$OPERATIONNAME" == "Backup" ]
+	then
+		echo "Backup data written, resuming normal operations before verification"
+		# Add your post-backup logic here, e.g., resuming services
 	fi
 
 elif [ "$EVENTNAME" == "AFTER" ]


### PR DESCRIPTION
This PR adds a new `--run-script-post-backup` option that allows running a script after the main backup operation has completed, but before locking, compacting and verification is done.

The use for this is intended for cases where you want to stop or pause some service, run a backup, and then resume the service. Prior to this PR you would need to wait for the entire backup operation to complete, but with the new option you can resume as soon as the source data is no longer needed.