### PR TITLE
Enforce metahash in filelist

### DIFF
--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -55,6 +55,8 @@ namespace Duplicati.Library.Main.Volumes
 
         private void WriteMetaProperties(string metahash, long metasize, string metablockhash, IEnumerable<string> metablocklisthashes)
         {
+            if (string.IsNullOrWhiteSpace(metahash))
+                throw new ArgumentNullException(nameof(metahash));
             m_writer.WritePropertyName("metahash");
             m_writer.WriteValue(metahash);
             m_writer.WritePropertyName("metasize");
@@ -109,8 +111,7 @@ namespace Duplicati.Library.Main.Volumes
             m_writer.WriteValue(size);
             m_writer.WritePropertyName("time");
             m_writer.WriteValue(Library.Utility.Utility.SerializeDateTime(lastmodified));
-            if (metahash != null)
-                WriteMetaProperties(metahash, metasize, metablockhash, metablocklisthashes);
+            WriteMetaProperties(metahash, metasize, metablockhash, metablocklisthashes);
 
             if (blocklisthashes != null)
             {
@@ -152,8 +153,7 @@ namespace Duplicati.Library.Main.Volumes
             m_writer.WriteValue(type.ToString());
             m_writer.WritePropertyName("path");
             m_writer.WriteValue(name);
-            if (metahash != null)
-                WriteMetaProperties(metahash, metasize, metablockhash, metablocklisthashes);
+            WriteMetaProperties(metahash, metasize, metablockhash, metablocklisthashes);
 
             m_writer.WriteEndObject();
         }


### PR DESCRIPTION
This PR adds a small change when writing the `filelist.json`. The code now *requires* that a metahash is present when writing an entry.

Previously, the code would handle cases where there was no metahash and output the `filelist.json` without these fields.

However, the recreate fails if the fields are missing due to database consistency requirements.

Also, there appear to be no regular code paths that should end up creating an entry without the metahash.

This may need to be reverted, but for now it will help track down if there are any cases where a missing metahash is needed, and if we find that, we can fix the relevant functions and revert this change.