### PR TITLE
Add endpoints for removal

### DIFF
--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -352,6 +352,61 @@ namespace Duplicati.Server
                 includeMetadata: searchMetadata);
         }
 
+        /// <summary>
+        /// Creates a task that deletes the specified backup versions from the remote storage.
+        /// </summary>
+        /// <param name="backup">The backup to delete versions from</param>
+        /// <param name="versions">The versions to delete</param>
+        /// <param name="extraOptions">Optional extra options</param>
+        /// <returns>The runner task</returns>
+        public static IRunnerData CreateDeleteVersionsTask(IBackup backup, long[] versions, IDictionary<string, string?>? extraOptions = null)
+        {
+            var dict = extraOptions ?? new Dictionary<string, string?>();
+            if (versions != null && versions.Length > 0)
+                dict["version"] = string.Join(",", versions.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+
+            return CreateTask(
+                DuplicatiOperation.DeleteVersions,
+                backup,
+                dict);
+        }
+
+        /// <summary>
+        /// Creates a task that lists broken files in the backup.
+        /// </summary>
+        /// <param name="backup">The backup to list broken files for</param>
+        /// <param name="filterStrings">Optional filter strings to apply</param>
+        /// <param name="extraOptions">Optional extra options</param>
+        /// <returns>The runner task</returns>
+        public static IRunnerData CreateListBrokenFilesTask(IBackup backup, string[]? filterStrings, IDictionary<string, string?>? extraOptions = null)
+        {
+            var dict = extraOptions ?? new Dictionary<string, string?>();
+
+            return CreateTask(
+                DuplicatiOperation.ListBrokenFiles,
+                backup,
+                dict,
+                filterStrings);
+        }
+
+        /// <summary>
+        /// Creates a task that purges broken files from the backup.
+        /// </summary>
+        /// <param name="backup">The backup to purge broken files from</param>
+        /// <param name="filterStrings">Optional filter strings to apply</param>
+        /// <param name="extraOptions">Optional extra options</param>
+        /// <returns>The runner task</returns>
+        public static IRunnerData CreatePurgeBrokenFilesTask(IBackup backup, string[]? filterStrings, IDictionary<string, string?>? extraOptions = null)
+        {
+            var dict = extraOptions ?? new Dictionary<string, string?>();
+
+            return CreateTask(
+                DuplicatiOperation.PurgeBrokenFiles,
+                backup,
+                dict,
+                filterStrings);
+        }
+
 
         public static IRunnerData CreateRestoreTask(IBackup backup, string[]? filters,
                                                     DateTime time, string? restoreTarget, bool overwrite, bool restore_permissions,
@@ -942,6 +997,30 @@ namespace Duplicati.Server
                                 var parsedfilter = new FilterExpression(data.FilterStrings);
                                 return await controller.SearchEntriesAsync(data.ExtraArguments, parsedfilter, data.CaseSensitiveSearch, data.PageOffset * data.PageSize, data.PageSize, data.ReturnExtendedData, data.SearchMetadata).ConfigureAwait(false);
                             }
+
+                        case DuplicatiOperation.DeleteVersions:
+                            {
+                                var r = await controller.DeleteAsync().ConfigureAwait(false);
+                                UpdateMetadataBase(databaseConnection, eventPollNotify, notificationUpdateService, backup, r);
+                                return r;
+                            }
+
+                        case DuplicatiOperation.ListBrokenFiles:
+                            {
+                                var filter = data.FilterStrings == null ? null : new FilterExpression(data.FilterStrings);
+                                var r = await controller.ListBrokenFilesAsync(filter).ConfigureAwait(false);
+                                UpdateMetadataBase(databaseConnection, eventPollNotify, notificationUpdateService, backup, r);
+                                return r;
+                            }
+
+                        case DuplicatiOperation.PurgeBrokenFiles:
+                            {
+                                var filter = data.FilterStrings == null ? null : new FilterExpression(data.FilterStrings);
+                                var r = await controller.PurgeBrokenFilesAsync(filter).ConfigureAwait(false);
+                                UpdateMetadataBase(databaseConnection, eventPollNotify, notificationUpdateService, backup, r);
+                                return r;
+                            }
+
                         default:
                             //TODO: Log this
                             return null;

--- a/Duplicati/Server/Duplicati.Server.Serialization/Enums.cs
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Enums.cs
@@ -49,6 +49,9 @@ namespace Duplicati.Server.Serialization
         ListFolderContents,
         ListFileVersions,
         SearchEntries,
+        DeleteVersions,
+        ListBrokenFiles,
+        PurgeBrokenFiles,
     }
 
     public enum SuggestedStatusIcon

--- a/Duplicati/WebserverCore/Dto/V2/DeleteVersionsRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/DeleteVersionsRequestDto.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions: 
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software. 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+namespace Duplicati.WebserverCore.Dto.V2;
+
+/// <summary>
+/// The request DTO for deleting specific backup versions.
+/// </summary>
+public sealed record DeleteVersionsRequestDto
+{
+    /// <summary>
+    /// The backup ID to delete versions from.
+    /// </summary>
+    public required string BackupId { get; init; }
+
+    /// <summary>
+    /// The versions to delete. Each version is a non-negative integer
+    /// corresponding to a fileset version reported by the list-filesets endpoint.
+    /// </summary>
+    public required long[] Versions { get; init; }
+
+    /// <summary>
+    /// A flag indicating if the last remaining fileset may be removed.
+    /// If not set, the last fileset is always kept.
+    /// </summary>
+    public bool? AllowFullRemoval { get; init; }
+
+    /// <summary>
+    /// A flag indicating whether to suppress automatic compaction after deleting versions.
+    /// </summary>
+    public bool? SuppressCompact { get; init; }
+}

--- a/Duplicati/WebserverCore/Dto/V2/ListBrokenFilesRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/ListBrokenFilesRequestDto.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions: 
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software. 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+namespace Duplicati.WebserverCore.Dto.V2;
+
+/// <summary>
+/// The request DTO for listing broken files in a backup.
+/// </summary>
+public sealed record ListBrokenFilesRequestDto
+{
+    /// <summary>
+    /// The backup ID to list broken files for.
+    /// </summary>
+    public required string BackupId { get; init; }
+
+    /// <summary>
+    /// Optional filter strings to limit the files reported as broken.
+    /// </summary>
+    public string[]? Filters { get; init; }
+}

--- a/Duplicati/WebserverCore/Dto/V2/ListBrokenFilesResponseDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/ListBrokenFilesResponseDto.cs
@@ -1,0 +1,104 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions: 
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software. 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+namespace Duplicati.WebserverCore.Dto.V2;
+
+/// <summary>
+/// The response DTO for listing broken files in a backup.
+/// </summary>
+public sealed record ListBrokenFilesResponseDto : PagedResponseEnvelope<ListBrokenFilesFilesetItem>
+{
+    /// <summary>
+    /// Creates a new instance of the ListBrokenFilesResponseDto with the given error and status code.
+    /// </summary>
+    /// <param name="error">The error message</param>
+    /// <param name="statusCode">The status code</param>
+    /// <returns>The ListBrokenFilesResponseDto instance</returns>
+    public static new ListBrokenFilesResponseDto Failure(
+        string error,
+        string statusCode
+    ) => new ListBrokenFilesResponseDto()
+    {
+        Success = false,
+        Error = error,
+        StatusCode = statusCode,
+        Data = null,
+        PageInfo = null
+    };
+
+    /// <summary>
+    /// Creates a new instance of the ListBrokenFilesResponseDto with the given broken filesets.
+    /// </summary>
+    /// <param name="filesets">The broken filesets to include in the response</param>
+    /// <returns>The ListBrokenFilesResponseDto instance</returns>
+    public static ListBrokenFilesResponseDto Create(
+        IEnumerable<ListBrokenFilesFilesetItem> filesets
+    ) => new ListBrokenFilesResponseDto()
+    {
+        Success = true,
+        Error = null,
+        StatusCode = "OK",
+        Data = filesets,
+        PageInfo = new PageInfo()
+        {
+            Total = filesets.Count(),
+            Page = 1,
+            Pages = 1,
+            PageSize = filesets.Count(),
+        }
+    };
+}
+
+/// <summary>
+/// A fileset containing broken files.
+/// </summary>
+public sealed record ListBrokenFilesFilesetItem
+{
+    /// <summary>
+    /// The fileset ID.
+    /// </summary>
+    public required long FilesetID { get; init; }
+
+    /// <summary>
+    /// The fileset time.
+    /// </summary>
+    public required DateTime FilesetTime { get; init; }
+
+    /// <summary>
+    /// The broken files within the fileset.
+    /// </summary>
+    public required IEnumerable<ListBrokenFilesFileItem> Files { get; init; }
+}
+
+/// <summary>
+/// A single broken file entry.
+/// </summary>
+public sealed record ListBrokenFilesFileItem
+{
+    /// <summary>
+    /// The path of the broken file.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// The size of the broken file.
+    /// </summary>
+    public required long Size { get; init; }
+}

--- a/Duplicati/WebserverCore/Dto/V2/PurgeBrokenFilesRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/PurgeBrokenFilesRequestDto.cs
@@ -1,0 +1,32 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions: 
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software. 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+namespace Duplicati.WebserverCore.Dto.V2;
+
+/// <summary>
+/// The request DTO for purging broken files from a backup.
+/// </summary>
+public sealed record PurgeBrokenFilesRequestDto
+{
+    /// <summary>
+    /// The backup ID to purge broken files from.
+    /// </summary>
+    public required string BackupId { get; init; }
+}

--- a/Duplicati/WebserverCore/Endpoints/V2/BackupBrokenFiles.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/BackupBrokenFiles.cs
@@ -1,0 +1,75 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions: 
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software. 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Duplicati.Library.Interface;
+using Duplicati.Server;
+using Duplicati.Server.Database;
+using Duplicati.Server.Serialization.Interface;
+using Duplicati.WebserverCore.Abstractions;
+using Duplicati.WebserverCore.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Duplicati.WebserverCore.Endpoints.V2.Backup;
+
+/// <summary>
+/// Endpoint for listing and purging broken files in a backup.
+/// </summary>
+public class BackupBrokenFiles : IEndpointV2
+{
+    public static void Map(RouteGroupBuilder group)
+    {
+        group.MapPost("/backup/list-broken-files", async ([FromServices] Connection connection, [FromServices] IQueueRunnerService queueRunnerService, [FromBody] Dto.V2.ListBrokenFilesRequestDto input)
+            => await ExecuteListBrokenFilesAsync(queueRunnerService, GetBackup(connection, input.BackupId), input).ConfigureAwait(false))
+            .RequireAuthorization();
+
+        group.MapPost("/backup/purge-broken-files", async ([FromServices] Connection connection, [FromServices] IQueueRunnerService queueRunnerService, [FromBody] Dto.V2.PurgeBrokenFilesRequestDto input)
+            => await ExecutePurgeBrokenFilesAsync(queueRunnerService, GetBackup(connection, input.BackupId)).ConfigureAwait(false))
+            .RequireAuthorization();
+    }
+
+    private static IBackup GetBackup(Connection connection, string id)
+        => connection.GetBackup(id) ?? throw new NotFoundException("Backup not found");
+
+    private static async Task<Dto.V2.ListBrokenFilesResponseDto> ExecuteListBrokenFilesAsync(IQueueRunnerService queueRunnerService, IBackup bk, Dto.V2.ListBrokenFilesRequestDto input)
+    {
+        var r = await queueRunnerService.RunImmediatelyAsync(Runner.CreateListBrokenFilesTask(bk, input.Filters)).ConfigureAwait(false) as IListBrokenFilesResults;
+        if (r == null)
+            throw new ServerErrorException("No result from list-broken-files operation");
+
+        return Dto.V2.ListBrokenFilesResponseDto.Create(
+            (r.BrokenFiles ?? [])
+                .Select(x => new Dto.V2.ListBrokenFilesFilesetItem()
+                {
+                    FilesetID = x.Item1,
+                    FilesetTime = x.Item2,
+                    Files = (x.Item3 ?? [])
+                        .Select(f => new Dto.V2.ListBrokenFilesFileItem()
+                        {
+                            Path = f.Item1,
+                            Size = f.Item2
+                        })
+                })
+        );
+    }
+
+    private static Task<Dto.TaskStartedDto> ExecutePurgeBrokenFilesAsync(IQueueRunnerService queueRunnerService, IBackup bk)
+        => Task.FromResult(new Dto.TaskStartedDto("OK", queueRunnerService.AddTask(Runner.CreatePurgeBrokenFilesTask(bk, null))));
+}

--- a/Duplicati/WebserverCore/Endpoints/V2/BackupDeleteVersions.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/BackupDeleteVersions.cs
@@ -1,0 +1,59 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions: 
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software. 
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using Duplicati.Server;
+using Duplicati.Server.Database;
+using Duplicati.Server.Serialization.Interface;
+using Duplicati.WebserverCore.Abstractions;
+using Duplicati.WebserverCore.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Duplicati.WebserverCore.Endpoints.V2.Backup;
+
+/// <summary>
+/// Endpoint for deleting specific backup versions.
+/// </summary>
+public class BackupDeleteVersions : IEndpointV2
+{
+    public static void Map(RouteGroupBuilder group)
+    {
+        group.MapPost("/backup/delete-versions", async ([FromServices] Connection connection, [FromServices] IQueueRunnerService queueRunnerService, [FromBody] Dto.V2.DeleteVersionsRequestDto input)
+            => await ExecuteDeleteVersionsAsync(queueRunnerService, GetBackup(connection, input.BackupId), input).ConfigureAwait(false))
+            .RequireAuthorization();
+    }
+
+    private static IBackup GetBackup(Connection connection, string id)
+        => connection.GetBackup(id) ?? throw new NotFoundException("Backup not found");
+
+    private static Task<Dto.TaskStartedDto> ExecuteDeleteVersionsAsync(IQueueRunnerService queueRunnerService, IBackup bk, Dto.V2.DeleteVersionsRequestDto input)
+    {
+        if (input.Versions is null || input.Versions.Length == 0)
+            throw new BadRequestException("No versions supplied");
+
+        var extra = new Dictionary<string, string?>();
+        if (input.AllowFullRemoval.HasValue)
+            extra["allow-full-removal"] = input.AllowFullRemoval.Value.ToString();
+        if (input.SuppressCompact.HasValue)
+            extra["no-auto-compact"] = input.SuppressCompact.Value.ToString();
+
+        return Task.FromResult(new Dto.TaskStartedDto("OK", queueRunnerService.AddTask(Runner.CreateDeleteVersionsTask(bk, input.Versions, extra))));
+    }
+}

--- a/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
+++ b/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
@@ -63,6 +63,9 @@ public class SystemInfoProvider(IApplicationSettings applicationSettings, Connec
         "v2:destination:list",
         "v1:backup:restorecontrolfiles",
         "v1:backup:sync-mode",
+        "v2:backup:list-broken-files",
+        "v2:backup:purge-broken-files",
+        "v2:backup:delete-versions",
 
         // "v1:subscribe:scheduler",
     ];


### PR DESCRIPTION
This PR adds new endpoints to support the removal of versions and the purge-broken-files flow.

Prior to this PR a UI-user had to resort to the commandline UI and figure out how to configure the commandline tool to perform the operations.

With this update, the user can now pick "Delete versions" and will be presented with a list of versions. Any versions that are checked will then be deleted.

For the purge-broken-files, this will first run "list-broken-files" and present any broken files to the user, and then allow the user to proceed with purging the broken files.