### PR TITLE
Fixed case-insensitive search

### DIFF
--- a/Duplicati/CommandLine/CLI/Commands.cs
+++ b/Duplicati/CommandLine/CLI/Commands.cs
@@ -476,7 +476,7 @@ namespace Duplicati.CommandLine
 
                 HandleDbAccessWithoutPassphrase(backend, options);
 
-                var res = i.SearchEntriesAsync(args.ToArray(), filter, 0, 0, false).Await();
+                var res = i.SearchEntriesAsync(args.ToArray(), filter, false, 0, 0, false).Await();
                 outwriter.WriteLine("File versions:");
                 var prevFile = string.Empty;
                 foreach (var e in res.FileVersions.Items)

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -230,9 +230,9 @@ namespace Duplicati.Library.Main
             ).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<ISearchFilesResults> SearchEntriesAsync(string[] pathprefixes, IFilter inputFilter, long offset, long limit, bool extendedData)
-            => await RunActionAsync(new SearchFilesResults(), pathprefixes, inputFilter, new { offset, limit, extendedData }, static config =>
-                Operation.SearchEntriesHandler.RunAsync(config.Options, config.Result, config.Paths, config.Filter, config.Context.offset, config.Context.limit, config.Context.extendedData)
+        public async Task<ISearchFilesResults> SearchEntriesAsync(string[] pathprefixes, IFilter inputFilter, bool caseSensitive, long offset, long limit, bool extendedData)
+            => await RunActionAsync(new SearchFilesResults(), pathprefixes, inputFilter, new { caseSensitive, offset, limit, extendedData }, static config =>
+                Operation.SearchEntriesHandler.RunAsync(config.Options, config.Result, config.Paths, config.Filter, config.Context.caseSensitive, config.Context.offset, config.Context.limit, config.Context.extendedData)
             ).ConfigureAwait(false);
 
         /// <inheritdoc />

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -1385,7 +1385,7 @@ namespace Duplicati.Library.Main.Database
         /// <param name="limit">The limit for pagination.</param>
         /// <param name="token"> A cancellation token to cancel the operation.</param>
         /// <returns>A task that when awaited returns all matching file versions ordered by path and then version time.</returns>
-        public async Task<IPaginatedResults<ISearchFileVersion>> SearchEntriesAsync(IEnumerable<string>? pathprefixes, IFilter filter, long[]? filesetIds, long offset, long limit, CancellationToken token)
+        public async Task<IPaginatedResults<ISearchFileVersion>> SearchEntriesAsync(IEnumerable<string>? pathprefixes, IFilter filter, bool caseSensitive, long[]? filesetIds, long offset, long limit, CancellationToken token)
         {
             if (offset != 0 && limit <= 0)
                 throw new ArgumentException("Cannot use offset without limit specified.", nameof(offset));
@@ -1408,7 +1408,6 @@ namespace Duplicati.Library.Main.Database
             FilterExpression.AnalyzeFilters(filter, out var includes, out var excludes);
             var defaultExclude = includes && !excludes; // true = exclude unmatched, false = include unmatched
             var defaultBehavior = defaultExclude ? 1 : 0;
-            var caseSensitive = false; //TODO: Should we expose this? Or use: Library.Utility.Utility.IsFSCaseSensitive?
 
             var filterProps = new Dictionary<string, object?>();
             var caseWhenParts = new List<string>();
@@ -1455,12 +1454,12 @@ namespace Duplicati.Library.Main.Database
                         filterProps[propName] = part;
                         if (caseSensitive)
                             caseWhenParts.Add($@"
-                                WHEN instr(LOWER(pp.""Prefix"" || fl.""Path""), LOWER({propName})) > 0
+                                WHEN instr(pp.""Prefix"" || fl.""Path"", {propName}) > 0
                                 THEN {(filterExpression.Result ? "0" : "1")}
                             ");
                         else
                             caseWhenParts.Add($@"
-                                WHEN instr(pp.""Prefix"" || fl.""Path"", {propName}) > 0
+                                WHEN instr(LOWER(pp.""Prefix"" || fl.""Path""), LOWER({propName})) > 0
                                 THEN {(filterExpression.Result ? "0" : "1")}
                             ");
                     }
@@ -1474,14 +1473,14 @@ namespace Duplicati.Library.Main.Database
                         filterProps[propName] = part;
                         if (caseSensitive)
                             caseWhenParts.Add($@"
-                                WHEN LOWER(pp.""Prefix"" || fl.""Path"") GLOB LOWER({propName})
-                                THEN {(filterExpression.Result ? "0" : "1")}
-                            ");
-                        else
-                            caseWhenParts.Add($@"
                             WHEN pp.""Prefix"" || fl.""Path"" GLOB {propName}
                             THEN {(filterExpression.Result ? "0" : "1")}
                         ");
+                        else
+                            caseWhenParts.Add($@"
+                                WHEN LOWER(pp.""Prefix"" || fl.""Path"") GLOB LOWER({propName})
+                                THEN {(filterExpression.Result ? "0" : "1")}
+                            ");
                     }
                 }
                 else

--- a/Duplicati/Library/Main/IController.cs
+++ b/Duplicati/Library/Main/IController.cs
@@ -235,7 +235,7 @@ public interface IController : IDisposable
     /// <param name="limit">The maximum number of results to return</param>
     /// <param name="extendedData">Whether to include extended data</param>
     /// <returns>The search results</returns>
-    Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, long offset, long limit, bool extendedData);
+    Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool extendedData);
 
     /// <summary>
     /// Sends an email notification

--- a/Duplicati/Library/Main/IPC/ControllerRpcProxy.cs
+++ b/Duplicati/Library/Main/IPC/ControllerRpcProxy.cs
@@ -403,8 +403,8 @@ public class ControllerRpcProxy : IController, IDisposable, IControllerRpcCallba
         => await Rpc.InvokeAsync<IListFileVersionsResults>(nameof(IController.ListFileVersionsAsync), files, offset, limit).ConfigureAwait(false);
 
     /// <inheritdoc />
-    public async Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, long offset, long limit, bool extendedData)
-        => await Rpc.InvokeAsync<ISearchFilesResults>(nameof(IController.SearchEntriesAsync), pathprefixes, filter, offset, limit, extendedData).ConfigureAwait(false);
+    public async Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool extendedData)
+        => await Rpc.InvokeAsync<ISearchFilesResults>(nameof(IController.SearchEntriesAsync), pathprefixes, filter, caseSensitive, offset, limit, extendedData).ConfigureAwait(false);
 
     /// <inheritdoc />
     public async Task<ICreateLogDatabaseResults> CreateLogDatabaseAsync(string targetpath)

--- a/Duplicati/Library/Main/IPC/ControllerRpcServer.cs
+++ b/Duplicati/Library/Main/IPC/ControllerRpcServer.cs
@@ -175,8 +175,8 @@ public class ControllerRpcServer : IController, IDisposable
         => Controller.ListFileVersionsAsync(files, offset, limit);
 
     /// <inheritdoc />
-    public Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, long offset, long limit, bool extendedData)
-        => Controller.SearchEntriesAsync(pathprefixes, filter, offset, limit, extendedData);
+    public Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool extendedData)
+        => Controller.SearchEntriesAsync(pathprefixes, filter, caseSensitive, offset, limit, extendedData);
 
     /// <inheritdoc />
     public Task<ICreateLogDatabaseResults> CreateLogDatabaseAsync(string targetpath)

--- a/Duplicati/Library/Main/Operation/SearchEntriesHandler.cs
+++ b/Duplicati/Library/Main/Operation/SearchEntriesHandler.cs
@@ -41,11 +41,12 @@ internal static class SearchEntriesHandler
     /// <param name="result">The result class</param>
     /// <param name="paths">The paths to search</param>
     /// <param name="filter">The filter to use for searching</param>
+    /// <param name="caseSensitive">Whether the search should be case sensitive</param>
     /// <param name="offset">The offset to start searching from</param>
     /// <param name="limit">The maximum number of results to return</param>
     /// <param name="extendedData">Whether to include extended data</param>
     /// <returns>A task representing the asynchronous operation</returns>
-    public static async Task RunAsync(Options options, SearchFilesResults result, string[] paths, IFilter filter, long offset, long limit, bool extendedData)
+    public static async Task RunAsync(Options options, SearchFilesResults result, string[] paths, IFilter filter, bool caseSensitive, long offset, long limit, bool extendedData)
     {
         if (!System.IO.File.Exists(options.Dbpath))
             throw new UserInformationException("No local database found, this operation requires a local database", "NoLocalDatabase");
@@ -69,7 +70,7 @@ internal static class SearchEntriesHandler
             paths = paths.Select(path => Util.AppendDirSeparator(path)).ToArray();
 
         result.FileVersions = await db
-            .SearchEntriesAsync(paths, filter, filesetIds, offset, limit, result.TaskControl.ProgressToken)
+            .SearchEntriesAsync(paths, filter, caseSensitive, filesetIds, offset, limit, result.TaskControl.ProgressToken)
             .ConfigureAwait(false);
 
         if (extendedData)

--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -50,6 +50,7 @@ namespace Duplicati.Server
             int PageSize { get; }
             int PageOffset { get; }
             bool ReturnExtended { get; }
+            bool CaseSensitiveSearch { get; }
             void SetController(Library.Main.IController? controller);
         }
 
@@ -78,6 +79,8 @@ namespace Duplicati.Server
             public int PageSize { get; internal set; } = 0;
             public int PageOffset { get; internal set; } = 0;
             public bool ReturnExtended { get; internal set; } = false;
+            public bool CaseSensitiveSearch { get; internal set; } = false;
+
             public DateTime? TaskStarted { get; set; }
             public DateTime? TaskFinished { get; set; }
 
@@ -181,7 +184,7 @@ namespace Duplicati.Server
             return new CustomRunnerTask(runner);
         }
 
-        public static IRunnerData CreateTask(DuplicatiOperation operation, IBackup backup, IDictionary<string, string?>? extraOptions = null, string[]? filterStrings = null, string[]? extraArguments = null, int pageSize = 0, int pageOffset = 0, bool returnExtended = false)
+        public static IRunnerData CreateTask(DuplicatiOperation operation, IBackup backup, IDictionary<string, string?>? extraOptions = null, string[]? filterStrings = null, string[]? extraArguments = null, int pageSize = 0, int pageOffset = 0, bool returnExtended = false, bool caseSensitiveSearch = false)
         {
             return new RunnerData()
             {
@@ -192,7 +195,8 @@ namespace Duplicati.Server
                 ExtraArguments = extraArguments,
                 PageSize = pageSize,
                 PageOffset = pageOffset,
-                ReturnExtended = returnExtended
+                ReturnExtended = returnExtended,
+                CaseSensitiveSearch = caseSensitiveSearch
             };
         }
 
@@ -262,7 +266,7 @@ namespace Duplicati.Server
                 pageOffset: pageOffset);
         }
 
-        public static IRunnerData CreateSearchEntriesTask(IBackup backup, string[]? filters, string[]? folders, DateTime time, long[]? version, int pageSize, int pageOffset, bool returnExtended)
+        public static IRunnerData CreateSearchEntriesTask(IBackup backup, string[]? filters, bool caseSensitive, string[]? folders, DateTime time, long[]? version, int pageSize, int pageOffset, bool returnExtended)
         {
             var dict = new Dictionary<string, string?>();
             if (time.Ticks > 0)
@@ -278,7 +282,8 @@ namespace Duplicati.Server
                 extraArguments: folders,
                 pageSize: pageSize,
                 pageOffset: pageOffset,
-                returnExtended: returnExtended);
+                returnExtended: returnExtended,
+                caseSensitiveSearch: caseSensitive);
         }
 
 
@@ -840,7 +845,7 @@ namespace Duplicati.Server
                         case DuplicatiOperation.SearchEntries:
                             {
                                 var parsedfilter = new FilterExpression(data.FilterStrings);
-                                return await controller.SearchEntriesAsync(data.ExtraArguments, parsedfilter, data.PageOffset * data.PageSize, data.PageSize, data.ReturnExtended).ConfigureAwait(false);
+                                return await controller.SearchEntriesAsync(data.ExtraArguments, parsedfilter, data.CaseSensitiveSearch, data.PageOffset * data.PageSize, data.PageSize, data.ReturnExtended).ConfigureAwait(false);
                             }
                         default:
                             //TODO: Log this

--- a/Duplicati/UnitTest/DirectListHandlerTests.cs
+++ b/Duplicati/UnitTest/DirectListHandlerTests.cs
@@ -259,42 +259,42 @@ namespace Duplicati.UnitTest
                 TestUtils.AssertResults(await c.BackupAsync(rootItems(initial).Select(x => Path.Combine(this.DATAFOLDER, x.Replace("/", Path.DirectorySeparatorChar.ToString()))).ToArray()));
 
                 // Simple Search for 'file'
-                var search = await c.SearchEntriesAsync(null, ParseFilters("+file"), 0, 0, false);
+                var search = await c.SearchEntriesAsync(null, ParseFilters("+file"), false, 0, 0, false);
                 Assert.That(search.FileVersions.Items.Count(), Is.EqualTo(3)); // file1.txt, file2.txt, file3.txt
 
                 // Simple Search for 'notes'
-                var searchNotes = await c.SearchEntriesAsync(null, ParseFilters("+notes"), 0, 0, false);
+                var searchNotes = await c.SearchEntriesAsync(null, ParseFilters("+notes"), false, 0, 0, false);
                 Assert.That(searchNotes.FileVersions.Items.Count(), Is.EqualTo(1));
                 Assert.That(searchNotes.FileVersions.Items.First().Path.EndsWith("notes.txt"));
 
                 // Simple Search for NOT 'notes'
-                var searchNotNotes = await c.SearchEntriesAsync(null, ParseFilters("-notes"), 0, 0, false);
+                var searchNotNotes = await c.SearchEntriesAsync(null, ParseFilters("-notes"), false, 0, 0, false);
                 Assert.That(searchNotNotes.FileVersions.Items.Count(), Is.EqualTo(5));
                 Assert.That(searchNotNotes.FileVersions.Items.All(x => !x.Path.Contains("notes")), Is.True);
 
                 // Simple Search for 'folder1' folder contents
-                var searchFolder = await c.SearchEntriesAsync(null, ParseFilters("+folder1"), 0, 0, false);
+                var searchFolder = await c.SearchEntriesAsync(null, ParseFilters("+folder1"), false, 0, 0, false);
                 Assert.That(searchFolder.FileVersions.Items.All(x => x.Path.Contains("folder1")), Is.True);
 
                 // Simple Search with exact file name
-                var searchExact = await c.SearchEntriesAsync(null, ParseFilters("+file1.txt"), 0, 0, false);
+                var searchExact = await c.SearchEntriesAsync(null, ParseFilters("+file1.txt"), false, 0, 0, false);
                 Assert.That(searchExact.FileVersions.Items.Count(), Is.EqualTo(1));
                 Assert.That(searchExact.FileVersions.Items.First().Path.EndsWith("file1.txt"));
 
                 // Mixed include and exclude
-                var searchMixed = await c.SearchEntriesAsync(null, ParseFilters("+file;-file2"), 0, 0, false);
+                var searchMixed = await c.SearchEntriesAsync(null, ParseFilters("+file;-file2"), false, 0, 0, false);
                 // Include has precedence over exclude, but we include non-matches as well
                 Assert.That(searchMixed.FileVersions.Items.Count(), Is.EqualTo(6));
                 Assert.That(searchMixed.FileVersions.Items.Any(x => x.Path.Contains("file2")), Is.True);
 
                 // Mixed include and exclude
-                var searchMixed2 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-file"), 0, 0, false);
+                var searchMixed2 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-file"), false, 0, 0, false);
                 // Include has precedence over exclude, but we include non-matches as well
                 Assert.That(searchMixed2.FileVersions.Items.Count(), Is.EqualTo(4));
                 Assert.That(searchMixed2.FileVersions.Items.Any(x => x.Path.Contains("file2")), Is.True);
 
                 // Mixed include and exclude, wildcards
-                var searchMixed3 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-*"), 0, 0, false);
+                var searchMixed3 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-*"), false, 0, 0, false);
                 // Include has precedence over exclude, but we include non-matches as well
                 Assert.That(searchMixed3.FileVersions.Items.Count(), Is.EqualTo(1));
                 Assert.That(searchMixed3.FileVersions.Items.All(x => x.Path.Contains("file2")), Is.True);
@@ -302,7 +302,7 @@ namespace Duplicati.UnitTest
                 // NEW: Search inside specific folder prefix: folder1
                 var searchInFolder1 = await c.SearchEntriesAsync(
                     new[] { Path.Combine(this.DATAFOLDER, "folder1") },
-                    ParseFilters("+file"),
+                    ParseFilters("+file"), false,
                     0, 0, false);
                 Assert.That(searchInFolder1.FileVersions.Items.Count(), Is.EqualTo(2)); // file2.txt, file3.txt inside folder1
                 Assert.That(searchInFolder1.FileVersions.Items.All(x => x.Path.Contains("folder1")), Is.True);
@@ -314,7 +314,7 @@ namespace Duplicati.UnitTest
                 Path.Combine(this.DATAFOLDER, "folder1"),
                 Path.Combine(this.DATAFOLDER, "folder2")
                     },
-                    ParseFilters("+file;+notes"),
+                    ParseFilters("+file;+notes"), false,
                     0, 0, false);
                 Assert.That(searchInFolders.FileVersions.Items.Count(), Is.EqualTo(3)); // file2.txt, file3.txt, notes.txt
                 Assert.That(searchInFolders.FileVersions.Items.Any(x => x.Path.Contains("folder1")), Is.True);
@@ -847,6 +847,7 @@ namespace Duplicati.UnitTest
             var result = await db.SearchEntriesAsync(
                 null,
                 new FilterExpression("*", true),
+                false,
                 filesetIds.ToArray(),
                 0,
                 2000,

--- a/Duplicati/WebserverCore/Dto/V2/SearchEntriesRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/SearchEntriesRequestDto.cs
@@ -49,4 +49,8 @@ public sealed record SearchEntriesRequestDto : PaginatedRequest
     /// The version(s) to search in
     /// </summary>
     public long[]? Version { get; init; }
+    /// <summary>
+    /// If true, the search will be case sensitive
+    /// </summary>
+    public bool? CaseSensitiveSearch { get; init; }
 }

--- a/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
@@ -145,7 +145,7 @@ public class BackupListing : IEndpointV2
             ? new DateTime(0)
             : Library.Utility.Timeparser.ParseTimeInterval(input.Time, DateTime.Now);
 
-        var r = await queueRunnerService.RunImmediatelyAsync(Runner.CreateSearchEntriesTask(bk, input.Filters, input.Paths, time, input.Version, input.PageSize ?? 1000, input.Page ?? 0, input.ReturnExtended ?? false)).ConfigureAwait(false) as ISearchFilesResults;
+        var r = await queueRunnerService.RunImmediatelyAsync(Runner.CreateSearchEntriesTask(bk, input.Filters, input.CaseSensitiveSearch ?? false, input.Paths, time, input.Version, input.PageSize ?? 1000, input.Page ?? 0, input.ReturnExtended ?? false)).ConfigureAwait(false) as ISearchFilesResults;
         if (r == null)
             throw new ServerErrorException("No result from list operation");
 


### PR DESCRIPTION
This PR fixes a bug that caused backup searching to be case-sensitive.

The PR also exposes the case sensitive-flag in the API endpoint so the UI can toggle case-sensitive searching.