### PR TITLE
Harden macOS disk-image eject to fix flaky DiskImage tests

### DIFF
--- a/Duplicati/UnitTest/DiskImage/Helpers/MacOSDiskImageHelper.cs
+++ b/Duplicati/UnitTest/DiskImage/Helpers/MacOSDiskImageHelper.cs
@@ -433,12 +433,13 @@ internal class MacOSDiskImageHelper : IDiskImageHelper
         {
             try
             {
-                // Unmount all volumes on the disk
-                RunProcess("diskutil", $"unmountDisk {diskIdentifier}");
+                // Unmount all volumes on the disk (force, since a volume can still be busy right after writing)
+                RunProcess("diskutil", $"unmountDisk force {diskIdentifier}");
+                return;
             }
             catch
             {
-                // Sometimes an unmount is issued too fast after writing data, which makes diskutil throw an errory.
+                // Sometimes an unmount is issued too fast after writing data, which makes diskutil throw an error.
                 Thread.Sleep(500);
             }
         }
@@ -494,7 +495,7 @@ internal class MacOSDiskImageHelper : IDiskImageHelper
 
         try
         {
-            RunProcess("diskutil", $"eject {diskIdentifier}");
+            EjectDisk(diskIdentifier);
         }
         catch (Exception ex)
         {
@@ -621,8 +622,10 @@ internal class MacOSDiskImageHelper : IDiskImageHelper
 
     public string ReAttach(string imagePath, string diskIdentifier, PartitionTableType tableType, bool readOnly = false)
     {
-        // Eject can fail if issued too fast after writing data, which makes diskutil throw an error. Retry a few times with a delay to mitigate this.
-        RunProcess("diskutil", $"eject {diskIdentifier}", retryCount: 3);
+        // Detach before re-attaching. `diskutil eject` can fail with "Volume failed to eject" if a
+        // volume is still busy right after writing, so EjectDisk flushes, force-unmounts and retries
+        // with exponential backoff (falling back to a forced hdiutil detach) to avoid CI flakiness.
+        EjectDisk(diskIdentifier);
         var readOnlyArg = readOnly ? " -readonly" : "";
         var reattachoutput = RunProcess("hdiutil", $"attach -nomount -noautofsck{readOnlyArg} \"{imagePath}\"");
         if (tableType == PartitionTableType.Unknown)
@@ -638,6 +641,46 @@ internal class MacOSDiskImageHelper : IDiskImageHelper
                 )
                 .Where(x => x.Length > 0 && x[^1].EndsWith("_partition_scheme"))
                 .First().First();
+    }
+
+    /// <summary>
+    /// Robustly ejects/detaches a disk image. macOS <c>diskutil eject</c> can fail with
+    /// "Volume failed to eject" when a volume is still busy right after writing, which is a common
+    /// source of CI flakiness. To make this deterministic we flush pending writes, force-unmount all
+    /// volumes first, then eject with exponential backoff, and finally fall back to a forced
+    /// <c>hdiutil detach</c> of the image-backed device.
+    /// </summary>
+    private static void EjectDisk(string diskIdentifier)
+    {
+        // Flush filesystem buffers so the volume is not busy when we try to eject.
+        try { RunProcess("sync", ""); }
+        catch { /* best effort */ }
+
+        // Force-unmount all volumes first; the disk may already be offline, so ignore failures here.
+        try { RunProcess("diskutil", $"unmountDisk force {diskIdentifier}"); }
+        catch { /* best effort */ }
+
+        const int maxAttempts = 5;
+        var baseDelay = TimeSpan.FromMilliseconds(500);
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                RunProcess("diskutil", $"eject {diskIdentifier}");
+                return;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Warning: Failed to eject {diskIdentifier} (attempt {attempt}/{maxAttempts}): {ex.Message}");
+                if (attempt < maxAttempts)
+                    Thread.Sleep(Utility.GetRetryDelay(baseDelay, attempt, useExponentialBackoff: true));
+            }
+        }
+
+        // Last resort: force-detach the image-backed device. diskutil expects "disk4" rather than
+        // "/dev/rdisk4" (see the partitionDisk normalization above); reuse the same normalization.
+        var normalizedDiskId = diskIdentifier.Replace("/dev/rdisk", "disk").Replace("/dev/disk", "disk");
+        RunProcess("hdiutil", $"detach /dev/{normalizedDiskId} -force");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Hardens the macOS disk-image detach path in the DiskImage test helper to eliminate a flaky CI failure. **Test infrastructure only — no product code is touched.**

## The flake

The macOS `Unit tests` job intermittently failed with a single test error such as:

```
Failed Test_GPT_FAT32_FAT32_FAT32_Async
System.InvalidOperationException : Process diskutil with arguments eject /dev/rdisk6
  exited with code 1: Volume failed to eject
  at MacOSDiskImageHelper.RunProcess(...) MacOSDiskImageHelper.cs:678
  at MacOSDiskImageHelper.ReAttach(...) :625
  at FullRoundTripTests.FullRoundTripAsync(...) :504
```

`ReAttach()` (and `CleanupDisk()`) called `diskutil eject` **directly on a disk whose volume could still be busy** right after the backup/restore wrote to it. When macOS reports the volume as briefly in use, `diskutil eject` returns `Volume failed to eject` and the whole test fails. The existing fixed `500ms × 3` retry was not enough, and it never flushed or force‑unmounted first.

This is environment-dependent and unrelated to the code under test — it spuriously failed the CI of several open PRs (e.g. #7017, #7018, #7020) even though those changes don't touch DiskImage code.

## The fix

Add a shared `EjectDisk()` helper used by both `ReAttach()` and `CleanupDisk()` that makes the detach robust instead of masking failures with a blanket retry:

1. `sync` — flush filesystem buffers so the volume isn't busy.
2. `diskutil unmountDisk force` — force‑unmount all volumes first (best‑effort; the disk may already be offline).
3. `diskutil eject` with **exponential backoff** (reusing `Duplicati.Library.Utility.Utility.GetRetryDelay`).
4. Fallback: `hdiutil detach <device> -force` — a forced detach of the image‑backed device as a last resort.

Also fixed `Unmount()` to force‑unmount and `return` on success (it previously always looped 3×).

## Scope / risk

- Only `Duplicati/UnitTest/DiskImage/Helpers/MacOSDiskImageHelper.cs` changes; all touched code runs exclusively on macOS (`diskutil` / `hdiutil` / `sync`).
- No public API / interface signatures change.
- No product (non-test) code is affected.

## Verification

- These paths can only be exercised on the macOS runner (no `diskutil` on Windows/Linux), so validation is via the **macOS `Unit tests` CI job** — ideally re-run a few times to confirm the eject flake no longer recurs.
