### PR TITLE
Add searching in metadata

### DIFF
--- a/Duplicati/CommandLine/CLI/Commands.cs
+++ b/Duplicati/CommandLine/CLI/Commands.cs
@@ -476,7 +476,7 @@ namespace Duplicati.CommandLine
 
                 HandleDbAccessWithoutPassphrase(backend, options);
 
-                var res = i.SearchEntriesAsync(args.ToArray(), filter, false, 0, 0, false).Await();
+                var res = i.SearchEntriesAsync(args.ToArray(), filter, false, 0, 0, false, false).Await();
                 outwriter.WriteLine("File versions:");
                 var prevFile = string.Empty;
                 foreach (var e in res.FileVersions.Items)

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -230,9 +230,9 @@ namespace Duplicati.Library.Main
             ).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public async Task<ISearchFilesResults> SearchEntriesAsync(string[] pathprefixes, IFilter inputFilter, bool caseSensitive, long offset, long limit, bool extendedData)
-            => await RunActionAsync(new SearchFilesResults(), pathprefixes, inputFilter, new { caseSensitive, offset, limit, extendedData }, static config =>
-                Operation.SearchEntriesHandler.RunAsync(config.Options, config.Result, config.Paths, config.Filter, config.Context.caseSensitive, config.Context.offset, config.Context.limit, config.Context.extendedData)
+        public async Task<ISearchFilesResults> SearchEntriesAsync(string[] pathprefixes, IFilter inputFilter, bool caseSensitive, long offset, long limit, bool returnExtendedData, bool searchMetadata)
+            => await RunActionAsync(new SearchFilesResults(), pathprefixes, inputFilter, new { caseSensitive, offset, limit, returnExtendedData, searchMetadata }, static config =>
+                Operation.SearchEntriesHandler.RunAsync(config.Options, config.Result, config.Paths, config.Filter, config.Context.caseSensitive, config.Context.offset, config.Context.limit, config.Context.returnExtendedData, config.Context.searchMetadata)
             ).ConfigureAwait(false);
 
         /// <inheritdoc />

--- a/Duplicati/Library/Main/Database/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/LocalListDatabase.cs
@@ -41,6 +41,21 @@ namespace Duplicati.Library.Main.Database
     internal class LocalListDatabase : LocalDatabase
     {
         private static readonly string LOGTAG = Log.LogTagFromType<LocalListDatabase>();
+
+        /// <summary>
+        /// Metadata JSON keys that are searched when SearchMetadata is enabled.
+        /// </summary>
+        private static readonly string[] METADATA_SEARCH_KEYS =
+        [
+            "o365:Name",
+            "o365:DisplayName",
+            "o365:Type",
+            "gsuite:Name",
+            "gsuite:DisplayName",
+            "gsuite:SpaceName",
+            "gsuite:Type"
+        ];
+
         /// <summary>
         /// Creates a new instance of the LocalListDatabase.
         /// </summary>
@@ -1376,16 +1391,44 @@ namespace Duplicati.Library.Main.Database
         }
 
         /// <summary>
+        /// Builds a SQL condition that checks if any metadata search key matches the given filter part.
+        /// </summary>
+        private static string BuildMetadataCondition(string propName, bool caseSensitive, bool isWildcard)
+        {
+            var conditions = new List<string>();
+            foreach (var key in METADATA_SEARCH_KEYS)
+            {
+                var extract = $"json_extract(md.\"Content\", '$.\"{key}\"')";
+                if (isWildcard)
+                {
+                    if (caseSensitive)
+                        conditions.Add($"{extract} GLOB {propName}");
+                    else
+                        conditions.Add($"LOWER({extract}) GLOB LOWER({propName})");
+                }
+                else
+                {
+                    if (caseSensitive)
+                        conditions.Add($"instr({extract}, {propName}) > 0");
+                    else
+                        conditions.Add($"instr(LOWER({extract}), LOWER({propName})) > 0");
+                }
+            }
+            return string.Join("\n                                OR ", conditions);
+        }
+
+        /// <summary>
         /// Searches for file versions matching a filter in the specified path prefixes.
         /// </summary>
         /// <param name="pathprefixes">The path prefixes to search in, or search in all if empty.</param>
         /// <param name="filter">The filter to match against file paths.</param>
         /// <param name="filesetIds">Optional fileset IDs to restrict the search to.</param>
+        /// <param name="searchMetadata">Whether to also search in metadata JSON values.</param>
         /// <param name="offset">The offset for pagination.</param>
         /// <param name="limit">The limit for pagination.</param>
         /// <param name="token"> A cancellation token to cancel the operation.</param>
         /// <returns>A task that when awaited returns all matching file versions ordered by path and then version time.</returns>
-        public async Task<IPaginatedResults<ISearchFileVersion>> SearchEntriesAsync(IEnumerable<string>? pathprefixes, IFilter filter, bool caseSensitive, long[]? filesetIds, long offset, long limit, CancellationToken token)
+        public async Task<IPaginatedResults<ISearchFileVersion>> SearchEntriesAsync(IEnumerable<string>? pathprefixes, IFilter filter, bool caseSensitive, long[]? filesetIds, bool searchMetadata, long offset, long limit, CancellationToken token)
         {
             if (offset != 0 && limit <= 0)
                 throw new ArgumentException("Cannot use offset without limit specified.", nameof(offset));
@@ -1453,15 +1496,37 @@ namespace Duplicati.Library.Main.Database
                         var propName = $"@Part{Library.Utility.Utility.FormatInvariantValue(filterProps.Count)}";
                         filterProps[propName] = part;
                         if (caseSensitive)
+                        {
                             caseWhenParts.Add($@"
                                 WHEN instr(pp.""Prefix"" || fl.""Path"", {propName}) > 0
                                 THEN {(filterExpression.Result ? "0" : "1")}
                             ");
+                            if (searchMetadata)
+                            {
+                                caseWhenParts.Add($@"
+                                    WHEN md.""Content"" IS NOT NULL AND (
+                                        {BuildMetadataCondition(propName, true, false)}
+                                    )
+                                    THEN {(filterExpression.Result ? "0" : "1")}
+                                ");
+                            }
+                        }
                         else
+                        {
                             caseWhenParts.Add($@"
                                 WHEN instr(LOWER(pp.""Prefix"" || fl.""Path""), LOWER({propName})) > 0
                                 THEN {(filterExpression.Result ? "0" : "1")}
                             ");
+                            if (searchMetadata)
+                            {
+                                caseWhenParts.Add($@"
+                                    WHEN md.""Content"" IS NOT NULL AND (
+                                        {BuildMetadataCondition(propName, false, false)}
+                                    )
+                                    THEN {(filterExpression.Result ? "0" : "1")}
+                                ");
+                            }
+                        }
                     }
                 }
                 else if (filterExpression.Type == FilterType.Wildcard)
@@ -1472,15 +1537,37 @@ namespace Duplicati.Library.Main.Database
                         var propName = $"@Part{Library.Utility.Utility.FormatInvariantValue(filterProps.Count)}";
                         filterProps[propName] = part;
                         if (caseSensitive)
+                        {
                             caseWhenParts.Add($@"
                             WHEN pp.""Prefix"" || fl.""Path"" GLOB {propName}
                             THEN {(filterExpression.Result ? "0" : "1")}
                         ");
+                            if (searchMetadata)
+                            {
+                                caseWhenParts.Add($@"
+                                    WHEN md.""Content"" IS NOT NULL AND (
+                                        {BuildMetadataCondition(propName, true, true)}
+                                    )
+                                    THEN {(filterExpression.Result ? "0" : "1")}
+                                ");
+                            }
+                        }
                         else
+                        {
                             caseWhenParts.Add($@"
                                 WHEN LOWER(pp.""Prefix"" || fl.""Path"") GLOB LOWER({propName})
                                 THEN {(filterExpression.Result ? "0" : "1")}
                             ");
+                            if (searchMetadata)
+                            {
+                                caseWhenParts.Add($@"
+                                    WHEN md.""Content"" IS NOT NULL AND (
+                                        {BuildMetadataCondition(propName, false, true)}
+                                    )
+                                    THEN {(filterExpression.Result ? "0" : "1")}
+                                ");
+                            }
+                        }
                     }
                 }
                 else
@@ -1559,6 +1646,8 @@ namespace Duplicati.Library.Main.Database
                     ON ""fe"".""FilesetID"" = ""f"".""ID""
                 LEFT JOIN ""Blockset"" ""b""
                     ON ""fl"".""BlocksetID"" = ""b"".""ID""
+                LEFT JOIN ""Metadataset"" ""md""
+                    ON ""fl"".""MetadataID"" = ""md"".""ID""
                 INNER JOIN ""PathPrefix"" ""pp""
                     ON ""fl"".""PrefixID"" = ""pp"".""ID""
                 WHERE {whereClause}
@@ -1622,6 +1711,8 @@ namespace Duplicati.Library.Main.Database
                     FROM ""FilesetEntry"" ""fe""
                     INNER JOIN ""FileLookup"" ""fl""
                         ON ""fe"".""FileID"" = ""fl"".""ID""
+                    LEFT JOIN ""Metadataset"" ""md""
+                        ON ""fl"".""MetadataID"" = ""md"".""ID""
                     INNER JOIN ""PathPrefix"" ""pp""
                         ON ""fl"".""PrefixID"" = ""pp"".""ID""
                     WHERE {whereClause}

--- a/Duplicati/Library/Main/IController.cs
+++ b/Duplicati/Library/Main/IController.cs
@@ -233,9 +233,10 @@ public interface IController : IDisposable
     /// <param name="filter">The filter to apply</param>
     /// <param name="offset">The offset to start searching from</param>
     /// <param name="limit">The maximum number of results to return</param>
-    /// <param name="extendedData">Whether to include extended data</param>
+    /// <param name="returnExtendedData">Whether to include extended data</param>
+    /// <param name="searchMetadata">Whether to also search in metadata JSON</param>
     /// <returns>The search results</returns>
-    Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool extendedData);
+    Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool returnExtendedData, bool searchMetadata);
 
     /// <summary>
     /// Sends an email notification

--- a/Duplicati/Library/Main/IPC/ControllerRpcProxy.cs
+++ b/Duplicati/Library/Main/IPC/ControllerRpcProxy.cs
@@ -403,8 +403,8 @@ public class ControllerRpcProxy : IController, IDisposable, IControllerRpcCallba
         => await Rpc.InvokeAsync<IListFileVersionsResults>(nameof(IController.ListFileVersionsAsync), files, offset, limit).ConfigureAwait(false);
 
     /// <inheritdoc />
-    public async Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool extendedData)
-        => await Rpc.InvokeAsync<ISearchFilesResults>(nameof(IController.SearchEntriesAsync), pathprefixes, filter, caseSensitive, offset, limit, extendedData).ConfigureAwait(false);
+    public async Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool returnExtendedData, bool searchMetadata)
+        => await Rpc.InvokeAsync<ISearchFilesResults>(nameof(IController.SearchEntriesAsync), pathprefixes, filter, caseSensitive, offset, limit, returnExtendedData, searchMetadata).ConfigureAwait(false);
 
     /// <inheritdoc />
     public async Task<ICreateLogDatabaseResults> CreateLogDatabaseAsync(string targetpath)

--- a/Duplicati/Library/Main/IPC/ControllerRpcServer.cs
+++ b/Duplicati/Library/Main/IPC/ControllerRpcServer.cs
@@ -175,8 +175,8 @@ public class ControllerRpcServer : IController, IDisposable
         => Controller.ListFileVersionsAsync(files, offset, limit);
 
     /// <inheritdoc />
-    public Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool extendedData)
-        => Controller.SearchEntriesAsync(pathprefixes, filter, caseSensitive, offset, limit, extendedData);
+    public Task<ISearchFilesResults> SearchEntriesAsync(string[]? pathprefixes, IFilter? filter, bool caseSensitive, long offset, long limit, bool returnExtendedData, bool searchMetadata)
+        => Controller.SearchEntriesAsync(pathprefixes, filter, caseSensitive, offset, limit, returnExtendedData, searchMetadata);
 
     /// <inheritdoc />
     public Task<ICreateLogDatabaseResults> CreateLogDatabaseAsync(string targetpath)

--- a/Duplicati/Library/Main/Operation/SearchEntriesHandler.cs
+++ b/Duplicati/Library/Main/Operation/SearchEntriesHandler.cs
@@ -44,9 +44,10 @@ internal static class SearchEntriesHandler
     /// <param name="caseSensitive">Whether the search should be case sensitive</param>
     /// <param name="offset">The offset to start searching from</param>
     /// <param name="limit">The maximum number of results to return</param>
-    /// <param name="extendedData">Whether to include extended data</param>
+    /// <param name="returnExtendedData">Whether to include extended data</param>
+    /// <param name="searchMetadata">Whether to also search in metadata JSON</param>
     /// <returns>A task representing the asynchronous operation</returns>
-    public static async Task RunAsync(Options options, SearchFilesResults result, string[] paths, IFilter filter, bool caseSensitive, long offset, long limit, bool extendedData)
+    public static async Task RunAsync(Options options, SearchFilesResults result, string[] paths, IFilter filter, bool caseSensitive, long offset, long limit, bool returnExtendedData, bool searchMetadata)
     {
         if (!System.IO.File.Exists(options.Dbpath))
             throw new UserInformationException("No local database found, this operation requires a local database", "NoLocalDatabase");
@@ -70,10 +71,10 @@ internal static class SearchEntriesHandler
             paths = paths.Select(path => Util.AppendDirSeparator(path)).ToArray();
 
         result.FileVersions = await db
-            .SearchEntriesAsync(paths, filter, caseSensitive, filesetIds, offset, limit, result.TaskControl.ProgressToken)
+            .SearchEntriesAsync(paths, filter, caseSensitive, filesetIds, searchMetadata, offset, limit, result.TaskControl.ProgressToken)
             .ConfigureAwait(false);
 
-        if (extendedData)
+        if (returnExtendedData)
         {
             var coreentries = result.FileVersions.Items.Cast<SearchFileVersion>().ToArray();
             var metadata = await db.GetMetadataForFilesetIdsAsync(coreentries.Select(e => e.FileId), result.TaskControl.ProgressToken).ConfigureAwait(false);

--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -49,8 +49,9 @@ namespace Duplicati.Server
             string[]? ExtraArguments { get; }
             int PageSize { get; }
             int PageOffset { get; }
-            bool ReturnExtended { get; }
+            bool ReturnExtendedData { get; }
             bool CaseSensitiveSearch { get; }
+            bool SearchMetadata { get; }
             void SetController(Library.Main.IController? controller);
         }
 
@@ -78,8 +79,9 @@ namespace Duplicati.Server
             public string[]? ExtraArguments { get; internal set; }
             public int PageSize { get; internal set; } = 0;
             public int PageOffset { get; internal set; } = 0;
-            public bool ReturnExtended { get; internal set; } = false;
+            public bool ReturnExtendedData { get; internal set; } = false;
             public bool CaseSensitiveSearch { get; internal set; } = false;
+            public bool SearchMetadata { get; internal set; } = false;
 
             public DateTime? TaskStarted { get; set; }
             public DateTime? TaskFinished { get; set; }
@@ -184,7 +186,7 @@ namespace Duplicati.Server
             return new CustomRunnerTask(runner);
         }
 
-        public static IRunnerData CreateTask(DuplicatiOperation operation, IBackup backup, IDictionary<string, string?>? extraOptions = null, string[]? filterStrings = null, string[]? extraArguments = null, int pageSize = 0, int pageOffset = 0, bool returnExtended = false, bool caseSensitiveSearch = false)
+        public static IRunnerData CreateTask(DuplicatiOperation operation, IBackup backup, IDictionary<string, string?>? extraOptions = null, string[]? filterStrings = null, string[]? extraArguments = null, int pageSize = 0, int pageOffset = 0, bool returnExtended = false, bool caseSensitiveSearch = false, bool includeMetadata = false)
         {
             return new RunnerData()
             {
@@ -195,8 +197,9 @@ namespace Duplicati.Server
                 ExtraArguments = extraArguments,
                 PageSize = pageSize,
                 PageOffset = pageOffset,
-                ReturnExtended = returnExtended,
-                CaseSensitiveSearch = caseSensitiveSearch
+                ReturnExtendedData = returnExtended,
+                CaseSensitiveSearch = caseSensitiveSearch,
+                SearchMetadata = includeMetadata
             };
         }
 
@@ -266,7 +269,7 @@ namespace Duplicati.Server
                 pageOffset: pageOffset);
         }
 
-        public static IRunnerData CreateSearchEntriesTask(IBackup backup, string[]? filters, bool caseSensitive, string[]? folders, DateTime time, long[]? version, int pageSize, int pageOffset, bool returnExtended)
+        public static IRunnerData CreateSearchEntriesTask(IBackup backup, string[]? filters, bool caseSensitive, string[]? folders, DateTime time, long[]? version, int pageSize, int pageOffset, bool returnExtendedData, bool searchMetadata)
         {
             var dict = new Dictionary<string, string?>();
             if (time.Ticks > 0)
@@ -282,8 +285,9 @@ namespace Duplicati.Server
                 extraArguments: folders,
                 pageSize: pageSize,
                 pageOffset: pageOffset,
-                returnExtended: returnExtended,
-                caseSensitiveSearch: caseSensitive);
+                returnExtended: returnExtendedData,
+                caseSensitiveSearch: caseSensitive,
+                includeMetadata: searchMetadata);
         }
 
 
@@ -835,7 +839,7 @@ namespace Duplicati.Server
                             }
                         case DuplicatiOperation.ListFolderContents:
                             {
-                                return await controller.ListFolderAsync(data.ExtraArguments, data.PageOffset * data.PageSize, data.PageSize, data.ReturnExtended).ConfigureAwait(false);
+                                return await controller.ListFolderAsync(data.ExtraArguments, data.PageOffset * data.PageSize, data.PageSize, data.ReturnExtendedData).ConfigureAwait(false);
                             }
 
                         case DuplicatiOperation.ListFileVersions:
@@ -845,7 +849,7 @@ namespace Duplicati.Server
                         case DuplicatiOperation.SearchEntries:
                             {
                                 var parsedfilter = new FilterExpression(data.FilterStrings);
-                                return await controller.SearchEntriesAsync(data.ExtraArguments, parsedfilter, data.CaseSensitiveSearch, data.PageOffset * data.PageSize, data.PageSize, data.ReturnExtended).ConfigureAwait(false);
+                                return await controller.SearchEntriesAsync(data.ExtraArguments, parsedfilter, data.CaseSensitiveSearch, data.PageOffset * data.PageSize, data.PageSize, data.ReturnExtendedData, data.SearchMetadata).ConfigureAwait(false);
                             }
                         default:
                             //TODO: Log this

--- a/Duplicati/UnitTest/DirectListHandlerTests.cs
+++ b/Duplicati/UnitTest/DirectListHandlerTests.cs
@@ -259,42 +259,42 @@ namespace Duplicati.UnitTest
                 TestUtils.AssertResults(await c.BackupAsync(rootItems(initial).Select(x => Path.Combine(this.DATAFOLDER, x.Replace("/", Path.DirectorySeparatorChar.ToString()))).ToArray()));
 
                 // Simple Search for 'file'
-                var search = await c.SearchEntriesAsync(null, ParseFilters("+file"), false, 0, 0, false);
+                var search = await c.SearchEntriesAsync(null, ParseFilters("+file"), false, 0, 0, false, false);
                 Assert.That(search.FileVersions.Items.Count(), Is.EqualTo(3)); // file1.txt, file2.txt, file3.txt
 
                 // Simple Search for 'notes'
-                var searchNotes = await c.SearchEntriesAsync(null, ParseFilters("+notes"), false, 0, 0, false);
+                var searchNotes = await c.SearchEntriesAsync(null, ParseFilters("+notes"), false, 0, 0, false, false);
                 Assert.That(searchNotes.FileVersions.Items.Count(), Is.EqualTo(1));
                 Assert.That(searchNotes.FileVersions.Items.First().Path.EndsWith("notes.txt"));
 
                 // Simple Search for NOT 'notes'
-                var searchNotNotes = await c.SearchEntriesAsync(null, ParseFilters("-notes"), false, 0, 0, false);
+                var searchNotNotes = await c.SearchEntriesAsync(null, ParseFilters("-notes"), false, 0, 0, false, false);
                 Assert.That(searchNotNotes.FileVersions.Items.Count(), Is.EqualTo(5));
                 Assert.That(searchNotNotes.FileVersions.Items.All(x => !x.Path.Contains("notes")), Is.True);
 
                 // Simple Search for 'folder1' folder contents
-                var searchFolder = await c.SearchEntriesAsync(null, ParseFilters("+folder1"), false, 0, 0, false);
+                var searchFolder = await c.SearchEntriesAsync(null, ParseFilters("+folder1"), false, 0, 0, false, false);
                 Assert.That(searchFolder.FileVersions.Items.All(x => x.Path.Contains("folder1")), Is.True);
 
                 // Simple Search with exact file name
-                var searchExact = await c.SearchEntriesAsync(null, ParseFilters("+file1.txt"), false, 0, 0, false);
+                var searchExact = await c.SearchEntriesAsync(null, ParseFilters("+file1.txt"), false, 0, 0, false, false);
                 Assert.That(searchExact.FileVersions.Items.Count(), Is.EqualTo(1));
                 Assert.That(searchExact.FileVersions.Items.First().Path.EndsWith("file1.txt"));
 
                 // Mixed include and exclude
-                var searchMixed = await c.SearchEntriesAsync(null, ParseFilters("+file;-file2"), false, 0, 0, false);
+                var searchMixed = await c.SearchEntriesAsync(null, ParseFilters("+file;-file2"), false, 0, 0, false, false);
                 // Include has precedence over exclude, but we include non-matches as well
                 Assert.That(searchMixed.FileVersions.Items.Count(), Is.EqualTo(6));
                 Assert.That(searchMixed.FileVersions.Items.Any(x => x.Path.Contains("file2")), Is.True);
 
                 // Mixed include and exclude
-                var searchMixed2 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-file"), false, 0, 0, false);
+                var searchMixed2 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-file"), false, 0, 0, false, false);
                 // Include has precedence over exclude, but we include non-matches as well
                 Assert.That(searchMixed2.FileVersions.Items.Count(), Is.EqualTo(4));
                 Assert.That(searchMixed2.FileVersions.Items.Any(x => x.Path.Contains("file2")), Is.True);
 
                 // Mixed include and exclude, wildcards
-                var searchMixed3 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-*"), false, 0, 0, false);
+                var searchMixed3 = await c.SearchEntriesAsync(null, ParseFilters("+file2;-*"), false, 0, 0, false, false);
                 // Include has precedence over exclude, but we include non-matches as well
                 Assert.That(searchMixed3.FileVersions.Items.Count(), Is.EqualTo(1));
                 Assert.That(searchMixed3.FileVersions.Items.All(x => x.Path.Contains("file2")), Is.True);
@@ -303,7 +303,7 @@ namespace Duplicati.UnitTest
                 var searchInFolder1 = await c.SearchEntriesAsync(
                     new[] { Path.Combine(this.DATAFOLDER, "folder1") },
                     ParseFilters("+file"), false,
-                    0, 0, false);
+                    0, 0, false, false);
                 Assert.That(searchInFolder1.FileVersions.Items.Count(), Is.EqualTo(2)); // file2.txt, file3.txt inside folder1
                 Assert.That(searchInFolder1.FileVersions.Items.All(x => x.Path.Contains("folder1")), Is.True);
 
@@ -315,7 +315,7 @@ namespace Duplicati.UnitTest
                 Path.Combine(this.DATAFOLDER, "folder2")
                     },
                     ParseFilters("+file;+notes"), false,
-                    0, 0, false);
+                    0, 0, false, false);
                 Assert.That(searchInFolders.FileVersions.Items.Count(), Is.EqualTo(3)); // file2.txt, file3.txt, notes.txt
                 Assert.That(searchInFolders.FileVersions.Items.Any(x => x.Path.Contains("folder1")), Is.True);
                 Assert.That(searchInFolders.FileVersions.Items.Any(x => x.Path.Contains("folder2")), Is.True);
@@ -849,6 +849,7 @@ namespace Duplicati.UnitTest
                 new FilterExpression("*", true),
                 false,
                 filesetIds.ToArray(),
+                false,
                 0,
                 2000,
                 CancellationToken.None)
@@ -856,6 +857,157 @@ namespace Duplicati.UnitTest
 
             // Assert: Should return all 1500 file versions (150 filesets * 10 files)
             Assert.That(result.Items.Count(), Is.EqualTo(1500));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="LocalListDatabase.SearchEntriesAsync"/> can match values inside
+        /// metadata JSON when <paramref name="searchMetadata"/> is <c>true</c>.
+        /// </summary>
+        [Test]
+        [Category("Database")]
+        public async Task SearchEntries_WithMetadataSearch_MatchesMetadataValuesAsync()
+        {
+            // Arrange
+            using var tempFile = new TempFile();
+            await using var db = await LocalListDatabase.CreateAsync(tempFile, null, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Insert operation entry
+            using (var cmd = db.Connection.CreateCommand())
+            {
+                await cmd.SetCommandAndParameters(@"
+                    INSERT OR IGNORE INTO Operation (ID, Description, Timestamp)
+                    VALUES (1, 'TestOperation', 0);")
+                    .ExecuteNonQueryAsync();
+            }
+
+            // Insert RemoteVolume and Fileset
+            using (var cmd = db.Connection.CreateCommand())
+            {
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO RemoteVolume (ID, OperationID, Name, Type, State, Size, VerificationCount, DeleteGraceTime, ArchiveTime, LockExpirationTime)
+                    VALUES (1, 1, 'volume.zip', 'Files', 'Verified', 1024, 0, 0, 0, 0);")
+                    .ExecuteNonQueryAsync();
+
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO Fileset (ID, OperationID, VolumeID, IsFullBackup, Timestamp)
+                    VALUES (1, 1, 1, 1, 0);")
+                    .ExecuteNonQueryAsync();
+            }
+
+            using (var cmd = db.Connection.CreateCommand())
+            {
+                // Insert Blockset for the Metadataset
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO Blockset (ID, Length, FullHash)
+                    VALUES (1, 1024, 'fullhash');")
+                    .ExecuteNonQueryAsync();
+
+                // Insert two metadata entries
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO Metadataset (ID, BlocksetID, Content)
+                    VALUES (1, 1, '{""o365:Name"": ""MyDocument"", ""o365:Type"": ""DriveFile""}');")
+                    .ExecuteNonQueryAsync();
+
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO Metadataset (ID, BlocksetID, Content)
+                    VALUES (2, 1, '{""gsuite:Name"": ""MySheet"", ""gsuite:Type"": ""Spreadsheet""}');")
+                    .ExecuteNonQueryAsync();
+
+                // Insert PathPrefix
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO PathPrefix (ID, Prefix)
+                    VALUES (1, '/test/');")
+                    .ExecuteNonQueryAsync();
+
+                // Insert FileLookup entries: one with metadata, one without
+                // File 1: has metadata matching "MyDocument"
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO FileLookup (ID, PrefixID, Path, BlocksetID, MetadataID)
+                    VALUES (1, 1, 'file1.txt', 1, 1);")
+                    .ExecuteNonQueryAsync();
+
+                // File 2: has metadata matching "MySheet" (different key)
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO FileLookup (ID, PrefixID, Path, BlocksetID, MetadataID)
+                    VALUES (2, 1, 'file2.txt', 1, 2);")
+                    .ExecuteNonQueryAsync();
+
+                // File 3: no metadata
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO FileLookup (ID, PrefixID, Path, BlocksetID, MetadataID)
+                    VALUES (3, 1, 'file3.txt', 1, 0);")
+                    .ExecuteNonQueryAsync();
+
+                // Folder 4: folder with metadata matching "MyDocument"
+                // BlocksetID = -100 is FOLDER_BLOCKSET_ID
+                await cmd.SetCommandAndParameters(@"
+                    INSERT INTO FileLookup (ID, PrefixID, Path, BlocksetID, MetadataID)
+                    VALUES (4, 1, 'folder1', -100, 1);")
+                    .ExecuteNonQueryAsync();
+
+                // Insert FilesetEntry for all four entries
+                for (int fileId = 1; fileId <= 4; fileId++)
+                {
+                    await cmd.SetCommandAndParameters(@"
+                        INSERT INTO FilesetEntry (FilesetID, FileID, Lastmodified)
+                        VALUES (@filesetId, @fileId, @lastModified);")
+                        .SetParameterValue("@filesetId", 1)
+                        .SetParameterValue("@fileId", fileId)
+                        .SetParameterValue("@lastModified", 0)
+                        .ExecuteNonQueryAsync();
+                }
+            }
+
+            // Act: Search for "MyDocument" with metadata search enabled
+            var result = await db.SearchEntriesAsync(
+                null,
+                new FilterExpression("MyDocument", true),
+                false,
+                [1],
+                true, // searchMetadata
+                0,
+                100,
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Assert: Both file1.txt and folder1 should match (via o365:Name metadata)
+            Assert.That(result.Items.Count(), Is.EqualTo(2));
+            var paths = result.Items.Select(x => x.Path).OrderBy(x => x).ToList();
+            Assert.That(paths[0], Is.EqualTo("/test/file1.txt"));
+            Assert.That(paths[1], Is.EqualTo("/test/folder1"));
+            Assert.That(result.Items.First(x => x.Path == "/test/folder1").IsDirectory, Is.True);
+
+            // Act: Search for "MySheet" with metadata search enabled
+            result = await db.SearchEntriesAsync(
+                null,
+                new FilterExpression("MySheet", true),
+                false,
+                [1],
+                true, // searchMetadata
+                0,
+                100,
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Assert: Only file2.txt should match (via gsuite:Name metadata)
+            Assert.That(result.Items.Count(), Is.EqualTo(1));
+            Assert.That(result.Items.First().Path, Is.EqualTo("/test/file2.txt"));
+
+            // Act: Search for "MyDocument" with metadata search DISABLED
+            result = await db.SearchEntriesAsync(
+                null,
+                new FilterExpression("MyDocument", true),
+                false,
+                [1],
+                false, // searchMetadata disabled
+                0,
+                100,
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Assert: No files should match (path doesn't contain "MyDocument")
+            Assert.That(result.Items.Count(), Is.EqualTo(0));
         }
     }
 }

--- a/Duplicati/WebserverCore/Dto/V2/SearchEntriesRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/SearchEntriesRequestDto.cs
@@ -53,4 +53,8 @@ public sealed record SearchEntriesRequestDto : PaginatedRequest
     /// If true, the search will be case sensitive
     /// </summary>
     public bool? CaseSensitiveSearch { get; init; }
+    /// <summary>
+    /// If true, the search will also look in the metadata JSON
+    /// </summary>
+    public bool? SearchMetadata { get; init; }
 }

--- a/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
@@ -145,7 +145,7 @@ public class BackupListing : IEndpointV2
             ? new DateTime(0)
             : Library.Utility.Timeparser.ParseTimeInterval(input.Time, DateTime.Now);
 
-        var r = await queueRunnerService.RunImmediatelyAsync(Runner.CreateSearchEntriesTask(bk, input.Filters, input.CaseSensitiveSearch ?? false, input.Paths, time, input.Version, input.PageSize ?? 1000, input.Page ?? 0, input.ReturnExtended ?? false)).ConfigureAwait(false) as ISearchFilesResults;
+        var r = await queueRunnerService.RunImmediatelyAsync(Runner.CreateSearchEntriesTask(bk, input.Filters, input.CaseSensitiveSearch ?? false, input.Paths, time, input.Version, input.PageSize ?? 1000, input.Page ?? 0, input.ReturnExtended ?? false, input.SearchMetadata ?? false)).ConfigureAwait(false) as ISearchFilesResults;
         if (r == null)
             throw new ServerErrorException("No result from list operation");
 


### PR DESCRIPTION
When performing searches on some remote source, like MS365, the actual file paths are not meaningfull to the user. Instead, the UI will display metadata that makes it easier to navigate.

This PR updates the search feature to optionally look in metadata and find matches there as well, making it simpler to work with such data.