### PR TITLE
Rename to fix warnings

### DIFF
--- a/Duplicati/CommandLine/ConfigureTool/Program.cs
+++ b/Duplicati/CommandLine/ConfigureTool/Program.cs
@@ -21,7 +21,6 @@
 
 using System.CommandLine;
 using System.CommandLine.Builder;
-using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
 using System.Reflection;
 using Duplicati.CommandLine.ConfigureTool.Commands;
@@ -37,7 +36,7 @@ public static class Program
     /// <summary>
     /// The main entry point for the application.
     /// </summary>
-    public static Task<int> Main(string[] args)
+    public static Task<int> MainAsync(string[] args)
     {
         Library.AutoUpdater.PreloadSettingsLoader.ConfigurePreloadSettings(ref args, Library.AutoUpdater.PackageHelper.NamedExecutable.ConfigureTool);
 
@@ -64,7 +63,7 @@ public static class Program
                 var rex = ex is TargetInvocationException tie
                     ? tie.InnerException
                     : ex;
-                    
+
                 if (rex is UserInformationException userInformationException)
                 {
                     Console.WriteLine("ErrorID: {0}", userInformationException.HelpID);

--- a/Duplicati/CommandLine/ServerUtil/Commands/ChangePassword.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/ChangePassword.cs
@@ -36,7 +36,7 @@ public static class ChangePassword
         .WithHandler(CommandHandler.Create<Settings, OutputInterceptor, string>(async (settings, output, newPassword) =>
         {
             // Ask for previous password first, if needed
-            var connection = await settings.GetConnection(output);
+            var connection = await settings.GetConnectionAsync(output);
 
             if (string.IsNullOrWhiteSpace(newPassword))
             {
@@ -52,11 +52,11 @@ public static class ChangePassword
             if (settings.SecretProvider != null)
             {
                 var opts = new Dictionary<string, string?> { { "password", newPassword } };
-                await settings.ReplaceSecrets(opts).ConfigureAwait(false);
+                await settings.ReplaceSecretsAsync(opts).ConfigureAwait(false);
                 newPassword = opts["password"]!;
             }
 
-            await connection.ChangePassword(newPassword);
+            await connection.ChangePasswordAsync(newPassword);
             output.SetResult(true);
         }));
 }

--- a/Duplicati/CommandLine/ServerUtil/Commands/DeleteBackup.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/DeleteBackup.cs
@@ -41,9 +41,9 @@ public static class DeleteBackup
         }
         .WithHandler(CommandHandler.Create<Settings, OutputInterceptor, string, bool, bool, bool, bool>(async (settings, output, backup, deleteRemoteFiles, deleteLocalDb, force, quiet) =>
         {
-            var connection = await settings.GetConnection(output);
+            var connection = await settings.GetConnectionAsync(output);
 
-            var matchingBackup = (await connection.ListBackups())
+            var matchingBackup = (await connection.ListBackupsAsync())
                 .FirstOrDefault(b => string.Equals(b.Name, backup, StringComparison.OrdinalIgnoreCase) || string.Equals(b.ID, backup));
 
             if (matchingBackup == null)
@@ -52,7 +52,7 @@ public static class DeleteBackup
             if (!quiet)
                 output.AppendConsoleMessage($"Queueing delete for backup {matchingBackup.Name} (ID: {matchingBackup.ID})");
 
-            await connection.DeleteBackup(matchingBackup.ID, deleteRemoteFiles: deleteRemoteFiles, deleteLocalDb: deleteLocalDb, force: force);
+            await connection.DeleteBackupAsync(matchingBackup.ID, deleteRemoteFiles: deleteRemoteFiles, deleteLocalDb: deleteLocalDb, force: force);
 
             if (!quiet)
                 output.AppendConsoleMessage("Delete task queued");

--- a/Duplicati/CommandLine/ServerUtil/Commands/Export.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/Export.cs
@@ -47,8 +47,8 @@ public static class Export
                 destination.Create();
             }
 
-            var connection = await settings.GetConnection(output);
-            var serverbackups = await connection.ListBackups();
+            var connection = await settings.GetConnectionAsync(output);
+            var serverbackups = await connection.ListBackupsAsync();
             var includeAllBackups = backups.Any(x => string.Equals(x, "all", StringComparison.OrdinalIgnoreCase));
             var targetbackups = serverbackups.Where(b => includeAllBackups || backups.Any(x => b.Name.Contains(x, StringComparison.OrdinalIgnoreCase)) || backups.Contains(b.ID.ToString())).ToArray();
             if (targetbackups.Length == 0)
@@ -83,7 +83,7 @@ public static class Export
                 if (settings.SecretProvider != null)
                 {
                     var opts = new Dictionary<string, string?> { { "password", encryptionPassphrase } };
-                    await settings.ReplaceSecrets(opts).ConfigureAwait(false);
+                    await settings.ReplaceSecretsAsync(opts).ConfigureAwait(false);
                     encryptionPassphrase = opts["password"]!;
                 }
 
@@ -107,7 +107,7 @@ public static class Export
                     continue;
                 }
 
-                await using (var s = await connection.ExportBackup(backup.ID, encryptionPassphrase, exportPasswords.Value))
+                await using (var s = await connection.ExportBackupAsync(backup.ID, encryptionPassphrase, exportPasswords.Value))
                 await using (var fs = file.Create())
                     await s.CopyToAsync(fs);
                 exportedBackups.Add(new { Id = backup.ID, Name = backup.Name, File = file.FullName });

--- a/Duplicati/CommandLine/ServerUtil/Commands/Import.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/Import.cs
@@ -59,7 +59,7 @@ public static class Import
                 if (settings.SecretProvider != null)
                 {
                     var opts = new Dictionary<string, string?> { { "password", passphrase } };
-                    await settings.ReplaceSecrets(opts).ConfigureAwait(false);
+                    await settings.ReplaceSecretsAsync(opts).ConfigureAwait(false);
                     passphrase = opts["password"]!;
                 }
             }
@@ -70,8 +70,8 @@ public static class Import
             if (!string.IsNullOrWhiteSpace(backupUrl))
                 extraSettings.Add("targeturl", backupUrl);
 
-            var connection = await settings.GetConnection(output);
-            var result = await connection.ImportBackup(file.FullName, passphrase, importMetadata, extraSettings);
+            var connection = await settings.GetConnectionAsync(output);
+            var result = await connection.ImportBackupAsync(file.FullName, passphrase, importMetadata, extraSettings);
 
             output.AppendConsoleMessage($"Imported \"{result.Name}\" with ID {result.ID}");
             output.AppendCustomObject("Imported", new { Id = result.ID, Name = result.Name });

--- a/Duplicati/CommandLine/ServerUtil/Commands/IssueForeverToken.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/IssueForeverToken.cs
@@ -29,7 +29,7 @@ public static class IssueForeverToken
     public static Command Create() =>
         new Command("issue-forever-token", "Issues a long-lived access token").WithHandler(CommandHandler.Create<Settings, OutputInterceptor>(async (settings, output) =>
         {
-            var token = await (await settings.GetConnection(output)).CreateForeverToken();
+            var token = await (await settings.GetConnectionAsync(output)).CreateForeverTokenAsync();
             output.AppendConsoleMessage("Token issued with a lifetime of 10 years.");
             output.AppendConsoleMessage("Make sure you disable the forever token API on the server, to avoid generating new tokens.");
             output.AppendConsoleMessage(string.Empty);
@@ -38,7 +38,7 @@ public static class IssueForeverToken
             output.AppendConsoleMessage("The issued token is:");
             output.AppendConsoleMessage($"Authorization: Bearer {token}");
             output.AppendConsoleMessage(string.Empty);
-            output.AppendCustomObject( "Token" ,new { Token = token });;
+            output.AppendCustomObject("Token", new { Token = token }); ;
             output.SetResult(true);
         }));
 }

--- a/Duplicati/CommandLine/ServerUtil/Commands/ListBackups.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/ListBackups.cs
@@ -37,7 +37,7 @@ public static class ListBackups
         }
         .WithHandler(CommandHandler.Create<Settings, OutputInterceptor, bool>(async (settings, output, detailed) =>
         {
-            var bks = await (await settings.GetConnection(output)).ListBackups();
+            var bks = await (await settings.GetConnectionAsync(output)).ListBackupsAsync();
 
             var backupEntries = bks as Connection.BackupEntry[] ?? bks.ToArray();
             if (backupEntries.Any())

--- a/Duplicati/CommandLine/ServerUtil/Commands/Login.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/Login.cs
@@ -31,7 +31,7 @@ public static class Login
         .WithHandler(CommandHandler.Create<Settings, OutputInterceptor>(async (settings, output) =>
             {
                 output.AppendConsoleMessage("Logging in to the server");
-                await Connection.Connect(settings, true, output);
+                await Connection.ConnectAsync(settings, true, output);
                 output.AppendConsoleMessage("Logged in, persistent token saved");
                 output.SetResult(true);
             })

--- a/Duplicati/CommandLine/ServerUtil/Commands/Logout.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/Logout.cs
@@ -31,7 +31,7 @@ public static class Logout
         .WithHandler(CommandHandler.Create<Settings, OutputInterceptor>(async (settings, output) =>
             {
                 output.AppendConsoleMessage("Logging out of the server...");
-                await (await settings.GetConnection(output)).Logout(settings, output);
+                await (await settings.GetConnectionAsync(output)).LogoutAsync(settings, output);
                 // If no exception we presume success
                 output.SetResult(true);
             })

--- a/Duplicati/CommandLine/ServerUtil/Commands/Pause.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/Pause.cs
@@ -39,8 +39,8 @@ public static class Pause
                 ? "Pausing the server indefinitely"
                 : $"Pausing the server for {duration}");
 
-            await (await settings.GetConnection(output)).Pause(duration);
-            
+            await (await settings.GetConnectionAsync(output)).PauseAsync(duration);
+
             // If no exception we presume success
             output.SetResult(true);
         }));

--- a/Duplicati/CommandLine/ServerUtil/Commands/Resume.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/Resume.cs
@@ -30,8 +30,8 @@ public static class Resume
         => new Command("resume", "Resumes the server")
             .WithHandler(CommandHandler.Create<Settings, OutputInterceptor>(async (settings, output) =>
             {
-               output.AppendConsoleMessage("Resuming the server...");
-               await (await settings.GetConnection(output)).Resume();
-               output.SetResult(true);
+                output.AppendConsoleMessage("Resuming the server...");
+                await (await settings.GetConnectionAsync(output)).ResumeAsync();
+                output.SetResult(true);
             }));
 }

--- a/Duplicati/CommandLine/ServerUtil/Commands/RunBackup.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/RunBackup.cs
@@ -50,9 +50,9 @@ public static class RunBackup
             if (pollinterval < 1)
                 throw new UserReportedException("Poll interval must be at least 1 second");
 
-            var connection = await settings.GetConnection(output);
+            var connection = await settings.GetConnectionAsync(output);
 
-            var matchingBackup = (await connection.ListBackups())
+            var matchingBackup = (await connection.ListBackupsAsync())
                 .FirstOrDefault(b => string.Equals(b.Name, backup, StringComparison.OrdinalIgnoreCase) || string.Equals(b.ID, backup));
 
             if (matchingBackup == null)
@@ -61,19 +61,19 @@ public static class RunBackup
             if (!quiet)
                 output.AppendConsoleMessage($"Running backup {matchingBackup.Name} (ID: {matchingBackup.ID})");
 
-            await connection.RunBackup(matchingBackup.ID, skipqueue);
+            await connection.RunBackupAsync(matchingBackup.ID, skipqueue);
 
             if (wait)
             {
                 if (!quiet)
                     output.AppendConsoleMessage("Waiting for backup to finish...");
 
-                await WaitForBackupWithRetries(connection, settings, matchingBackup.ID, pollinterval, output, msg =>
+                await WaitForBackupWithRetriesAsync(connection, settings, matchingBackup.ID, pollinterval, output, msg =>
                 {
                     if (!quiet)
                         output.AppendConsoleMessage($"[{DateTime.Now}]: {msg}");
                 });
-                var response = await connection.GetBackupStatus(matchingBackup.ID);
+                var response = await connection.GetBackupStatusAsync(matchingBackup.ID);
                 if (!quiet)
                     output.AppendConsoleMessage("Backup status: " + response);
             }
@@ -90,7 +90,7 @@ public static class RunBackup
     /// <param name="output">The output interceptor to use</param>
     /// <param name="onPoll">The action to perform on each poll</param>
     /// <returns>A task that represents the asynchronous operation</returns>
-    private static async Task WaitForBackupWithRetries(Connection connection, Settings settings, string backupId, int pollInterval, OutputInterceptor output, Action<string> onPoll)
+    private static async Task WaitForBackupWithRetriesAsync(Connection connection, Settings settings, string backupId, int pollInterval, OutputInterceptor output, Action<string> onPoll)
     {
         var retry = true;
 
@@ -98,7 +98,7 @@ public static class RunBackup
         {
             try
             {
-                await connection.WaitForBackup(backupId, TimeSpan.FromSeconds(pollInterval), onPoll);
+                await connection.WaitForBackupAsync(backupId, TimeSpan.FromSeconds(pollInterval), onPoll);
                 return;
             }
             catch (Exception)
@@ -108,7 +108,7 @@ public static class RunBackup
                 {
                     // See if we can get a new connection (re-connect)
                     onPoll("Re-authenticating...");
-                    connection = await settings.ReloadPersistedSettings().GetConnection(output);
+                    connection = await settings.ReloadPersistedSettings().GetConnectionAsync(output);
                     retry = true;
                 }
                 catch (Exception)

--- a/Duplicati/CommandLine/ServerUtil/Commands/ServerStatus.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/ServerStatus.cs
@@ -30,11 +30,11 @@ public static class ServerStatus
         new Command("status", "Gets the server status")
         .WithHandler(CommandHandler.Create<Settings, OutputInterceptor>(async (settings, output) =>
         {
-            var state = await (await settings.GetConnection(output)).GetServerState();
-            
+            var state = await (await settings.GetConnectionAsync(output)).GetServerStateAsync();
+
             output.AppendConsoleMessage($"Server state: {state.ProgramState}");
             output.AppendCustomObject("ServerState", state.ProgramState);
-            
+
             if (state.ActiveTask != null)
             {
                 output.AppendConsoleMessage(
@@ -59,7 +59,7 @@ public static class ServerStatus
                 output.AppendConsoleMessage("Scheduler tasks: Empty");
                 output.AppendCustomObject("SchedulerTasks", null);
             }
-            
+
             output.SetResult(true);
         }));
 }

--- a/Duplicati/CommandLine/ServerUtil/Connection.cs
+++ b/Duplicati/CommandLine/ServerUtil/Connection.cs
@@ -158,7 +158,7 @@ public class Connection
     /// <param name="obtainRefreshToken">Whether to obtain a refresh token</param>
     /// <param name="console">Console messages interceptor</param>
     /// <returns>The connection</returns>
-    public static async Task<Connection> Connect(Settings settings, bool obtainRefreshToken = false, OutputInterceptor? console = null)
+    public static async Task<Connection> ConnectAsync(Settings settings, bool obtainRefreshToken = false, OutputInterceptor? console = null)
     {
         if (console != null)
             console.AppendConsoleMessage($"Connecting to {settings.HostUrl}...");
@@ -192,7 +192,7 @@ public class Connection
         {
             if (!string.IsNullOrWhiteSpace(settings.RefreshToken))
             {
-                var (accessToken, refreshToken, refreshNonce) = await LoginWithRefreshToken(client, settings.RefreshToken, settings.RefreshNonce);
+                var (accessToken, refreshToken, refreshNonce) = await LoginWithRefreshTokenAsync(client, settings.RefreshToken, settings.RefreshNonce);
                 if (string.IsNullOrWhiteSpace(accessToken))
                     throw new InvalidOperationException("Failed to get access token");
                 if (string.IsNullOrWhiteSpace(refreshToken))
@@ -241,7 +241,7 @@ public class Connection
                         ).CreateSigninToken("server-cli");
 
                         var responseTask = client.PostAsync("auth/signin", JsonContent.Create(new { SigninToken = signinjwt, RememberMe = obtainRefreshToken }));
-                        var (accessToken, refreshToken, refreshNonce) = await ParseAuthResponse(responseTask);
+                        var (accessToken, refreshToken, refreshNonce) = await ParseAuthResponseAsync(responseTask);
                         if (string.IsNullOrWhiteSpace(accessToken))
                             throw new InvalidOperationException("Failed to get access token");
 
@@ -278,7 +278,7 @@ public class Connection
             if (string.IsNullOrWhiteSpace(settings.Password))
                 throw new UserReportedException("Password is required");
 
-            var (accessToken, refreshToken, refreshNonce) = await LoginWithPassword(client, settings.Password, obtainRefreshToken);
+            var (accessToken, refreshToken, refreshNonce) = await LoginWithPasswordAsync(client, settings.Password, obtainRefreshToken);
             if (string.IsNullOrWhiteSpace(accessToken))
                 throw new InvalidOperationException("Failed to get access token");
 
@@ -313,8 +313,8 @@ public class Connection
     /// <param name="password">The password to use</param>
     /// <param name="obtainRefreshToken">Whether to obtain a refresh token</param>
     /// <returns>The access and refresh tokens</returns>
-    private static Task<(string AccessToken, string? RefreshToken, string? RefreshNonce)> LoginWithPassword(HttpClient client, string password, bool obtainRefreshToken)
-        => ParseAuthResponse(
+    private static Task<(string AccessToken, string? RefreshToken, string? RefreshNonce)> LoginWithPasswordAsync(HttpClient client, string password, bool obtainRefreshToken)
+        => ParseAuthResponseAsync(
             client.PostAsync("auth/login", JsonContent.Create(new { Password = password, RememberMe = obtainRefreshToken }))
         );
 
@@ -324,9 +324,9 @@ public class Connection
     /// <param name="client">The HTTP client</param>
     /// <param name="refreshToken">The refresh token to use</param>
     /// <returns>The access token, refresh tokens, and nonce</returns>
-    private static Task<(string AccessToken, string? RefreshToken, string? RefreshNonce)> LoginWithRefreshToken(HttpClient client, string refreshToken, string? nonce)
+    private static Task<(string AccessToken, string? RefreshToken, string? RefreshNonce)> LoginWithRefreshTokenAsync(HttpClient client, string refreshToken, string? nonce)
     {
-        return ParseAuthResponse(client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "auth/refresh")
+        return ParseAuthResponseAsync(client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "auth/refresh")
         {
             Headers = { { "Cookie", $"RefreshToken_{client.BaseAddress!.Port}={refreshToken}" } },
             Content = string.IsNullOrWhiteSpace(nonce) ? null : JsonContent.Create(new { Nonce = nonce })
@@ -339,11 +339,11 @@ public class Connection
     /// </summary>
     /// <param name="response">The response to parse</param>
     /// <returns>The access and refresh tokens</returns>
-    private static async Task<(string AccessToken, string? RefreshToken, string? RefreshNonce)> ParseAuthResponse(Task<HttpResponseMessage> responseTask)
+    private static async Task<(string AccessToken, string? RefreshToken, string? RefreshNonce)> ParseAuthResponseAsync(Task<HttpResponseMessage> responseTask)
     {
         var response = await responseTask;
-        await EnsureSuccessStatusCodeWithParsing(response);
-        var json = JsonSerializer.Deserialize<Dictionary<string, string>>(response.Content.ReadAsStringAsync().Result)
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
+        var json = JsonSerializer.Deserialize<Dictionary<string, string>>(await response.Content.ReadAsStringAsync())
             ?? throw new InvalidOperationException("Failed to parse response");
 
         if (!json.TryGetValue("AccessToken", out var accessToken))
@@ -362,31 +362,31 @@ public class Connection
     /// </summary>
     /// <param name="duration">The duration to pause for</param>
     /// <returns>The task</returns>
-    public async Task Pause(string? duration)
+    public async Task PauseAsync(string? duration)
     {
         var query = string.IsNullOrWhiteSpace(duration) ? "" : $"?duration={Uri.EscapeDataString(duration)}";
         var response = await client.PostAsync($"serverstate/pause{query}", null);
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
     }
 
     /// <summary>
     /// Resumes the server
     /// </summary>
     /// <returns>The task</returns>
-    public async Task Resume()
+    public async Task ResumeAsync()
     {
         var response = await client.PostAsync("serverstate/resume", null);
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
     }
 
     /// <summary>
     /// Lists the backups configured on the server
     /// </summary>
     /// <returns>The backups</returns>
-    public async Task<IEnumerable<BackupEntry>> ListBackups()
+    public async Task<IEnumerable<BackupEntry>> ListBackupsAsync()
     {
         var response = await client.GetAsync("backups");
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
 
         return (JsonSerializer.Deserialize<IEnumerable<ResponseBackupEntry>>(await response.Content.ReadAsStringAsync())
             ?? throw new UserReportedException("Failed to parse response"))
@@ -399,10 +399,10 @@ public class Connection
     /// </summary>
     /// <param name="backupId">The ID of the backup</param>
     /// <returns>The backup</returns>
-    public async Task<BackupEntry> GetBackup(string backupId)
+    public async Task<BackupEntry> GetBackupAsync(string backupId)
     {
         var response = await client.GetAsync($"backup/{Uri.EscapeDataString(backupId)}");
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
 
         return (JsonSerializer.Deserialize<ResponseBackupEntry>(await response.Content.ReadAsStringAsync())
             ?? throw new UserReportedException("Failed to parse response"))
@@ -415,10 +415,10 @@ public class Connection
     /// <param name="backupId">The ID of the backup</param>
     /// <param name="skipQueue">Whether to skip the queue</param>
     /// <returns>The task</returns>
-    public async Task RunBackup(string backupId, bool skipQueue)
+    public async Task RunBackupAsync(string backupId, bool skipQueue)
     {
         var response = await client.PostAsync($"backup/{Uri.EscapeDataString(backupId)}/run?skipqueue={skipQueue}", null);
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
     }
 
     /// <summary>
@@ -429,20 +429,20 @@ public class Connection
     /// <param name="deleteLocalDb">Whether to delete the local database</param>
     /// <param name="force">Whether to force the deletion even if the backup is running at the moment</param>
     /// <returns>The task</returns>
-    public async Task DeleteBackup(string backupId, bool deleteRemoteFiles, bool deleteLocalDb, bool force)
+    public async Task DeleteBackupAsync(string backupId, bool deleteRemoteFiles, bool deleteLocalDb, bool force)
     {
         var response = await client.DeleteAsync($"backup/{Uri.EscapeDataString(backupId)}?delete-remote-files={deleteRemoteFiles}&delete-local-db={deleteLocalDb}&force={force}");
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
     }
 
     /// <summary>
     /// Gets the server state
     /// </summary>
     /// <returns>The server state</returns>
-    public async Task<ServerState> GetServerState()
+    public async Task<ServerState> GetServerStateAsync()
     {
         var response = await client.GetAsync("serverstate");
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
         return await response.Content.ReadFromJsonAsync<ServerState>()
             ?? throw new InvalidDataException("Failed to parse server response");
     }
@@ -452,10 +452,10 @@ public class Connection
     /// </summary>
     /// <param name="backupId">The ID of the backup</param>
     /// <returns>The status of the most recent backup log</returns>
-    public async Task<string> GetBackupStatus(string backupId)
+    public async Task<string> GetBackupStatusAsync(string backupId)
     {
         var response = await client.GetAsync($"backup/{Uri.EscapeDataString(backupId)}/log");
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
 
         var parsedLogs = await response.Content.ReadFromJsonAsync<List<Dictionary<string, object>>>()
             ?? throw new UserReportedException("Failed to parse response");
@@ -480,9 +480,9 @@ public class Connection
     /// </summary>
     /// <param name="backupId">The ID of the backup</param>
     /// <returns>The task</returns>
-    public async Task WaitForBackup(string backupId, TimeSpan delay, Action<string> statusMessage)
+    public async Task WaitForBackupAsync(string backupId, TimeSpan delay, Action<string> statusMessage)
     {
-        var state = await GetServerState();
+        var state = await GetServerStateAsync();
 
         if (!state.SchedulerQueueIds.Any(x => x.Item2 == backupId) && state.ActiveTask?.Item2 != backupId)
             throw new UserReportedException("Backup is not queued or running");
@@ -492,7 +492,7 @@ public class Connection
         while (true)
         {
             await Task.Delay(delay);
-            state = await GetServerState();
+            state = await GetServerStateAsync();
 
             if (state.ActiveTask?.Item2 == backupId)
             {
@@ -515,10 +515,10 @@ public class Connection
     /// Lists the active tasks
     /// </summary>
     /// <returns>The tasks</returns>
-    public async Task<IEnumerable<TaskEntry>> ListTasks()
+    public async Task<IEnumerable<TaskEntry>> ListTasksAsync()
     {
         var response = await client.GetAsync("tasks");
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
 
         return JsonSerializer.Deserialize<IEnumerable<TaskEntry>>(await response.Content.ReadAsStringAsync())
             ?? throw new InvalidOperationException("Failed to parse response");
@@ -530,7 +530,7 @@ public class Connection
     /// <param name="taskId">The ID of the task</param>
     /// <param name="level">The level to stop at</param>
     /// <returns>The task</returns>
-    public async Task StopTask(string taskId, StopLevel level = StopLevel.AfterCurrentFile)
+    public async Task StopTaskAsync(string taskId, StopLevel level = StopLevel.AfterCurrentFile)
     {
         var levelString = level switch
         {
@@ -540,7 +540,7 @@ public class Connection
             _ => throw new ArgumentOutOfRangeException(nameof(level))
         };
         var response = await client.PostAsync($"task/{Uri.EscapeDataString(taskId)}/{levelString}", null);
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
     }
 
     /// <summary>
@@ -549,13 +549,13 @@ public class Connection
     /// <param name="settings">The settings to use</param>
     /// <param name="output"></param>
     /// <returns>The task</returns>
-    public async Task Logout(Settings settings, OutputInterceptor output)
+    public async Task LogoutAsync(Settings settings, OutputInterceptor output)
     {
         var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, "auth/refresh/logout")
         {
             Headers = { { "Cookie", $"RefreshToken_{client.BaseAddress!.Port}={settings.RefreshToken}" } }
         });
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
         (settings with { RefreshToken = null }).Save(output);
     }
 
@@ -564,10 +564,10 @@ public class Connection
     /// </summary>
     /// <param name="newPassword">The new password to use</param>
     /// <returns>The task</returns>
-    public async Task ChangePassword(string newPassword)
+    public async Task ChangePasswordAsync(string newPassword)
     {
         var response = await client.PutAsync("serversetting/server-passphrase", JsonContent.Create(newPassword));
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
     }
 
     /// <summary>
@@ -578,7 +578,7 @@ public class Connection
     /// <param name="importMetadata">Whether to import metadata</param>
     /// <param name="extraSettings">Extra settings to apply to the imported backup</param>
     /// <returns>The backup</returns>
-    public async Task<BackupEntry> ImportBackup(string file, string? password, bool importMetadata, Dictionary<string, string> extraSettings)
+    public async Task<BackupEntry> ImportBackupAsync(string file, string? password, bool importMetadata, Dictionary<string, string> extraSettings)
     {
         var payload = JsonContent.Create(new
         {
@@ -589,14 +589,14 @@ public class Connection
             replace_settings = extraSettings
         });
         var response = await client.PostAsync("backups/import", payload);
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
 
         var json = JsonSerializer.Deserialize<Dictionary<string, string>>(await response.Content.ReadAsStringAsync())
             ?? throw new UserReportedException("Failed to parse response");
         if (!json.TryGetValue("Id", out var id))
             throw new UserReportedException("Added backup but failed to get from response");
 
-        return await GetBackup(id);
+        return await GetBackupAsync(id);
     }
 
     /// <summary>
@@ -606,10 +606,10 @@ public class Connection
     /// <param name="passphrase">The passphrase to use, if encrypting</param>
     /// <param name="includeKeys">Whether to include sensitive keys</param>
     /// <returns>The stream with the exported backup</returns>
-    public async Task<Stream> ExportBackup(string backupId, string? passphrase, bool includeKeys)
+    public async Task<Stream> ExportBackupAsync(string backupId, string? passphrase, bool includeKeys)
     {
         var exportTokenResponse = await client.PostAsync("auth/issuetoken/export", null);
-        await EnsureSuccessStatusCodeWithParsing(exportTokenResponse);
+        await EnsureSuccessStatusCodeWithParsingAsync(exportTokenResponse);
         var values = JsonSerializer.Deserialize<Dictionary<string, string>>(await exportTokenResponse.Content.ReadAsStringAsync())
             ?? throw new UserReportedException("Failed to parse response");
 
@@ -617,7 +617,7 @@ public class Connection
             throw new UserReportedException("Failed to get export token");
 
         var response = await client.GetAsync($"backup/{Uri.EscapeDataString(backupId)}/export?passphrase={Uri.EscapeDataString(passphrase ?? "")}&export-passwords={includeKeys}&token={token}");
-        await EnsureSuccessStatusCodeWithParsing(response);
+        await EnsureSuccessStatusCodeWithParsingAsync(response);
 
         return await response.Content.ReadAsStreamAsync();
     }
@@ -626,9 +626,9 @@ public class Connection
     /// Creates a forever token
     /// </summary>
     /// <returns>The token</returns>
-    public async Task<string> CreateForeverToken()
+    public async Task<string> CreateForeverTokenAsync()
     {
-        var (accessToken, _, _) = await ParseAuthResponse(client.PostAsync("auth/issue-forever-token", null));
+        var (accessToken, _, _) = await ParseAuthResponseAsync(client.PostAsync("auth/issue-forever-token", null));
         return accessToken;
     }
 
@@ -645,7 +645,7 @@ public class Connection
     /// </summary>
     /// <param name="message">The message to check</param>
     /// <returns>The task</returns>
-    private static async Task EnsureSuccessStatusCodeWithParsing(HttpResponseMessage? message)
+    private static async Task EnsureSuccessStatusCodeWithParsingAsync(HttpResponseMessage? message)
     {
         if (message is null)
             throw new UserReportedException("No response received");

--- a/Duplicati/CommandLine/ServerUtil/Program.cs
+++ b/Duplicati/CommandLine/ServerUtil/Program.cs
@@ -38,7 +38,7 @@ public static class Program
     /// </summary>
     /// <param name="args"></param>
     /// <returns>The return code</returns>
-    public static async Task<int> Main(string[] args)
+    public static async Task<int> MainAsync(string[] args)
     {
         PreloadSettingsLoader.ConfigurePreloadSettings(ref args, PackageHelper.NamedExecutable.ServerUtil);
 
@@ -66,7 +66,7 @@ public static class Program
             .UseExceptionHandler((ex, context) =>
             {
                 OutputInterceptorBinder.Instance?.SetResult(false);
-                
+
                 if (ex is UserReportedException ure)
                 {
                     OutputInterceptorBinder.Instance?.AppendExceptionMessage(ure.Message);
@@ -89,9 +89,9 @@ public static class Program
                 // Inject settings with custom binder
                 if (context.ParseResult.CommandResult.Command is { } cmd)
                     context.BindingContext.AddService(_ => SettingsBinder.GetSettings(context.BindingContext));
-                
+
                 context.BindingContext.AddService(_ => OutputInterceptorBinder.GetConsoleInterceptor(context.BindingContext));
-                
+
                 await next(context);
                 Console.WriteLine(OutputInterceptorBinder.Instance?.GetSerializedResult());
             })

--- a/Duplicati/CommandLine/ServerUtil/Settings.cs
+++ b/Duplicati/CommandLine/ServerUtil/Settings.cs
@@ -166,7 +166,7 @@ public sealed record Settings(
     /// <param name="args">The arguments to replace</param>
     /// <param name="options">The options to replace</param>
     /// <returns>The task to await</returns>
-    public Task ReplaceSecrets(Dictionary<string, string?> options)
+    public Task ReplaceSecretsAsync(Dictionary<string, string?> options)
     {
         if (SecretProvider == null)
             return Task.CompletedTask;
@@ -216,18 +216,18 @@ public sealed record Settings(
     /// Gets a connection to the server
     /// </summary>
     /// <returns>The connection</returns>
-    public Task<Connection> GetConnection()
+    public Task<Connection> GetConnectionAsync()
     {
-        return Connection.Connect(this);
+        return Connection.ConnectAsync(this);
     }
 
     /// <summary>
     /// Gets a connection to the server
     /// </summary>
     /// <returns>The connection</returns>
-    public Task<Connection> GetConnection(OutputInterceptor output)
+    public Task<Connection> GetConnectionAsync(OutputInterceptor output)
     {
-        return Connection.Connect(this, false, output);
+        return Connection.ConnectAsync(this, false, output);
     }
 
     /// <summary>

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
@@ -57,16 +57,16 @@ namespace Duplicati.GUI.TrayIcon
             base.Init(args);
         }
 
-        protected override Task UpdateUIState(Action action)
-            => RunOnUIThread(action);
+        protected override Task UpdateUIStateAsync(Action action)
+            => RunOnUIThreadAsync(action);
 
 
-        internal Task RunOnUIThread(Action action)
+        internal Task RunOnUIThreadAsync(Action action)
         {
             if (_disposed != 0)
                 return Task.CompletedTask;
 
-            return actionDelayer.ExecuteAction(() =>
+            return actionDelayer.ExecuteActionAsync(() =>
               {
                   try
                   {
@@ -101,7 +101,7 @@ namespace Duplicati.GUI.TrayIcon
 
         protected override void RegisterStatusUpdateCallback()
         {
-            Program.Connection.OnStatusUpdated += this.OnStatusUpdated;
+            Program.Connection.OnStatusUpdated += this.OnStatusUpdatedAsync;
         }
 
         #region implemented abstract members of Duplicati.GUI.TrayIcon.TrayIconBase
@@ -277,7 +277,7 @@ namespace Duplicati.GUI.TrayIcon
 
         protected override void SetIcon(TrayIcons icon)
         {
-            UpdateUIState(() => this.application?.SetIcon(icon));
+            UpdateUIStateAsync(() => this.application?.SetIcon(icon)).FireAndForget();
         }
 
         protected override void SetMenu(IEnumerable<IMenuItem> items)
@@ -288,7 +288,7 @@ namespace Duplicati.GUI.TrayIcon
             }
             this.menuItems = items.Select(i => (AvaloniaMenuItem)i);
             if (this.application != null)
-                UpdateUIState(() => this.application?.SetMenu(menuItems));
+                UpdateUIStateAsync(() => this.application?.SetMenu(menuItems)).FireAndForget();
         }
 
         public override void Dispose()
@@ -362,14 +362,14 @@ namespace Duplicati.GUI.TrayIcon
         {
             this.Text = text;
             if (nativeMenuItem != null)
-                parent.RunOnUIThread(() => nativeMenuItem.Header = text);
+                parent.RunOnUIThreadAsync(() => nativeMenuItem.Header = text).FireAndForget();
         }
 
         public void SetIcon(MenuIcons icon)
         {
             this.Icon = icon;
             if (nativeMenuItem != null)
-                parent.RunOnUIThread(() => this.UpdateIcon());
+                parent.RunOnUIThreadAsync(() => this.UpdateIcon()).FireAndForget();
         }
 
         /// <summary>
@@ -397,7 +397,7 @@ namespace Duplicati.GUI.TrayIcon
         {
             this.Enabled = isEnabled;
             if (nativeMenuItem != null)
-                parent.RunOnUIThread(() => nativeMenuItem.IsEnabled = this.Enabled);
+                parent.RunOnUIThreadAsync(() => nativeMenuItem.IsEnabled = this.Enabled).FireAndForget();
         }
 
         public void SetDefault(bool value)
@@ -411,7 +411,7 @@ namespace Duplicati.GUI.TrayIcon
         {
             this.Hidden = hidden;
             if (nativeMenuItem != null)
-                parent.RunOnUIThread(() => nativeMenuItem.IsVisible = !this.Hidden);
+                parent.RunOnUIThreadAsync(() => nativeMenuItem.IsVisible = !this.Hidden).FireAndForget();
 
         }
         #endregion

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/HttpServerConnection.cs
@@ -192,8 +192,8 @@ namespace Duplicati.GUI.TrayIcon
                 }
             };
 
-            m_requestHandlerTask = ThreadRunner();
-            m_pollThread = LongPollRunner();
+            m_requestHandlerTask = ThreadRunnerAsync();
+            m_pollThread = LongPollRunnerAsync();
 
             m_requestHandlerTask.ContinueWith(t =>
             {
@@ -214,9 +214,9 @@ namespace Duplicati.GUI.TrayIcon
             });
         }
 
-        public async Task UpdateStatus()
+        public async Task UpdateStatusAsync()
         {
-            await PasswordAvailableIfNeeded().ConfigureAwait(false);
+            await PasswordAvailableIfNeededAsync().ConfigureAwait(false);
             await UpdateStatusAsync(false).ConfigureAwait(false);
         }
 
@@ -267,7 +267,7 @@ namespace Duplicati.GUI.TrayIcon
                 m_disableTrayIconLogin = Library.Utility.Utility.ParseBool(str, false);
         }
 
-        private async Task PasswordAvailableIfNeeded()
+        private async Task PasswordAvailableIfNeededAsync()
         {
             if (m_passwordSource == Program.PasswordSource.SuppliedPassword && string.IsNullOrWhiteSpace(_passwordStorageHelper.Password))
             {
@@ -276,7 +276,7 @@ namespace Duplicati.GUI.TrayIcon
             }
         }
 
-        private async Task LongPollRunner()
+        private async Task LongPollRunnerAsync()
         {
             var started = DateTime.Now;
             var errorCount = 0;
@@ -294,7 +294,7 @@ namespace Duplicati.GUI.TrayIcon
                         await Task.Delay(waitTime, cts.Token).ConfigureAwait(false);
                     }
 
-                    await PasswordAvailableIfNeeded().ConfigureAwait(false);
+                    await PasswordAvailableIfNeededAsync().ConfigureAwait(false);
 
                     started = DateTime.Now;
                     await UpdateStatusAsync(true).ConfigureAwait(false);
@@ -329,7 +329,7 @@ namespace Duplicati.GUI.TrayIcon
             }
         }
 
-        private async Task ThreadRunner()
+        private async Task ThreadRunnerAsync()
         {
             while (true)
             {

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/PasswordStorageHelper.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/PasswordStorageHelper.cs
@@ -35,7 +35,7 @@ public class PasswordStorageHelper
 
     public static async Task<PasswordStorageHelper> CreateAsync(string? hostUrl, bool customUrl, string? password, Program.PasswordSource passwordSource, Dictionary<string, string?> options)
     {
-        var secretProvider = await SecretProviderHelper.GetDefaultSecretProvider(options, CancellationToken.None);
+        var secretProvider = await SecretProviderHelper.GetDefaultSecretProviderAsync(options, CancellationToken.None);
 
         // If we get the password from the secret provider, we should save it back to the secret provider
         var shouldSavePassword = false;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/ProcessBasedActionDelay.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/ProcessBasedActionDelay.cs
@@ -45,7 +45,7 @@ public class ProcessBasedActionDelay : IDisposable
     /// Reference to the task running
     /// </summary>
     private readonly Task m_task;
-    
+
     /// <summary>
     /// CancellationToken for the running task
     /// </summary>
@@ -56,7 +56,7 @@ public class ProcessBasedActionDelay : IDisposable
     /// </summary>
     public ProcessBasedActionDelay()
     {
-        m_task = RunProcessor(m_inboundActionChannel.AsReadOnly(), m_initializedChannel.AsReadOnly(), _cancellationToken.Token);
+        m_task = RunProcessorAsync(m_inboundActionChannel.AsReadOnly(), m_initializedChannel.AsReadOnly(), _cancellationToken.Token);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class ProcessBasedActionDelay : IDisposable
     /// <param name="initializedChannel">The channel that sends the start signal.</param>
     /// <param name="cancellationToken">A cancelationToken</param>
     /// <returns>The task running the processor process.</returns>
-    private static Task RunProcessor(IReadChannelEnd<Action> inboundChannel, IReadChannelEnd<bool> initializedChannel, CancellationToken cancellationToken)
+    private static Task RunProcessorAsync(IReadChannelEnd<Action> inboundChannel, IReadChannelEnd<bool> initializedChannel, CancellationToken cancellationToken)
         => AutomationExtensions.RunTask(new
         {
             inboundChannel,
@@ -87,14 +87,14 @@ public class ProcessBasedActionDelay : IDisposable
     /// Adds a new task to the processor
     /// </summary>
     /// <param name="action">The action to execute</param>
-    public async Task ExecuteAction(Action action)
+    public async Task ExecuteActionAsync(Action action)
     {
         if (_cancellationToken.IsCancellationRequested)
         {
             // If the processor is cancelled, we do not queue the action
             return;
         }
-        
+
         // Note: WriteNoWait() is used to avoid waiting for the action to be read,
         // as this would cause deadlocks if called from within the processor.
         // The buffer size should be sufficient to allow for a reasonable number of actions to be queued.

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -278,7 +278,7 @@ namespace Duplicati.GUI.TrayIcon
                         using (Connection = new HttpServerConnection(hosted?.applicationSettings, passwordSource, disableTrayIconLogin, acceptedHostCertificate, options, PasswordStorage))
                         {
                             // Make sure we have the latest status, but don't care if it fails
-                            Connection.UpdateStatus().FireAndForget();
+                            Connection.UpdateStatusAsync().FireAndForget();
                             using (var tk = RunTrayIcon())
                             {
                                 if (Server.Program.ApplicationInstance != null)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/TrayIconBase.cs
@@ -92,7 +92,7 @@ namespace Duplicati.GUI.TrayIcon
             RegisterNotificationCallback();
             m_onDoubleClick = ShowStatusWindow;
             m_onNotificationClick = ShowStatusWindow;
-            OnStatusUpdated(Program.Connection.Status)
+            OnStatusUpdatedAsync(Program.Connection.Status)
                 .FireAndForget();
             Run(args);
         }
@@ -101,14 +101,14 @@ namespace Duplicati.GUI.TrayIcon
 
         public void InvokeExit()
         {
-            UpdateUIState(() =>
+            UpdateUIStateAsync(() =>
             {
                 Program.Connection?.Close();
                 this.Exit();
             });
         }
 
-        protected virtual Task UpdateUIState(Action action)
+        protected virtual Task UpdateUIStateAsync(Action action)
         {
             action();
             return Task.CompletedTask;
@@ -126,7 +126,7 @@ namespace Duplicati.GUI.TrayIcon
 
         protected virtual void RegisterStatusUpdateCallback()
         {
-            Program.Connection.OnStatusUpdated = OnStatusUpdated;
+            Program.Connection.OnStatusUpdated = OnStatusUpdatedAsync;
         }
 
         protected virtual void RegisterNotificationCallback()
@@ -150,7 +150,7 @@ namespace Duplicati.GUI.TrayIcon
                     break;
             }
 
-            UpdateUIState(() =>
+            UpdateUIStateAsync(() =>
             {
                 NotifyUser(notification.Title, notification.Message, type);
             });
@@ -185,12 +185,12 @@ namespace Duplicati.GUI.TrayIcon
         {
             var res = await PasswordPrompt.ShowPasswordDialogAsync(isChangePassword: true);
             if (res)
-                await OnStatusUpdated(Program.Connection.Status);
+                await OnStatusUpdatedAsync(Program.Connection.Status);
         }
 
         private void Reconnect()
         {
-            Program.Connection.UpdateStatus().ContinueWith(t =>
+            Program.Connection.UpdateStatusAsync().ContinueWith(t =>
             {
                 if (t.IsFaulted)
                 {
@@ -247,10 +247,10 @@ namespace Duplicati.GUI.TrayIcon
             ? Task.Delay(1000)
             : Task.CompletedTask;
 
-        protected async Task OnStatusUpdated(IServerStatus status)
+        protected async Task OnStatusUpdatedAsync(IServerStatus status)
         {
             await m_startupDelay;
-            await this.UpdateUIState(()
+            await this.UpdateUIStateAsync(()
             =>
             {
                 switch (status.SuggestedStatusIcon)

--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -143,7 +143,7 @@ namespace Duplicati.Library.Main.Operation
                 if (filteredList.Count == 0)
                     throw new UserInformationException("No filesets found on remote target", "EmptyRemoteFolder");
 
-                var numberSeq = await CreateResultSequence(filteredList, backendManager, m_options, cancellationToken)
+                var numberSeq = await CreateResultSequenceAsync(filteredList, backendManager, m_options, cancellationToken)
                     .ConfigureAwait(false);
                 if (filter.Empty)
                 {
@@ -251,7 +251,7 @@ namespace Duplicati.Library.Main.Operation
             public long Size => Volume.File.Size;
         }
 
-        private static async Task<IEnumerable<IListResultFileset>> CreateResultSequence(IEnumerable<KeyValuePair<long, IParsedVolume>> filteredList, IBackendManager backendManager, Options options, CancellationToken cancelToken)
+        private static async Task<IEnumerable<IListResultFileset>> CreateResultSequenceAsync(IEnumerable<KeyValuePair<long, IParsedVolume>> filteredList, IBackendManager backendManager, Options options, CancellationToken cancelToken)
         {
             var list = new List<IListResultFileset>();
             var map = filteredList.ToDictionary(x => x.Value.File.Name, x => x);

--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -221,7 +221,7 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// the VolumeDownloader will be notified.
             /// </summary>
             /// <param name="blockRequest">The block request to check.</param>
-            public async Task CheckCounts(BlockRequest blockRequest)
+            public async Task CheckCountsAsync(BlockRequest blockRequest)
             {
                 long error_block_id = -1;
                 long error_volume_id = -1;
@@ -290,7 +290,7 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// </summary>
             /// <param name="block_request">The requested block.</param>
             /// <returns>A `Task` holding the data block.</returns>
-            public async Task<DataBlock> Get(BlockRequest block_request)
+            public async Task<DataBlock> GetAsync(BlockRequest block_request)
             {
                 Logging.Log.WriteExplicitMessage(LOGTAG, "BlockCacheGet", "Getting block {0} from cache", block_request.BlockID);
 
@@ -565,7 +565,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                             {
                                 case BlockRequestType.Download:
                                     sw_get?.Start();
-                                    var datatask = cache.Get(block_request);
+                                    var datatask = cache.GetAsync(block_request);
                                     sw_get?.Stop();
                                     Logging.Log.WriteExplicitMessage(LOGTAG, "BlockHandler", null, "Retrieved data for block {0} and volume {1}", block_request.BlockID, block_request.VolumeID);
 
@@ -577,7 +577,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                 case BlockRequestType.CacheEvict:
                                     sw_cache?.Start();
                                     // Target file already had the block.
-                                    await cache.CheckCounts(block_request).ConfigureAwait(false);
+                                    await cache.CheckCountsAsync(block_request).ConfigureAwait(false);
                                     sw_cache?.Stop();
 
                                     Logging.Log.WriteExplicitMessage(LOGTAG, "BlockHandler", null, "Decremented counts for block {0} and volume {1}", block_request.BlockID, block_request.VolumeID);

--- a/Duplicati/Library/Main/SecretProviderHelper.cs
+++ b/Duplicati/Library/Main/SecretProviderHelper.cs
@@ -110,7 +110,7 @@ public static class SecretProviderHelper
     /// <param name="options">The options passed</param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>The default secret provider, or null if none is available</returns>
-    public static async Task<ISecretProvider?> GetDefaultSecretProvider(Dictionary<string, string?> options, CancellationToken cancellationToken)
+    public static async Task<ISecretProvider?> GetDefaultSecretProviderAsync(Dictionary<string, string?> options, CancellationToken cancellationToken)
     {
         var providerConfig = options.GetValueOrDefault("secret-provider");
         if (!string.IsNullOrWhiteSpace(providerConfig))

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -1158,7 +1158,7 @@ namespace Duplicati.Server
                     disableDbEncryption = true;
             }
 
-            var defaultSecretProvider = SecretProviderHelper.GetDefaultSecretProvider(commandlineOptions, CancellationToken.None).Await();
+            var defaultSecretProvider = SecretProviderHelper.GetDefaultSecretProviderAsync(commandlineOptions, CancellationToken.None).Await();
 
             // If we are supposed to have an encryption key, but do not, try to get it from the (default) secret provider
             if (!hasValidEncryptionKey && defaultSecretProvider != null)

--- a/Duplicati/UnitTest/DiskImage/Ntfs/NtfsMftWalkerTests.cs
+++ b/Duplicati/UnitTest/DiskImage/Ntfs/NtfsMftWalkerTests.cs
@@ -340,7 +340,7 @@ public class NtfsMftWalkerTests
     }
 
     [Test]
-    public async Task Test_NtfsMftWalker_SkipDeletedRecords()
+    public async Task Test_NtfsMftWalker_SkipDeletedRecords_Async()
     {
         var bootSectorData = CreateValidBootSector();
         var bootSector = new NtfsBootSector(bootSectorData);
@@ -386,7 +386,7 @@ public class NtfsMftWalkerTests
     }
 
     [Test]
-    public async Task Test_NtfsMftWalker_ClusterTimestampMap_Correct()
+    public async Task Test_NtfsMftWalker_ClusterTimestampMap_Correct_Async()
     {
         var bootSectorData = CreateValidBootSector();
         var bootSector = new NtfsBootSector(bootSectorData);
@@ -434,7 +434,7 @@ public class NtfsMftWalkerTests
     }
 
     [Test]
-    public async Task Test_NtfsMftWalker_SystemMetafiles_UseCurrentTimestamp()
+    public async Task Test_NtfsMftWalker_SystemMetafiles_UseCurrentTimestamp_Async()
     {
         var bootSectorData = CreateValidBootSector();
         var bootSector = new NtfsBootSector(bootSectorData);
@@ -475,7 +475,7 @@ public class NtfsMftWalkerTests
     }
 
     [Test]
-    public async Task Test_NtfsMftWalker_OverlappingClusters_UsesMostRecentTimestamp()
+    public async Task Test_NtfsMftWalker_OverlappingClusters_UsesMostRecentTimestamp_Async()
     {
         var bootSectorData = CreateValidBootSector();
         var bootSector = new NtfsBootSector(bootSectorData);
@@ -539,7 +539,7 @@ public class NtfsMftWalkerTests
     }
 
     [Test]
-    public async Task Test_NtfsMftWalker_DataRunParsing_MultipleRuns()
+    public async Task Test_NtfsMftWalker_DataRunParsing_MultipleRuns_Async()
     {
         var bootSectorData = CreateValidBootSector();
         var bootSector = new NtfsBootSector(bootSectorData);
@@ -597,7 +597,7 @@ public class NtfsMftWalkerTests
     }
 
     [Test]
-    public async Task Test_NtfsMftWalker_EmptyDataRun_Skipped()
+    public async Task Test_NtfsMftWalker_EmptyDataRun_Skipped_Async()
     {
         var bootSectorData = CreateValidBootSector();
         var bootSector = new NtfsBootSector(bootSectorData);
@@ -639,7 +639,7 @@ public class NtfsMftWalkerTests
     }
 
     [Test]
-    public async Task Test_NtfsMftWalker_JournalClusters_AlwaysAllocated()
+    public async Task Test_NtfsMftWalker_JournalClusters_AlwaysAllocated_Async()
     {
         var bootSectorData = CreateValidBootSector();
         var bootSector = new NtfsBootSector(bootSectorData);

--- a/Duplicati/UnitTest/DiskImage/Ntfs/NtfsZeroStreamTests.cs
+++ b/Duplicati/UnitTest/DiskImage/Ntfs/NtfsZeroStreamTests.cs
@@ -38,7 +38,7 @@ public class NtfsZeroStreamTests
     }
 
     [Test]
-    public async Task Test_NtfsZeroStream_ReadAsync_ReturnsZeros()
+    public async Task Test_NtfsZeroStream_ReadAsync_ReturnsZeros_Async()
     {
         const int blockSize = 1024 * 1024; // 1MB
         using var stream = new NtfsFilesystem.NtfsZeroStream(blockSize);

--- a/Duplicati/UnitTest/SyntheticFilelistMetadataTests.cs
+++ b/Duplicati/UnitTest/SyntheticFilelistMetadataTests.cs
@@ -81,7 +81,7 @@ namespace Duplicati.UnitTest
             /// <param name="fileId">The file ID of the entry to remove.</param>
             /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
             /// <returns>The number of rows that were removed.</returns>
-            public async Task<int> RemoveFilesetEntry(long filesetId, long fileId, CancellationToken token)
+            public async Task<int> RemoveFilesetEntryAsync(long filesetId, long fileId, CancellationToken token)
             {
                 await using var cmd = await m_connection.CreateCommandAsync(@"
                     DELETE FROM ""FilesetEntry""
@@ -107,7 +107,7 @@ namespace Duplicati.UnitTest
             /// <param name="filesetId">The fileset ID to query.</param>
             /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
             /// <returns>An async enumerable of (FileID, FullPath) pairs.</returns>
-            public async IAsyncEnumerable<(long FileId, string FullPath)> GetFilesetEntries(long filesetId, [EnumeratorCancellation] CancellationToken token)
+            public async IAsyncEnumerable<(long FileId, string FullPath)> GetFilesetEntriesAsync(long filesetId, [EnumeratorCancellation] CancellationToken token)
             {
                 await using var cmd = await m_connection.CreateCommandAsync(@"
                     SELECT ""fe"".""FileID"", ""p"".""Prefix"" || ""f"".""Path"" AS ""FullPath""
@@ -224,7 +224,7 @@ namespace Duplicati.UnitTest
         [Category("Disruption")]
         [Category("SyntheticFilelist")]
         [Category("ExcludedFromCLI")]
-        public async Task SyntheticFilelistShouldIncludeMetadata()
+        public async Task SyntheticFilelistShouldIncludeMetadataAsync()
         {
             // Use no-encryption so we can read the dlist files directly
             var options = new Dictionary<string, string>(this.TestOptions)
@@ -314,7 +314,7 @@ namespace Duplicati.UnitTest
                 .ToList();
 
             var syntheticDlist = orderedDlists[1].Path;
-            TestContext.Progress.WriteLine($"Synthetic dlist: {Path.GetFileName(syntheticDlist)}");
+            await TestContext.Progress.WriteLineAsync($"Synthetic dlist: {Path.GetFileName(syntheticDlist)}");
 
             // 6. Parse the synthetic dlist and verify all files have metahash and metasize
             var entries = ParseDlistFile(syntheticDlist, options);
@@ -322,7 +322,7 @@ namespace Duplicati.UnitTest
 
             foreach (var entry in entries)
             {
-                TestContext.Progress.WriteLine(
+                await TestContext.Progress.WriteLineAsync(
                     $"Entry: {entry.Path}, Hash: {entry.Hash}, Size: {entry.Size}, Metahash: {entry.Metahash ?? "NULL"}, Metasize: {entry.Metasize}");
 
                 Assert.That(entry.Metahash, Is.Not.Null,
@@ -339,7 +339,7 @@ namespace Duplicati.UnitTest
         [Category("Disruption")]
         [Category("SyntheticFilelist")]
         [Category("ExcludedFromCLI")]
-        public async Task SyntheticFilelistShouldPassTestOperation()
+        public async Task SyntheticFilelistShouldPassTestOperationAsync()
         {
             var options = new Dictionary<string, string>(this.TestOptions)
             {
@@ -505,17 +505,17 @@ namespace Duplicati.UnitTest
                 // fileset. There should be exactly one such row (one for the
                 // directory and one for the file; we want the file).
                 long candidateFileId = -1;
-                await foreach (var entry in db.GetFilesetEntries(interruptedFilesetId, default).ConfigureAwait(false))
+                await foreach (var entry in db.GetFilesetEntriesAsync(interruptedFilesetId, default).ConfigureAwait(false))
                 {
-                    TestContext.Progress.WriteLine($"  FS{interruptedFilesetId} entry: F{entry.FileId} {entry.FullPath}");
+                    await TestContext.Progress.WriteLineAsync($"  FS{interruptedFilesetId} entry: F{entry.FileId} {entry.FullPath}");
                     if (entry.FullPath.EndsWith("testfile.txt"))
                         candidateFileId = entry.FileId;
                 }
                 Assert.That(candidateFileId, Is.GreaterThan(0), "Expected to find testfile.txt FileLookup in the interrupted fileset");
                 orphanFileId = candidateFileId;
 
-                TestContext.Progress.WriteLine($"Detaching F{candidateFileId} from FS{interruptedFilesetId} (will become orphan FileLookup)");
-                var removed = await db.RemoveFilesetEntry(interruptedFilesetId, candidateFileId, default).ConfigureAwait(false);
+                await TestContext.Progress.WriteLineAsync($"Detaching F{candidateFileId} from FS{interruptedFilesetId} (will become orphan FileLookup)");
+                var removed = await db.RemoveFilesetEntryAsync(interruptedFilesetId, candidateFileId, default).ConfigureAwait(false);
                 Assert.AreEqual(1, removed, "Expected exactly one FilesetEntry row to be removed");
                 await db.Transaction.CommitAsync("test-detach-orphan", true, default).ConfigureAwait(false);
             }
@@ -528,7 +528,7 @@ namespace Duplicati.UnitTest
             var allDblocks = Directory.EnumerateFiles(this.TARGETFOLDER, "*.dblock.*")
                 .OrderBy(File.GetCreationTimeUtc)
                 .ToList();
-            TestContext.Progress.WriteLine($"Dblock candidates ({allDblocks.Count}): " +
+            await TestContext.Progress.WriteLineAsync($"Dblock candidates ({allDblocks.Count}): " +
                 string.Join(", ", allDblocks.Select(Path.GetFileName)));
             Assert.That(allDblocks.Count, Is.GreaterThanOrEqualTo(2),
                 "Expected at least two dblocks (one per backup attempt)");
@@ -536,7 +536,7 @@ namespace Duplicati.UnitTest
             var dblockToRemove = allDblocks.Last();
             await using (var db = await TestDatabase.CreateAsync(this.DBFILE, default).ConfigureAwait(false))
             {
-                TestContext.Progress.WriteLine($"Removing dblock from DB: {Path.GetFileName(dblockToRemove)}");
+                await TestContext.Progress.WriteLineAsync($"Removing dblock from DB: {Path.GetFileName(dblockToRemove)}");
                 await db.RemoveRemoteVolumesAsync(new[] { Path.GetFileName(dblockToRemove) }, default)
                     .ConfigureAwait(false);
                 await db.Transaction.CommitAsync("test-remove-dblock", true, default).ConfigureAwait(false);
@@ -565,7 +565,7 @@ namespace Duplicati.UnitTest
             DumpDatabaseState(this.DBFILE, "After recovery backup");
 
             var dlistFiles = Directory.EnumerateFiles(this.TARGETFOLDER, "*.dlist.*").ToList();
-            TestContext.Progress.WriteLine($"Dlists on backend: {dlistFiles.Count}");
+            await TestContext.Progress.WriteLineAsync($"Dlists on backend: {dlistFiles.Count}");
 
             int missingMetahash = 0;
             foreach (var dlist in dlistFiles)
@@ -573,7 +573,7 @@ namespace Duplicati.UnitTest
                 var entries = ParseDlistFile(dlist, options);
                 foreach (var entry in entries)
                 {
-                    TestContext.Progress.WriteLine(
+                    await TestContext.Progress.WriteLineAsync(
                         $"Dlist: {Path.GetFileName(dlist)}, Entry: {entry.Path}, Metahash: {entry.Metahash ?? "NULL"}, Metasize: {entry.Metasize}");
                     if (entry.Metahash == null)
                         missingMetahash++;
@@ -611,7 +611,7 @@ namespace Duplicati.UnitTest
         [Category("Disruption")]
         [Category("SyntheticFilelist")]
         [Category("ExcludedFromCLI")]
-        public async Task SyntheticFilelistAfterDeletingOldVersions()
+        public async Task SyntheticFilelistAfterDeletingOldVersionsAsync()
         {
             var options = new Dictionary<string, string>(this.TestOptions)
             {
@@ -652,8 +652,8 @@ namespace Duplicati.UnitTest
 
             using (var c = new Controller(failtarget, options, null))
             {
-                Assert.Throws<DeterministicErrorBackend.DeterministicErrorBackendException>(async () =>
-                    await c.BackupAsync(new[] { this.DATAFOLDER }));
+                Assert.ThrowsAsync<DeterministicErrorBackend.DeterministicErrorBackendException>(() =>
+                    c.BackupAsync(new[] { this.DATAFOLDER }));
             }
             Assert.IsTrue(failed, "Expected dlist upload to fail");
 
@@ -705,7 +705,7 @@ namespace Duplicati.UnitTest
                 var entries = ParseDlistFile(dlist, options);
                 foreach (var entry in entries)
                 {
-                    TestContext.Progress.WriteLine(
+                    await TestContext.Progress.WriteLineAsync(
                         $"Dlist: {Path.GetFileName(dlist)}, Entry: {entry.Path}, Metahash: {entry.Metahash ?? "NULL"}, Metasize: {entry.Metasize}");
 
                     Assert.That(entry.Metahash, Is.Not.Null,

--- a/Duplicati/WebserverCore/Endpoints/V1/RemoteControl.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/RemoteControl.cs
@@ -52,11 +52,11 @@ public class RemoteControl : IEndpointV1
             .RequireAuthorization();
 
         group.MapPost("/remotecontrol/register", ([FromBody] Dto.StartRegistrationInput input, [FromServices] IRemoteControllerRegistration registration, [FromServices] IRemoteController remoteController, CancellationToken cancellationToken)
-            => BeginRegisterMachine(registration, remoteController, input.RegistrationUrl, cancellationToken))
+            => BeginRegisterMachineAsync(registration, remoteController, input.RegistrationUrl, cancellationToken))
             .RequireAuthorization();
 
         group.MapPost("/remotecontrol/register/wait", ([FromServices] IRemoteControllerRegistration registration, [FromServices] IRemoteController remoteController, CancellationToken cancellationToken)
-            => WaitForRegistration(registration, remoteController, cancellationToken))
+            => WaitForRegistrationAsync(registration, remoteController, cancellationToken))
             .RequireAuthorization();
 
         group.MapDelete("/remotecontrol/register", ([FromServices] IRemoteControllerRegistration registration, [FromServices] IRemoteController remoteController)
@@ -64,7 +64,7 @@ public class RemoteControl : IEndpointV1
             .RequireAuthorization();
     }
 
-    private static async Task<Dto.RemoteControlStatusOutput> BeginRegisterMachine(IRemoteControllerRegistration registration, IRemoteController remoteController, string? registrationUrl, CancellationToken cancellationToken)
+    private static async Task<Dto.RemoteControlStatusOutput> BeginRegisterMachineAsync(IRemoteControllerRegistration registration, IRemoteController remoteController, string? registrationUrl, CancellationToken cancellationToken)
     {
         if (remoteController.CanEnable)
             throw new BadRequestException("Existing remote control must be removed before registering");
@@ -84,7 +84,7 @@ public class RemoteControl : IEndpointV1
         return GetStatus(registration, remoteController);
     }
 
-    private static async Task<Dto.RemoteControlStatusOutput> WaitForRegistration(IRemoteControllerRegistration registration, IRemoteController remoteController, CancellationToken cancellationToken)
+    private static async Task<Dto.RemoteControlStatusOutput> WaitForRegistrationAsync(IRemoteControllerRegistration registration, IRemoteController remoteController, CancellationToken cancellationToken)
     {
         if (remoteController.CanEnable)
             throw new BadRequestException("Existing remote control must be removed before waiting for registration");

--- a/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
@@ -35,11 +35,11 @@ public class DestinationVerify : IEndpointV2
     public static void Map(RouteGroupBuilder group)
     {
         group.MapPost("/destination/test", ([FromServices] Connection connection, [FromServices] IApplicationSettings applicationSettings, [FromBody] Dto.V2.DestinationTestRequestDto input, CancellationToken cancelToken)
-            => ExecuteTest(connection, applicationSettings, input, cancelToken))
+            => ExecuteTestAsync(connection, applicationSettings, input, cancelToken))
             .RequireAuthorization();
     }
 
-    private static async Task<DestinationTestResponseDto> ExecuteTest(Connection connection, IApplicationSettings applicationSettings, DestinationTestRequestDto input, CancellationToken cancelToken)
+    private static async Task<DestinationTestResponseDto> ExecuteTestAsync(Connection connection, IApplicationSettings applicationSettings, DestinationTestRequestDto input, CancellationToken cancelToken)
     {
         var destinationType = input.DestinationType ?? RemoteDestinationType.Backend;
 

--- a/Executables/Duplicati.CommandLine.ConfigureTool/Program.cs
+++ b/Executables/Duplicati.CommandLine.ConfigureTool/Program.cs
@@ -27,6 +27,6 @@ namespace Duplicati.CommandLine.ConfigureTool.Net10
     public static class Program
     {
         public static Task<int> Main(string[] args)
-            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.ConfigureTool.Program.Main(args));
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.ConfigureTool.Program.MainAsync(args));
     }
 }

--- a/Executables/Duplicati.CommandLine.ServerUtil/Program.cs
+++ b/Executables/Duplicati.CommandLine.ServerUtil/Program.cs
@@ -27,6 +27,6 @@ namespace Duplicati.CommandLine.ServerUtil.Net10
     public static class Program
     {
         public static Task<int> Main(string[] args)
-            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.ServerUtil.Program.Main(args));
+            => CrashlogHelper.WrapWithCrashLog(() => Duplicati.CommandLine.ServerUtil.Program.MainAsync(args));
     }
 }


### PR DESCRIPTION
Recent C# compilers warn if async methods are not suffixed with `Async`.

This PR fixes a number of such warnings.