### PR TITLE
Fix OneDrive timeout

### DIFF
--- a/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/OAuthHttpClient.cs
@@ -46,6 +46,8 @@ namespace Duplicati.Library
 
             // Set the default user agent
             this.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Duplicati", USER_AGENT_VERSION));
+            // Make sure the client never times out, we use a custom timeout setup
+            this.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
         }
 
         /// <summary>

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -86,11 +86,6 @@ namespace Duplicati.Library.Backend
         private const int UPLOAD_SESSION_FRAGMENT_MULTIPLE_SIZE = 320 * 1024;
 
         /// <summary>
-        /// Cached copy of the PATH method
-        /// </summary>
-        private static readonly HttpMethod PatchMethod = new HttpMethod("PATCH");
-
-        /// <summary>
         /// Dummy UploadSession given as an empty body to createUploadSession requests when using the OAuthHelper instead of the OAuthHttpClient.
         /// The API expects a ContentLength to be specified, but the body content is optional.
         /// Passing an empty object (or specifying the ContentLength explicitly) bypasses this error.
@@ -700,7 +695,7 @@ namespace Duplicati.Library.Backend
 
         protected Task<T> PatchAsync<T>(string url, T body, CancellationToken cancelToken) where T : class
         {
-            return this.SendRequestAsync(PatchMethod, url, body, cancelToken);
+            return this.SendRequestAsync(HttpMethod.Patch, url, body, cancelToken);
         }
 
         private async Task<T> SendRequestAsync<T>(HttpMethod method, string url, CancellationToken cancelToken)


### PR DESCRIPTION
This removes a built-in HTTP timeout of 100s that is applied to all requests.

Since Duplicati sometimes need more than 100s to transfer a file, this could cause problems.

Duplicati already handles timeouts, but this timeout was happening regardless of Duplicati's other timeouts.