### PR TITLE
Handle extended Win32 file attributes 

### DIFF
--- a/Duplicati/Library/Common/IO/ExtendedFileAttributes.cs
+++ b/Duplicati/Library/Common/IO/ExtendedFileAttributes.cs
@@ -1,0 +1,180 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+
+namespace Duplicati.Library.Common.IO;
+
+/// <summary>
+/// Helper class for working with file attributes not listed in <see cref="FileAttributes"/>
+/// </summary>
+public static class ExtendedFileAttributes
+{
+    /// <summary>
+    /// Comprehensive mapping of Windows FILE_ATTRIBUTE_* constants from winnt.h
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    [Flags]
+    public enum Win32FileAttributes : uint
+    {
+        /// <summary>No attributes set.</summary>
+        None = 0x00000000,
+
+        /// <summary>FILE_ATTRIBUTE_READONLY: File is read-only.</summary>
+        ReadOnly = 0x00000001,
+
+        /// <summary>FILE_ATTRIBUTE_HIDDEN: File or directory is hidden.</summary>
+        Hidden = 0x00000002,
+
+        /// <summary>FILE_ATTRIBUTE_SYSTEM: Part of or used exclusively by the OS.</summary>
+        System = 0x00000004,
+
+        /// <summary>FILE_ATTRIBUTE_DIRECTORY: Identifies a directory handle.</summary>
+        Directory = 0x00000010,
+
+        /// <summary>FILE_ATTRIBUTE_ARCHIVE: Marked for backup or removal.</summary>
+        Archive = 0x00000020,
+
+        /// <summary>FILE_ATTRIBUTE_DEVICE: Reserved for system use.</summary>
+        Device = 0x00000040,
+
+        /// <summary>FILE_ATTRIBUTE_NORMAL: No other attributes set (only valid when used alone).</summary>
+        Normal = 0x00000080,
+
+        /// <summary>FILE_ATTRIBUTE_TEMPORARY: Used for temporary storage; cached heavily.</summary>
+        Temporary = 0x00000100,
+
+        /// <summary>FILE_ATTRIBUTE_SPARSE_FILE: File is a sparse file.</summary>
+        SparseFile = 0x00000200,
+
+        /// <summary>FILE_ATTRIBUTE_REPARSE_POINT: Has an associated reparse point or symlink.</summary>
+        ReparsePoint = 0x00000400,
+
+        /// <summary>FILE_ATTRIBUTE_COMPRESSED: All data in the file/directory is compressed.</summary>
+        Compressed = 0x00000800,
+
+        /// <summary>FILE_ATTRIBUTE_OFFLINE: Data physically moved to offline storage.</summary>
+        Offline = 0x00001000,
+
+        /// <summary>FILE_ATTRIBUTE_NOT_CONTENT_INDEXED: Will not be indexed by content indexing services.</summary>
+        NotContentIndexed = 0x00002000,
+
+        /// <summary>FILE_ATTRIBUTE_ENCRYPTED: File or directory is encrypted.</summary>
+        Encrypted = 0x00004000,
+
+        /// <summary>FILE_ATTRIBUTE_INTEGRITY_STREAM: ReFS directory/stream configured with integrity.</summary>
+        IntegrityStream = 0x00008000,
+
+        /// <summary>FILE_ATTRIBUTE_VIRTUAL: Reserved for internal system use.</summary>
+        Virtual = 0x00010000,
+
+        /// <summary>FILE_ATTRIBUTE_NO_SCRUB_DATA: Stream skipped by background data integrity scanner.</summary>
+        NoScrubData = 0x00020000,
+
+        /// <summary>FILE_ATTRIBUTE_EA: File/directory has extended attributes (Internal use only).</summary>
+        ExtendedAttributes = 0x00040000,
+
+        /// <summary>FILE_ATTRIBUTE_RECALL_ON_OPEN: Completely virtual, has no local physical representation.</summary>
+        RecallOnOpen = 0x00040000,
+
+        /// <summary>FILE_ATTRIBUTE_PINNED: Cloud file system user intent to keep fully present locally.</summary>
+        Pinned = 0x00080000,
+
+        /// <summary>FILE_ATTRIBUTE_UNPINNED: Cloud file system intent to NOT keep present unless active.</summary>
+        Unpinned = 0x00100000,
+
+        /// <summary>FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS: Not fully present locally; reading will fetch from cloud.</summary>
+        RecallOnDataAccess = 0x00400000
+    }
+
+    /// <summary>
+    /// Merge the default C# FileAttributes with the Win32FileAttributes and return the union.
+    /// </summary>
+    private static Lazy<Dictionary<string, uint>> _nameToValueMap = new Lazy<Dictionary<string, uint>>(() =>
+    {
+        var map = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
+        var included = new HashSet<uint>();
+
+        // Add the built-in values
+        foreach (var name in Enum.GetNames<FileAttributes>())
+        {
+            map[name] = (uint)Enum.Parse<FileAttributes>(name);
+            included.Add(map[name]);
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            // Merge in the Win32FileAttributes, but prefer the built-in values
+            foreach (var name in Enum.GetNames<Win32FileAttributes>())
+            {
+                if (map.ContainsKey(name))
+                    continue;
+
+                var value = (uint)Enum.Parse<Win32FileAttributes>(name);
+                if (included.Contains(value))
+                    continue;
+
+                map[name] = value;
+            }
+        }
+
+        return map;
+    });
+
+    /// <summary>
+    /// Get the names of all known file attributes, including both the built-in and Win32 values.
+    /// </summary>
+    /// <returns>The list of known file attribute names.</returns>
+    public static IEnumerable<string> GetNames(bool includeNone)
+        => _nameToValueMap.Value.Keys.Where(x => includeNone || x != nameof(FileAttributes.None));
+
+    /// <summary>
+    /// Get the file attributes that mark files as not local on the system.
+    /// </summary>
+    public static FileAttributes NonLocalAttributes
+        => OperatingSystem.IsWindows()
+            ? (FileAttributes)(Win32FileAttributes.Offline | Win32FileAttributes.RecallOnOpen | Win32FileAttributes.RecallOnDataAccess)
+            : FileAttributes.Offline;
+
+    /// <summary>
+    /// Parse a comma-separated list of file attribute names into a FileAttributes value.
+    /// </summary>
+    /// <param name="names">The comma-separated list of file attribute names.</param>
+    /// <returns>The parsed FileAttributes value.</returns>
+    public static FileAttributes Parse(string names)
+    {
+        if (string.IsNullOrWhiteSpace(names))
+            return FileAttributes.None;
+
+        var result = 0u;
+        foreach (var name in names.Split([','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (_nameToValueMap.Value.TryGetValue(name, out var value))
+                result |= value;
+        }
+
+        return (FileAttributes)result;
+    }
+}

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1181,7 +1181,7 @@ namespace Duplicati.Library.Main
             get
             {
                 var result = Common.IO.ExtendedFileAttributes.Parse(m_options.GetValueOrDefault("exclude-files-attributes"));
-                var excludeNonLocalFiles = GetBool("exclude-nonlocal-files");
+                var excludeNonLocalFiles = GetBool("exclude-non-local-files");
                 if (excludeNonLocalFiles)
                     result |= Common.IO.ExtendedFileAttributes.NonLocalAttributes;
                 return result;

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -376,6 +376,7 @@ namespace Duplicati.Library.Main
                 yield return new CommandLineArgument("vss-use-mapping", CommandLineArgument.ArgumentType.Boolean, Strings.Options.VssusemappingShort, Strings.Options.VssusemappingLong, "false");
                 yield return new CommandLineArgument("usn-policy", CommandLineArgument.ArgumentType.Enumeration, Strings.Options.UsnpolicyShort, Strings.Options.UsnpolicyLong, "off", null, Enum.GetNames(typeof(OptimizationStrategy)));
                 yield return new CommandLineArgument("backupread-policy", CommandLineArgument.ArgumentType.Enumeration, Strings.Options.BackupreadpolicyShort, Strings.Options.BackupreadpolicyLong, DEFAULT_BACKUPREAD_POLICY.ToString(), null, Enum.GetNames(typeof(OptimizationStrategy)));
+                yield return new CommandLineArgument("exclude-non-local-files", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ExcludenonlocalfilesShort, Strings.Options.ExcludenonlocalfilesLong, "false");
             }
 
             if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
@@ -493,7 +494,7 @@ namespace Duplicati.Library.Main
 
             new CommandLineArgument("symlink-policy", CommandLineArgument.ArgumentType.Enumeration, Strings.Options.SymlinkpolicyShort, Strings.Options.SymlinkpolicyLong("store", "ignore", "follow"), Enum.GetName(typeof(SymlinkStrategy), SymlinkStrategy.Store), null, Enum.GetNames(typeof(SymlinkStrategy))),
             new CommandLineArgument("hardlink-policy", CommandLineArgument.ArgumentType.Enumeration, Strings.Options.HardlinkpolicyShort, Strings.Options.HardlinkpolicyLong("first", "all", "none"), Enum.GetName(typeof(HardlinkStrategy), HardlinkStrategy.All), null, Enum.GetNames(typeof(HardlinkStrategy))),
-            new CommandLineArgument("exclude-files-attributes", CommandLineArgument.ArgumentType.String, Strings.Options.ExcludefilesattributesShort, Strings.Options.ExcludefilesattributesLong(Enum.GetNames(typeof(System.IO.FileAttributes)))),
+            new CommandLineArgument("exclude-files-attributes", CommandLineArgument.ArgumentType.Flags, Strings.Options.ExcludefilesattributesShort, Strings.Options.ExcludefilesattributesLong, null, null, Common.IO.ExtendedFileAttributes.GetNames(false).ToArray()),
             new CommandLineArgument("compression-extension-file", CommandLineArgument.ArgumentType.Path, Strings.Options.CompressionextensionfileShort, Strings.Options.CompressionextensionfileLong(DEFAULT_COMPRESSED_EXTENSION_FILE), DEFAULT_COMPRESSED_EXTENSION_FILE),
 
             new CommandLineArgument("machine-id", CommandLineArgument.ArgumentType.String, Strings.Options.MachineidShort, Strings.Options.MachineidLong, Library.AutoUpdater.DataFolderManager.InstallID),
@@ -1176,7 +1177,16 @@ namespace Duplicati.Library.Main
         /// Gets the attribute filter used to exclude files and folders.
         /// </summary>
         public System.IO.FileAttributes FileAttributeFilter
-            => Library.Utility.Utility.ParseFlagsOption(m_options, "exclude-files-attributes", default(System.IO.FileAttributes));
+        {
+            get
+            {
+                var result = Common.IO.ExtendedFileAttributes.Parse(m_options.GetValueOrDefault("exclude-files-attributes"));
+                var excludeNonLocalFiles = GetBool("exclude-nonlocal-files");
+                if (excludeNonLocalFiles)
+                    result |= Common.IO.ExtendedFileAttributes.NonLocalAttributes;
+                return result;
+            }
+        }
 
         /// <summary>
         /// A value indicating if server uploads are verified by listing the folder contents

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -173,8 +173,10 @@ namespace Duplicati.Library.Main.Strings
         public static string SymlinkpolicyShort { get { return LC.L(@"Symlink handling"); } }
         public static string HardlinkpolicyLong(string first, string all, string none) { return LC.L(@"Use this option to handle hardlinks (only works on Linux/OSX). The ""{0}"" option will record a hardlink ID for each hardlink to avoid storing hardlinked paths multiple times. The option ""{1}"" will ignore hardlink information, and treat each hardlink as a unique path. The option ""{2}"" will ignore all hardlinks with more than one link.", first, all, none); }
         public static string HardlinkpolicyShort { get { return LC.L(@"Hardlink handling"); } }
-        public static string ExcludefilesattributesLong(string[] attributes) { return LC.L(@"Use this option to exclude files with certain attributes. Use a comma separated list of attribute names to specify more than one. Possible values are: {0}.", string.Join(", ", attributes)); }
+        public static string ExcludefilesattributesLong { get { return LC.L(@"Use this option to exclude files with certain attributes. Use a comma separated list of attribute names to specify more than one."); } }
         public static string ExcludefilesattributesShort { get { return LC.L(@"Exclude files by attribute"); } }
+        public static string ExcludenonlocalfilesShort { get { return LC.L(@"Exclude non-local files"); } }
+        public static string ExcludenonlocalfilesLong { get { return LC.L(@"Use this option to exclude files that are not stored locally, such as those from synchroniztion tools like Dropbox, OneDrive, etc."); } }
         public static string VssusemappingLong { get { return LC.L(@"Activate this option to map VSS snapshots to a drive (similar to SUBST, using Win32 DefineDosDevice). This will create temporary drives that are then used to access the contents of a snapshot. This workaround can speed up file access on Windows XP."); } }
         public static string VssusemappingShort { get { return LC.L(@"Map snapshots to a drive (Windows only)"); } }
         public static string BackupnameLong { get { return LC.L(@"A display name that is attached to this backup. This can be used to identify the backup when sending mail or running scripts."); } }

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -813,10 +813,9 @@ namespace Duplicati.Library.Utility
                 return @default;
 
             var flags = 0;
-            foreach (var s in value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var s in value.Split([','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
-                var trimmed = s.Trim();
-                if (Enum.TryParse(trimmed, true, out T flag))
+                if (Enum.TryParse(s, true, out T flag))
                     flags = flags | (int)(object)flag;
             }
 


### PR DESCRIPTION
This PR extends the handling of excluded file attributes on Windows to include additional values that are present in Windows 10+11, but are not yet part of the .NET file attributes.

Specifically, this handles the `FILE_ATTRIBUTE_RECALL_ON_OPEN` and `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS` attributes which are used to signal files are not available locally and will be fetched on access.

On Windows, a new option `--exclude-non-local-files` is added which will simply update `--exclude-files-attributes` with `Offline,RecallOnOpen,RecallOnDataAccess` such that setting the option will exclude offline files from the backup, without requiring that the user is aware of the attribute names or effects.

For all platforms, this PR also updates the parsing of the `--exclude-files-attributes` so it is now a flags-type enum and will validate the input as well as show the possible options in help and dropdowns.

This fixes #6942