### PR TITLE
Add package to Docker image

### DIFF
--- a/ReleaseBuilder/Resources/Docker/Dockerfile
+++ b/ReleaseBuilder/Resources/Docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest
 
 RUN apt update -y && \
-    apt install -y libssl3t64 ca-certificates libicu76 rclone gnupg tini
+    apt install -y libssl3t64 ca-certificates libicu76 libgssapi-krb5-2 rclone gnupg tini
 
 ENTRYPOINT [ "/usr/bin/tini", "--", "/run-as-user.sh" ]
 


### PR DESCRIPTION
This PR adds the `libgssapi` package to the Docker image to avoid warnings when starting Duplicati inside Docker.

This fixes #6862