### PR TITLE
Strip xattrs from tar

### DIFF
--- a/ReleaseBuilder/Build/Command.CreatePackage.cs
+++ b/ReleaseBuilder/Build/Command.CreatePackage.cs
@@ -1402,7 +1402,7 @@ public static partial class Command
         // Create the tarball
         var tarfile = Path.Combine(tmpbuild, $"duplicati-{rtcfg.ReleaseInfo.Version}.tar.bz2");
         await ProcessHelper.Execute(
-            ["tar", "-cjf", tarfile, Path.GetFileName(tarsrc)],
+            ["tar", "--no-acls", "--no-xattrs", "-cjf", tarfile, Path.GetFileName(tarsrc)],
             workingDirectory: Path.GetDirectoryName(tarsrc)
         );
         Directory.Delete(tarsrc, true);


### PR DESCRIPTION
During building of the RPM packages we use a tar file. This update simply avoid bundling unused ACLs and XATTR values in the tar file.