### PR TITLE
Fix obsolete certificate loading in SSL validator tests

### DIFF
--- a/Duplicati/UnitTest/SslCertificateValidatorTests.cs
+++ b/Duplicati/UnitTest/SslCertificateValidatorTests.cs
@@ -67,8 +67,8 @@ public class SslCertificateValidatorTests
         var notBefore = DateTimeOffset.UtcNow.AddDays(-2);
         var notAfter = DateTimeOffset.UtcNow.AddDays(-1);
 
-        var certificate = request.CreateSelfSigned(notBefore, notAfter);
-        return new X509Certificate2(certificate.Export(X509ContentType.Cert));
+        using var certificate = request.CreateSelfSigned(notBefore, notAfter);
+        return X509CertificateLoader.LoadCertificate(certificate.RawData);
     }
 
     /// <summary>
@@ -89,8 +89,8 @@ public class SslCertificateValidatorTests
         var notBefore = DateTimeOffset.UtcNow.AddDays(1);
         var notAfter = DateTimeOffset.UtcNow.AddDays(365);
 
-        var certificate = request.CreateSelfSigned(notBefore, notAfter);
-        return new X509Certificate2(certificate.Export(X509ContentType.Cert));
+        using var certificate = request.CreateSelfSigned(notBefore, notAfter);
+        return X509CertificateLoader.LoadCertificate(certificate.RawData);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Replace obsolete `X509Certificate2(byte[])` usage in `SslCertificateValidatorTests` with `X509CertificateLoader.LoadCertificate`.
- Keep the generated certificates as public certificate copies without private keys, preserving the existing test behavior.
- Limit the change to unit test code only.

## Why
.NET 10 reports `SYSLIB0057` for loading certificate data through `X509Certificate2` constructors. The test helpers were exporting generated self-signed certificates and reloading them with the obsolete byte-array constructor.

## Validation
- `dotnet build Duplicati\UnitTest\Duplicati.UnitTest.csproj --no-restore --no-dependencies --verbosity minimal -p:UseSharedCompilation=false -nr:false`
  - Build succeeded.
  - The `SslCertificateValidatorTests.cs` `SYSLIB0057` warnings are gone.
  - Unrelated `Microsoft.OpenApi 2.3.0` `NU1903` warnings remain in `Duplicati.UnitTest`, `Duplicati.Server`, and `Duplicati.WebserverCore`.
- `dotnet test Duplicati\UnitTest\Duplicati.UnitTest.csproj --filter "FullyQualifiedName~SslCertificateValidatorTests" --no-restore --no-build --verbosity minimal`
  - Passed: 21, Failed: 0, Skipped: 1, Total: 22.

Note: validation used the repo-external temporary .NET SDK 10.0.301 install because the default PATH SDK is older.