### PR TITLE
Report script execution in operation status

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -739,7 +739,7 @@ namespace Duplicati.Library.Main
             {
                 foreach (var mx in m_options.LoadedModules)
                     if (mx is IGenericCallbackModule module)
-                        try { module.OnFinish(result, exception); }
+                        try { RunScriptCallbackWithStatus(result, mx, () => module.OnFinish(result, exception)); }
                         catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, $"OnFinishError{mx.Key}", ex, "OnFinish callback {0} failed: {1}", mx.Key, ex.Message); }
 
                 foreach (var mx in m_options.LoadedModules)
@@ -820,7 +820,7 @@ namespace Duplicati.Library.Main
                     }
 
                     if (mx is IGenericCallbackModule module)
-                        module.OnStart(result.MainOperation.ToString(), ref m_backendUrl, ref paths);
+                        RunScriptCallbackWithStatus(result, mx, () => module.OnStart(result.MainOperation.ToString(), ref m_backendUrl, ref paths));
                 }
 
                 // If the filters were changed by a module, read them back in
@@ -861,6 +861,28 @@ namespace Duplicati.Library.Main
             ValidateOptions();
 
             return (paths, filter);
+        }
+
+        internal static void RunScriptCallbackWithStatus(object result, IGenericModule module, Action callback)
+        {
+            if (!string.Equals(module?.Key, "runscript", StringComparison.OrdinalIgnoreCase) || result is not BasicResults basicResults)
+            {
+                callback();
+                return;
+            }
+
+            var progress = basicResults.OperationProgressUpdater;
+            progress.UpdateOverall(out var previousPhase, out _, out _, out _, out _, out _, out _);
+
+            progress.UpdatePhase(OperationPhase.RunScript_Running);
+            try
+            {
+                callback();
+            }
+            finally
+            {
+                progress.UpdatePhase(previousPhase);
+            }
         }
 
 

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -774,7 +774,7 @@ namespace Duplicati.Library.Main.Operation
                         using var _ = Controller.PushFilterToOptions(m_options, filter);
                         foreach (var mx in m_options.LoadedModules)
                             if (mx is IBackupCallbackModule module)
-                                try { module.OnFinishBackup(m_result, null); }
+                                try { Controller.RunScriptCallbackWithStatus(m_result, mx, () => module.OnFinishBackup(m_result, null)); }
                                 catch (Exception ex) { Logging.Log.WriteWarningMessage(LOGTAG, $"OnFinishBackupError{mx.Key}", ex, "OnFinishBackup callback {0} failed: {1}", mx.Key, ex.Message); }
                     }
 

--- a/Duplicati/Library/Main/OperationPhase.cs
+++ b/Duplicati/Library/Main/OperationPhase.cs
@@ -73,7 +73,9 @@ namespace Duplicati.Library.Main
         Sync_WaitForUpload,
         Sync_Complete,
 
-        Error
+        Error,
+
+        RunScript_Running
     }
 }
 

--- a/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
+++ b/Duplicati/Server/webroot/ngax/scripts/services/ServerStatus.js
@@ -62,6 +62,7 @@ backupApp.service('ServerStatus', function ($rootScope, $timeout, AppService, Ap
             'Repair_Running': gettextCatalog.getString('Repairing database …'),
             'Verify_Running': gettextCatalog.getString('Verifying files …'),
             'BugReport_Running': gettextCatalog.getString('Creating bug report …'),
+            'RunScript_Running': gettextCatalog.getString('Running script …'),
             'Delete_Listing': gettextCatalog.getString('Listing remote files …'),
             'Delete_Deleting': gettextCatalog.getString('Deleting remote files …'),
             'PurgeFiles_Begin,': gettextCatalog.getString('Listing remote files for purge …'),

--- a/Duplicati/UnitTest/RunScriptTests.cs
+++ b/Duplicati/UnitTest/RunScriptTests.cs
@@ -240,6 +240,32 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Border")]
+        public async Task RunScriptReportsRunningPhaseAsync()
+        {
+            var options = new Dictionary<string, string>(this.TestOptions);
+            options["run-script-before"] = CreateScript(0);
+            options["run-script-post-backup"] = CreateScript(0);
+            options["run-script-after"] = CreateScript(0);
+
+            var observedPhases = new List<OperationPhase>();
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                c.OnOperationStarted += results =>
+                {
+                    if (results is BasicResults basicResults)
+                        basicResults.OperationProgressUpdater.PhaseChanged += (phase, _) => observedPhases.Add(phase);
+                };
+
+                var backupResults = await c.BackupAsync(new[] { this.DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+            }
+
+            Assert.AreEqual(3, observedPhases.Count(phase => phase == OperationPhase.RunScript_Running),
+                "Expected each configured run-script callback to report that a script is running.");
+        }
+
+        [Test]
+        [Category("Border")]
         [TestCase(0)]
         [TestCase(1)]
         [TestCase(2)]


### PR DESCRIPTION
Closes #5542

## Summary
- Adds a dedicated `RunScript_Running` operation phase for `run-script-*` callbacks.
- Reports that phase while the `runscript` module is executing `run-script-before`, `run-script-post-backup`, or `run-script-after`.
- Adds the UI status text `Running script ...` without exposing script paths or arguments.

## Validation
- `C:\Users\Jam\AppData\Local\Temp\codex-dotnet-10\dotnet.exe restore Duplicati\UnitTest\Duplicati.UnitTest.csproj --force --verbosity minimal`
- `C:\Users\Jam\AppData\Local\Temp\codex-dotnet-10\dotnet.exe build Duplicati\Library\Main\Duplicati.Library.Main.csproj --no-restore --verbosity minimal -p:UseSharedCompilation=false -nr:false`
- `C:\Users\Jam\AppData\Local\Temp\codex-dotnet-10\dotnet.exe build Duplicati\UnitTest\Duplicati.UnitTest.csproj --no-restore --no-dependencies --verbosity minimal -p:UseSharedCompilation=false -nr:false`
- `C:\Users\Jam\AppData\Local\Temp\codex-dotnet-10\dotnet.exe test Duplicati\UnitTest\Duplicati.UnitTest.csproj --filter "FullyQualifiedName~Duplicati.UnitTest.RunScriptTests" --no-restore --verbosity minimal`

## Notes
- The UnitTest build still reports existing unrelated `SYSLIB0057` warnings in `SslCertificateValidatorTests.cs`.
