### PR TITLE
AESCrypt default v2

### DIFF
--- a/Duplicati/Library/Encryption/AESEncryption.cs
+++ b/Duplicati/Library/Encryption/AESEncryption.cs
@@ -140,6 +140,10 @@ namespace Duplicati.Library.Encryption
                     InsertPlaceholder = false
                 };
 
+            // Until the next stable release, use version 2 by default
+            if (version == null)
+                version = 2;
+
             if (version.HasValue)
                 encOpts = encOpts with { FileVersion = (byte)version.Value };
             if (iterations.HasValue)


### PR DESCRIPTION
This PR sets the default AESCrypt stream format to v2.

This is done to introduce the ability to read the v3 format before switching to the new format. With a delayed activation, it is more likely that users can easily roll back a version if needed.