### PR TITLE
Fix SMB source listing misclassifying directories as files

### DIFF
--- a/Duplicati/Library/Backend/SMB/SMBShareConnection.cs
+++ b/Duplicati/Library/Backend/SMB/SMBShareConnection.cs
@@ -282,7 +282,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
                             info.LastAccessTime,
                             info.LastWriteTime)
                         {
-                            IsFolder = info.FileAttributes == FileAttributes.Directory,
+                            IsFolder = (info.FileAttributes && FileAttributes.Directory) == FileAttributes.Directory,
                             Created = info.CreationTime
                         })
                         .ToList()

--- a/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
+++ b/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
@@ -84,7 +84,7 @@ public class BackendSourceProvider(IFolderEnabledBackend backend, string mounted
 
     /// <inheritdoc/>
     public Task Test(CancellationToken cancellationToken)
-        => backend.TestAsync(cancellationToken);
+        => Initialize(cancellationToken);
 
     /// <inheritdoc/>
     public IAsyncEnumerable<ISourceProviderEntry> Enumerate(CancellationToken cancellationToken)

--- a/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
@@ -52,8 +52,19 @@ public class DestinationVerify : IEndpointV2
                 // We do not call TestAsync here, because we may have read-only access to the source, and test will verify write access
                 // Instead we just check if we can enumerate the files, which is the main thing we need to verify for a source provider
 
+                await wrapper.SourceProvider.Test(cancelToken).ConfigureAwait(false);
                 // Technically we also count folders as files here, but really we just want to know if there is data to backup
-                var anyFiles = await wrapper.SourceProvider.Enumerate(cancelToken).AnyAsync(cancelToken);
+                var anyFiles = false;
+  
+                await foreach (var root in wrapper.SourceProvider.Enumerate(cancelToken).ConfigureAwait(false))
+                {
+                    await foreach (var _ in root.Enumerate(cancelToken).ConfigureAwait(false))
+                    {
+                        anyFiles = true;
+                        break;
+                    }
+                    break;
+                }
 
                 return DestinationTestResponseDto.Create(
                     anyFiles: anyFiles,


### PR DESCRIPTION
When using SMB/CIFS share as a backup source, directories are identified as files. This then causes STATUS_FILE_IS_A_DIRECTORY error to be logged and only files in the root of the source are backed up.

SMBShareConnection.ListAsync and IsFolder was set with an exact match:
info.FileAttributes == FileAttributes.Directory

I updated this to match the same check as used in GetEntryAsync and have tested this locally and it is working.

I raised this under issue #6924 