### PR TITLE
Remove explicit defaults

### DIFF
--- a/Duplicati/Library/RestAPI/newbackup.json
+++ b/Duplicati/Library/RestAPI/newbackup.json
@@ -2,8 +2,6 @@
   "Backup": {
     "Settings": [
       { "Name": "encryption-module", "Value": "aes" },
-      { "Name": "compression-module", "Value": "zip" },
-      { "Name": "dblock-size", "Value": "50mb" },
       { "Name": "keep-time", "Value": "" }
     ]
   },


### PR DESCRIPTION
This modifies the `newbackup.json` embedded file that specifies how to configure a new backup to no longer set the compression module or the dblock-size.

These options have a default value already defined, so there is no need to store the settings in the database.