### PR TITLE
Cleanup after registering

### DIFF
--- a/Duplicati/WebserverCore/Services/RemoteControllerRegistrationService.cs
+++ b/Duplicati/WebserverCore/Services/RemoteControllerRegistrationService.cs
@@ -139,6 +139,9 @@ public class RemoteControllerRegistrationService(Connection connection, IHttpCli
             }
             finally
             {
+                // Machine is claimed or failed and we are done with the registration process, throw away the data
+                _registerForRemote = null;
+                RegistrationUrl = null;
                 eventPollNotify.SignalRemoteControlUpdate();
             }
         });


### PR DESCRIPTION
If the user connects to the console, and then disconnects without restarting Duplicati, the UI state would look like it was still registering.

This PR fixes it by clearing the stale data after the registration completes or fails, so the UI does not show an incorrect state.