### PR TITLE
Use relative database paths

### DIFF
--- a/Duplicati/CommandLine/DatabaseTool/Commands/Verify.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Commands/Verify.cs
@@ -148,7 +148,11 @@ public static class Verify
                 {
                     var path = rd.ConvertValueToString(0);
                     if (!string.IsNullOrEmpty(path))
+                    {
+                        if (!Path.IsPathRooted(path))
+                            path = Path.Combine(datafolder, path);
                         serverDbPaths.Add(Path.GetFullPath(path));
+                    }
                 }
             }
             catch (Exception ex)

--- a/Duplicati/CommandLine/DatabaseTool/Helper.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Helper.cs
@@ -67,7 +67,14 @@ public static class Helper
                     FROM ""Backup""
                 ");
                 await foreach (var rd in cmd.ExecuteReaderEnumerableAsync(CancellationToken.None).ConfigureAwait(false))
-                    dbpaths.Add(rd.ConvertValueToString(0) ?? "");
+                {
+                    var rawPath = rd.ConvertValueToString(0) ?? "";
+                    if (!string.IsNullOrEmpty(rawPath))
+                    {
+                        var resolvedPath = Path.IsPathRooted(rawPath) ? rawPath : Path.Combine(datafolder, rawPath);
+                        dbpaths.Add(Path.GetFullPath(resolvedPath));
+                    }
+                }
             }
             catch
             {

--- a/Duplicati/Library/RestAPI/Database/Connection.cs
+++ b/Duplicati/Library/RestAPI/Database/Connection.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Duplicati.Server.Serialization.Interface;
 using System.Text;
@@ -36,6 +37,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Text.RegularExpressions;
 using Duplicati.WebserverCore.Abstractions;
 using System.Text.Json;
+using Duplicati.Library.Common.IO;
 
 #nullable enable
 
@@ -202,10 +204,12 @@ namespace Duplicati.Server.Database
         public Serializable.ImportExportStructure PrepareBackupForExport(IBackup backup)
         {
             var scheduleId = GetScheduleIDsFromTags(new string[] { "ID=" + backup.ID });
+            var exportBackup = ((Database.Backup)backup).Clone();
+            exportBackup.SetDBPath(GetRelativeDbPath(backup.DBPath));
             return new Serializable.ImportExportStructure()
             {
                 CreatedByVersion = UpdaterManager.SelfVersion.Version ?? "Unknown",
-                Backup = (Database.Backup)backup,
+                Backup = exportBackup,
                 Schedule = scheduleId != null && scheduleId.Any() ? (Schedule?)GetSchedule(scheduleId.First()) : null,
                 DisplayNames = SpecialFolders.GetSourceNames(backup)
             };
@@ -550,7 +554,7 @@ namespace Duplicati.Server.Database
                         Description = ConvertToString(rd, 2),
                         Tags = (ConvertToString(rd, 3) ?? "").Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
                         TargetURL = EncryptedFieldHelper.Decrypt(ConvertToString(rd, 4), m_key),
-                        DBPath = ConvertToString(rd, 5),
+                        DBPath = ResolveDbPath(ConvertToString(rd, 5)),
                     },
                     cmd => cmd.SetCommandAndParameters(@"SELECT ""ID"", ""Name"", ""Description"", ""Tags"", ""TargetURL"", ""DBPath"" FROM ""Backup"" WHERE ID = @Id")
                         .SetParameterValue("@Id", id))
@@ -745,6 +749,38 @@ namespace Duplicati.Server.Database
             return null;
         }
 
+        /// <summary>
+        /// Resolves a DB path, converting relative paths to absolute paths based on the data folder.
+        /// </summary>
+        /// <param name="dbPath">The DB path to resolve.</param>
+        /// <returns>The absolute DB path.</returns>
+        private string ResolveDbPath(string? dbPath)
+        {
+            if (string.IsNullOrWhiteSpace(dbPath) || Path.IsPathRooted(dbPath))
+                return dbPath ?? "";
+
+            return Path.GetFullPath(Path.Combine(m_dataFolder, dbPath));
+        }
+
+        /// <summary>
+        /// Converts an absolute DB path to a relative path if it is under the data folder.
+        /// </summary>
+        /// <param name="dbPath">The DB path to convert.</param>
+        /// <returns>The relative DB path if under the data folder, otherwise the original path.</returns>
+        private string GetRelativeDbPath(string? dbPath)
+        {
+            if (string.IsNullOrWhiteSpace(dbPath) || !Path.IsPathRooted(dbPath))
+                return dbPath ?? "";
+
+            var fullDataFolder = Util.AppendDirSeparator(Path.GetFullPath(m_dataFolder));
+            var fullDbPath = Path.GetFullPath(dbPath);
+
+            if (fullDbPath.StartsWith(fullDataFolder, Library.Utility.Utility.ClientFilenameStringComparison))
+                return fullDbPath.Substring(fullDataFolder.Length);
+
+            return dbPath;
+        }
+
         public void UpdateBackupDBPath(IBackup item, string path)
         {
             lock (m_lock)
@@ -753,7 +789,7 @@ namespace Duplicati.Server.Database
                 {
                     using (var cmd = m_connection.CreateCommand(tr, @"UPDATE ""Backup"" SET ""DBPath""= @Dbpath WHERE ""ID""= @Id"))
                     {
-                        cmd.SetParameterValue("@Dbpath", path)
+                        cmd.SetParameterValue("@Dbpath", GetRelativeDbPath(path))
                             .SetParameterValue("@Id", item.ID)
                             .ExecuteNonQuery();
                         tr.Commit();
@@ -773,13 +809,14 @@ namespace Duplicati.Server.Database
                 if (!update && item.DBPath == null)
                 {
                     var folder = m_dataFolder;
-                    if (!System.IO.Directory.Exists(folder))
-                        System.IO.Directory.CreateDirectory(folder);
+                    if (!Directory.Exists(folder))
+                        Directory.CreateDirectory(folder);
 
                     for (var i = 0; i < 100; i++)
                     {
-                        var guess = System.IO.Path.Combine(folder, System.IO.Path.ChangeExtension(CLIDatabaseLocator.GenerateRandomName(), ".sqlite"));
-                        if (!System.IO.File.Exists(guess))
+                        var guess = Path.ChangeExtension(CLIDatabaseLocator.GenerateRandomName(), ".sqlite");
+                        var fullGuess = Path.GetFullPath(Path.Combine(folder, guess));
+                        if (!File.Exists(fullGuess))
                         {
                             ((Backup)item).DBPath = guess;
                             break;
@@ -818,7 +855,7 @@ namespace Duplicati.Server.Database
                             if (update)
                                 cmd.SetParameterValue("@Id", item.ID);
                             else
-                                cmd.SetParameterValue("@DbPath", n.DBPath)
+                                cmd.SetParameterValue("@DbPath", GetRelativeDbPath(n.DBPath))
                                     .SetParameterValue("@ExternalID", n.ExternalID ?? "");
 
                         });
@@ -1006,7 +1043,7 @@ namespace Duplicati.Server.Database
                             Description = ConvertToString(rd, 3),
                             Tags = (ConvertToString(rd, 4) ?? "").Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
                             TargetURL = EncryptedFieldHelper.Decrypt(ConvertToString(rd, 5), m_key),
-                            DBPath = ConvertToString(rd, 6),
+                            DBPath = ResolveDbPath(ConvertToString(rd, 6)),
                         },
                         cmd => cmd.SetCommandAndParameters(@"SELECT ""ID"", ""Name"", ""ExternalID"", ""Description"", ""Tags"", ""TargetURL"", ""DBPath"" FROM ""Backup"" "))
                         .ToArray();

--- a/Duplicati/UnitTest/DatabaseToolTests.cs
+++ b/Duplicati/UnitTest/DatabaseToolTests.cs
@@ -442,6 +442,75 @@ INSERT INTO ""Version"" (""Version"") VALUES (12);
 
         [Test]
         [Category("DatabaseTool")]
+        public async Task TestVerifyCommandWithRelativeDbPathAsync()
+        {
+            using var tempFolder = new Library.Utility.TempFolder();
+            string tempDir = tempFolder;
+
+            var serverDb = Path.Combine(tempDir, "server.sqlite");
+            var localDb1 = Path.Combine(tempDir, "local1.sqlite");
+            var relativeDbPath = "local1.sqlite";
+            var orphanDb = Path.Combine(tempDir, "ABCDEFGHIJ.sqlite");
+
+            // Create server database
+            using (var db = await SQLiteLoader.LoadConnectionAsync(serverDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = ServerSchemaV6;
+                await cmd.ExecuteNonQueryAsync();
+
+                // Insert a backup with a relative DBPath
+                cmd.CommandText = $@"
+                    INSERT INTO ""Backup"" (""Name"", ""Tags"", ""TargetURL"", ""DBPath"")
+                    VALUES ('Test Backup', '', 'file:///test', '{relativeDbPath.Replace("'", "''")}');
+                ";
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            // Create local database
+            using (var db = await SQLiteLoader.LoadConnectionAsync(localDb1))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            // Create orphan database
+            using (var db = await SQLiteLoader.LoadConnectionAsync(orphanDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            // Copy server database to expected location
+            var serverTargetPath = Path.Combine(tempDir, "Duplicati-server.sqlite");
+            File.Copy(serverDb, serverTargetPath);
+
+            // Test verify command with JSON output
+            var output = new StringWriter();
+            var originalOut = Console.Out;
+            Console.SetOut(output);
+
+            try
+            {
+                Assert.AreEqual(0, await Program.MainAsync(["verify", "--datafolder", tempDir, "--output-json"]));
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            var result = output.ToString();
+
+            // Should report localDb1 as Found (referenced with relative path but resolved)
+            Assert.That(result, Does.Contain("\"Status\": \"Found\""));
+            // Should report orphanDb as Orphaned (exists but not referenced)
+            Assert.That(result, Does.Contain("\"Status\": \"Orphaned\""));
+        }
+
+        [Test]
+        [Category("DatabaseTool")]
         [TestCase(true)]  // Dry run - no files should be deleted
         [TestCase(false)] // Force - only orphaned files should be deleted
         public async Task TestCleanupCommandAsync(bool dryRun)

--- a/Duplicati/UnitTest/RelativeDbPathTests.cs
+++ b/Duplicati/UnitTest/RelativeDbPathTests.cs
@@ -1,0 +1,221 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.AutoUpdater;
+using Duplicati.Library.SQLiteHelper;
+using Duplicati.Server.Database;
+using Duplicati.Server.Serialization.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Tests for relative DBPath storage and resolution in the server database.
+    /// </summary>
+    [TestFixture]
+    [Category("RelativeDbPath")]
+    public class RelativeDbPathTests
+    {
+        private string _tempDataFolder = null!;
+        private string _databasePath = null!;
+        private Connection _connection = null!;
+
+        [SetUp]
+        public async Task SetUpAsync()
+        {
+            _tempDataFolder = Path.Combine(Path.GetTempPath(), $"duplicati-relative-db-test-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_tempDataFolder);
+
+            _databasePath = Path.Combine(_tempDataFolder, DataFolderManager.SERVER_DATABASE_FILENAME);
+
+            var dbConnection = await SQLiteLoader.LoadConnectionAsync(_databasePath);
+            DatabaseUpgrader.UpgradeDatabase(dbConnection, _databasePath, typeof(Library.RestAPI.Database.DatabaseSchemaMarker));
+
+            _connection = new Connection(dbConnection, true, null, _tempDataFolder, () => { });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _connection?.Dispose();
+
+            if (Directory.Exists(_tempDataFolder))
+            {
+                try
+                {
+                    Directory.Delete(_tempDataFolder, true);
+                }
+                catch
+                {
+                    // Best effort cleanup
+                }
+            }
+        }
+
+        private static Backup CreateTestBackup()
+        {
+            return new Backup()
+            {
+                ID = null,
+                Name = "Test Backup",
+                Description = "Test Description",
+                Tags = new string[] { "test" },
+                TargetURL = "file:///test",
+                Sources = new string[] { "/test" },
+                Settings = new ISetting[0],
+                Filters = new IFilter[0],
+                Metadata = new Dictionary<string, string>()
+            };
+        }
+
+        [Test]
+        public void NewBackup_StoresRelativeDbPath()
+        {
+            var backup = CreateTestBackup();
+
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+            Assert.IsNotNull(backup.DBPath);
+            Assert.IsFalse(Path.IsPathRooted(backup.DBPath), "New backup DBPath should be stored as relative");
+            Assert.IsTrue(backup.DBPath.EndsWith(".sqlite", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void LoadBackup_ResolvesRelativeDbPath()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+            var loadedBackup = _connection.GetBackup(backup.ID);
+            Assert.IsNotNull(loadedBackup);
+            Assert.IsTrue(Path.IsPathRooted(loadedBackup!.DBPath), "Loaded backup DBPath should be absolute");
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(_tempDataFolder, backup.DBPath)), loadedBackup.DBPath);
+        }
+
+        [Test]
+        public void UpdateBackupDbPath_UnderDataFolder_StoresRelative()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+            var newPath = Path.Combine(_tempDataFolder, "moved-backup.sqlite");
+            File.WriteAllText(newPath, "");
+
+            _connection.UpdateBackupDBPath(backup, newPath);
+
+            var loadedBackup = _connection.GetBackup(backup.ID);
+            Assert.IsNotNull(loadedBackup);
+            // The loaded DBPath should be resolved to absolute
+            Assert.IsTrue(Path.IsPathRooted(loadedBackup!.DBPath));
+            Assert.AreEqual(Path.GetFileName(newPath), Path.GetFileName(loadedBackup.DBPath));
+
+            // Verify the raw stored value is relative by querying the database directly
+            using (var db = SQLiteLoader.LoadConnection(_databasePath))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = @"SELECT ""DBPath"" FROM ""Backup"" WHERE ""ID"" = @id";
+                var param = cmd.CreateParameter();
+                param.ParameterName = "@id";
+                param.Value = long.Parse(backup.ID);
+                cmd.Parameters.Add(param);
+                var rawDbPath = cmd.ExecuteScalar()?.ToString() ?? "";
+                Assert.AreEqual("moved-backup.sqlite", rawDbPath);
+            }
+        }
+
+        [Test]
+        public void UpdateBackupDbPath_OutsideDataFolder_StoresAbsolute()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+            var outsideFolder = Path.Combine(Path.GetTempPath(), $"duplicati-outside-{Guid.NewGuid()}");
+            Directory.CreateDirectory(outsideFolder);
+            try
+            {
+                var newPath = Path.Combine(outsideFolder, "moved-backup.sqlite");
+                File.WriteAllText(newPath, "");
+
+                _connection.UpdateBackupDBPath(backup, newPath);
+
+                var loadedBackup = _connection.GetBackup(backup.ID);
+                Assert.IsNotNull(loadedBackup);
+                Assert.AreEqual(newPath, loadedBackup!.DBPath);
+            }
+            finally
+            {
+                Directory.Delete(outsideFolder, true);
+            }
+        }
+
+        [Test]
+        public void BackupsProperty_ResolvesRelativeDbPaths()
+        {
+            var backup1 = CreateTestBackup();
+            backup1.Name = "Backup 1";
+            var backup2 = CreateTestBackup();
+            backup2.Name = "Backup 2";
+
+            _connection.AddOrUpdateBackupAndSchedule(backup1, null);
+            _connection.AddOrUpdateBackupAndSchedule(backup2, null);
+
+            var backups = _connection.Backups;
+            Assert.AreEqual(2, backups.Length);
+
+            foreach (var bk in backups)
+            {
+                Assert.IsTrue(Path.IsPathRooted(bk.DBPath), $"Backup '{bk.Name}' DBPath should be absolute");
+            }
+        }
+
+        [Test]
+        public void ExistingAbsoluteDbPath_StaysAbsolute()
+        {
+            var outsideFolder = Path.Combine(Path.GetTempPath(), $"duplicati-outside-{Guid.NewGuid()}");
+            Directory.CreateDirectory(outsideFolder);
+            try
+            {
+                var absolutePath = Path.Combine(outsideFolder, "external-backup.sqlite");
+                File.WriteAllText(absolutePath, "");
+
+                var backup = CreateTestBackup();
+                backup.SetDBPath(absolutePath);
+                _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+                var loadedBackup = _connection.GetBackup(backup.ID);
+                Assert.IsNotNull(loadedBackup);
+                Assert.AreEqual(absolutePath, loadedBackup!.DBPath);
+            }
+            finally
+            {
+                Directory.Delete(outsideFolder, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR changes to use relative database paths by default. The default mode is to store all databases in the same folder.

With this update, the paths stored in the server database can now be relative, in which case they are resolved relative to the datafolder.

This makes it simpler to move the data folder as the paths are not stored in full.

For new backups, relative paths are assigned.
For existing backups, the full paths are retained. If the database path is updated manually, the path will be made relative, if it is relative to the datafolder; otherwise a full path is stored.

This fixes #6677