### PR TITLE
Log 500 errors to live-log

### DIFF
--- a/Duplicati/WebserverCore/DuplicatiWebserver.cs
+++ b/Duplicati/WebserverCore/DuplicatiWebserver.cs
@@ -392,6 +392,8 @@ public class DuplicatiWebserver
                     app.ApplicationServices.GetRequiredService<ILogger<DuplicatiWebserver>>()
                         .LogError(thrownException, "Unhandled exception");
 
+                    Library.Logging.Log.WriteErrorMessage(LOGTAG, "UnhandledException", thrownException, "Unhandled exception in webserver request to {0}", context.Request.Path);
+
                     context.Response.StatusCode = 500;
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(JsonSerializer.Serialize(new { Error = "An error occurred", Code = 500 }));


### PR DESCRIPTION
This PR adds logging for 500 errors to the live logs.

As a precaution, errors that are unknown in nature are not reported to the client as they could expose sensitive information to an unauthenticated caller.

With this PR the errors are logged in the live-log and are visible to authenticated users.