### PR TITLE
Fix Agent startup race

### DIFF
--- a/Duplicati/Agent/Program.cs
+++ b/Duplicati/Agent/Program.cs
@@ -46,6 +46,12 @@ public static class Program
     private static readonly string LogTag = Log.LogTagFromType(typeof(Program));
 
     /// <summary>
+    /// The cancellation token that signals the agent is shutting down.
+    /// Used by the remote-control callbacks to stop waiting for the local webserver.
+    /// </summary>
+    private static CancellationToken s_shutdownToken;
+
+    /// <summary>
     /// Commandline arguments for the agent
     /// </summary>
     /// <param name="AgentRegistrationUrl">The server URL to connect to</param>
@@ -289,6 +295,7 @@ public static class Program
             WebserverCore.Middlewares.PreSharedKeyFilter.PreSharedKey = RandomNumberGenerator.GetHexString(128);
 
         using var cts = new CancellationTokenSource();
+        s_shutdownToken = cts.Token;
 
         var target = new ControllerMultiLogTarget(new ConsoleLogDestination(), LogMessageType.Information, null, null);
         using (Log.StartScope(target))
@@ -339,15 +346,67 @@ public static class Program
         }
     }
 
-    private static Task<Dictionary<string, string?>> OnConnectAsync(Dictionary<string, string?> metadata)
-        => Server.Program.DuplicatiWebserver.Provider.GetRequiredService<IRemoteControllerHandler>().OnConnectAsync(metadata);
+    private static async Task<Duplicati.WebserverCore.DuplicatiWebserver?> WaitForServerAsync()
+    {
+        var cancellationToken = s_shutdownToken;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var server = Server.Program.DuplicatiWebserver;
+            if (server != null
+                && Server.Program.ServerStartedEvent.WaitOne(0, false)
+                && !server.TerminationTask.IsCompleted)
+            {
+                return server;
+            }
 
-    private static Task OnControlAsync(KeepRemoteConnection.ControlMessage message)
-        => Server.Program.DuplicatiWebserver.Provider.GetRequiredService<IRemoteControllerHandler>().OnControlAsync(message);
+            try
+            {
+                await Task.Delay(500, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
 
-    private static Task OnMessageAsync(KeepRemoteConnection.CommandMessage message)
-        => Server.Program.DuplicatiWebserver.Provider.GetRequiredService<IRemoteControllerHandler>().OnMessageAsync(message);
+        return null;
+    }
 
+    private static async Task<Dictionary<string, string?>> OnConnectAsync(Dictionary<string, string?> metadata)
+    {
+        var server = await WaitForServerAsync();
+        if (server == null)
+        {
+            Log.WriteMessage(LogMessageType.Warning, LogTag, "RemoteControlNoServer", null, "Local webserver not available, returning empty response to OnConnect");
+            return new Dictionary<string, string?>();
+        }
+
+        return await server.Provider.GetRequiredService<IRemoteControllerHandler>().OnConnectAsync(metadata);
+    }
+
+    private static async Task OnControlAsync(KeepRemoteConnection.ControlMessage message)
+    {
+        var server = await WaitForServerAsync();
+        if (server == null)
+        {
+            Log.WriteMessage(LogMessageType.Warning, LogTag, "RemoteControlNoServer", null, "Local webserver not available, dropping control message");
+            return;
+        }
+
+        await server.Provider.GetRequiredService<IRemoteControllerHandler>().OnControlAsync(message);
+    }
+
+    private static async Task OnMessageAsync(KeepRemoteConnection.CommandMessage message)
+    {
+        var server = await WaitForServerAsync();
+        if (server == null)
+        {
+            Log.WriteMessage(LogMessageType.Warning, LogTag, "RemoteControlNoServer", null, "Local webserver not available, dropping command message");
+            return;
+        }
+
+        await server.Provider.GetRequiredService<IRemoteControllerHandler>().OnMessageAsync(message);
+    }
 
     private static Task ReKeyAsync(IApplicationSettings applicationSettings, ClaimedClientData keydata, CommandLineArguments agentConfig)
     {

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -189,6 +189,12 @@ namespace Duplicati.Server
         [STAThread]
         public static int Main(IApplicationSettings applicationSettings, string[] _args)
         {
+            // Reset the started event and clear any stale webserver reference so that
+            // waiters (e.g. the agent's remote-control callbacks) do not observe a
+            // previous, now-stopped, instance when the local server is restarted.
+            ServerStartedEvent.Reset();
+            DuplicatiWebserver = null;
+
             PreloadSettingsLoader.ConfigurePreloadSettings(ref _args, PackageHelper.NamedExecutable.Server, out var preloadDbSettings);
 
             applicationSettings ??= new ApplicationSettings();


### PR DESCRIPTION
This PR fixes a race that could happen if the server was slow in starting, but the connection to the console was fast. In this case, the console connection would attempt to access the non-existing server and reach a "partially connected" state.

With this PR the callbacks that rely on the server being ready are now explicitly waiting for the server to start before attempting to access it.