### PR TITLE
Handle immediate usagereporter update

### DIFF
--- a/Duplicati/Library/RestAPI/Database/Connection.cs
+++ b/Duplicati/Library/RestAPI/Database/Connection.cs
@@ -102,6 +102,9 @@ namespace Duplicati.Server.Database
             this.ApplicationSettings = new ServerSettings(this);
         }
 
+        public void UpdateUsageReporterCallback(Action startOrStopUsageReporter)
+            => m_startOrStopUsageReporter = startOrStopUsageReporter;
+
         /// <summary>
         /// The service provider is used to resolve dependencies
         /// </summary>

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -265,6 +265,8 @@ namespace Duplicati.Server
                 CreateApplicationInstance(applicationSettings.DataFolder, writeToConsoleOnException);
 
                 applicationSettings.StartOrStopUsageReporter = () => StartOrStopUsageReporter(connection);
+                // Bit messy, but the callback needs the connection, and the connection needs the callback
+                connection.UpdateUsageReporterCallback(applicationSettings.StartOrStopUsageReporter);
                 applicationSettings.StartOrStopUsageReporter?.Invoke();
 
                 AdjustApplicationSettings(connection, commandlineOptions);


### PR DESCRIPTION
This PR fixes an issue where the callback for updating the usage reporter was not correctly registered.

The effect of this was that settings changes should update the usagereporter (disabling or setting the level), but due to the missing callback settings were not applied until the server restarted.

With this fix, the settings are applied immediately.

This fixes #6540