### PR TITLE
Allow versions in search

### DIFF
--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -34,6 +34,7 @@ using Duplicati.Server.Serialization.Interface;
 using Duplicati.WebserverCore.Abstractions;
 using System.Threading;
 using System.Text.Json;
+using System.Globalization;
 
 namespace Duplicati.Server
 {
@@ -256,11 +257,13 @@ namespace Duplicati.Server
                 pageOffset: pageOffset);
         }
 
-        public static IRunnerData CreateSearchEntriesTask(IBackup backup, string[]? filters, string[]? folders, DateTime time, int pageSize, int pageOffset, bool returnExtended)
+        public static IRunnerData CreateSearchEntriesTask(IBackup backup, string[]? filters, string[]? folders, DateTime time, long[]? version, int pageSize, int pageOffset, bool returnExtended)
         {
             var dict = new Dictionary<string, string?>();
             if (time.Ticks > 0)
                 dict["time"] = Utility.SerializeDateTime(time.ToUniversalTime());
+            if (version != null)
+                dict["version"] = string.Join(",", version.Select(v => v.ToString(CultureInfo.InvariantCulture)));
 
             return CreateTask(
                 DuplicatiOperation.SearchEntries,

--- a/Duplicati/WebserverCore/Dto/V2/SearchEntriesRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/SearchEntriesRequestDto.cs
@@ -40,9 +40,13 @@ public sealed record SearchEntriesRequestDto : PaginatedRequest
     /// <summary>
     /// The time to search in
     /// </summary>
-    public required string? Time { get; init; }
+    public string? Time { get; init; }
     /// <summary>
     /// If true, return extended information
     /// </summary>
     public bool? ReturnExtended { get; init; }
+    /// <summary>
+    /// The version(s) to search in
+    /// </summary>
+    public long[]? Version { get; init; }
 }

--- a/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
@@ -145,7 +145,7 @@ public class BackupListing : IEndpointV2
             ? new DateTime(0)
             : Library.Utility.Timeparser.ParseTimeInterval(input.Time, DateTime.Now);
 
-        var r = queueRunnerService.RunImmediately(Runner.CreateSearchEntriesTask(bk, input.Filters, input.Paths, time, input.PageSize ?? 1000, input.Page ?? 0, input.ReturnExtended ?? false)) as ISearchFilesResults;
+        var r = queueRunnerService.RunImmediately(Runner.CreateSearchEntriesTask(bk, input.Filters, input.Paths, time, input.Version, input.PageSize ?? 1000, input.Page ?? 0, input.ReturnExtended ?? false)) as ISearchFilesResults;
         if (r == null)
             throw new ServerErrorException("No result from list operation");
 


### PR DESCRIPTION
This PR extends the search API to allow versions to be added so searching can be limited to specific versions.

Before this PR, only time was supported, but this is picking versions older than the timestamp as well.