### PR TITLE
Improve restore message

### DIFF
--- a/Duplicati/Library/Interface/ResultInterfaces.cs
+++ b/Duplicati/Library/Interface/ResultInterfaces.cs
@@ -354,12 +354,15 @@ namespace Duplicati.Library.Interface
     {
         long RestoredFiles { get; }
         long SizeOfRestoredFiles { get; }
+        long SizeOfRestoredData { get; }
         long RestoredFolders { get; }
         long RestoredSymlinks { get; }
         long PatchedFiles { get; }
         long DeletedFiles { get; }
         long DeletedFolders { get; }
         long DeletedSymlinks { get; }
+        long UnmodifiedFiles { get; }
+        long SizeOfUnmodifiedFiles { get; }
         string RestorePath { get; }
 
         IRecreateDatabaseResults RecreateDatabaseResults { get; }

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -509,7 +509,17 @@ namespace Duplicati.Library.Main.Operation.Restore
                             lock (results)
                             {
                                 results.RestoredFiles++;
-                                results.SizeOfRestoredFiles += bytes_written;
+                                results.SizeOfRestoredFiles += file.Length;
+                                results.SizeOfRestoredData += bytes_written;
+                            }
+                        }
+                        else
+                        {
+                            // Keep track of the existing files and their sizes
+                            lock (results)
+                            {
+                                results.UnmodifiedFiles++;
+                                results.SizeOfUnmodifiedFiles += file.Length;
                             }
                         }
                         sw_work_results?.Stop();

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -260,6 +260,7 @@ namespace Duplicati.Library.Main.Operation
                                         await blockmarker
                                             .SetBlockRestored(restorelist.FileID, targetblock.Offset / blocksize, targetblock.Key, size, false, cancellationToken)
                                             .ConfigureAwait(false);
+                                        result.SizeOfRestoredData += size;
                                     }
                                 }
                                 else
@@ -498,7 +499,12 @@ namespace Duplicati.Library.Main.Operation
                 Logging.Log.WriteErrorMessage(LOGTAG, "RestoreFailures", null, $"{remoteMessage}{nl}{localMessage}{nl}{remoteList}{nl}{localList}");
             }
             else if (m_result.RestoredFiles == 0)
-                Logging.Log.WriteWarningMessage(LOGTAG, "NoFilesRestored", null, "Restore completed without errors but no files were restored");
+            {
+                if (m_result.UnmodifiedFiles == 0)
+                    Logging.Log.WriteWarningMessage(LOGTAG, "NoFilesRestored", null, "Restore completed without errors but no files were restored");
+                else
+                    Logging.Log.WriteInformationMessage(LOGTAG, "NoFilesNeededRestore", null, "Restore completed but all files were already present");
+            }
 
             // Drop the temp tables
             await database.DropRestoreTable(cancellationToken).ConfigureAwait(false);
@@ -596,6 +602,14 @@ namespace Duplicati.Library.Main.Operation
                     await RestoreCoreAsync(backendManager, database, filter, restoreDestination, metadatastorage, cancellationToken)
                         .ConfigureAwait(false);
                 }
+            }
+
+            if (m_result.RestoredFiles == 0)
+            {
+                if (m_result.UnmodifiedFiles == 0)
+                    Logging.Log.WriteWarningMessage(LOGTAG, "NoFilesRestored", null, "Restore completed without errors but no files were restored");
+                else
+                    Logging.Log.WriteInformationMessage(LOGTAG, "NoFilesNeededRestore", null, "Restore completed but all files were already present");
             }
 
             m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Restore_Finalize);
@@ -1248,6 +1262,9 @@ namespace Duplicati.Library.Main.Operation
                                     .ConfigureAwait(false);
                                 Logging.Log.WriteVerboseMessage(LOGTAG, "TargetExistsInCorrectVersion", "Target file exists{1} and is correct version: {0}", targetpath, wasTruncated ? " (but was truncated)" : "");
                                 rename = false;
+
+                                result.UnmodifiedFiles++;
+                                result.SizeOfUnmodifiedFiles += targetfilelength;
                             }
                             else if (rename)
                             {

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -532,12 +532,15 @@ namespace Duplicati.Library.Main
         public Library.Utility.FileBackedStringList BrokenRemoteFiles { get; internal set; } = [];
         public long RestoredFiles { get; internal set; }
         public long SizeOfRestoredFiles { get; internal set; }
+        public long SizeOfRestoredData { get; internal set; }
         public long RestoredFolders { get; internal set; }
         public long RestoredSymlinks { get; internal set; }
         public long PatchedFiles { get; internal set; }
         public long DeletedFiles { get; internal set; }
         public long DeletedFolders { get; internal set; }
         public long DeletedSymlinks { get; internal set; }
+        public long UnmodifiedFiles { get; internal set; }
+        public long SizeOfUnmodifiedFiles { get; internal set; }
         public string RestorePath { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
This PR changes the restore message when no files are restored.

The logic now keeps track of existing files that do not need to be restored, as well as the actual number of bytes written.

The size of restored files was tracked previously, but was instead reporting the size of the written data.

With this update the legacy restore and new restore report the same numbers.

The warning that is shown if no files are restored has been updated to check if existing files were present, and if so, the restore is assumed to have worked as expected, and an information message is logged, instead of the warning message.