### PR TITLE
Escape Windows commandline percent expansion

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -41,6 +41,8 @@ using System.Threading.Tasks;
 using Duplicati.Library.Common.IO;
 using Duplicati.StreamUtil;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Utility
 {
     public static class Utility
@@ -1466,11 +1468,22 @@ namespace Duplicati.Library.Utility
         /// <param name="allowEnvExpansion">A flag indicating if environment variables are allowed to be expanded</param>
         [return: NotNullIfNotNull("arg")]
         public static string? WrapCommandLineElement(string? arg, bool allowEnvExpansion)
+            => WrapCommandLineElement(arg, allowEnvExpansion, OperatingSystem.IsWindows());
+
+        /// <summary>
+        /// Wraps a single argument in quotes suitable for passing on a commandline.
+        /// </summary>
+        /// <returns>The wrapped commandline element.</returns>
+        /// <param name="arg">The argument to wrap.</param>
+        /// <param name="allowEnvExpansion">A flag indicating if environment variables are allowed to be expanded.</param>
+        /// <param name="isWindows">A flag indicating if Windows commandline escaping should be used.</param>
+        [return: NotNullIfNotNull("arg")]
+        internal static string? WrapCommandLineElement(string? arg, bool allowEnvExpansion, bool isWindows)
         {
             if (string.IsNullOrWhiteSpace(arg))
                 return arg;
 
-            if (!OperatingSystem.IsWindows())
+            if (!isWindows)
             {
                 // We could consider using single quotes that prevents all expansions
                 //if (!allowEnvExpansion)
@@ -1490,16 +1503,13 @@ namespace Duplicati.Library.Utility
             }
             else
             {
-                // Windows needs only needs " replaced with "",
-                // but is prone to %var% expansion when used in
-                // immediate mode (i.e. from command prompt)
+                // Windows needs " replaced with "", but is prone to %var%
+                // expansion when used in immediate mode (i.e. from command prompt)
                 // Fortunately it does not expand when processes
                 // are started from within .Net
+                if (!allowEnvExpansion)
+                    arg = arg.Replace("%", "%%");
 
-                // TODO: I have not found a way to avoid escaping %varname%,
-                // and sadly it expands only if the variable exists
-                // making it even rarer and harder to diagnose when
-                // it happens
                 arg = arg.Replace(@"""", @"""""");
 
                 // Also fix the case where the argument ends with a slash

--- a/Duplicati/UnitTest/CommandLineWrappingTests.cs
+++ b/Duplicati/UnitTest/CommandLineWrappingTests.cs
@@ -1,0 +1,61 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    public class CommandLineWrappingTests
+    {
+        [Test]
+        [Category("Utility")]
+        public static void WrapCommandLineElementEscapesWindowsPercentWhenEnvironmentExpansionIsDisabled()
+        {
+            Assert.AreEqual("\"abc%%TEMP%%def\"", Utility.WrapCommandLineElement("abc%TEMP%def", false, true));
+            Assert.AreEqual("\"100%%\"", Utility.WrapCommandLineElement("100%", false, true));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void WrapCommandLineElementKeepsWindowsPercentWhenEnvironmentExpansionIsEnabled()
+        {
+            Assert.AreEqual("\"abc%TEMP%def\"", Utility.WrapCommandLineElement("abc%TEMP%def", true, true));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void WrapCommandLineElementKeepsExistingWindowsQuotingBehavior()
+        {
+            Assert.AreEqual("\"has\"\"quote\"", Utility.WrapCommandLineElement("has\"quote", false, true));
+            Assert.AreEqual("\"C:\\Temp\\folder\\\\\"", Utility.WrapCommandLineElement("C:\\Temp\\folder\\", false, true));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void WrapCommandLineElementRespectsUnixEnvironmentExpansionFlag()
+        {
+            Assert.AreEqual("\"$HOME/file\"", Utility.WrapCommandLineElement("$HOME/file", true, false));
+            Assert.AreEqual("\"\\$HOME/file\"", Utility.WrapCommandLineElement("$HOME/file", false, false));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Windows command-line wrapping so exported command lines do not accidentally expand `%VAR%` when environment expansion is not allowed.

`WrapCommandLineElement()` already accepted an `allowEnvExpansion` flag, but the Windows path only escaped quotes and left `%` untouched. That made exported command lines fragile when run through `cmd.exe`, because `%TEMP%`-style values could be expanded depending on the user's environment.

Closes #5667

## Changes

- Keeps the public `WrapCommandLineElement(string?, bool)` API unchanged.
- Adds an internal overload for explicit OS selection so Windows and Unix wrapping can be unit tested on any platform.
- Escapes `%` to `%%` on the Windows path only when `allowEnvExpansion` is `false`.
- Preserves `%VAR%` when `allowEnvExpansion` is `true`.
- Adds focused tests for Windows percent escaping, existing quote/trailing slash behavior, and Unix `$` handling.

## Validation

- `DOTNET_ROOT=/home/ec2-user/.dotnet PATH=/home/ec2-user/.dotnet:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test Duplicati/UnitTest/Duplicati.UnitTest.csproj --filter "FullyQualifiedName~CommandLineWrappingTests" --verbosity minimal`

Result: 4 passed, 0 failed.