### PR TITLE
Make FS parsing experimental

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -1023,6 +1023,10 @@ namespace Duplicati.Library.Main
             if (BackendModules.DeprecatedBackendModules.Contains(scheme))
                 Logging.Log.WriteWarningMessage(LOGTAG, "BackendDeprecated", null, $"The backend {scheme} is deprecated and should be migrated away from.");
 
+            //Warn about experimental diskimage filesystem parsing
+            if (m_options.RawOptions.ContainsKey("diskimage-filesystem-parsed"))
+                Logging.Log.WriteWarningMessage(LOGTAG, "ExperimentalDiskImageFilesystemParsed", null, "The option 'diskimage-filesystem-parsed' is experimental and should be used with caution.");
+
             //TODO: Based on the action, see if all options are relevant
         }
 

--- a/Duplicati/UnitTest/DiskImage/DiskImageTests.cs
+++ b/Duplicati/UnitTest/DiskImage/DiskImageTests.cs
@@ -1047,9 +1047,9 @@ public class DiskImageTests : BasicSetupHelper
         options["enable-module"] = "diskimage";
         options["concurrency-fileprocessors"] = "1";
 
-        if (treatFilesystemAsUnknown)
+        if (!treatFilesystemAsUnknown)
         {
-            options["diskimage-filesystem-unknown"] = "true";
+            options["diskimage-filesystem-parsed"] = "true";
         }
 
         using var c = new Controller("file://" + TARGETFOLDER, options, null);

--- a/Duplicati/UnitTest/DiskImage/DiskImageTests.cs
+++ b/Duplicati/UnitTest/DiskImage/DiskImageTests.cs
@@ -812,7 +812,7 @@ public class DiskImageTests : BasicSetupHelper
 
         // Backup
         var backupResults = await RunBackupAsync(sourceDrivePath);
-        TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
+        TestUtils.AssertResults(backupResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         await TestContext.Progress.WriteLineAsync($"Backup completed successfully");
 
         // Setup restore target disk image with same geometry
@@ -865,7 +865,7 @@ public class DiskImageTests : BasicSetupHelper
 
         // Backup
         var backupResults = await RunBackupAsync(sourceDrivePath);
-        TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
+        TestUtils.AssertResults(backupResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
 
         // List backup contents and verify geometry.json is present
         using (var c = new Controller("file://" + TARGETFOLDER, TestOptions, null))
@@ -964,7 +964,7 @@ public class DiskImageTests : BasicSetupHelper
 
         // Backup
         var backupResults = await RunBackupAsync(sourceDrivePath);
-        TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
+        TestUtils.AssertResults(backupResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         await TestContext.Progress.WriteLineAsync($"Backup completed successfully");
 
         // Create and attach disk image
@@ -1306,7 +1306,7 @@ public class DiskImageTests : BasicSetupHelper
         }
         else
         {
-            TestUtils.AssertResults(firstBackupResults);
+            TestUtils.AssertResults(firstBackupResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         }
 
         var firstBackupSize = firstBackupResults.SizeOfOpenedFiles;
@@ -1324,7 +1324,7 @@ public class DiskImageTests : BasicSetupHelper
         await TestContext.Progress.WriteLineAsync($"Restore disk created at: {_restoreImagePath}");
 
         var restoreResults = await RunRestoreAsync(restoreDrivePath);
-        TestUtils.AssertResults(restoreResults);
+        TestUtils.AssertResults(restoreResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         await TestContext.Progress.WriteLineAsync("Initial restore completed successfully");
 
         // Reattach and verify initial restore
@@ -1405,7 +1405,7 @@ public class DiskImageTests : BasicSetupHelper
         }
         else
         {
-            TestUtils.AssertResults(secondBackupResults);
+            TestUtils.AssertResults(secondBackupResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         }
 
         var secondBackupSize = secondBackupResults.SizeOfOpenedFiles;
@@ -1441,7 +1441,7 @@ public class DiskImageTests : BasicSetupHelper
         await TestContext.Progress.WriteLineAsync($"Fresh restore disk created for incremental restore");
 
         var incrementalRestoreResults = await RunRestoreAsync(restoreDrivePath);
-        TestUtils.AssertResults(incrementalRestoreResults);
+        TestUtils.AssertResults(incrementalRestoreResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         await TestContext.Progress.WriteLineAsync("Incremental restore completed successfully");
 
         // Reattach and verify the incremental restore matches the modified source
@@ -1497,7 +1497,7 @@ public class DiskImageTests : BasicSetupHelper
         }
         else
         {
-            TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
+            TestUtils.AssertResults(backupResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         }
         await TestContext.Progress.WriteLineAsync($"Backup completed: {backupResults.SizeOfOpenedFiles} bytes examined");
 
@@ -1586,7 +1586,7 @@ public class DiskImageTests : BasicSetupHelper
         }
         else
         {
-            TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
+            TestUtils.AssertResults(backupResults, ignoredWarnings: ["diskimage-filesystem-parsed"]);
         }
 
         await TestContext.Progress.WriteLineAsync($"Backup completed: {backupResults.SizeOfOpenedFiles} bytes examined, {backupResults.SizeOfAddedFiles} bytes added");

--- a/Duplicati/UnitTest/DiskImage/DiskImageTests.cs
+++ b/Duplicati/UnitTest/DiskImage/DiskImageTests.cs
@@ -812,7 +812,7 @@ public class DiskImageTests : BasicSetupHelper
 
         // Backup
         var backupResults = await RunBackupAsync(sourceDrivePath);
-        TestUtils.AssertResults(backupResults);
+        TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
         await TestContext.Progress.WriteLineAsync($"Backup completed successfully");
 
         // Setup restore target disk image with same geometry
@@ -865,7 +865,7 @@ public class DiskImageTests : BasicSetupHelper
 
         // Backup
         var backupResults = await RunBackupAsync(sourceDrivePath);
-        TestUtils.AssertResults(backupResults);
+        TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
 
         // List backup contents and verify geometry.json is present
         using (var c = new Controller("file://" + TARGETFOLDER, TestOptions, null))
@@ -964,7 +964,7 @@ public class DiskImageTests : BasicSetupHelper
 
         // Backup
         var backupResults = await RunBackupAsync(sourceDrivePath);
-        TestUtils.AssertResults(backupResults);
+        TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
         await TestContext.Progress.WriteLineAsync($"Backup completed successfully");
 
         // Create and attach disk image
@@ -1497,7 +1497,7 @@ public class DiskImageTests : BasicSetupHelper
         }
         else
         {
-            TestUtils.AssertResults(backupResults);
+            TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
         }
         await TestContext.Progress.WriteLineAsync($"Backup completed: {backupResults.SizeOfOpenedFiles} bytes examined");
 
@@ -1586,7 +1586,7 @@ public class DiskImageTests : BasicSetupHelper
         }
         else
         {
-            TestUtils.AssertResults(backupResults);
+            TestUtils.AssertResults(backupResults, "diskimage-filesystem-parsed");
         }
 
         await TestContext.Progress.WriteLineAsync($"Backup completed: {backupResults.SizeOfOpenedFiles} bytes examined, {backupResults.SizeOfAddedFiles} bytes added");

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -287,7 +287,7 @@ namespace Duplicati.UnitTest
         {
         }
 
-        public static void AssertResults(IBasicResults results)
+        public static void AssertResults(IBasicResults results, params string[] ignoredWarnings)
         {
             string operation = "Result";
             // Use dynamic property access for MainOperation, because it is only exposed in internal classes
@@ -330,11 +330,12 @@ namespace Duplicati.UnitTest
                 throw new TestVerificationException(sb.ToString());
             }
 
-            if (results.Warnings.Count() != 0)
+            var remainingWarnings = results.Warnings.Where(w => !ignoredWarnings.Any(ignored => w.Contains(ignored)));
+            if (remainingWarnings.Any())
             {
                 var sb = new StringBuilder();
                 sb.AppendLine($"Warnings - {operation}:");
-                foreach (var w in results.Warnings)
+                foreach (var w in remainingWarnings)
                     sb.AppendLine(w.ToString());
                 throw new TestVerificationException(sb.ToString());
             }

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -287,15 +287,15 @@ namespace Duplicati.UnitTest
         {
         }
 
-        public static void AssertResults(IBasicResults results, params string[] ignoredWarnings)
+        public static void AssertResults(IBasicResults results, string[] ignoredWarnings = null)
         {
-            string operation = "Result";
+            var operation = "Result";
+            ignoredWarnings ??= [];
+
             // Use dynamic property access for MainOperation, because it is only exposed in internal classes
-            PropertyInfo operationProperty = results.GetType().GetProperty("MainOperation", typeof(Library.Main.OperationMode));
+            var operationProperty = results.GetType().GetProperty("MainOperation", typeof(Library.Main.OperationMode));
             if (operationProperty != null)
-            {
                 operation = ((Library.Main.OperationMode)operationProperty.GetValue(results)).ToString();
-            }
 
             if (results is ITestResults testResults)
             {

--- a/proprietary/DiskImage/General/OptionsHelper.cs
+++ b/proprietary/DiskImage/General/OptionsHelper.cs
@@ -31,7 +31,12 @@ internal static class OptionsHelper
     /// <summary>
     /// Option to treat filesystem as unknown (force raw block-based backup).
     /// </summary>
-    internal const string DISK_IMAGE_FILESYSTEM_UNKNOWN_OPTION = "diskimage-filesystem-unknown";
+    // internal const string DISK_IMAGE_FILESYSTEM_UNKNOWN_OPTION = "diskimage-filesystem-unknown";
+
+    /// <summary>
+    /// Option to opt-in to filesystem parsing (enables filesystem-aware backup).
+    /// </summary>
+    internal const string DISK_IMAGE_FILESYSTEM_PARSED_OPTION = "diskimage-filesystem-parsed";
 
     /// <summary>
     /// Gets the list of supported command-line arguments for the DiskImage module.
@@ -41,6 +46,7 @@ internal static class OptionsHelper
         new CommandLineArgument(DISK_RESTORE_AUTO_UNMOUNT_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskRestoreAutoUnmountShort, Strings.DiskRestoreAutoUnmountLong, "false"),
         new CommandLineArgument(DISK_RESTORE_SKIP_PARTITION_TABLE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskRestoreSkipPartitionTableShort, Strings.DiskRestoreSkipPartitionTableLong, "false"),
         new CommandLineArgument(DISK_RESTORE_VALIDATE_SIZE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskRestoreValidateSizeShort, Strings.DiskRestoreValidateSizeLong, "true"),
-        new CommandLineArgument(DISK_IMAGE_FILESYSTEM_UNKNOWN_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskImageFilesystemUnknownShort, Strings.DiskImageFilesystemUnknownLong, "false")
+        //new CommandLineArgument(DISK_IMAGE_FILESYSTEM_UNKNOWN_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskImageFilesystemUnknownShort, Strings.DiskImageFilesystemUnknownLong, "false"),
+        new CommandLineArgument(DISK_IMAGE_FILESYSTEM_PARSED_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskImageFilesystemParsedShort, Strings.DiskImageFilesystemParsedLong, "false"),
     ];
 }

--- a/proprietary/DiskImage/General/Strings.cs
+++ b/proprietary/DiskImage/General/Strings.cs
@@ -140,4 +140,14 @@ internal static class Strings
     /// Long description for the filesystem unknown option.
     /// </summary>
     public static string DiskImageFilesystemUnknownLong => LC.L("If set, the filesystem on partitions will be treated as unknown, rather than trying to detect it. This forces raw block-based backup instead of filesystem-aware backup.");
+
+    /// <summary>
+    /// Short description for the filesystem parsed option.
+    /// </summary>
+    public static string DiskImageFilesystemParsedShort => LC.L("Enable filesystem-aware backup.");
+
+    /// <summary>
+    /// Long description for the filesystem parsed option.
+    /// </summary>
+    public static string DiskImageFilesystemParsedLong => LC.L("If set, the filesystem on partitions will be parsed, rather than treating the disk as a raw block device. This enables filesystem-aware backup instead of raw block-based backup.");
 }

--- a/proprietary/DiskImage/SourceProvider.cs
+++ b/proprietary/DiskImage/SourceProvider.cs
@@ -78,7 +78,7 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
         var uri = new Library.Utility.Uri(url);
         _devicePath = uri.HostAndPath;
 
-        _treatFilesystemAsUnknown = Library.Utility.Utility.ParseBoolOption(options, OptionsHelper.DISK_IMAGE_FILESYSTEM_UNKNOWN_OPTION);
+        _treatFilesystemAsUnknown = !Library.Utility.Utility.ParseBoolOption(options, OptionsHelper.DISK_IMAGE_FILESYSTEM_PARSED_OPTION);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This PR flips the logic so filesystem parsing is not enabled by default. This means that any disk source will be treated as an opaque stream of blocks.

Brave users can still try out the filesystem parsing, but we need more time to ensure the logic works across variations on filesystems.