### PR TITLE
Guard compact against race

### DIFF
--- a/Duplicati/Library/Main/Operation/CompactHandler.cs
+++ b/Duplicati/Library/Main/Operation/CompactHandler.cs
@@ -307,6 +307,13 @@ namespace Duplicati.Library.Main.Operation
                         }
                     }
 
+                    // Wait for any in-flight uploads (and their index-volume blocklist
+                    // callbacks) to complete before committing/restarting the transaction,
+                    // since the callbacks hold a reference to the current transaction and
+                    // would otherwise fail once it is disposed by the commit below.
+                    await backendManager.WaitForEmptyAsync(db, m_result.TaskControl.ProgressToken)
+                        .ConfigureAwait(false);
+
                     // The remainder of the operation cannot leave partial files
                     if (!m_options.Dryrun)
                         await db


### PR DESCRIPTION
This ensures all in-flight backend requests are completed before the compact handler continues. Prior to this, particular situations could cause the compact to throw an exception before actually removing files.