### PR TITLE
Ignore environmental SleepPreventionError warning in test assertions

### DIFF
--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -287,10 +287,18 @@ namespace Duplicati.UnitTest
         {
         }
 
+        /// <summary>
+        /// Warnings that are purely environmental (never a correctness signal) and are therefore
+        /// always ignored by <see cref="AssertResults"/>. For example, CI runners that cannot set
+        /// sleep prevention emit "Failed to set sleep prevention" (SleepPreventionError).
+        /// </summary>
+        private static readonly string[] AlwaysIgnoredWarnings = ["SleepPreventionError"];
+
         public static void AssertResults(IBasicResults results, string[] ignoredWarnings = null)
         {
             var operation = "Result";
             ignoredWarnings ??= [];
+            var effectiveIgnoredWarnings = ignoredWarnings.Concat(AlwaysIgnoredWarnings);
 
             // Use dynamic property access for MainOperation, because it is only exposed in internal classes
             var operationProperty = results.GetType().GetProperty("MainOperation", typeof(Library.Main.OperationMode));
@@ -330,7 +338,7 @@ namespace Duplicati.UnitTest
                 throw new TestVerificationException(sb.ToString());
             }
 
-            var remainingWarnings = results.Warnings.Where(w => !ignoredWarnings.Any(ignored => w.Contains(ignored)));
+            var remainingWarnings = results.Warnings.Where(w => !effectiveIgnoredWarnings.Any(ignored => w.Contains(ignored)));
             if (remainingWarnings.Any())
             {
                 var sb = new StringBuilder();


### PR DESCRIPTION
## Summary

Makes `TestUtils.AssertResults` ignore the purely environmental `SleepPreventionError` warning, so it no longer causes intermittent unit-test failures on CI. **Test infrastructure only — no product code changes.**

## The flake

`Test_GeometryMetadata_Verification_Async` (and potentially any other test that calls `AssertResults`) intermittently failed in CI with:

```
Duplicati.UnitTest.TestUtils+TestVerificationException : Warnings - List:
… - [Warning-Duplicati.Library.Main.ProcessController-SleepPreventionError]: Failed to set sleep prevention
   at Duplicati.UnitTest.TestUtils.AssertResults(...) TestUtils.cs
   at Duplicati.UnitTest.DiskImage.IntegrationTests.ParsingTests.Test_GeometryMetadata_Verification_Async()
```

On some CI runners, setting OS sleep prevention fails and Duplicati logs a `SleepPreventionError` **warning** during the operation. `AssertResults` treats any non-ignored warning as a test failure, so the run flakes even though nothing about the backup/restore under test is wrong.

## The fix

Add an always-ignored list of environment-only warnings to `AssertResults` and union it with the caller-supplied `ignoredWarnings`:

```csharp
private static readonly string[] AlwaysIgnoredWarnings = ["SleepPreventionError"];
…
var effectiveIgnoredWarnings = ignoredWarnings.Concat(AlwaysIgnoredWarnings);
```

`SleepPreventionError` (failure to prevent system sleep) is never a correctness signal for a test, so ignoring it everywhere is safe and fixes this class of flake for all tests that use `AssertResults`.

## Scope / notes

- One-file change in `Duplicati/UnitTest/TestUtils.cs`; no product code affected.
- Follow-up to #7025 — both came out of the same DiskImage CI-flake investigation but were kept as separate, single-purpose PRs.
