### PR TITLE
Add commandline target URL done action

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js
@@ -4,7 +4,8 @@ backupApp.directive('backupEditUri', function(gettextCatalog) {
     scope: {
         uri: '=uri',
         backupId: '=backupId',
-        setBuilduriFn: '&'
+        setBuilduriFn: '&',
+        hide: '&?'
     },
     templateUrl: 'templates/edituri.html',
     controller: function($scope, AppService, AppUtils, SystemInfo, EditUriBackendConfig, DialogService, EditUriBuiltins) {

--- a/Duplicati/Server/webroot/ngax/templates/commandline.html
+++ b/Duplicati/Server/webroot/ngax/templates/commandline.html
@@ -1,6 +1,6 @@
 <div class="commandline form" ng-controller="CommandlineController">
     <form class="styled" ng-hide="Mode == 'view'">
-        <backup-edit-uri uri="TargetURL" hide="HideEditUri" ng-show="EditUriState"></backup-edit-uri>
+        <backup-edit-uri uri="TargetURL" hide="HideEditUri()" ng-show="EditUriState"></backup-edit-uri>
 
         <div ng-hide="EditUriState">
 

--- a/Duplicati/Server/webroot/ngax/templates/edituri.html
+++ b/Duplicati/Server/webroot/ngax/templates/edituri.html
@@ -18,6 +18,7 @@
 </div>
 
 <div class="buttons">
+    <a href ng-if="hide" class="back" ng-click="hide()" translate>Done</a>
     <a href ng-hide="Testing" class="test-connection" ng-click="testConnection()" translate>Test connection</a>
     <a href ng-show="Testing" class="test-connection" translate>Testing …</a>
 </div>


### PR DESCRIPTION
## Summary

Fixes the legacy ngax Commandline page so users can return from the Target URL editor.

The Commandline template already passed a `hide` callback to `backup-edit-uri`, but the directive did not expose that binding, so opening `Target URL >` left no way back to the command form. This change wires the optional callback through the directive and shows a `Done` action only when that callback is provided.

Closes #2477

## Impact

- Adds a `Done` link to the Commandline Target URL editor.
- Leaves the Add/Edit backup and Direct restore destination editors unchanged because they do not pass `hide`.

## Validation

- `node --check Duplicati/Server/webroot/ngax/scripts/directives/backupEditUri.js`
- Confirmed the only `backup-edit-uri` callers are Commandline, Add/Edit backup, and Direct restore.