### PR TITLE
Improve TLS cert validation

### DIFF
--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -365,11 +365,7 @@ namespace Duplicati.Library.Backend
             if (m_httpClient == null)
             {
                 var httpHandler = new HttpClientHandler();
-
-                // Custom certificate validation to throw exception on failure
-                var validator = new SslCertificateValidator(m_certificateOptions.AcceptAllCertificates, m_certificateOptions.AcceptSpecificCertificateHashes, m_certificateOptions.IgnoreRevocationFailure);
-                httpHandler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) =>
-                    validator.ValidateServerCertificate(sender, cert, chain, sslPolicyErrors);
+                HttpClientHelper.ConfigureHandlerCertificateValidator(httpHandler, m_certificateOptions.AcceptAllCertificates, m_certificateOptions.AcceptSpecificCertificateHashes, m_certificateOptions.IgnoreRevocationFailure);
 
                 if (m_useIntegratedAuthentication)
                 {

--- a/Duplicati/Library/Utility/SslCertificateValidator.cs
+++ b/Duplicati/Library/Utility/SslCertificateValidator.cs
@@ -59,7 +59,10 @@ public class SslCertificateValidator(bool acceptAll, string[]? validHashes, bool
 
             using var certificate = cert as X509Certificate2 ?? new X509Certificate2(cert ?? throw new ArgumentNullException(nameof(cert)));
 
-            // Validate date range before anything else, reject expired certs
+            // Validate date range before anything else, reject expired certs.
+            // NotBefore/NotAfter are returned by .NET as DateTime with Kind=Local (the UTC
+            // instant expressed in local time), so DateTime.Now (also Kind=Local) is the
+            // correct comparison; using UtcNow here would skew the window by the timezone offset.
             if (!IsDateValid(certificate, now))
                 return false;
 
@@ -77,7 +80,11 @@ public class SslCertificateValidator(bool acceptAll, string[]? validHashes, bool
             }
 
 
-            // If requested, ignore revocation check failures (e.g. OCSP server offline or status unknown)
+            // If requested, ignore revocation check failures (e.g. OCSP server offline or status unknown).
+            // This strips revocation-only flags from the sslPolicyErrors that the TLS stack reported using
+            // its own chain object. The explicit chain built below operates on a separate X509Chain and
+            // applies the same soft-fail logic independently, so both the reported-policy path and the
+            // verify path honor ignoreRevocationFailure consistently.
             if (ignoreRevocationFailure)
                 sslPolicyErrors = FilterRevocationErrors(sslPolicyErrors, chain);
 
@@ -85,7 +92,70 @@ public class SslCertificateValidator(bool acceptAll, string[]? validHashes, bool
                 throw new InvalidCertificateException(certificate.GetCertHashString(), sslPolicyErrors);
 
             // If no hash is found, perform the standard validations
-            return sslPolicyErrors == SslPolicyErrors.None && certificate.Verify();
+            if (sslPolicyErrors != SslPolicyErrors.None)
+                return false;
+
+            // certificate.Verify() builds its own X509Chain with a default policy that
+            // hard-fails when a revocation check cannot be completed (OCSP/CRL endpoint
+            // unreachable). The OS-native TLS stacks instead soft-fail in that situation:
+            // the certificate is accepted when the revocation status is merely unknown
+            // (not confirmed revoked). Build the chain explicitly so we can replicate that
+            // behavior and honor the ignoreRevocationFailure setting.
+            //
+            // Note: ChainPolicy.TrustMode is left at its default (UseSystemDefault), which
+            // resolves intermediate/root trust through the OS trust store exactly as
+            // certificate.Verify() did, so the trust-root behaviour of the previous
+            // implementation is preserved.
+            using var verifyChain = new X509Chain();
+            // The primary mechanism for honoring ignoreRevocationFailure: skip the online
+            // revocation fetch entirely so an unreachable OCSP/CRL endpoint cannot fail the
+            // chain. The post-build soft-fail below is a safety net for platforms that
+            // still surface revocation status flags even under NoCheck, not the main path.
+            verifyChain.ChainPolicy.RevocationMode =
+                ignoreRevocationFailure ? X509RevocationMode.NoCheck : X509RevocationMode.Online;
+            bool chainValid = verifyChain.Build(certificate);
+
+            // Soft-fail on unreachable revocation checks, but only when the caller has
+            // explicitly requested it via ignoreRevocationFailure. This replicates the
+            // OS-native TLS behavior of accepting a certificate whose revocation status is
+            // merely unknown (OCSP/CRL endpoint unreachable) rather than confirmed revoked.
+            //
+            // This block is a safety net for the NoCheck mode above: on some platforms
+            // Build() can still report revocation-related flags despite RevocationMode being
+            // NoCheck, so strip those flags here rather than relying on NoCheck alone.
+            //
+            // The guard requires a non-empty ChainStatus: if Build() returned false with no
+            // status flags (rare platform edge case), we must not silently accept the
+            // certificate, as that would widen trust beyond what any status indicates.
+            // A confirmed Revoked flag, PartialChain, or any other non-revocation status
+            // still fails the chain because the All() predicate would be false. The using
+            // scope ensures verifyChain is disposed even if Build() throws and the outer
+            // catch wraps the exception.
+            if (!chainValid && ignoreRevocationFailure && verifyChain.ChainStatus.Length > 0 &&
+                verifyChain.ChainStatus.All(s => (s.Status & ~RevocationFailureFlags) == 0))
+                chainValid = true;
+
+            if (!chainValid)
+            {
+                var chainStatus = string.Join("; ", verifyChain.ChainStatus.Select(s => $"{s.Status}={s.StatusInformation?.Trim()}"));
+                var elementDetails = verifyChain.ChainElements.Count == 0
+                    ? "(no chain elements)"
+                    : string.Join(" | ", verifyChain.ChainElements.Select(e =>
+                    {
+                        var elemStatus = e.ChainElementStatus.Length == 0
+                            ? "(none)"
+                            : string.Join(", ", e.ChainElementStatus.Select(s => $"{s.Status}={s.StatusInformation?.Trim()}"));
+                        return $"{e.Certificate.Subject} [{elemStatus}]";
+                    }));
+
+                Duplicati.Library.Logging.Log.WriteWarningMessage(
+                    "SslCertificateValidator",
+                    "VerifyChainFailed",
+                    null,
+                    $"Certificate chain validation failed for {certificate.Subject} (issuer={certificate.Issuer}, " +
+                    $"thumbprint={certificate.Thumbprint}). Chain status: {chainStatus}. Per-element: {elementDetails}");
+            }
+            return chainValid;
         }
         catch (InvalidCertificateException)
         {


### PR DESCRIPTION
This addresses a logic issue in the previous check for TLS certs introduced with the option to ignore CRL failures. Since the call would end up calling `.Verify()` on the certificate, even toggling for soft-fail CRL issues, the certificate would be rejected.

With the new logic we manually verify the chain. This is only done if the user has requested specific certificates should be validated as we otherwise rely on the OS cert validation.