### PR TITLE
Remove explicit defaults

### DIFF
--- a/Duplicati/Library/RestAPI/newbackup.json
+++ b/Duplicati/Library/RestAPI/newbackup.json
@@ -2,8 +2,6 @@
   "Backup": {
     "Settings": [
       { "Name": "encryption-module", "Value": "aes" },
-      { "Name": "compression-module", "Value": "zip" },
-      { "Name": "dblock-size", "Value": "50mb" },
       { "Name": "keep-time", "Value": "" }
     ]
   },

--- a/ReleaseBuilder/Build/Command.CreatePackage.cs
+++ b/ReleaseBuilder/Build/Command.CreatePackage.cs
@@ -552,6 +552,22 @@ public static partial class Command
 
             await ProcessHelper.Execute(wixArgs, workingDirectory: buildRoot);
 
+            // Apply any installer data tables present
+            // On Windows, the wxs files include the tables, but on Linux/MacOS, we need to apply them separately
+            // because wixl does not support the tables directly
+            if (!OperatingSystem.IsWindows())
+            {
+                if (string.IsNullOrWhiteSpace(rtcfg.Configuration.Commands.MsiBuild))
+                {
+                    Console.WriteLine("WARNING: msiBuild not found, skipping IDT file injection.");
+                }
+                else
+                {
+                    foreach (var idtFile in Directory.GetFiles(resourcesSubDir, "*.idt"))
+                        await ProcessHelper.Execute([rtcfg.Configuration.Commands.MsiBuild, msiFile, "-i", idtFile]);
+                }
+            }
+
             if (rtcfg.UseAuthenticodeSigning)
                 await rtcfg.AuthenticodeSign(msiFile);
 

--- a/ReleaseBuilder/Configuration.cs
+++ b/ReleaseBuilder/Configuration.cs
@@ -347,6 +347,7 @@ public record ConfigFiles(
 /// <param name="Codesign">The &quot;codesign&quot; command</param>
 /// <param name="Productsign">The &quot;productsign&quot; command</param>
 /// <param name="Wix">The &quot;wix&quot; command</param>
+/// <param name="MsiBuild">The &quot;msibuild&quot; command from msitools</param>
 /// <param name="Docker">The &quot;docker&quot; command</param>
 /// <param name="Npm">The &quot;npm&quot; command</param>
 public record Commands(
@@ -357,6 +358,7 @@ public record Commands(
     string? Codesign,
     string? Productsign,
     string? Wix,
+    string? MsiBuild,
     string? Docker,
     string? Npm
 )
@@ -374,6 +376,7 @@ public record Commands(
             OperatingSystem.IsMacOS() ? FindCommand("codesign", "CODESIGN") : null,
             OperatingSystem.IsMacOS() ? FindCommand("productsign", "PRODUCTSIGN") : null,
             FindCommand(OperatingSystem.IsWindows() ? "wix" : "wixl", "WIX"),
+            OperatingSystem.IsWindows() ? null : FindCommand("msibuild", "MSIBUILD"),
             FindCommand("docker", "DOCKER"),
             FindCommand("npm", "NPM")
         );

--- a/ReleaseBuilder/Resources/Windows/Agent/Duplicati.wxs
+++ b/ReleaseBuilder/Resources/Windows/Agent/Duplicati.wxs
@@ -40,13 +40,23 @@
       <Directory Id="DesktopFolder" Name="Desktop"/>
     
       <Directory Id="$(var.ProgramFilesFolder)">
-        <Directory Id="INSTALLLOCATION" Name="Duplicati Agent" />
+        <Directory Id="INSTALLLOCATION" Name="Duplicati Agent" >
+          <Component Id="SecureInstallDirComp" Guid="7C52A563-7182-411E-8B57-79F881775E9B">
+              <CreateFolder>
+              <!-- WiX supports permssions, wixl uses a .idt table -->
+<?if $(var.BuildEnv) = "Windows" ?>
+                <util:PermissionEx Sddl="D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;GRFX;;;BU)" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"/>
+<?endif?>
+              </CreateFolder>
+          </Component>
+        </Directory>
       </Directory>
     </Directory>
 
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLLOCATION" />
 
     <Feature Id="DuplicatiCore" Title="Duplicati Agent files" Level="1" Description="Installs the required files for the Duplicati Agent." AllowAdvertise="no" Absent="disallow" ConfigurableDirectory="INSTALLLOCATION" >
+      <ComponentRef Id="SecureInstallDirComp" />
       <ComponentGroupRef Id="DUPLICATIBIN" />
     </Feature>
     

--- a/ReleaseBuilder/Resources/Windows/Agent/MsiLockPermissionsEx.idt
+++ b/ReleaseBuilder/Resources/Windows/Agent/MsiLockPermissionsEx.idt
@@ -1,0 +1,4 @@
+MsiLockPermissionsEx	LockObject	Table	SDDLText	Condition
+s72	s72	s32	s255	S255
+MsiLockPermissionsEx	MsiLockPermissionsEx	LockObject	Table
+SecureFolderACLs	INSTALLLOCATION	CreateFolder	D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;GRFX;;;BU)	

--- a/ReleaseBuilder/Resources/Windows/TrayIcon/Duplicati.wxs
+++ b/ReleaseBuilder/Resources/Windows/TrayIcon/Duplicati.wxs
@@ -36,13 +36,24 @@
       <Directory Id="DesktopFolder" Name="Desktop"/>
     
       <Directory Id="$(var.ProgramFilesFolder)">
-        <Directory Id="INSTALLLOCATION" Name="Duplicati 2" />
+        <Directory Id="INSTALLLOCATION" Name="Duplicati 2" >
+          <Component Id="SecureInstallDirComp" Guid="7C52A563-7182-411E-8B57-79F881775E9B">
+              <CreateFolder>
+              <!-- WiX supports permssions, wixl uses a .idt table -->
+<?if $(var.BuildEnv) = "Windows" ?>
+                <util:PermissionEx Sddl="D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;GRFX;;;BU)" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"/>
+<?endif?>
+              </CreateFolder>
+          </Component>
+        </Directory>
       </Directory>
     </Directory>
 
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLLOCATION" />
 
     <Feature Id="DuplicatiCore" Title="Duplicati core files" Level="1" Description="Installs the required files for Duplicati." AllowAdvertise="no" Absent="disallow" ConfigurableDirectory="INSTALLLOCATION" >
+      <ComponentRef Id="SecureInstallDirComp" />
+      
       <Feature Id="DuplicatiDesktopShortCutFeature" Title="Desktop Shortcut" Level="1" Description ="Installs a shortcut to Duplicati on the desktop" Absent="allow" AllowAdvertise="no">
         <ComponentRef Id="DuplicatiDesktopShortcutComponent"/>
         <Condition Level="0">FORSERVICE = "true"</Condition>

--- a/ReleaseBuilder/Resources/Windows/TrayIcon/MsiLockPermissionsEx.idt
+++ b/ReleaseBuilder/Resources/Windows/TrayIcon/MsiLockPermissionsEx.idt
@@ -1,0 +1,4 @@
+MsiLockPermissionsEx	LockObject	Table	SDDLText	Condition
+s72	s72	s32	s255	S255
+MsiLockPermissionsEx	MsiLockPermissionsEx	LockObject	Table
+SecureFolderACLs	INSTALLLOCATION	CreateFolder	D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;GRFX;;;BU)	


### PR DESCRIPTION
This modifies the `newbackup.json` embedded file that specifies how to configure a new backup to no longer set the compression module or the dblock-size.

These options have a default value already defined, so there is no need to store the settings in the database.