### PR TITLE
Update Swashbuckle to patched OpenApi

### DIFF
--- a/Duplicati/WebserverCore/Duplicati.WebserverCore.csproj
+++ b/Duplicati/WebserverCore/Duplicati.WebserverCore.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Update `Swashbuckle.AspNetCore` from `10.0.1` to `10.2.3`
- Move the transitive `Microsoft.OpenApi` dependency from vulnerable `2.3.0` to patched `2.7.5`
- Leave Swagger/OpenAPI code unchanged because the existing API usage remains compatible

## Root cause

`Duplicati.WebserverCore` referenced `Swashbuckle.AspNetCore 10.0.1`, whose `Swashbuckle.AspNetCore.Swagger` dependency pulls in `Microsoft.OpenApi 2.3.0`. That version is affected by GHSA-v5pm-xwqc-g5wc / CVE-2026-49451. `Swashbuckle.AspNetCore 10.2.3` depends on `Microsoft.OpenApi 2.7.5`, which is the patched 2.x version line.

## Validation

Passed locally:

```bash
DOTNET_ROOT=/home/ec2-user/.dotnet PATH=/home/ec2-user/.dotnet:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet restore Duplicati/Server/Duplicati.Server.csproj
DOTNET_ROOT=/home/ec2-user/.dotnet PATH=/home/ec2-user/.dotnet:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet list Duplicati/Server/Duplicati.Server.csproj package --vulnerable --include-transitive
DOTNET_ROOT=/home/ec2-user/.dotnet PATH=/home/ec2-user/.dotnet:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build Duplicati/WebserverCore/Duplicati.WebserverCore.csproj --no-restore --verbosity minimal
```

Results:

- `Microsoft.OpenApi` no longer appears in the vulnerable package list
- `Duplicati.WebserverCore` builds successfully with `0 Warning(s), 0 Error(s)`
- `SQLitePCLRaw.lib.e_sqlite3 2.1.11` still appears as a separate transitive vulnerability and is intentionally left for a follow-up
