### PR TITLE
Fix incorrect option types for lock mode

### DIFF
--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -71,6 +71,11 @@ namespace Duplicati.Library.Backend.AzureBlob
         public const int DEFAULT_INTERNAL_RETRIES = 3;
 
         /// <summary>
+        /// The default immutability policy mode
+        /// </summary>
+        private const BlobImmutabilityPolicyMode DEFAULT_IMMUTABILITY_MODE = BlobImmutabilityPolicyMode.Unlocked;
+
+        /// <summary>
         /// The immutability policy mode
         /// </summary>
         private readonly BlobImmutabilityPolicyMode _immutabilityPolicyMode;
@@ -124,10 +129,9 @@ namespace Duplicati.Library.Backend.AzureBlob
                 ? null
                 // Warning: The cast here is required to avoid implicit casting null to AccessTier
                 : (AccessTier?)new AccessTier(accessTierValue);
-            var internalRetries = Library.Utility.Utility.ParseIntOption(options, AZURE_INTERNAL_RETRIES_OPTION, DEFAULT_INTERNAL_RETRIES);
+            var internalRetries = Utility.Utility.ParseIntOption(options, AZURE_INTERNAL_RETRIES_OPTION, DEFAULT_INTERNAL_RETRIES);
 
-            var immutabilityPolicyModeValue = options.GetValueOrDefault(AZURE_BLOB_IMMUTABILITY_POLICY_MODE_OPTION);
-            _immutabilityPolicyMode = Library.Utility.Utility.ParseEnumOption(options, AZURE_BLOB_IMMUTABILITY_POLICY_MODE_OPTION, BlobImmutabilityPolicyMode.Unlocked);
+            _immutabilityPolicyMode = Utility.Utility.ParseEnumOption(options, AZURE_BLOB_IMMUTABILITY_POLICY_MODE_OPTION, DEFAULT_IMMUTABILITY_MODE);
 
             _azureBlob = new AzureBlobWrapper(auth.Username!, auth.Password, sasToken, containerName, accessTier, archiveClasses, timeouts, internalRetries);
         }
@@ -241,10 +245,10 @@ namespace Duplicati.Library.Backend.AzureBlob
                         Strings.AzureBlobBackend.InternalRetriesDescriptionLong,
                         Library.Utility.Utility.FormatInvariantValue(DEFAULT_INTERNAL_RETRIES)),
                     new CommandLineArgument(AZURE_BLOB_IMMUTABILITY_POLICY_MODE_OPTION,
-                        CommandLineArgument.ArgumentType.String,
+                        CommandLineArgument.ArgumentType.Enumeration,
                         Strings.AzureBlobBackend.ImmutabilityPolicyModeDescriptionShort,
                         Strings.AzureBlobBackend.ImmutabilityPolicyModeDescriptionLong,
-                        "Unlocked",
+                        DEFAULT_IMMUTABILITY_MODE.ToString(),
                         null,
                         Enum.GetNames(typeof(BlobImmutabilityPolicyMode))),
                     .. TimeoutOptionsHelper.GetOptions()

--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -93,6 +93,11 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
     private const int DEFAULT_PAGE_SIZE = 500;
 
     /// <summary>
+    /// The default lock mode for the backend
+    /// </summary>
+    private const B2LockMode DEFAULT_LOCK_MODE = B2LockMode.Governance;
+
+    /// <summary>
     /// Default retry-after time in seconds for B2 API requests
     /// </summary>
     private const int B2_RETRY_AFTER_SECONDS = 5;
@@ -224,18 +229,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
         if (options.TryGetValue(B2_DOWNLOAD_URL_OPTION, out var option)) _downloadUrl = option;
 
         // Parse lock mode option, default to Governance
-        _lockMode = B2LockMode.Governance; // Default to governance
-        if (options.TryGetValue(B2_LOCK_MODE_OPTION, out var lockModeOption))
-        {
-            if (Enum.TryParse<B2LockMode>(lockModeOption, true, out var parsedMode))
-            {
-                _lockMode = parsedMode;
-            }
-            else
-            {
-                throw new UserInformationException(Strings.B2.InvalidLockModeError(B2_LOCK_MODE_OPTION, lockModeOption), "B2InvalidLockMode");
-            }
-        }
+        _lockMode = Library.Utility.Utility.ParseEnumOption(options, B2_LOCK_MODE_OPTION, DEFAULT_LOCK_MODE);
 
         _httpClient = HttpClientHelper.CreateClient();
         _httpClient.Timeout = Timeout.InfiniteTimeSpan;
@@ -338,7 +332,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
             new CommandLineArgument(B2_CREATE_BUCKET_TYPE_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2createbuckettypeDescriptionShort, Strings.B2.B2createbuckettypeDescriptionLong, DEFAULT_BUCKET_TYPE),
             new CommandLineArgument(B2_PAGESIZE_OPTION, CommandLineArgument.ArgumentType.Integer, Strings.B2.B2pagesizeDescriptionShort, Strings.B2.B2pagesizeDescriptionLong, DEFAULT_PAGE_SIZE.ToString()),
             new CommandLineArgument(B2_DOWNLOAD_URL_OPTION, CommandLineArgument.ArgumentType.String, Strings.B2.B2downloadurlDescriptionShort, Strings.B2.B2downloadurlDescriptionLong),
-            new CommandLineArgument(B2_LOCK_MODE_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.B2.B2lockmodeDescriptionShort, Strings.B2.B2lockmodeDescriptionLong, B2LockMode.Governance.ToString()),
+            new CommandLineArgument(B2_LOCK_MODE_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.B2.B2lockmodeDescriptionShort, Strings.B2.B2lockmodeDescriptionLong, DEFAULT_LOCK_MODE.ToString(), null, Enum.GetNames(typeof(B2LockMode))),
             ..TimeoutOptionsHelper.GetOptions()
         ]);
 

--- a/Duplicati/Library/Backend/Backblaze/Strings.cs
+++ b/Duplicati/Library/Backend/Backblaze/Strings.cs
@@ -41,6 +41,5 @@ namespace Duplicati.Library.Backend.Strings
         public static string B2lockmodeDescriptionLong { get { return LC.L(@"Sets the lock mode for B2 object retention. Governance mode allows privileged users to bypass retention, while Compliance mode enforces strict retention that cannot be bypassed."); } }
         public static string B2lockmodeDescriptionShort { get { return LC.L(@"The lock mode for B2 object retention (Governance or Compliance)"); } }
         public static string InvalidPageSizeError(string argname, string? value) { return LC.L(@"The setting ""{0}"" is invalid for ""{1}"". It must be an integer larger than zero.", value, argname); }
-        public static string InvalidLockModeError(string argname, string? value) { return LC.L(@"The setting ""{0}"" is invalid for ""{1}"". It must be either ""Governance"" or ""Compliance"".", value, argname); }
     }
 }

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -348,7 +348,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
                     .. AuthIdOptionsHelper.GetOptions(TOKEN_URL),
                     new CommandLineArgument(SERVICE_ACCOUNT_JSON_OPTION, CommandLineArgument.ArgumentType.Password, Strings.GoogleCloudStorage.ServiceAccountJsonDescriptionShort, Strings.GoogleCloudStorage.ServiceAccountJsonDescriptionLong),
                     new CommandLineArgument(SERVICE_ACCOUNT_FILE_OPTION, CommandLineArgument.ArgumentType.String, Strings.GoogleCloudStorage.ServiceAccountFileDescriptionShort, Strings.GoogleCloudStorage.ServiceAccountFileDescriptionLong),
-                    new CommandLineArgument(RETENTION_POLICY_MODE_OPTION, CommandLineArgument.ArgumentType.String, Strings.GoogleCloudStorage.RetentionPolicyModeDescriptionShort, Strings.GoogleCloudStorage.RetentionPolicyModeDescriptionLong, DEFAULT_RETENTION_POLICY_MODE.ToString(), null, Enum.GetNames(typeof(RetentionPolicyMode))),
+                    new CommandLineArgument(RETENTION_POLICY_MODE_OPTION, CommandLineArgument.ArgumentType.Enumeration, Strings.GoogleCloudStorage.RetentionPolicyModeDescriptionShort, Strings.GoogleCloudStorage.RetentionPolicyModeDescriptionLong, DEFAULT_RETENTION_POLICY_MODE.ToString(), null, Enum.GetNames(typeof(RetentionPolicyMode))),
                     new CommandLineArgument(PROJECT_OPTION, CommandLineArgument.ArgumentType.String, Strings.GoogleCloudStorage.ProjectDescriptionShort, Strings.GoogleCloudStorage.ProjectDescriptionLong),
                     .. TimeoutOptionsHelper.GetOptions(),
                 ];


### PR DESCRIPTION
This PR fixes a few places where the lock mode was a string, resulting in the UI asking the user to type a string.

With this change, the parsing is standardized and the options present as enums, giving a dropdown in the UI.