### PR TITLE
Update SQLitePCLRaw.lib.e_sqlite3 to 3.53.3

### DIFF
--- a/Duplicati/Library/Backend/Storj/Duplicati.Library.Backend.Storj.csproj
+++ b/Duplicati/Library/Backend/Storj/Duplicati.Library.Backend.Storj.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <!-- Force these versions to avoid a version with vulnerabilities -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.11" ExcludeAssets="All" NoWarn="NU1903" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" ExcludeAssets="All" />
 
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
## Summary
- Update the Storj backend's explicit `SQLitePCLRaw.lib.e_sqlite3` package reference from `2.1.11` to `3.53.3`.
- Remove the `NU1903` suppression while keeping `ExcludeAssets="All"` so the package reference only affects dependency resolution.
- Keep `SQLitePCLRaw.bundle_e_sqlite3` and `sqlite-net-pcl` unchanged, preserving the existing `SourceGear.sqlite3` native SQLite path.

## Why
`SQLitePCLRaw.lib.e_sqlite3 2.1.11` is reported as vulnerable/deprecated in the Storj dependency graph. Updating the explicit reference prevents the older vulnerable 2.x package from being resolved while leaving the runtime asset path unchanged.

## Validation
- `dotnet restore Duplicati\Library\Backend\Storj\Duplicati.Library.Backend.Storj.csproj --force --verbosity minimal`
- `dotnet list Duplicati\Library\Backend\Storj\Duplicati.Library.Backend.Storj.csproj package --vulnerable --include-transitive`
  - No vulnerable packages found.
- `dotnet list Duplicati\Library\Backend\Storj\Duplicati.Library.Backend.Storj.csproj package --deprecated --include-transitive`
  - No deprecated packages found.
- `dotnet build Duplicati\Library\Backend\Storj\Duplicati.Library.Backend.Storj.csproj --no-restore --verbosity minimal -p:UseSharedCompilation=false -nr:false`
  - Build succeeded with 0 warnings and 0 errors.
- Confirmed generated targets import `SourceGear.sqlite3 3.50.4.5` for the native SQLite target path.

Note: local PATH only had .NET SDK 5.0.408, so validation used a temporary repo-external .NET SDK 10.0.301 install.