### PR TITLE
Use OS-default cert validator

### DIFF
--- a/Duplicati/Library/Utility/HttpClientHelper.cs
+++ b/Duplicati/Library/Utility/HttpClientHelper.cs
@@ -79,6 +79,10 @@ public static class HttpClientHelper
     /// <param name="ignoreRevocationFailure">If revocation check failures (offline or unknown status) should be ignored</param>
     public static void ConfigureHandlerCertificateValidator(HttpClientHandler handler, bool acceptAllCertificates, string[]? acceptSpecificCertificateHashes, bool ignoreRevocationFailure)
     {
+        // If no special handling is applied, use the OS default validation
+        if (!acceptAllCertificates && acceptSpecificCertificateHashes == null && !ignoreRevocationFailure)
+            return;
+
         var validator = new SslCertificateValidator(acceptAllCertificates, acceptSpecificCertificateHashes, ignoreRevocationFailure);
         handler.ServerCertificateCustomValidationCallback = validator.ValidateServerCertificate;
     }


### PR DESCRIPTION
If the user has not specified any overrides, use the OS default validator.

Prior to this PR all certs were validated by the .NET default chain validator, which is more strict with regards to revocation checks. With this PR, the OS default is now used to validate certificates.