### PR TITLE
Avoid secondary transaction errors after repair failure

### DIFF
--- a/Duplicati/Library/Main/Database/ReusableTransaction.cs
+++ b/Duplicati/Library/Main/Database/ReusableTransaction.cs
@@ -149,9 +149,12 @@ internal class ReusableTransaction(SqliteConnection con, SqliteTransaction? tran
 
     // Microsoft.Data.Sqlite throws InvalidOperationException ("This SqliteTransaction has completed;
     // it is no longer usable.") when a transaction is rolled back or disposed after it has already
-    // been completed. Match on the exception type rather than the (localizable) message text.
+    // been completed. Unfortunately there is nothing specific that can be used to differentiate it
+    // from other exceptions that might occur during disposal, so we rely on the exception type, source and message.
     private static bool IsInactiveTransactionException(Exception ex)
-        => ex is InvalidOperationException;
+        => ex is InvalidOperationException
+            && ex.Source == "Microsoft.Data.Sqlite"
+            && ex.Message.StartsWith("This SqliteTransaction has completed", StringComparison.Ordinal);
 
     /// <summary>
     /// Rolls back the transaction and restarts it.

--- a/Duplicati/Library/Main/Database/ReusableTransaction.cs
+++ b/Duplicati/Library/Main/Database/ReusableTransaction.cs
@@ -153,7 +153,6 @@ internal class ReusableTransaction(SqliteConnection con, SqliteTransaction? tran
     // from other exceptions that might occur during disposal, so we rely on the exception type, source and message.
     private static bool IsInactiveTransactionException(Exception ex)
         => ex is InvalidOperationException
-            && ex.Source == "Microsoft.Data.Sqlite"
             && ex.Message.StartsWith("This SqliteTransaction has completed", StringComparison.Ordinal);
 
     /// <summary>

--- a/Duplicati/Library/Main/Database/ReusableTransaction.cs
+++ b/Duplicati/Library/Main/Database/ReusableTransaction.cs
@@ -121,16 +121,36 @@ internal class ReusableTransaction(SqliteConnection con, SqliteTransaction? tran
             }
             catch (Exception ex)
             {
-                Logging.Log.WriteErrorMessage(LOGTAG, "ReusableTransaction dispose", ex, "Transaction disposed with error: {0}", ex.Message);
-                throw;
+                if (!IsInactiveTransactionException(ex))
+                {
+                    Logging.Log.WriteErrorMessage(LOGTAG, "ReusableTransaction dispose", ex, "Transaction disposed with error: {0}", ex.Message);
+                    throw;
+                }
+
+                Logging.Log.WriteVerboseMessage(LOGTAG, "ReusableTransactionAlreadyCompleted", ex, "Transaction was already completed during dispose: {0}", ex.Message);
             }
             finally
             {
                 m_disposed = true;
-                await m_transaction.DisposeAsync().ConfigureAwait(false);
+                try
+                {
+                    await m_transaction.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    if (!IsInactiveTransactionException(ex))
+                        throw;
+
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "ReusableTransactionAlreadyDisposed", ex, "Transaction was already completed before dispose: {0}", ex.Message);
+                }
             }
         }
     }
+
+    private static bool IsInactiveTransactionException(Exception ex)
+        => ex.Message.Contains("No transaction is active", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("transaction has completed", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("no longer usable", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Rolls back the transaction and restarts it.

--- a/Duplicati/Library/Main/Database/ReusableTransaction.cs
+++ b/Duplicati/Library/Main/Database/ReusableTransaction.cs
@@ -127,7 +127,7 @@ internal class ReusableTransaction(SqliteConnection con, SqliteTransaction? tran
                     throw;
                 }
 
-                Logging.Log.WriteVerboseMessage(LOGTAG, "ReusableTransactionAlreadyCompleted", ex, "Transaction was already completed during dispose: {0}", ex.Message);
+                Logging.Log.WriteWarningMessage(LOGTAG, "ReusableTransactionAlreadyCompleted", ex, "Transaction was already completed during dispose: {0}", ex.Message);
             }
             finally
             {
@@ -141,16 +141,17 @@ internal class ReusableTransaction(SqliteConnection con, SqliteTransaction? tran
                     if (!IsInactiveTransactionException(ex))
                         throw;
 
-                    Logging.Log.WriteVerboseMessage(LOGTAG, "ReusableTransactionAlreadyDisposed", ex, "Transaction was already completed before dispose: {0}", ex.Message);
+                    Logging.Log.WriteWarningMessage(LOGTAG, "ReusableTransactionAlreadyDisposed", ex, "Transaction was already completed before dispose: {0}", ex.Message);
                 }
             }
         }
     }
 
+    // Microsoft.Data.Sqlite throws InvalidOperationException ("This SqliteTransaction has completed;
+    // it is no longer usable.") when a transaction is rolled back or disposed after it has already
+    // been completed. Match on the exception type rather than the (localizable) message text.
     private static bool IsInactiveTransactionException(Exception ex)
-        => ex.Message.Contains("No transaction is active", StringComparison.OrdinalIgnoreCase)
-        || ex.Message.Contains("transaction has completed", StringComparison.OrdinalIgnoreCase)
-        || ex.Message.Contains("no longer usable", StringComparison.OrdinalIgnoreCase);
+        => ex is InvalidOperationException;
 
     /// <summary>
     /// Rolls back the transaction and restarts it.

--- a/Duplicati/UnitTest/Issue5827.cs
+++ b/Duplicati/UnitTest/Issue5827.cs
@@ -1,0 +1,44 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Threading.Tasks;
+using Duplicati.Library.Main.Database;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+public class Issue5827
+{
+    [Test]
+    public async Task DisposeDoesNotThrowWhenTransactionAlreadyCompletedAsync()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var transaction = (SqliteTransaction)await connection.BeginTransactionAsync();
+        await using var reusableTransaction = new ReusableTransaction(connection, transaction);
+
+        await transaction.CommitAsync();
+
+        Assert.DoesNotThrowAsync(async () => await reusableTransaction.DisposeAsync().AsTask());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #5827.
- Prevent `ReusableTransaction.DisposeAsync()` cleanup from replacing the original repair/recreate failure with a secondary completed-transaction error.
- Keep explicit `CommitAsync()` and `RollBackAsync()` behavior unchanged; only dispose-time cleanup suppresses already-completed transaction errors.

## Why
When repair/recreate fails for the real underlying reason, disposal may try to roll back or dispose a transaction that has already completed. That can produce a secondary `No transaction is active` / completed transaction error and obscure the actual repair failure.

## Validation
- `dotnet build Duplicati\UnitTest\Duplicati.UnitTest.csproj --no-restore --no-dependencies --verbosity minimal -p:UseSharedCompilation=false -nr:false`
  - Build succeeded.
  - Existing unrelated `Microsoft.OpenApi 2.3.0` `NU1903` warnings remain in `Duplicati.UnitTest`, `Duplicati.Server`, and `Duplicati.WebserverCore`.
- `dotnet test Duplicati\UnitTest\Duplicati.UnitTest.csproj --filter "FullyQualifiedName~Issue5827" --no-restore --no-build --verbosity minimal`
  - Passed: 1, Failed: 0, Skipped: 0.
- `dotnet test Duplicati\UnitTest\Duplicati.UnitTest.csproj --filter "FullyQualifiedName~Issue4988" --no-restore --no-build --verbosity minimal`
  - Passed: 1, Failed: 0, Skipped: 0.

Note: validation used the repo-external temporary .NET SDK 10.0.301 install because the default PATH SDK is older.