### PR TITLE
Persist used compression module

### DIFF
--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -164,14 +164,14 @@ namespace Duplicati.Library.Main.Volumes
                 if (d.Version > ManifestData.VERSION)
                     throw new InvalidManifestException("Version", d.Version.ToString(), ManifestData.VERSION.ToString());
 
-                string n;
-
-                if (!options.RawOptions.TryGetValue("blocksize", out n) || string.IsNullOrEmpty(n))
+                if (string.IsNullOrWhiteSpace(options.RawOptions.GetValueOrDefault("blocksize")))
                     options.RawOptions["blocksize"] = d.Blocksize + "b";
-                if (!options.RawOptions.TryGetValue("block-hash-algorithm", out n) || string.IsNullOrEmpty(n))
+                if (string.IsNullOrWhiteSpace(options.RawOptions.GetValueOrDefault("block-hash-algorithm")))
                     options.RawOptions["block-hash-algorithm"] = d.BlockHash;
-                if (!options.RawOptions.TryGetValue("file-hash-algorithm", out n) || string.IsNullOrEmpty(n))
+                if (string.IsNullOrWhiteSpace(options.RawOptions.GetValueOrDefault("file-hash-algorithm")))
                     options.RawOptions["file-hash-algorithm"] = d.FileHash;
+                if (string.IsNullOrWhiteSpace(options.RawOptions.GetValueOrDefault("compression-module")))
+                    options.RawOptions["compression-module"] = compressor.FilenameExtension;
             }
         }
 

--- a/Duplicati/UnitTest/RecoveryToolTests.cs
+++ b/Duplicati/UnitTest/RecoveryToolTests.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using Duplicati.Library.Main.Database;
+using Duplicati.Library.Utility;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -296,6 +297,62 @@ namespace Duplicati.UnitTest
             Directory.CreateDirectory(downloadFolder);
             int status = CommandLine.RecoveryTool.Program.Main(new[] { "recompress", "zip", $"{backendURL}", this.RESTOREFOLDER, $"--passphrase={options["passphrase"]}" });
             Assert.AreEqual(0, status);
+        }
+
+        [Test]
+        [Category("RecoveryTool")]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void RecompressAndRecreateDatabase(bool noEncryption)
+        {
+            // Create a small dataset.
+            File.WriteAllBytes(Path.Combine(this.DATAFOLDER, "file.txt"), new byte[] { 1, 2, 3 });
+
+            // Run a backup with default zip compression.
+            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["no-encryption"] = noEncryption.ToString()
+            };
+            string backendURL = "file://" + this.TARGETFOLDER;
+            using (Controller c = new Controller(backendURL, options, null))
+            {
+                IBackupResults backupResults = c.Backup(new[] { this.DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            // Delete the local database.
+            File.Delete(options["dbpath"]);
+
+            // Recompress remote files from zip to tzstd and reupload.
+            string recompressFolder = Path.Combine(this.RESTOREFOLDER, "recompressed");
+            Directory.CreateDirectory(recompressFolder);
+            int status = CommandLine.RecoveryTool.Program.Main(new[] { "recompress", "tzstd", backendURL, recompressFolder, "--reupload", $"--passphrase={options["passphrase"]}" });
+            Assert.AreEqual(0, status);
+
+            // Verify that the remote now contains tzstd files and no zip files.
+            var remoteFiles = Directory.GetFiles(this.TARGETFOLDER);
+            Assert.That(remoteFiles.Any(f => f.EndsWith(".tzstd", StringComparison.OrdinalIgnoreCase)), Is.True, "Remote should contain tzstd files after recompress.");
+            Assert.That(remoteFiles.Any(f => f.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)), Is.False, "Remote should not contain zip files after recompress.");
+
+            // Recreate the local database via Repair.
+            using (Controller c = new Controller(backendURL, options, null))
+            {
+                IRepairResults repairResults = c.Repair();
+                Assert.AreEqual(0, repairResults.Errors.Count());
+                Assert.AreEqual(0, repairResults.Warnings.Count());
+            }
+
+            // The recreated database should have compression-module set to tzstd,
+            // because that is the actual compression format now used on the remote.
+            using (var db = Duplicati.Library.Main.Database.LocalDatabase.CreateLocalDatabaseAsync(options["dbpath"], "Test", true, null, System.Threading.CancellationToken.None).Await())
+            {
+                var dbOptions = db.GetDbOptions(System.Threading.CancellationToken.None).Await();
+                Assert.That(dbOptions.ContainsKey("compression-module"), Is.True, "Database should contain compression-module option.");
+                // This assertion replicates the reported issue: after recreate the database
+                // still stores the old compression module (zip) instead of the actual one (tzstd).
+                Assert.That(dbOptions["compression-module"], Is.EqualTo("tzstd"), "Recreated database should reflect the actual compression module used by remote files.");
+            }
         }
 
     }


### PR DESCRIPTION
This PR fixes an issue with using a non-default compression method. The recreate database will detect the compression module correctly and restore everything. But when recreating the database it will look at the `compression-module` from the given options and persist this value into the database.

If the recreate was made without passing in the compression module in the options, the default compression module would be persisted to the database, which would later cause problems for operations that rely on this value.

With this PR there is a test for the behavior, and the compression module is extracted from the first volume, similar to how blocksize and other options are written back.