### PR TITLE
Simplify console handling

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -120,7 +120,7 @@ namespace Duplicati.GUI.TrayIcon
             var options = CommandLineParser.ExtractOptions(args);
 
             if (OperatingSystem.IsWindows() && !Utility.ParseBoolOption(options, DETACHED_PROCESS))
-                Win32.AttachConsole(Win32.ATTACH_PARENT_PROCESS);
+                Utility.AttachWindowsConsole();
 
             if (HelpOptionExtensions.IsArgumentAnyHelpString(_args))
             {

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -2071,6 +2071,34 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// Windows-only helper to attach the console to the parent process.
+        /// This is required if the start application is a Windows Executable (WinExe),
+        /// as this has not console attached and cannot write to the console, if launched from a command prompt.
+        /// By attaching the console, Console.Write/Read calls work as expected.
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        public static void AttachWindowsConsole()
+        {
+            // The parent process ID
+            const int ATTACH_PARENT_PROCESS = -1;
+
+            // WinExe has no console attached; when launched from a command
+            // prompt (e.g. for reset-password or help) attach to the parent
+            // console so Console.Write/Read calls work as expected.
+            if (Win32.AttachConsole(ATTACH_PARENT_PROCESS))
+            {
+                var stdout = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+                Console.SetOut(stdout);
+                var stderr = new StreamWriter(Console.OpenStandardError()) { AutoFlush = true };
+                Console.SetError(stderr);
+                var standardInput = new StreamReader(Console.OpenStandardInput());
+                Console.SetIn(standardInput);
+            }
+        }
+
+
+
+        /// <summary>
         /// Gets the free and total space available for the specified path.
         /// Uses the same approach as FileBackend.GetQuotaInfoAsync.
         /// </summary>

--- a/ReleaseBuilder/ConsoleHelper.cs
+++ b/ReleaseBuilder/ConsoleHelper.cs
@@ -52,32 +52,5 @@ public static class ConsoleHelper
     /// <param name="prompt">The text to show the user</param>
     /// <returns>The password</returns>
     public static string ReadPassword(string prompt)
-    {
-        Console.WriteLine(prompt);
-
-        // From: https://stackoverflow.com/a/3404522
-        var pass = string.Empty;
-        ConsoleKey key;
-        do
-        {
-            var keyInfo = Console.ReadKey(intercept: true);
-            key = keyInfo.Key;
-
-            if (key == ConsoleKey.Backspace && pass.Length > 0)
-            {
-                Console.Write("\b \b");
-                pass = pass[0..^1];
-            }
-            else if (!char.IsControl(keyInfo.KeyChar))
-            {
-                if (OperatingSystem.IsWindows())
-                    Console.Write("*");
-
-                pass += keyInfo.KeyChar;
-            }
-        } while (key != ConsoleKey.Enter);
-
-        return pass;
-    }
-
+        => Duplicati.Library.Utility.Utility.ReadSecretFromConsole(prompt);
 }


### PR DESCRIPTION
This PR changes so the ReleaseBuilder uses the regular secret reading code instead of a replicated version.

The TrayIcon's attachment code now explicitly maps up the streams if possible.