### PR TITLE
Fix SMB source listing misclassifying directories as files

### DIFF
--- a/Duplicati/Library/Backend/SMB/SMBShareConnection.cs
+++ b/Duplicati/Library/Backend/SMB/SMBShareConnection.cs
@@ -282,7 +282,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
                             info.LastAccessTime,
                             info.LastWriteTime)
                         {
-                            IsFolder = (info.FileAttributes && FileAttributes.Directory) == FileAttributes.Directory,
+                            IsFolder = info.FileAttributes.HasFlag(FileAttributes.Directory),
                             Created = info.CreationTime
                         })
                         .ToList()
@@ -346,7 +346,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
                     var name = path.TrimEnd('/').Split('/').Last();
                     if (string.IsNullOrEmpty(name)) name = "";
 
-                    var isFolder = (basic.FileAttributes & FileAttributes.Directory) == FileAttributes.Directory;
+                    var isFolder = basic.FileAttributes.HasFlag(FileAttributes.Directory);
                     if (isFolder && !name.EndsWith("/")) name += "/";
 
                     return (IFileEntry)new FileEntry(

--- a/Duplicati/Library/Backend/SMB/SMBShareConnection.cs
+++ b/Duplicati/Library/Backend/SMB/SMBShareConnection.cs
@@ -282,7 +282,7 @@ public class SMBShareConnection : IDisposable, IAsyncDisposable
                             info.LastAccessTime,
                             info.LastWriteTime)
                         {
-                            IsFolder = info.FileAttributes == FileAttributes.Directory,
+                            IsFolder = (info.FileAttributes && FileAttributes.Directory) == FileAttributes.Directory,
                             Created = info.CreationTime
                         })
                         .ToList()


### PR DESCRIPTION
When using SMB/CIFS share as a backup source, directories are identified as files. This then causes STATUS_FILE_IS_A_DIRECTORY error to be logged and only files in the root of the source are backed up.

SMBShareConnection.ListAsync and IsFolder was set with an exact match:
info.FileAttributes == FileAttributes.Directory

I updated this to match the same check as used in GetEntryAsync and have tested this locally and it is working.

I raised this under issue #6924 