### PR TITLE
Reset restore rendezvous barriers per operation (fixes flaky folder-metadata restore)

### DIFF
--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -868,6 +868,17 @@ namespace Duplicati.Library.Main.Operation
             volsize = volsize > 0 ? volsize : m_options.VolumeSize;
             Restore.DeadlockTimer.initial_threshold = (int)TimeSpan.FromMinutes(1).TotalMilliseconds * Math.Max(1, (int)(volsize / (10L * 1024L * 1024L)));
             Restore.FileProcessor.file_processors_restoring_files = m_options.RestoreFileProcessors;
+            // Reset the restore synchronization barriers for this operation. These are process-wide
+            // static fields: the counters are reset per run, but the TaskCompletionSources were only
+            // created once at field initialization and were never reset. Without resetting them here
+            // (before any FileLister/FileProcessor tasks are started below, so there is no race),
+            // they stay in the completed state from a previous restore in the same process. On the
+            // second and later restores the barriers then no longer wait - both the priority-files
+            // barrier and the folder-metadata rendezvous return immediately - so folder metadata
+            // (including Windows ACLs) can be applied before all file content is restored. That lost
+            // ordering guarantee causes intermittent metadata/permission restore failures.
+            Restore.FileProcessor.file_processor_continue = new();
+            Restore.FileProcessor.priority_files_completed = new();
 
             // Initialize priority files synchronization.
             // Wrap in a List<> so restore callback modules can freely modify the list


### PR DESCRIPTION
## Summary

Fixes a restore-engine synchronization bug where the folder-metadata rendezvous barrier is only effective for the **first** restore in a process. On every subsequent restore, folder metadata (including Windows ACLs) can be applied **before all file content is restored**, causing intermittent metadata/permission restore failures. This is the root cause of the flaky `Issue6068FileAndFolderAttributesAndPermissions` unit test on the Windows CI runner.

## Root cause

The new (default) restore engine uses two **process-wide `static`** fields as synchronization barriers in `Restore/FileProcessor.cs`:

```csharp
public static TaskCompletionSource file_processor_continue = new();   // folder-metadata rendezvous
public static TaskCompletionSource priority_files_completed = new();  // priority-files barrier
```

Their **counters** (`file_processors_restoring_files`, `priority_files_remaining`) are reset at the start of each restore, but the `TaskCompletionSource` objects were created once at field initialization and **never reset**.

So the first restore in a process runs `SetResult()` on `file_processor_continue`, leaving its `Task` in the **completed** state. On the second and later restores in the same process:

- `RendezvousBeforeProcessingFolderMetadataAsync()` computes `should_wait` and then `await file_processor_continue.Task` — but that task is **already completed**, so the `await` returns **immediately** and the barrier no longer waits for the other `FileProcessor`s to finish restoring file content.
- The ordering guarantee introduced by #6079 ("rendezvous so there are no further writes to target folders before folder metadata is restored") is lost. Folder metadata (timestamps, attributes, and **ACLs**) can be applied while file content is still being written.

This is timing-dependent, so it surfaces as an intermittent flake — most visibly on the CI Windows runner (which runs as the built-in Administrator), where the affected restored directory ends up with its **default** ACL instead of the backed-up one.

> Note: this is not just a test artifact — any long-lived Duplicati process (server/tray) that performs **more than one restore** hits the broken barrier on the 2nd+ restore.

## Fix

Reset both barrier `TaskCompletionSource`s in `RestoreHandler` at the per-operation setup point (right after the existing counter reset, and **before** any `FileLister`/`FileProcessor` tasks are started, so there is no race):

```csharp
Restore.FileProcessor.file_processors_restoring_files = m_options.RestoreFileProcessors;
Restore.FileProcessor.file_processor_continue = new();
Restore.FileProcessor.priority_files_completed = new();
```

- `file_processor_continue` is the **demonstrated** root cause of the Issue6068 flake.
- `priority_files_completed` has the **identical never-reset pattern** and is reset here defensively (it is not exercised by the Issue6068 test, which has no priority files, but the same latent bug would affect any process that restores priority files more than once).

## Verification (local, .NET 10 via mise)

- **Demonstrated the bug:** logging `file_processor_continue.Task.IsCompleted` immediately before the reset, across the 8-combination Issue6068 test (which does several sequential restores in one process):

  | restore | `IsCompleted` before reset |
  |---|---|
  | 1st | `False` (fresh) |
  | 2nd, 3rd, 4th | `True` ← already completed → barrier broken without the reset |

- **No regression:** `Issue6068FileAndFolderAttributesAndPermissions` (all 8 combinations) passes repeatedly (14+ consecutive runs green), and the build is clean.
- The exact CI failure (built-in Administrator / `-500`) is environment-specific and not reproducible on a normal dev account, but the fix addresses the demonstrated ordering bug that produces it.

## Scope / risk

- One-file change in `Duplicati/Library/Main/Operation/RestoreHandler.cs`; resets two synchronization primitives at the correct per-operation setup point. No behavior change for the first restore in a process; restores after the first now correctly wait as intended.
