### PR TITLE
Allow disable default secret provider

### DIFF
--- a/Duplicati/Agent/Program.cs
+++ b/Duplicati/Agent/Program.cs
@@ -57,6 +57,7 @@ public static class Program
     /// <param name="SettingsEncryptionKey">The encryption key for the database settings</param>
     /// <param name="WindowsEventLog">The Windows event log to write to</param>
     /// <param name="DisableDbEncryption">Disable database encryption</param>
+    /// <param name="DisableDefaultSecretProvider">Disable default secret provider</param>
     /// <param name="WebserviceResetJwtConfig">Reset the JWT configuration</param>
     /// <param name="WebserviceAllowedHostnames">The allowed hostnames for the webserver</param>
     /// <param name="WebserviceApiOnly">Only allow API access to the webserver</param>
@@ -78,6 +79,7 @@ public static class Program
         string? SettingsEncryptionKey,
         string WindowsEventLog,
         bool DisableDbEncryption,
+        bool DisableDefaultSecretProvider,
         bool WebserviceResetJwtConfig,
         string WebserviceAllowedHostnames,
         bool WebserviceApiOnly,
@@ -118,6 +120,7 @@ public static class Program
             new Option<string?>("--settings-encryption-key", description: "The encryption key for the database settings", getDefaultValue: () => null),
             new Option<string>("--windows-eventlog", description: "The Windows event log to use as source.", getDefaultValue: () => ""),
             new Option<bool>("--disable-db-encryption", description: "Disable database encryption", getDefaultValue: () => false),
+            new Option<bool>("--disable-default-secret-provider", description: "Disable the default secret provider", getDefaultValue: () => false),
             new Option<bool>("--webservice-reset-jwt-config", description: "Reset the JWT configuration", getDefaultValue: () => true),
             new Option<string>("--webservice-allowed-hostnames", description: "The allowed hostnames for the webserver", getDefaultValue: () => "127.0.0.1"),
             new Option<bool>("--webservice-api-only", description: "Only allow API access to the webserver", getDefaultValue: () => true),
@@ -213,6 +216,7 @@ public static class Program
             SettingsEncryptionKey: null,
             WindowsEventLog: "",
             DisableDbEncryption: false,
+            DisableDefaultSecretProvider: false,
             WebserviceResetJwtConfig: false,
             WebserviceAllowedHostnames: "",
             WebserviceApiOnly: true,
@@ -507,6 +511,7 @@ public static class Program
             EncodeOption("--webservice-api-only", agentConfig.WebserviceApiOnly.ToString()),
             EncodeOption("--webservice-disable-signin-tokens", agentConfig.WebserviceDisableSigninTokens.ToString()),
             EncodeOption("--disable-db-encryption", agentConfig.DisableDbEncryption.ToString()),
+            EncodeOption("--disable-default-secret-provider", agentConfig.DisableDefaultSecretProvider.ToString()),
             EncodeOption("--settings-encryption-key", settingsEncryptionKey),
             EncodeOption("--webservice-disable-api-extensions", string.Join(",", disabledExtensions))
             }

--- a/Duplicati/Library/Main/SecretProviderHelper.cs
+++ b/Duplicati/Library/Main/SecretProviderHelper.cs
@@ -112,6 +112,9 @@ public static class SecretProviderHelper
     /// <returns>The default secret provider, or null if none is available</returns>
     public static async Task<ISecretProvider?> GetDefaultSecretProvider(Dictionary<string, string?> options, CancellationToken cancellationToken)
     {
+        if (Library.Utility.Utility.ParseBoolOption(options, "disable-default-secret-provider"))
+            return null;
+
         var providerConfig = options.GetValueOrDefault("secret-provider");
         if (!string.IsNullOrWhiteSpace(providerConfig))
         {

--- a/Duplicati/Library/RestAPI/Strings.cs
+++ b/Duplicati/Library/RestAPI/Strings.cs
@@ -84,6 +84,8 @@ Error message: {0}", error); }
         public static string WebserverEnableFolderStatusServiceDescription { get { return LC.L(@"Enable the folder status service for showing overlay icons in the file explorer"); } }
         public static string DisabledbencryptionLong { get { return LC.L(@"Use this option to disable database encryption of sensitive fields"); } }
         public static string DisabledbencryptionShort { get { return LC.L(@"Disable database encryption"); } }
+        public static string DisabledefaultsecretproviderLong { get { return LC.L(@"Use this option to disable the default secret provider"); } }
+        public static string DisabledefaultsecretproviderShort { get { return LC.L(@"Disable the default secret provider"); } }
         public static string LogwindowseventlogLong { get { return LC.L(@"Use this option to log to the Windows event log. The provided name is in the format Log:Source. If no log name is provided, ""Duplicati 2"" is used."); } }
         public static string LogwindowseventlogShort { get { return LC.L(@"Log to the Windows event log"); } }
         public static string LogwindowseventloglevelLong { get { return LC.L(@"Use this option to set the log level for the Windows event log."); } }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -57,6 +57,8 @@ namespace Duplicati.Server
         private const string WINDOWS_EVENTLOG_LEVEL_OPTION = "windows-eventlog-level";
         /// <summary>The commandline argument name for disabling database encryption.</summary>
         private const string DISABLE_DB_ENCRYPTION_OPTION = "disable-db-encryption";
+        /// <summary>The commandline argument name for disabling the default secret provider.</summary>
+        private const string DISABLE_DEFAULT_SECRET_PROVIDER_OPTION = "disable-default-secret-provider";
         /// <summary>The commandline argument name for requiring database encryption key.</summary>
         private const string REQUIRE_DB_ENCRYPTION_KEY_OPTION = "require-db-encryption-key";
         /// <summary>The commandline argument name for settings encryption key.</summary>
@@ -1576,6 +1578,7 @@ namespace Duplicati.Server
             new CommandLineArgument(LOG_RETENTION_OPTION, CommandLineArgument.ArgumentType.Timespan, Strings.Program.LogretentionShort, Strings.Program.LogretentionLong, DEFAULT_LOG_RETENTION),
             new CommandLineArgument(DataFolderManager.SERVER_DATAFOLDER_OPTION, CommandLineArgument.ArgumentType.Path, Strings.Program.ServerdatafolderShort, Strings.Program.ServerdatafolderLong(DataFolderManager.DATAFOLDER_ENV_NAME), DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly)),
             new CommandLineArgument(DISABLE_DB_ENCRYPTION_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.DisabledbencryptionShort, Strings.Program.DisabledbencryptionLong),
+            new CommandLineArgument(DISABLE_DEFAULT_SECRET_PROVIDER_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.DisabledefaultsecretproviderShort, Strings.Program.DisabledefaultsecretproviderLong),
             new CommandLineArgument(REQUIRE_DB_ENCRYPTION_KEY_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.Program.RequiredbencryptionShort, Strings.Program.RequiredbencryptionLong),
             new CommandLineArgument(SETTINGS_ENCRYPTION_KEY_OPTION, CommandLineArgument.ArgumentType.Password, Strings.Program.SettingsencryptionkeyShort, Strings.Program.SettingsencryptionkeyLong(EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME)),
             new CommandLineArgument(REGISTER_REMOTE_CONTROL_OPTION, CommandLineArgument.ArgumentType.String, Strings.Program.RegisterRemoteControlShort, Strings.Program.RegisterRemoteControlLong),


### PR DESCRIPTION
This PR adds a new option `--disable-default-secret-provider` that will fully disable probing for the default secret provider.

This is to assist in cases where the secret provider is broken or shows unwanted popup dialogs.