### PR TITLE
Fix remote source connection test for backend provider

### DIFF
--- a/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
+++ b/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
@@ -84,7 +84,7 @@ public class BackendSourceProvider(IFolderEnabledBackend backend, string mounted
 
     /// <inheritdoc/>
     public Task Test(CancellationToken cancellationToken)
-        => backend.TestAsync(cancellationToken);
+        => Initialize(cancellationToken);
 
     /// <inheritdoc/>
     public IAsyncEnumerable<ISourceProviderEntry> Enumerate(CancellationToken cancellationToken)

--- a/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
@@ -52,9 +52,21 @@ public class DestinationVerify : IEndpointV2
                 // We do not call TestAsync here, because we may have read-only access to the source, and test will verify write access
                 // Instead we just check if we can enumerate the files, which is the main thing we need to verify for a source provider
 
-                // Technically we also count folders as files here, but really we just want to know if there is data to backup
-                var anyFiles = await wrapper.SourceProvider.Enumerate(cancelToken).AnyAsync(cancelToken);
+                await wrapper.SourceProvider.Test(cancelToken).ConfigureAwait(false);
 
+                // Technically we also count folders as files here, but really we just want to know if there is data to backup
+
+                var anyFiles = false;
+                await foreach (var root in wrapper.SourceProvider.Enumerate(cancelToken).ConfigureAwait(false))
+                {
+                    await foreach (var _ in root.Enumerate(cancelToken).ConfigureAwait(false))
+                    {
+                        anyFiles = true;
+                        break;
+                    }
+                    break;
+                }
+                
                 return DestinationTestResponseDto.Create(
                     anyFiles: anyFiles,
                     anyBackups: false,


### PR DESCRIPTION
When using the Test button in the UI on source such as smb, it does not perform a real test.

Fix remote source “Test connection” for SMB and other file sources: `BackendSourceProvider.Test()` now runs read-only `Initialize()` (list share path) instead of `TestAsync()` (write test) like we do on the destination.

This is updated as it was only calling Enumerate().AnyAsync() which was returning the in memory root and not actually doing a connection. So now I updated it to use Initialize() and then performed a read-only operation considering as this is a remote source and not destination.

I have tested it with smb and it is fully working.