### PR TITLE
Fixed a case-change issue with USN

### DIFF
--- a/Duplicati/Library/Snapshots/USN/USNJournal.cs
+++ b/Duplicati/Library/Snapshots/USN/USNJournal.cs
@@ -555,7 +555,12 @@ namespace Duplicati.Library.Snapshots.USN
                 FlushRecords(tempRecords, result);
             }
 
-            return result.Values;
+            // We rely on the USN record order,
+            // specifically for rename where the old name
+            // is emitted before the new name
+            var sorted = result.Values.ToList();
+            sorted.Sort((a, b) => a.UsnRecord.Usn.CompareTo(b.UsnRecord.Usn));
+            return sorted;
         }
 
         private static void FlushRecords(List<Record> tempRecords, Dictionary<string, Record> resultRecords)

--- a/Duplicati/Library/Snapshots/USN/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/USN/UsnJournalService.cs
@@ -155,8 +155,8 @@ namespace Duplicati.Library.Snapshots.USN
                     if (prevData.ConfigHash != nextData.ConfigHash)
                         throw new UsnJournalSoftFailureException(Strings.USNHelper.ConfigHashChanged);
 
-                    var changedFiles = new HashSet<string>(Utility.Utility.ClientFilenameStringComparer);
-                    var changedFolders = new HashSet<string>(Utility.Utility.ClientFilenameStringComparer);
+                    var changedFiles = new Dictionary<string, string>(Utility.Utility.ClientFilenameStringComparer);
+                    var changedFolders = new Dictionary<string, string>(Utility.Utility.ClientFilenameStringComparer);
 
                     // obtain changed files and folders, per volume
                     foreach (var source in volumeSources)
@@ -169,11 +169,13 @@ namespace Duplicati.Library.Snapshots.USN
 
                             if (entry.Item2.HasFlag(USNJournal.EntryType.File))
                             {
-                                changedFiles.Add(entry.Item1);
+                                // Retain the new path, but overwrite previous path (case-preserving)
+                                changedFiles[entry.Item1] = entry.Item1;
                             }
                             else
                             {
-                                changedFolders.Add(Util.AppendDirSeparator(entry.Item1));
+                                var folder = Util.AppendDirSeparator(entry.Item1);
+                                changedFolders[folder] = folder;
                             }
                         }
                     }
@@ -186,13 +188,13 @@ namespace Duplicati.Library.Snapshots.USN
                     //
                     // 1. Simplify the folder list, such that it only contains the parent-most entries 
                     //     (e.g. { "C:\A\B\", "C:\A\B\C\", "C:\A\B\D\E\" } => { "C:\A\B\" }
-                    volumeData.Folders = Utility.Utility.SimplifyFolderList(changedFolders).ToList();
+                    volumeData.Folders = Utility.Utility.SimplifyFolderList(changedFolders.Values).ToList();
 
                     // 2. Our list of files may contain entries inside one of the simplified folders (from step 1., above).
                     //    Since that folder is going to be fully scanned, those files can be removed.
                     //    Note: it would be wrong to use the result from step 2. as the folder list! The entries removed
                     //          between 1. and 2. are *excluded* folders, and files below them are to be *excluded*, too.
-                    volumeData.Files = [.. Utility.Utility.GetFilesNotInFolders(changedFiles, volumeData.Folders)];
+                    volumeData.Files = new HashSet<string>(Utility.Utility.GetFilesNotInFolders(changedFiles.Values, volumeData.Folders), Utility.Utility.ClientFilenameStringComparer);
 
                     // Record success for volume
                     volumeData.IsFullScan = false;
@@ -203,7 +205,7 @@ namespace Duplicati.Library.Snapshots.USN
                     volumeData.Exception = e;
                     volumeData.IsFullScan = true;
                     volumeData.Folders = new List<string>();
-                    volumeData.Files = new HashSet<string>();
+                    volumeData.Files = new HashSet<string>(Utility.Utility.ClientFilenameStringComparer);
 
                     // use original sources
                     foreach (var path in volumeSources)

--- a/Duplicati/UnitTest/Issue4951.cs
+++ b/Duplicati/UnitTest/Issue4951.cs
@@ -1,0 +1,88 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest;
+
+public class Issue4951 : BasicSetupHelper
+{
+    [Test]
+    [Category("USN")]
+    public async Task RenameCaseChangeUSNAsync([Values(true, false)] bool useUSN)
+    {
+        if (!OperatingSystem.IsWindows())
+            Assert.Ignore("USN journal is only supported on Windows");
+
+        var testopts = TestOptions;
+        if (useUSN)
+            testopts["usn-policy"] = "required";
+
+        // Step 1: Create a directory and a file
+        var dataFolder = Path.Combine(DATAFOLDER, "usn_case_test");
+        if (Directory.Exists(dataFolder))
+            Directory.Delete(dataFolder, true);
+        Directory.CreateDirectory(dataFolder);
+
+        var originalFileName = "testFILE.txt";
+        var renamedFileName = "testfile.txt";
+
+        var filePath = Path.Combine(dataFolder, originalFileName);
+        File.WriteAllText(filePath, "Some initial content");
+
+        // Step 2: Initial backup
+        using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+        {
+            var res = await c.BackupAsync([dataFolder]);
+            Assert.AreEqual(0, res.Errors.Count(), "Errors in initial backup");
+            Assert.AreEqual(0, res.Warnings.Count(), $"Warnings in initial backup: {string.Join(Environment.NewLine, res.Warnings)}");
+            Assert.AreEqual(1, res.AddedFiles, "Expected 1 added file");
+        }
+
+        // Step 3: Rename file by changing case
+        var renamedFilePath = Path.Combine(dataFolder, renamedFileName);
+        File.Move(filePath, renamedFilePath);
+
+        // Step 4: Backup again
+        using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+        {
+            var res = await c.BackupAsync([dataFolder]);
+            Assert.AreEqual(0, res.Errors.Count(), "Errors in second backup");
+            Assert.AreEqual(0, res.Warnings.Count(), $"Added:{res.AddedFiles}, Warnings in second backup: {string.Join(Environment.NewLine, res.Warnings)}");
+
+            var list = await c.ListAsync("*");
+            // Case sensitive compare to check we have the new file
+            Assert.IsTrue(list.Files.Any(x => x.Path.EndsWith("testfile.txt")),
+                $"Incorrect file list:{string.Join(", ", list.Files.Select(x => x.Path))}");
+
+            // Rename is path delete+add
+            Assert.IsTrue(
+                res.AddedFiles == 1,
+                $"Backup did not record the case change, added: {res.AddedFiles}, deleted: {res.DeletedFiles} , opened files {res.OpenedFiles}, modified files: {res.ModifiedFiles}, examinedFiles: {res.ExaminedFiles}."
+            );
+        }
+    }
+}


### PR DESCRIPTION
This fixes a case where an unmodified file that was renamed, but only had changes to the casing (i.e., `file.txt` to `FILE.txt`) would ignore the new name.

If the file contents or metadata were changed, the filename would be updated, but for pure renames, the new name would not be picked up.

This issue is only present if USN was also applied, and the bug is only present on Windows.

This fixes #4951.
This closes #4952.