### PR TITLE
Update Duplicati-backend

### DIFF
--- a/Duplicati/Library/Backend/Duplicati/Duplicati.Library.Backend.Duplicati.csproj
+++ b/Duplicati/Library/Backend/Duplicati/Duplicati.Library.Backend.Duplicati.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\Localization\Duplicati.Library.Localization.csproj" />
     <ProjectReference Include="..\..\Utility\Duplicati.Library.Utility.csproj" />
     <ProjectReference Include="..\..\Snapshots\Duplicati.Library.Snapshots.csproj" />
+    <ProjectReference Include="..\S3\Duplicati.Library.Backend.S3.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
+++ b/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
@@ -25,6 +25,7 @@ using Duplicati.Library.Common.IO;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility.Options;
 using Duplicati.Library.Utility;
+using System.Text.Json;
 
 namespace Duplicati.Library.Backend.Duplicati;
 
@@ -42,6 +43,10 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     /// The backup ID option name
     /// </summary>
     public const string BACKUP_ID_OPTION = "duplicati-backup-id";
+    /// <summary>
+    /// The endpoint option name
+    /// </summary>
+    public const string ENDPOINT_OPTION = "duplicati-endpoint";
 
     /// <summary>
     /// The protocol key for this backend
@@ -81,6 +86,24 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     private readonly HttpClient _client;
 
     /// <summary>
+    /// The mode to use for the backend
+    /// </summary>
+    private string _mode = "unknown";
+    /// <summary>
+    /// The S3 backend used for direct mode
+    /// </summary>
+    private S3? _s3Backend;
+    /// <summary>
+    /// The credential expiration time for direct mode
+    /// </summary>
+    private DateTime _credentialsExpiry = DateTime.MinValue;
+    /// <summary>
+    /// The lock used to protect the credentials
+    /// </summary>
+    private readonly SemaphoreSlim _credentialsLock = new(1, 1);
+
+
+    /// <summary>
     /// Constructor used for dynamic loading
     /// </summary>
     public DuplicatiBackend()
@@ -102,10 +125,16 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
         var uri = new Utility.Uri(url);
         if (string.IsNullOrWhiteSpace(uri.HostAndPath))
             uri = new Utility.Uri(DEFAULT_ENDPOINT);
+        else
+            uri = uri.SetScheme("https").SetQuery(null);
+
+        var endpoint = options.GetValueOrDefault(ENDPOINT_OPTION);
+        if (!string.IsNullOrWhiteSpace(endpoint))
+            uri = new Utility.Uri(endpoint);
 
         _client = new HttpClient
         {
-            BaseAddress = new System.Uri(uri.SetScheme("https").SetQuery(null).ToString()),
+            BaseAddress = new System.Uri(uri.ToString()),
             DefaultRequestHeaders =
             {
                 Accept = { new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json") },
@@ -120,6 +149,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
 
         _client.DefaultRequestHeaders.Add("X-Api-Key", _auth.Password);
         _client.DefaultRequestHeaders.Add("X-Organization-Id", _auth.Username);
+        _client.DefaultRequestHeaders.Add("X-Machine-Id", System.Uri.EscapeDataString(AutoUpdater.DataFolderManager.MachineID));
         _client.DefaultRequestHeaders.Add("X-Backup-Id", System.Uri.EscapeDataString(_backup_id));
 
         _timeouts = TimeoutOptionsHelper.Parse(options);
@@ -144,7 +174,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
 
         var qp = uri.QueryParameters;
         foreach (var kvp in opts)
-            if (!string.IsNullOrWhiteSpace(kvp.Value))
+            if (!string.IsNullOrWhiteSpace(kvp.Value) && string.IsNullOrWhiteSpace(qp.Get(kvp.Key)))
                 qp[kvp.Key] = Utility.Uri.UrlEncode(kvp.Value);
 
         var query = Utility.Uri.BuildUriQuery(qp);
@@ -185,6 +215,86 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
         _client.Dispose();
     }
 
+    /// <summary>
+    /// Ensures that we have valid credentials for direct S3 access
+    /// </summary>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>An awaitable task</returns>
+    private async Task EnsureCredentialsAsync(CancellationToken cancelToken)
+    {
+        if (_mode == "gateway")
+            return;
+
+        // Credentials are still valid with a 5-minute buffer
+        if (_mode == "direct" && _s3Backend != null && DateTime.UtcNow < _credentialsExpiry.AddMinutes(-5))
+            return;
+
+        await _credentialsLock.WaitAsync(cancelToken).ConfigureAwait(false);
+        try
+        {
+            // Double-check after acquiring lock
+            if (_mode == "direct" && _s3Backend != null && DateTime.UtcNow < _credentialsExpiry.AddMinutes(-5))
+                return;
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/credentials");
+            using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, ct =>
+                _client.SendAsync(request, ct)
+            ).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var creds = await response.Content.ReadFromJsonAsync<CredentialsResponse>(options, cancellationToken: cancelToken).ConfigureAwait(false);
+            if (creds != null &&
+                creds.Mode == "direct" &&
+                !string.IsNullOrEmpty(creds.Endpoint) &&
+                !string.IsNullOrEmpty(creds.AccessKeyId) &&
+                !string.IsNullOrEmpty(creds.SecretKey) &&
+                !string.IsNullOrEmpty(creds.Bucket))
+            {
+                _mode = "direct";
+                _credentialsExpiry = DateTime.UnixEpoch.AddSeconds(creds.RotateAfter ?? 0);
+                // In case the server doesn't provide a rotate-after value, we set a buffer
+                if (_credentialsExpiry - DateTime.UtcNow < TimeSpan.FromMinutes(15))
+                    _credentialsExpiry = DateTime.UtcNow.AddMinutes(15);
+
+                // Build S3 URL: s3://bucket
+                var s3Url = $"s3://{creds.Bucket}";
+                if (!string.IsNullOrWhiteSpace(creds.Prefix))
+                    s3Url += (creds.Prefix.StartsWith('/') ? "" : "/") + creds.Prefix;
+
+                // Configure S3 options
+                var s3Options = new Dictionary<string, string?>
+                {
+                    ["aws-access-key-id"] = creds.AccessKeyId,
+                    ["aws-secret-access-key"] = creds.SecretKey,
+                    ["s3-server-name"] = creds.Endpoint,
+                    ["s3-ext-forcepathstyle"] = "true",
+                };
+
+                // Plug in timeout options
+                _timeouts.ApplyTo(s3Options, overwrite: true);
+
+                _s3Backend?.Dispose();
+                _s3Backend = new S3(s3Url, s3Options);
+            }
+            else
+            {
+                _mode = "gateway";
+                _s3Backend?.Dispose();
+                _s3Backend = null;
+            }
+        }
+        finally
+        {
+            _credentialsLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// A request to rename a file
+    /// </summary>
+    /// <param name="Source">The source file</param>
+    /// <param name="Destination">The destination file</param>
     private record RenameRequest(
         string Source,
         string Destination
@@ -193,47 +303,70 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     /// <inheritdoc />
     public async Task CreateFolderAsync(CancellationToken cancelToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, "/createfolder");
-        using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
-            ct => _client.SendAsync(request, ct))
-            .ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        await EnsureCredentialsAsync(cancelToken).ConfigureAwait(false);
+        if (_s3Backend != null)
+        {
+            await _s3Backend.CreateFolderAsync(cancelToken).ConfigureAwait(false);
+        }
+        else
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/createfolder");
+            using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
+                ct => _client.SendAsync(request, ct))
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
     }
 
     /// <inheritdoc />
     public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"/delete/{remotename}");
+        await EnsureCredentialsAsync(cancelToken).ConfigureAwait(false);
+        if (_s3Backend != null)
+        {
+            await _s3Backend.DeleteAsync(remotename, cancelToken).ConfigureAwait(false);
+        }
+        else
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"/delete/{remotename}");
 
-        using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
-            ct => _client.SendAsync(request, ct))
-            .ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+            using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
+                ct => _client.SendAsync(request, ct))
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
     }
 
     /// <inheritdoc />
-    public async Task GetAsync(string remotename, Stream destination, CancellationToken token)
+    public async Task GetAsync(string remotename, Stream destination, CancellationToken cancelToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"/get/{remotename}");
+        await EnsureCredentialsAsync(cancelToken).ConfigureAwait(false);
+        if (_s3Backend != null)
+        {
+            await _s3Backend.GetAsync(remotename, destination, cancelToken).ConfigureAwait(false);
+        }
+        else
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"/get/{remotename}");
 
-        using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, token,
-            ct => _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+            using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
+                ct => _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
 
-        await using var responseStream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
+            await using var responseStream = await response.Content.ReadAsStreamAsync(cancelToken).ConfigureAwait(false);
 
-        using (var timeoutStream = destination.ObserveWriteTimeout(_timeouts.ReadWriteTimeout, false))
-            await Utility.Utility.CopyStreamAsync(responseStream, timeoutStream, token).ConfigureAwait(false);
+            using (var timeoutStream = destination.ObserveWriteTimeout(_timeouts.ReadWriteTimeout, false))
+                await Utility.Utility.CopyStreamAsync(responseStream, timeoutStream, cancelToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
     public Task GetAsync(string remotename, string filename, CancellationToken cancelToken)
-    {
-        return GetAsync(remotename, File.OpenWrite(filename), cancelToken);
-    }
+        => GetAsync(remotename, File.OpenWrite(filename), cancelToken);
 
     /// <inheritdoc />
-    public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult(new[] { _client.BaseAddress?.Host ?? string.Empty });
+    public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken)
+        => Task.FromResult(new[] { _client.BaseAddress?.Host ?? string.Empty });
 
     /// <inheritdoc />
     public async Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
@@ -253,41 +386,59 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     /// <inheritdoc />
     public async IAsyncEnumerable<IFileEntry> ListAsync([EnumeratorCancellation] CancellationToken cancelToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, "/list");
-
-        using var response = await Utility.Utility.WithTimeout(_timeouts.ListTimeout, cancelToken,
-            ct => _client.SendAsync(request, ct))
-            .ConfigureAwait(false);
-
-        response.EnsureSuccessStatusCode();
-
-        var entries = await response.Content.ReadFromJsonAsync<List<FileEntry>>(cancellationToken: cancelToken).ConfigureAwait(false) ?? [];
-
-        foreach (var entry in entries)
+        await EnsureCredentialsAsync(cancelToken).ConfigureAwait(false);
+        if (_s3Backend != null)
         {
-            if (cancelToken.IsCancellationRequested)
-                yield break;
-            yield return entry;
+            await foreach (var f in _s3Backend.ListAsync(cancelToken).ConfigureAwait(false))
+                yield return f;
+        }
+        else
+        {
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/list");
+
+            using var response = await Utility.Utility.WithTimeout(_timeouts.ListTimeout, cancelToken,
+                ct => _client.SendAsync(request, ct))
+                .ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            var entries = await response.Content.ReadFromJsonAsync<List<FileEntry>>(cancellationToken: cancelToken).ConfigureAwait(false) ?? [];
+
+            foreach (var entry in entries)
+            {
+                if (cancelToken.IsCancellationRequested)
+                    yield break;
+                yield return entry;
+            }
         }
     }
 
     /// <inheritdoc />
-    public async Task PutAsync(string remotename, Stream source, CancellationToken token)
+    public async Task PutAsync(string remotename, Stream source, CancellationToken cancelToken)
     {
-        (source, var hashes, var tmp) = await Utility.Utility.CalculateThrottledStreamHash(source, ["MD5", "SHA256"], token).ConfigureAwait(false);
-        using var _ = tmp;
-        var md5 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[0]));
-        var sha256 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[1]));
-        using var timeoutStream = source.ObserveReadTimeout(_timeouts.ReadWriteTimeout, false);
+        await EnsureCredentialsAsync(cancelToken).ConfigureAwait(false);
+        if (_s3Backend != null)
+        {
+            await _s3Backend.PutAsync(remotename, source, cancelToken).ConfigureAwait(false);
+        }
+        else
+        {
+            (source, var hashes, var tmp) = await Utility.Utility.CalculateThrottledStreamHash(source, ["MD5", "SHA256"], cancelToken).ConfigureAwait(false);
+            using var _ = tmp;
+            var md5 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[0]));
+            var sha256 = Convert.ToBase64String(Utility.Utility.HexStringAsByteArray(hashes[1]));
+            using var timeoutStream = source.ObserveReadTimeout(_timeouts.ReadWriteTimeout, false);
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"/put/{remotename}");
-        request.Content = new StreamContent(timeoutStream);
-        request.Content.Headers.ContentLength = source.Length;
-        request.Headers.Add("X-Content-MD5", md5 ?? string.Empty);
-        request.Headers.Add("X-Content-SHA256", sha256 ?? string.Empty);
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"/put/{remotename}");
+            request.Content = new StreamContent(timeoutStream);
+            request.Content.Headers.ContentLength = source.Length;
+            request.Headers.Add("X-Content-MD5", md5 ?? string.Empty);
+            request.Headers.Add("X-Content-SHA256", sha256 ?? string.Empty);
 
-        using var response = await _client.SendAsync(request, token).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+            using var response = await _client.SendAsync(request, cancelToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
     }
 
     /// <inheritdoc />
@@ -298,14 +449,22 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     }
 
     /// <inheritdoc />
-    public async Task RenameAsync(string oldname, string newname, CancellationToken cancellationToken)
+    public async Task RenameAsync(string oldname, string newname, CancellationToken cancelToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/rename");
-        var renameRequest = new RenameRequest(oldname, newname);
-        request.Content = JsonContent.Create(renameRequest);
+        await EnsureCredentialsAsync(cancelToken).ConfigureAwait(false);
+        if (_s3Backend != null)
+        {
+            await _s3Backend.RenameAsync(oldname, newname, cancelToken).ConfigureAwait(false);
+        }
+        else
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, "/rename");
+            var renameRequest = new RenameRequest(oldname, newname);
+            request.Content = JsonContent.Create(renameRequest);
 
-        using var response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+            using var response = await _client.SendAsync(request, cancelToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
     }
 
     /// <inheritdoc />
@@ -314,6 +473,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
             new CommandLineArgument(AUTH_API_ID_OPTION, CommandLineArgument.ArgumentType.String, Strings.DuplicatiBackend.AuthIdOptionsShort, Strings.DuplicatiBackend.AuthIdOptionsLong, null, [AuthOptionsHelper.AuthUsernameOption]),
             new CommandLineArgument(AUTH_API_KEY_OPTION, CommandLineArgument.ArgumentType.Password, Strings.DuplicatiBackend.AuthKeyOptionsShort, Strings.DuplicatiBackend.AuthKeyOptionsLong, null, [AuthOptionsHelper.AuthPasswordOption]),
             new CommandLineArgument(BACKUP_ID_OPTION, CommandLineArgument.ArgumentType.String, Strings.DuplicatiBackend.BackupIdOptionsShort, Strings.DuplicatiBackend.BackupIdOptionsLong),
+            new CommandLineArgument(ENDPOINT_OPTION, CommandLineArgument.ArgumentType.String, Strings.DuplicatiBackend.EndpointOptionsShort, Strings.DuplicatiBackend.EndpointOptionsLong),
             .. TimeoutOptionsHelper.GetOptions()
         ];
 
@@ -321,4 +481,46 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     public Task TestAsync(CancellationToken cancelToken)
         => this.TestReadWritePermissionsAsync(cancelToken);
 
+    /// <summary>
+    /// Response from getting credentials
+    /// </summary>
+    private sealed record CredentialsResponse
+    {
+        /// <summary>
+        /// The mode for connecting to storage, either "direct" or "gateway"
+        /// </summary>
+        public string? Mode { get; set; }
+        /// <summary>
+        /// The S3 endpoint to connect to, in "direct" mode
+        /// </summary>
+        public string? Endpoint { get; set; }
+        /// <summary>
+        /// The access key ID to use for S3 in "direct" mode
+        /// </summary>
+        public string? AccessKeyId { get; set; }
+        /// <summary>
+        /// The secret key to use for S3 in "direct" mode
+        /// </summary>
+        public string? SecretKey { get; set; }
+        /// <summary>
+        /// The bucket to use for S3 in "direct" mode
+        /// </summary>
+        public string? Bucket { get; set; }
+        /// <summary>
+        /// The prefix to use for S3 in "direct" mode
+        /// </summary>
+        public string? Prefix { get; set; }
+        /// <summary>
+        /// The region to use for S3 in "direct" mode
+        /// </summary>
+        public string? Region { get; set; }
+        /// <summary>
+        /// The time the credentials were issued
+        /// </summary>
+        public long? IssuedAt { get; set; }
+        /// <summary>
+        /// The time the credentials expire
+        /// </summary>
+        public long? RotateAfter { get; set; }
+    }
 }

--- a/Duplicati/Library/Backend/Duplicati/Strings.cs
+++ b/Duplicati/Library/Backend/Duplicati/Strings.cs
@@ -34,6 +34,8 @@ internal static class DuplicatiBackend
     public static string AuthKeyOptionsLong { get { return LC.L(@"Specifies the API Key to use when authenticating with the Duplicati storage server."); } }
     public static string BackupIdOptionsShort { get { return LC.L(@"The Backup ID to use on the Duplicati storage server."); } }
     public static string BackupIdOptionsLong { get { return LC.L(@"Each backupID identifies a separate backup set on the Duplicati storage server."); } }
+    public static string EndpointOptionsShort { get { return LC.L(@"The URL of the Duplicati storage server."); } }
+    public static string EndpointOptionsLong { get { return LC.L(@"Specifies the URL of the Duplicati storage server."); } }
     public static string ErrorMissingBackupId { get { return LC.L(@"A unique backup id must be specified"); } }
 }
 

--- a/Duplicati/Library/Utility/Options/TimeoutOptionsHelper.cs
+++ b/Duplicati/Library/Utility/Options/TimeoutOptionsHelper.cs
@@ -92,5 +92,21 @@ public static class TimeoutOptionsHelper
     /// <param name="ShortTimeout">The timeout in seconds for short operations like delete and create folder</param>
     /// <param name="ListTimeout">The timeout in seconds for listing files and folders</param>
     /// <param name="ReadWriteTimeout">The timeout in seconds for read and write operations.</param>
-    public sealed record Timeouts(TimeSpan ShortTimeout, TimeSpan ListTimeout, TimeSpan ReadWriteTimeout);
+    public sealed record Timeouts(TimeSpan ShortTimeout, TimeSpan ListTimeout, TimeSpan ReadWriteTimeout)
+    {
+        /// <summary>
+        /// Applies the timeout configuration to a dictionary
+        /// </summary>
+        /// <param name="target">The target dictionary</param>
+        /// <param name="overwrite">Whether to overwrite existing values</param>
+        public void ApplyTo(IDictionary<string, string?> target, bool overwrite = false, string? prefix = null)
+        {
+            if (overwrite || !target.ContainsKey(ReadWriteTimeoutOption))
+                target[$"{prefix}{ReadWriteTimeoutOption}"] = ((long)ReadWriteTimeout.TotalSeconds).ToString() + "s";
+            if (overwrite || !target.ContainsKey(ListTimeoutOption))
+                target[$"{prefix}{ListTimeoutOption}"] = ((long)ListTimeout.TotalSeconds).ToString() + "s";
+            if (overwrite || !target.ContainsKey(ShortTimeoutOption))
+                target[$"{prefix}{ShortTimeoutOption}"] = ((long)ShortTimeout.TotalSeconds).ToString() + "s";
+        }
+    }
 }


### PR DESCRIPTION
Updated the Duplicati backend to support direct backups where the storage server returns keys to an AWS compatible storage and lets the client communicate directly with the storage.

The gateway mode is stil supported.