### PR TITLE
Add DfsrPrivate to default excludes

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -355,6 +355,7 @@ namespace Duplicati.Library.Utility
                 yield return FilterGroups.CreateWildcardFilter(@"?:/Recycled/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/Recycler/");
                 yield return FilterGroups.CreateWildcardFilter(@"?:/System Volume Information/");
+                yield return FilterGroups.CreateWildcardFilter(@"*/DfsrPrivate/"); // DFS Replication private folder
                 yield return FilterGroups.CreateWildcardFilter(FilterGroups.CreateSpecialFolderFilter(Environment.SpecialFolder.Windows) + "Installer/");
 
                 foreach (var s in GetWindowsRegistryFilters() ?? new string[0])

--- a/Duplicati/UnitTest/FilterTest.cs
+++ b/Duplicati/UnitTest/FilterTest.cs
@@ -192,6 +192,22 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Filter")]
+        public static void WindowsDefaultExcludesDfsrPrivate()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            var expectedFilter = $"*{Util.DirectorySeparatorString}DfsrPrivate{Util.DirectorySeparatorString}";
+            var systemFilters = FilterGroups.GetFilterStrings(FilterGroup.SystemFiles).ToList();
+            Assert.IsTrue(systemFilters.Contains(expectedFilter, StringComparer.OrdinalIgnoreCase), $"Expected filter {expectedFilter} was not found.");
+
+            IFilter defaultExcludes = new FilterExpression("{DefaultExcludes}");
+            Assert.IsTrue(defaultExcludes.Matches(@"C:\Replicated\DfsrPrivate\", out _, out _));
+            Assert.IsFalse(defaultExcludes.Matches(@"C:\Replicated\.DfsrPrivate\", out _, out _));
+        }
+
+        [Test]
+        [Category("Filter")]
         public static void WildcardPatterns()
         {
             // These examples were taken from https://www.c-sharpcorner.com/uploadfile/b81385/efficient-string-matching-algorithm-with-use-of-wildcard-characters/.


### PR DESCRIPTION
## Summary
- Add the DFS Replication `DfsrPrivate` folder to the Windows default exclude filters.
- Cover the default exclude expansion with a Windows-only filter test.

## Why
Microsoft documents DFS Replication preserving internal files under `<replicated folder>\DfsrPrivate\...`, so this folder is system-managed data that should be skipped by the default Windows exclusions.

Closes #3444

## Validation
- Installed .NET SDK 10.0.301 in a temporary directory because the machine default SDK is 5.0.408.
- `dotnet restore Duplicati\UnitTest\Duplicati.UnitTest.csproj --verbosity minimal`
- `dotnet test Duplicati\UnitTest\Duplicati.UnitTest.csproj --filter "FullyQualifiedName~Duplicati.UnitTest.FilterTest" --no-build --logger "console;verbosity=normal" -p:UseSharedCompilation=false -m:1 -nr:false`

Note: restore/build emitted existing NU1903 warnings for `Microsoft.OpenApi` 2.3.0 and SYSLIB0057 warnings in `SslCertificateValidatorTests`; they are unrelated to this change.