### PR TITLE
Return non-zero exit code from server-util run --wait on backup failures

### DIFF
--- a/Duplicati/CommandLine/ServerUtil/Commands/RunBackup.cs
+++ b/Duplicati/CommandLine/ServerUtil/Commands/RunBackup.cs
@@ -21,6 +21,7 @@
 
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
+using Duplicati.Library.Interface;
 
 namespace Duplicati.CommandLine.ServerUtil.Commands;
 
@@ -76,8 +77,28 @@ public static class RunBackup
                 var response = await connection.GetBackupStatusAsync(matchingBackup.ID);
                 if (!quiet)
                     output.AppendConsoleMessage("Backup status: " + response);
+
+                // Map the parsed backup result to a process exit code so that callers
+                // (scripts, CI) can detect a backup that finished with warnings/errors.
+                // Codes mirror the main Duplicati CLI: warnings = 2, errors = 3, fatal = 4.
+                var parsedResult = Enum.TryParse<ParsedResultType>(response, ignoreCase: true, out var pr)
+                    ? pr
+                    : ParsedResultType.Unknown;
+
+                output.ExitCode = parsedResult switch
+                {
+                    ParsedResultType.Warning => 2,
+                    ParsedResultType.Error => 3,
+                    ParsedResultType.Fatal => 4,
+                    _ => 0
+                };
+                output.SetResult(output.ExitCode == 0);
             }
-            output.SetResult(true);
+            else
+            {
+                // Without --wait the backup is only queued; its outcome is unknown here.
+                output.SetResult(true);
+            }
         }));
 
     /// <summary>

--- a/Duplicati/CommandLine/ServerUtil/Program.cs
+++ b/Duplicati/CommandLine/ServerUtil/Program.cs
@@ -93,6 +93,13 @@ public static class Program
                 context.BindingContext.AddService(_ => OutputInterceptorBinder.GetConsoleInterceptor(context.BindingContext));
 
                 await next(context);
+
+                // Propagate a non-zero result from the command (e.g. a backup that
+                // finished with warnings/errors) to the process exit code. The exception
+                // path already sets context.ExitCode directly and never reaches here.
+                if (OutputInterceptorBinder.Instance is { ExitCode: not 0 } instance)
+                    context.ExitCode = instance.ExitCode;
+
                 Console.WriteLine(OutputInterceptorBinder.Instance?.GetSerializedResult());
             })
             .UseAdditionalHelpAliases()


### PR DESCRIPTION
## Summary

`duplicati-server-util run <backup> --wait` always returned exit code `0`, even when the backup finished with warnings or errors. This made it impossible for scripts and CI pipelines to detect a degraded or failed backup by checking the exit status.

This change maps the parsed backup result (already retrieved via `GetBackupStatusAsync` after `--wait`) to the process exit code.

## Changes

- **`RunBackup.cs`** — after `--wait`, parse the backup result and set the exit code, mirroring the main Duplicati CLI convention:
  - `Success` / `Unknown` → `0`
  - `Warning` → `2`
  - `Error` → `3`
  - `Fatal` → `4`
  - When run without `--wait` the backup is only queued (outcome unknown), so it still reports success.
- **`Program.cs`** — propagate a non-zero `OutputInterceptor.ExitCode` from the command handler to the process exit code. Previously only the exception path set `context.ExitCode`, so a successfully-returning-but-degraded backup could never surface a non-zero code.

## Rationale for exit codes

Codes follow the existing main Duplicati CLI backup convention (`CommandLine/CLI/Commands.cs`: warnings = 2, errors = 3) so behaviour is consistent across the two entry points.

## Testing

- `dotnet build` of the ServerUtil project succeeds (0 errors).
- The result-to-exit-code mapping was verified against the real `ParsedResultType` enum, including the fallback status strings that `GetBackupStatusAsync` can return (e.g. `"No log generated"` → `Unknown` → `0`, so an indeterminate result does not falsely report failure).

Fixes #5870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
