### PR TITLE
Deprecate old SharePoint

### DIFF
--- a/Duplicati/Library/Backend/OneDrive/Strings.cs
+++ b/Duplicati/Library/Backend/OneDrive/Strings.cs
@@ -45,7 +45,7 @@ namespace Duplicati.Library.Backend.Strings
     internal static class SharePointV2
     {
         public static string Description(string mssadescription, string mssalink, string msopdescription, string msoplink) { return LC.L(@"Store files in a Microsoft SharePoint site via the Microsoft Graph API. Usage of this backend requires that you agree to the terms in {0} ({1}) and {2} ({3}).", mssadescription, mssalink, msopdescription, msoplink); }
-        public static string DisplayName { get { return LC.L(@"Microsoft SharePoint v2"); } }
+        public static string DisplayName { get { return LC.L(@"Microsoft SharePoint"); } }
         public static string SiteIdLong { get { return LC.L(@"ID of the site to store data in."); } }
         public static string SiteIdShort { get { return LC.L(@"ID of the site"); } }
         public static string MissingSiteId { get { return LC.L(@"No site ID was provided"); } }

--- a/Duplicati/Library/Backend/SharePoint/Strings.cs
+++ b/Duplicati/Library/Backend/SharePoint/Strings.cs
@@ -23,8 +23,8 @@ namespace Duplicati.Library.Backend.Strings
 {
     internal static class SharePoint
     {
-        public static string Description => LC.L(@"This backend can read and write data to a SharePoint server (including OneDrive for Business). Allowed formats are ""mssp://tennant.sharepoint.com/PathToWeb//BaseDocLibrary/subfolder"" and ""mssp://username:password@tennant.sharepoint.com/PathToWeb//BaseDocLibrary/subfolder"". Use a double slash '//' in the path to denote the web from the documents library.");
-        public static string DisplayName => LC.L(@"Microsoft SharePoint");
+        public static string Description => LC.L(@"This backend is deprecated. Please use the SharePoint backend instead. This backend can read and write data to a SharePoint server (including OneDrive for Business). Allowed formats are ""mssp://tennant.sharepoint.com/PathToWeb//BaseDocLibrary/subfolder"" and ""mssp://username:password@tennant.sharepoint.com/PathToWeb//BaseDocLibrary/subfolder"". Use a double slash '//' in the path to denote the web from the documents library.");
+        public static string DisplayName => LC.L(@"Microsoft SharePoint using legacy API");
         public static string DescriptionIntegratedAuthenticationLong => LC.L(@"If the server and client both supports integrated authentication, this option enables that authentication method. This is likely only available with windows servers and clients.");
         public static string DescriptionIntegratedAuthenticationShort => LC.L(@"Use windows integrated authentication to connect to the server");
         public static string DescriptionUseRecyclerLong => LC.L(@"Use this option to have files moved to the recycle bin folder instead of removing them permanently when compacting or deleting backups.");
@@ -46,7 +46,7 @@ namespace Duplicati.Library.Backend.Strings
 
     internal static class OneDriveForBusiness
     {
-        public static string Description => LC.L(@"This backend can read and write data to Microsoft OneDrive for Business. Allowed formats are ""od4b://tennant.sharepoint.com/personal/username_domain/Documents/subfolder"" and ""od4b://username:password@tennant.sharepoint.com/personal/username_domain/Documents/folder"". You can use a double slash '//' in the path to denote the base path from the documents folder.");
-        public static string DisplayName => LC.L(@"Microsoft OneDrive for Business");
+        public static string Description => LC.L(@"This backend is deprecated. Please use the SharePoint backend instead. This backend can read and write data to Microsoft OneDrive for Business. Allowed formats are ""od4b://tennant.sharepoint.com/personal/username_domain/Documents/subfolder"" and ""od4b://username:password@tennant.sharepoint.com/personal/username_domain/Documents/folder"". You can use a double slash '//' in the path to denote the base path from the documents folder.");
+        public static string DisplayName => LC.L(@"Microsoft OneDrive for Business (deprecated)");
     }
 }

--- a/Duplicati/Library/Backends/BackendModules.cs
+++ b/Duplicati/Library/Backends/BackendModules.cs
@@ -36,6 +36,25 @@ public static class BackendModules
     public static IReadOnlyList<IBackend> BuiltInBackendModules => SupportedBackends;
 
     /// <summary>
+    /// List of backend modules that are not tested as it was not possible to get a test account
+    /// </summary>
+    public static IReadOnlySet<string> UntestedBackendModules => new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+        new Backend.AliyunOSS.OSS().ProtocolKey,
+        new Backend.TencentCOS.COS().ProtocolKey
+    };
+
+    /// <summary>
+    /// List of backend modules that are deprecated and should be migrated away from
+    /// </summary>
+    public static IReadOnlySet<string> DeprecatedBackendModules => new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+        new Backend.Mega.MegaBackend().ProtocolKey,
+        new Backend.OneDriveForBusinessBackend().ProtocolKey,
+        new Backend.SharePointBackend().ProtocolKey,
+        new Backend.CIFSBackend().ProtocolKey,
+        new Backend.Filejump().ProtocolKey
+    };
+
+    /// <summary>
     /// Calculate list once and cache it
     /// </summary>
     private static readonly IReadOnlyList<IBackend> SupportedBackends = new IBackend[] {

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -30,6 +30,7 @@ using Duplicati.Library.Main.Database;
 using System.Threading.Tasks;
 using Duplicati.Library.Main.Operation.Common;
 using System.IO;
+using Duplicati.Library.Backends;
 
 namespace Duplicati.Library.Main
 {
@@ -1024,13 +1025,9 @@ namespace Duplicati.Library.Main
                 throw new UserInformationException(Strings.Controller.BackendNotSupportedError(scheme, string.Join(", ", DynamicLoader.BackendLoader.Keys)), "BackendNotSupported");
             }
 
-            //Inform the user about the deprecated Tardigrade-Backend. They should switch to Storj DCS instead.
-            if (string.Equals(scheme, "tardigrade", StringComparison.OrdinalIgnoreCase))
-                Logging.Log.WriteWarningMessage(LOGTAG, "TardigradeRename", null, "The Tardigrade-backend got renamed to Storj DCS - please migrate your backups to the new configuration by changing the destination storage type to Storj DCS.");
-
-            //Inform the user about the unmaintained Mega support library
-            if (string.Equals(scheme, "mega", StringComparison.OrdinalIgnoreCase))
-                Logging.Log.WriteWarningMessage(LOGTAG, "MegaUnmaintained", null, "The Mega support library is currently unmaintained and may not work as expected. Mega has not published an official API so it may break at any moment. Please consider migrating to another backend.");
+            //Inform the user about unmaintained backends
+            if (BackendModules.DeprecatedBackendModules.Contains(scheme))
+                Logging.Log.WriteWarningMessage(LOGTAG, "BackendDeprecated", null, $"The backend {scheme} is deprecated and should be migrated away from.");
 
             //TODO: Based on the action, see if all options are relevant
         }

--- a/Duplicati/Library/RestAPI/Serializable/ServerSettings.cs
+++ b/Duplicati/Library/RestAPI/Serializable/ServerSettings.cs
@@ -44,6 +44,8 @@ namespace Duplicati.Server.Serializable
                 this.Description = backend.Description;
                 this.DisplayName = backend.DisplayName;
                 this.Options = backend.SupportedCommands?.ToArray() ?? [];
+                this.IsDeprecated = Duplicati.Library.Backends.BackendModules.DeprecatedBackendModules.Contains(backend.ProtocolKey);
+                this.IsUntested = Duplicati.Library.Backends.BackendModules.UntestedBackendModules.Contains(backend.ProtocolKey);
             }
 
             /// <summary>
@@ -124,27 +126,23 @@ namespace Duplicati.Server.Serializable
                 this.Options = module.SupportedCommands?.ToArray() ?? [];
             }
 
-            /// <summary>
-            /// The module key
-            /// </summary>
+            /// <inheritdoc/>
             public string Key { get; private set; }
-            /// <summary>
-            /// The localized module description
-            /// </summary>
+            /// <inheritdoc/>
             public string Description { get; private set; }
             /// <summary>
-            /// Gets the localized display name
-            /// </summary>
-            /// <value>The display name.</value>
+            /// <inheritdoc/>
             public string DisplayName { get; private set; }
             /// <summary>
-            /// The options supported by the module
-            /// </summary>
+            /// <inheritdoc/>
             public Library.Interface.ICommandLineArgument[] Options { get; private set; }
             /// <summary>
-            /// The lookups supported by the module
-            /// </summary>
+            /// <inheritdoc/>
             public IDictionary<string, IDictionary<string, string>> Lookups { get; private set; }
+            /// <inheritdoc/>
+            public bool IsDeprecated { get; private set; }
+            /// <inheritdoc/>
+            public bool IsUntested { get; private set; }
         }
 
         /// <summary>

--- a/Duplicati/Server/Duplicati.Server.Serialization/Interface/IDynamicModule.cs
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Interface/IDynamicModule.cs
@@ -49,6 +49,14 @@ namespace Duplicati.Server.Serialization.Interface
         /// The lookups supported by the module
         /// </summary>
         IDictionary<string, IDictionary<string, string>> Lookups { get; }
+        /// <summary>
+        /// Indicated the module is deprecated
+        /// </summary>
+        bool IsDeprecated { get; }
+        /// <summary>
+        /// Indicated the module is untested
+        /// </summary>
+        bool IsUntested { get; }
     }
 }
 


### PR DESCRIPTION
This PR deprecates the `mssp` and `od4b` backends as they stopped working when the APIs were turned off.

The upgrade path is to use `sharepoint` instead (which used to be named "SharePoint v2").

This PR also adds a small amount of metadata to modules so they can be marked as "untested" or "deprecated", and the configuration for marking modules has been set up in `BackendModules.cs`.

The backends that we currently cannot test (usualy due to not having public signups) are now marked as untested.