### PR TITLE
Detatch options on controller

### DIFF
--- a/Duplicati/CommandLine/RecoveryTool/Restore.cs
+++ b/Duplicati/CommandLine/RecoveryTool/Restore.cs
@@ -78,8 +78,10 @@ namespace Duplicati.CommandLine.RecoveryTool
                 filelist = List.SelectListFile(args[2], folder);
             }
 
-            Library.Main.Volumes.VolumeReaderBase.UpdateOptionsFromManifest(Path.GetExtension(filelist).Trim('.'), filelist, new Duplicati.Library.Main.Options(options));
+            var parsedoptions = new Library.Main.Options(options);
+            Library.Main.Volumes.VolumeReaderBase.UpdateOptionsFromManifest(Path.GetExtension(filelist).Trim('.'), filelist, parsedoptions);
 
+            options = parsedoptions.RawOptions;
             options.TryGetValue("blocksize", out var blocksize_str);
             options.TryGetValue("block-hash-algorithm", out var blockhash_str);
             options.TryGetValue("block-hash-algorithm", out var filehash_str);

--- a/Duplicati/Library/Main/Backend/BackendManager.GetOperation.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.GetOperation.cs
@@ -97,7 +97,7 @@ partial class BackendManager
 
                 // Perform decryption after hash validation, if needed
                 if (Decrypt)
-                    tmpfile = DecryptFile(tmpfile, RemoteFilename, Context.Options);
+                    tmpfile = DecryptFile(tmpfile, RemoteFilename, Context.Options, true);
 
                 return (tmpfile, fileHash, dataSizeDownloaded);
             }
@@ -221,7 +221,7 @@ partial class BackendManager
         /// <param name="tempFile">The encrypted file</param>
         /// <param name="decrypter">Then encryption module to use, or <c>null</c> for no encryption</param>
         /// <returns>The decrypted file</returns>
-        private static TempFile DecryptFile(TempFile tempFile, IEncryption? decrypter)
+        private static TempFile DecryptFile(TempFile tempFile, IEncryption? decrypter, bool dispose)
         {
             // Support no encryption
             if (decrypter == null)
@@ -230,7 +230,7 @@ partial class BackendManager
             TempFile? decryptTarget = null;
 
             // Always dispose the source file
-            using (tempFile)
+            using (dispose ? tempFile : null)
             using (new Logging.Timer(LOGTAG, "DecryptFile", "Decrypting " + tempFile))
             {
                 try
@@ -259,15 +259,16 @@ partial class BackendManager
         /// <param name="tmpfile">The file to decrypt</param>
         /// <param name="filename">The name of the file. Used for detecting encryption algorithm if not specified in options or if it differs from the options</param>
         /// <param name="options">The Duplicati options</param>
+        /// <param name="dispose">If true, the source file will be disposed after decryption</param>
         /// <returns>The decrypted file</returns>
-        public static TempFile DecryptFile(TempFile tmpfile, string filename, Options options)
+        public static TempFile DecryptFile(TempFile tmpfile, string filename, Options options, bool dispose)
         {
             using var encryption = options.NoEncryption
                                     ? null
                                     : (DynamicLoader.EncryptionLoader.GetModule(options.EncryptionModule, options.Passphrase, options.RawOptions)
                                         ?? throw new Exception(Strings.BackendMananger.EncryptionModuleNotFound(options.EncryptionModule))
                                 );
-            return DecryptFile(tmpfile, DetectEncryptionModule(filename, options, encryption));
+            return DecryptFile(tmpfile, DetectEncryptionModule(filename, options, encryption), dispose);
         }
     }
 }

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -156,11 +156,10 @@ internal partial class BackendManager : IBackendManager
     /// <param name="tmpfile">The file to decrypt</param>
     /// <param name="filename">The name of the file. Used for detecting encryption algorithm if not specified in options or if it differs from the options</param>
     /// <param name="options">The Duplicati options</param>
+    /// <param name="dispose">True if the input file should be disposed after decryption</param>
     /// <returns>The decrypted file</returns>
-    public TempFile DecryptFile(TempFile volume, string volume_name, Options options)
-    {
-        return GetOperation.DecryptFile(volume, volume_name, options);
-    }
+    public TempFile DecryptFile(TempFile volume, string volume_name, Options options, bool dispose)
+        => GetOperation.DecryptFile(volume, volume_name, options, dispose);
 
     /// <summary>
     /// Deletes a remote file
@@ -438,6 +437,41 @@ internal partial class BackendManager : IBackendManager
         // Return the last result
         yield return (prevResult.File, prevResult.Hash, prevResult.Size, prevVolume.Name);
         prevResult.File.Dispose();
+    }
+
+    /// <summary>
+    /// Performs a direct download of the files specified, with pre-fetch to overlap the download and processing
+    /// </summary>
+    /// <param name="volumes">The volumes to download</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>The downloaded files and the volume they came from</returns>
+    public async IAsyncEnumerable<(TempFile File, string Name)> GetFilesOverlappedDirectAsync(IEnumerable<IRemoteVolume> volumes, [EnumeratorCancellation] CancellationToken cancelToken)
+    {
+        var prevVolume = volumes.FirstOrDefault();
+        if (prevVolume == null)
+            yield break;
+
+        // Get the first volume, so we do not have pending parallel transfers
+        var prevResult = await GetDirectAsync(prevVolume.Name, prevVolume.Hash, prevVolume.Size, cancelToken)
+            .ConfigureAwait(false);
+
+        foreach (var volume in volumes.Skip(1))
+        {
+            // Prepare the next volume, while processing the previous one
+            var nextTask = GetDirectAsync(volume.Name, volume.Hash, volume.Size, cancelToken);
+
+            // Assuming we do not throw while yielding, otherwise we would need to dispose nextTask
+            yield return (prevResult, prevVolume.Name);
+            prevResult.Dispose();
+
+            // Set up for next iteration
+            prevVolume = volume;
+            prevResult = await nextTask.ConfigureAwait(false);
+        }
+
+        // Return the last result
+        yield return (prevResult, prevVolume.Name);
+        prevResult.Dispose();
     }
 
     /// <summary>

--- a/Duplicati/Library/Main/IBackendManager.cs
+++ b/Duplicati/Library/Main/IBackendManager.cs
@@ -87,8 +87,9 @@ internal interface IBackendManager : IDisposable
     /// <param name="volume">The file to decrypt</param>
     /// <param name="volume_name">The name of the file. Used for detecting encryption algorithm if not specified in options or if it differs from the options</param>
     /// <param name="options">The Duplicati options</param>
+    /// <param name="dispose">True if the input file should be disposed after decryption</param>
     /// <returns>The decrypted file</returns>
-    TempFile DecryptFile(TempFile volume, string volume_name, Options options);
+    TempFile DecryptFile(TempFile volume, string volume_name, Options options, bool dispose);
 
     /// <summary>
     /// Deletes a file on the backend
@@ -160,6 +161,14 @@ internal interface IBackendManager : IDisposable
     /// <param name="cancelToken">The cancellation token</param>
     /// <returns>The downloaded files, hash, size, and name</returns>
     IAsyncEnumerable<(TempFile File, string Hash, long Size, string Name)> GetFilesOverlappedAsync(IEnumerable<IRemoteVolume> volumes, CancellationToken cancelToken);
+
+    /// <summary>
+    /// Performs a direct download of the files specified, with pre-fetch to overlap the download and processing
+    /// </summary>
+    /// <param name="volumes">The volumes to download</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>The downloaded files and the volume they came from</returns>
+    IAsyncEnumerable<(TempFile File, string Name)> GetFilesOverlappedDirectAsync(IEnumerable<IRemoteVolume> volumes, CancellationToken cancelToken);
 
     /// <summary>
     /// Flushes the database messages to the database

--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -160,35 +160,38 @@ namespace Duplicati.Library.Main.Operation
                     return;
 
                 using (var tmpfile = await backendManager.GetAsync(firstEntry.File.Name, null, firstEntry.File.Size, cancellationToken).ConfigureAwait(false))
-                using (var rd = new FilesetVolumeReader(RestoreHandler.GetCompressionModule(firstEntry.File.Name), tmpfile, m_options))
-                    if (simpleList)
-                    {
-                        m_result.SetResult(
-                            numberSeq.Take(1),
-                            (from n in rd.Files
-                             where Library.Utility.FilterExpression.Matches(filter, n.Path)
-                             orderby n.Path
-                             select new ListResultFile(n.Path, new long[] { n.Size }))
-                                  .ToArray()
-                        );
+                {
+                    VolumeReaderBase.UpdateOptionsFromManifest(RestoreHandler.GetCompressionModule(firstEntry.File.Name), tmpfile, m_options);
+                    using (var rd = new FilesetVolumeReader(RestoreHandler.GetCompressionModule(firstEntry.File.Name), tmpfile, m_options))
+                        if (simpleList)
+                        {
+                            m_result.SetResult(
+                                numberSeq.Take(1),
+                                (from n in rd.Files
+                                 where Library.Utility.FilterExpression.Matches(filter, n.Path)
+                                 orderby n.Path
+                                 select new ListResultFile(n.Path, new long[] { n.Size }))
+                                      .ToArray()
+                            );
 
-                        return;
-                    }
-                    else
-                    {
-                        res = rd.Files
-                              .Where(x => Library.Utility.FilterExpression.Matches(filter, x.Path))
-                              .ToDictionary(
-                                    x => x.Path,
-                                    y =>
-                                    {
-                                        var lst = new List<long>();
-                                        lst.Add(y.Size);
-                                        return lst;
-                                    },
-                                    Library.Utility.Utility.ClientFilenameStringComparer
-                              );
-                    }
+                            return;
+                        }
+                        else
+                        {
+                            res = rd.Files
+                                  .Where(x => Library.Utility.FilterExpression.Matches(filter, x.Path))
+                                  .ToDictionary(
+                                        x => x.Path,
+                                        y =>
+                                        {
+                                            var lst = new List<long>();
+                                            lst.Add(y.Size);
+                                            return lst;
+                                        },
+                                        Library.Utility.Utility.ClientFilenameStringComparer
+                                  );
+                        }
+                }
 
                 long flindex = 1;
                 var filteredListMap = filteredList.ToDictionary(x => x.Value.File.Name, x => x.Value);

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -234,9 +234,10 @@ namespace Duplicati.Library.Main.Operation
             }
 
             var isFirstFilelist = true;
-            await foreach (var (tmpfile, hash, size, name) in backendManager.GetFilesOverlappedAsync(filelistWork, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
+            // At this point, we do not know the hashing used to verify the files, so we need to use direct download, and manually decrypt the files
+            // so we can calculate the hash AFTER we have read the manifest content and updated the options
+            await foreach (var (tmpencfile, name) in backendManager.GetFilesOverlappedDirectAsync(filelistWork, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
             {
-                var entry = new RemoteVolume(name, hash, size);
                 try
                 {
                     if (!await m_result.TaskControl.ProgressRendevouzAsync().ConfigureAwait(false))
@@ -261,16 +262,10 @@ namespace Duplicati.Library.Main.Operation
                         Logging.Log.WriteVerboseMessage(LOGTAG, "ProcessingFilelistVolumes", "Processing filelist volume {0} of {1}", progress, filelistWork.Count);
                     }
 
-                    using (tmpfile)
+                    using (var tmpfile = backendManager.DecryptFile(tmpencfile, name, m_options, dispose: false))
                     {
                         isFirstFilelist = false;
-
-                        if (!string.IsNullOrWhiteSpace(hash) && size > 0)
-                            await restoredb
-                                .UpdateRemoteVolumeAsync(entry.Name, RemoteVolumeState.Verified, size, hash, m_result.TaskControl.ProgressToken)
-                                .ConfigureAwait(false);
-
-                        var parsed = VolumeBase.ParseFilename(entry.Name);
+                        var parsed = VolumeBase.ParseFilename(name);
 
                         using var stream = new FileStream(tmpfile, FileMode.Open, FileAccess.Read, FileShare.Read);
                         using var compressor = DynamicLoader.CompressionLoader.GetModule(parsed.CompressionModule, stream, ArchiveMode.Read, m_options.RawOptions);
@@ -283,9 +278,21 @@ namespace Duplicati.Library.Main.Operation
                             hasUpdatedOptions = true;
                         }
 
+                        var size = new FileInfo(tmpencfile).Length;
+                        string hash;
+                        using (var fs = File.OpenRead(tmpencfile))
+                        using (var hasher = HashFactory.CreateHasher(m_options.FileHashAlgorithm))
+                            hash = Convert.ToBase64String(hasher.ComputeHash(fs));
+
+                        if (!string.IsNullOrWhiteSpace(hash) && size > 0)
+                            await restoredb
+                                .UpdateRemoteVolumeAsync(name, RemoteVolumeState.Verified, size, hash, m_result.TaskControl.ProgressToken)
+                                .ConfigureAwait(false);
+
+
                         // Create timestamped operations based on the file timestamp
                         var filesetid = await restoredb
-                            .CreateFilesetAsync(volumeIds[entry.Name], parsed.Time, m_result.TaskControl.ProgressToken)
+                            .CreateFilesetAsync(volumeIds[name], parsed.Time, m_result.TaskControl.ProgressToken)
                             .ConfigureAwait(false);
 
                         await RecreateFilesetFromRemoteListAsync(restoredb, compressor, filesetid, m_options, filter, m_result.TaskControl.ProgressToken)
@@ -294,7 +301,7 @@ namespace Duplicati.Library.Main.Operation
                 }
                 catch (Exception ex)
                 {
-                    Logging.Log.WriteWarningMessage(LOGTAG, "FileProcessingFailed", ex, "Failed to process file: {0}", entry.Name);
+                    Logging.Log.WriteWarningMessage(LOGTAG, "FileProcessingFailed", ex, "Failed to process file: {0}", name);
                     if (ex.IsAbortException())
                     {
                         m_result.EndTime = DateTime.UtcNow;

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
@@ -76,7 +76,7 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         // Decrypt the volume.
                         sw_decrypt?.Start();
-                        var tmpfile = backend.DecryptFile(volume, volume_name, options);
+                        var tmpfile = backend.DecryptFile(volume, volume_name, options, dispose: true);
                         sw_decrypt?.Stop();
                         Logging.Log.WriteExplicitMessage(LOGTAG, "DecryptVolume", null, "Decrypted volume {0} (ID: {1})", volume_name, volume_id);
 

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -332,7 +332,7 @@ namespace Duplicati.Library.Main
 
         public Options(Dictionary<string, string?> options)
         {
-            m_options = options;
+            m_options = new Dictionary<string, string?>(options);
         }
 
         public Dictionary<string, string?> RawOptions => m_options;

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -206,7 +206,7 @@ namespace Duplicati.UnitTest
 #endif
 
             // Choose a dblock size that is small enough so that more than one volume is needed.
-            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions)
+            var options = new Dictionary<string, string>(this.TestOptions)
             {
                 ["dblock-size"] = "10mb",
                 ["disable-file-scanner"] = "true",
@@ -245,9 +245,9 @@ namespace Duplicati.UnitTest
 
             // Set the keep-time option so that the threshold lies between the first and second backups
             // and run the delete operation.
+            options["keep-time"] = $"{(int)((DateTime.Now - firstBackupTime).TotalSeconds - (secondBackupTime - firstBackupTime).TotalSeconds / 2)}s";
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                options["keep-time"] = $"{(int)((DateTime.Now - firstBackupTime).TotalSeconds - (secondBackupTime - firstBackupTime).TotalSeconds / 2)}s";
                 TestUtils.AssertResults(await c.DeleteAsync());
 
                 var filesets = (await c.ListAsync()).Filesets.ToList();
@@ -260,16 +260,20 @@ namespace Duplicati.UnitTest
 
             // Run another partial backup. We will then verify that a full backup is retained
             // even when all the "recent" backups are partial.
+            DateTime fourthBackupTime;
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
                 (var backupResults, _) = await this.RunPartialBackupAsync(c).ConfigureAwait(false);
                 Assert.AreEqual(0, backupResults.Errors.Count());
                 Assert.AreEqual(1, backupResults.Warnings.Count());
-                var fourthBackupTime = (await c.ListAsync()).Filesets.First().Time;
+                fourthBackupTime = (await c.ListAsync()).Filesets.First().Time;
+            }
 
-                // Set the keep-time option so that the threshold lies after the most recent full backup
-                // and run the delete operation.
-                options["keep-time"] = "1s";
+            // Set the keep-time option so that the threshold lies after the most recent full backup
+            // and run the delete operation.
+            options["keep-time"] = "1s";
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
                 TestUtils.AssertResults(await c.DeleteAsync());
 
                 var filesets = (await c.ListAsync()).Filesets.ToList();
@@ -292,7 +296,7 @@ namespace Duplicati.UnitTest
 #endif
 
             // Choose a dblock size that is small enough so that more than one volume is needed.
-            Dictionary<string, string> options = new Dictionary<string, string>(this.TestOptions)
+            var options = new Dictionary<string, string>(this.TestOptions)
             {
                 ["dblock-size"] = "10mb",
                 ["disable-file-scanner"] = "true",
@@ -333,9 +337,9 @@ namespace Duplicati.UnitTest
             }
 
             // Run a partial backup.
+            options["keep-versions"] = "2";
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                options["keep-versions"] = "2";
                 (var backupResults, _) = await this.RunPartialBackupAsync(c).ConfigureAwait(false);
                 Assert.AreEqual(0, backupResults.Errors.Count());
                 Assert.AreEqual(1, backupResults.Warnings.Count());

--- a/Duplicati/UnitTest/Issue5196.cs
+++ b/Duplicati/UnitTest/Issue5196.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,6 +36,8 @@ public class Issue5196 : BasicSetupHelper
     [Category("Targeted")]
     public async Task RunCommandsAsync()
     {
+        List<Library.Interface.IListResultFileset> versions;
+
         var testopts = TestOptions;
         testopts["upload-unchanged-backups"] = "true";
         testopts["blocksize"] = "50kb";
@@ -60,32 +63,36 @@ public class Issue5196 : BasicSetupHelper
             if (pr.KnownFileSize == 0 || pr.KnownFileCount != 4 || pr.BackupListCount != 2)
                 throw new Exception(string.Format("Failed to get stats from remote backend: {0}, {1}, {2}", pr.KnownFileSize, pr.KnownFileCount, pr.BackupListCount));
 
-            var versions = (await c.ListAsync()).Filesets.ToList();
-
-            using (var tempDbPath = new Library.Utility.TempFile())
-            {
-                testopts["dbpath"] = tempDbPath;
-                testopts["repair-only-paths"] = "true";
-                testopts.Remove("blocksize");
-                testopts["time"] = Library.Utility.Utility.SerializeDateTime(versions[0].Time);
-                var rcr1 = await c.UpdateDatabaseWithVersionsAsync();
-
-                testopts["time"] = Library.Utility.Utility.SerializeDateTime(versions[1].Time);
-                var rcr2 = await c.UpdateDatabaseWithVersionsAsync();
-
-                File.Delete(tempDbPath);
-                testopts["repair-only-paths"] = "true";
-                testopts["blocksize"] = "25kb";
-                try
-                {
-                    await c.UpdateDatabaseWithVersionsAsync();
-                    throw new Exception("Expected an exception when changing blocksize");
-                }
-                catch (InvalidManifestException)
-                {
-                }
-            }
+            versions = (await c.ListAsync()).Filesets.ToList();
         }
 
+
+        using (var tempDbPath = new Library.Utility.TempFile())
+        {
+            testopts["dbpath"] = tempDbPath;
+            testopts["repair-only-paths"] = "true";
+            testopts.Remove("blocksize");
+
+            testopts["time"] = Library.Utility.Utility.SerializeDateTime(versions[0].Time);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                await c.UpdateDatabaseWithVersionsAsync();
+
+            testopts["time"] = Library.Utility.Utility.SerializeDateTime(versions[1].Time);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                await c.UpdateDatabaseWithVersionsAsync();
+
+            File.Delete(tempDbPath);
+            testopts["repair-only-paths"] = "true";
+            testopts["blocksize"] = "25kb";
+            try
+            {
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                    await c.UpdateDatabaseWithVersionsAsync();
+                throw new Exception("Expected an exception when changing blocksize");
+            }
+            catch (InvalidManifestException)
+            {
+            }
+        }
     }
 }

--- a/Duplicati/UnitTest/LockingDeleteAndCompactTests.cs
+++ b/Duplicati/UnitTest/LockingDeleteAndCompactTests.cs
@@ -59,13 +59,14 @@ namespace Duplicati.UnitTest
             public Task PutAsync(Duplicati.Library.Main.Volumes.VolumeWriterBase blockVolume, Duplicati.Library.Main.Volumes.IndexVolumeWriter? indexVolume, Func<Task>? indexVolumeFinished, bool waitForComplete, Func<Task>? onDbUpdate, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task PutVerificationFileAsync(string remotename, TempFile tempFile, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<System.Collections.Generic.IEnumerable<Duplicati.Library.Interface.IFileEntry>> ListAsync(CancellationToken cancelToken) => throw new NotImplementedException();
-            public TempFile DecryptFile(TempFile volume, string volume_name, Options options) => throw new NotImplementedException();
+            public TempFile DecryptFile(TempFile volume, string volume_name, Options options, bool dispose) => throw new NotImplementedException();
             public Task DeleteAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<(TempFile File, string Hash, long Size)> GetWithInfoAsync(string remotename, string hash, long size, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<TempFile> GetAsync(string remotename, string hash, long size, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<TempFile> GetDirectAsync(string remotename, string hash, long size, CancellationToken cancelToken) => throw new NotImplementedException();
             public System.Collections.Generic.IAsyncEnumerable<(TempFile File, string Hash, long Size, string Name)> GetFilesOverlappedAsync(System.Collections.Generic.IEnumerable<IRemoteVolume> volumes, CancellationToken cancelToken) => throw new NotImplementedException();
+            public System.Collections.Generic.IAsyncEnumerable<(TempFile File, string Name)> GetFilesOverlappedDirectAsync(System.Collections.Generic.IEnumerable<IRemoteVolume> volumes, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task FlushPendingMessagesAsync(LocalDatabase database, CancellationToken cancellationToken) => Task.CompletedTask;
             public void UpdateThrottleValues(long maxUploadPrSecond, long maxDownloadPrSecond) => throw new NotImplementedException();
             #endregion

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -108,101 +108,134 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(0, res.Warnings.Count());
                 if (res.ParsedResult != ParsedResultType.Success)
                     throw new Exception("Unexpected result from base backup");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(0);
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(0);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Success)
                     throw new Exception("Unexpected result from backup with return code 0");
                 if (res.ExaminedFiles <= 0)
                     throw new Exception("Backup did not examine any files for code 0?");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(1);
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(1);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Success)
                     throw new Exception("Unexpected result from backup with return code 1");
                 if (res.ExaminedFiles > 0)
                     throw new Exception("Backup did examine files for code 1?");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(2);
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(2);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Warning)
                     throw new Exception("Unexpected result from backup with return code 2");
                 if (res.ExaminedFiles <= 0)
                     throw new Exception("Backup did not examine any files for code 2?");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(3);
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(3);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Warning)
                     throw new Exception("Unexpected result from backup with return code 3");
                 if (res.ExaminedFiles > 0)
                     throw new Exception("Backup did examine files for code 3?");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(4);
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(4);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Error)
                     throw new Exception("Unexpected result from backup with return code 4");
                 if (res.ExaminedFiles <= 0)
                     throw new Exception("Backup did not examine any files for code 4?");
+            }
 
-                foreach (int exitCode in new[] { 5, 6, 10, 99 })
+            foreach (int exitCode in new[] { 5, 6, 10, 99 })
+            {
+                System.Threading.Thread.Sleep(PAUSE_TIME);
+                options["run-script-before"] = CreateScript(exitCode);
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
                 {
-                    System.Threading.Thread.Sleep(PAUSE_TIME);
-                    options["run-script-before"] = CreateScript(exitCode);
-                    res = await c.BackupAsync(new string[] { DATAFOLDER });
+                    var res = await c.BackupAsync(new string[] { DATAFOLDER });
                     if (res.ParsedResult != ParsedResultType.Error)
                         throw new Exception($"Unexpected result from backup with return code {exitCode}");
                     if (res.ExaminedFiles > 0)
                         throw new Exception($"Backup did examine files for code {exitCode}?");
                 }
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(2, "TEST WARNING MESSAGE");
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(2, "TEST WARNING MESSAGE");
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Warning)
                     throw new Exception("Unexpected result from backup with return code 2");
                 if (res.ExaminedFiles <= 0)
                     throw new Exception("Backup did examine files for code 2?");
                 if (!res.Warnings.Any(x => x.IndexOf("TEST WARNING MESSAGE", StringComparison.Ordinal) >= 0))
                     throw new Exception("Found no warning message in output for code 2");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(3, "TEST WARNING MESSAGE");
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(3, "TEST WARNING MESSAGE");
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Warning)
                     throw new Exception("Unexpected result from backup with return code 3");
                 if (res.ExaminedFiles > 0)
                     throw new Exception("Backup did examine files for code 3?");
                 if (!res.Warnings.Any(x => x.IndexOf("TEST WARNING MESSAGE", StringComparison.Ordinal) >= 0))
                     throw new Exception("Found no warning message in output for code 3");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(4, "TEST ERROR MESSAGE");
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(4, "TEST ERROR MESSAGE");
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Error)
                     throw new Exception("Unexpected result from backup with return code 4");
                 if (res.ExaminedFiles <= 0)
                     throw new Exception("Backup did examine files for code 4?");
                 if (!res.Errors.Any(x => x.IndexOf("TEST ERROR MESSAGE", StringComparison.Ordinal) >= 0))
                     throw new Exception("Found no error message in output for code 4");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(5, "TEST ERROR MESSAGE");
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(5, "TEST ERROR MESSAGE");
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Error)
                     throw new Exception("Unexpected result from backup with return code 5");
                 if (res.ExaminedFiles > 0)
                     throw new Exception("Backup did examine files for code 5?");
                 if (!res.Errors.Any(x => x.IndexOf("TEST ERROR MESSAGE", StringComparison.Ordinal) >= 0))
                     throw new Exception("Found no error message in output for code 5");
+            }
 
-                System.Threading.Thread.Sleep(PAUSE_TIME);
-                options["run-script-before"] = CreateScript(0, sleeptime: 10);
-                res = await c.BackupAsync(new string[] { DATAFOLDER });
+            System.Threading.Thread.Sleep(PAUSE_TIME);
+            options["run-script-before"] = CreateScript(0, sleeptime: 10);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, options, null))
+            {
+                var res = await c.BackupAsync(new string[] { DATAFOLDER });
                 if (res.ParsedResult != ParsedResultType.Warning)
                     throw new Exception("Unexpected result from backup with timeout script");
                 if (res.ExaminedFiles <= 0)

--- a/Duplicati/UnitTest/SetLocksHandlerTests.cs
+++ b/Duplicati/UnitTest/SetLocksHandlerTests.cs
@@ -91,13 +91,14 @@ namespace Duplicati.UnitTest
             public Task PutAsync(VolumeWriterBase blockVolume, IndexVolumeWriter? indexVolume, Func<Task>? indexVolumeFinished, bool waitForComplete, Func<Task>? onDbUpdate, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task PutVerificationFileAsync(string remotename, TempFile tempFile, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<IEnumerable<InterfaceFileEntry>> ListAsync(CancellationToken cancelToken) => throw new NotImplementedException();
-            public TempFile DecryptFile(TempFile volume, string volume_name, Options options) => throw new NotImplementedException();
+            public TempFile DecryptFile(TempFile volume, string volume_name, Options options, bool dispose) => throw new NotImplementedException();
             public Task DeleteAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<(TempFile File, string Hash, long Size)> GetWithInfoAsync(string remotename, string hash, long size, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<TempFile> GetAsync(string remotename, string hash, long size, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<TempFile> GetDirectAsync(string remotename, string hash, long size, CancellationToken cancelToken) => throw new NotImplementedException();
             public IAsyncEnumerable<(TempFile File, string Hash, long Size, string Name)> GetFilesOverlappedAsync(IEnumerable<IRemoteVolume> volumes, CancellationToken cancelToken) => throw new NotImplementedException();
+            public IAsyncEnumerable<(TempFile File, string Name)> GetFilesOverlappedDirectAsync(IEnumerable<IRemoteVolume> volumes, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task FlushPendingMessagesAsync(LocalDatabase database, CancellationToken cancellationToken) => Task.CompletedTask;
             public void UpdateThrottleValues(long maxUploadPrSecond, long maxDownloadPrSecond) => throw new NotImplementedException();
             #endregion


### PR DESCRIPTION
When creating a new controller, the options dictionary was used by-reference.

This meant that code could update the options dictionary *after* creating the controller, which would not be thread-safe.

It does not have much effect on regular operations as the normal method is to create the dictionary, pass it, and not modify it.

But in the tests, we frequently re-use the dictionary and update it with new values to test various cases.

Due to the dictionary being a reference, the controller would update the dictionary to fit the operations, but this would reflect back into the tests, meaning that some tests were being run with options that were not supposed to be there.

This meant that at least two edge cases that we test for were never found to have errors, even though they do.

The first issue is the listing of files using a non-default blocksize. The second issue is recreating the database with a non-default file-hash algorithm.

This PR removes the reference passing, and fixes the issues that were uncovered.