### PR TITLE
Make CLI `find` search all backup versions by default (fixes #2287)

### DIFF
--- a/Duplicati/CommandLine/CLI/Commands.cs
+++ b/Duplicati/CommandLine/CLI/Commands.cs
@@ -498,6 +498,17 @@ namespace Duplicati.CommandLine
             return 0;
         }
 
+        public static int Find(TextWriter outwriter, Action<Duplicati.Library.Main.Controller> setup, List<string> args, Dictionary<string, string> options, Library.Utility.IFilter filter)
+        {
+            // Unlike "list" (which shows only the newest version by default), "find" searches every
+            // backup version, so a file is located regardless of which version it appears in.
+            // Respect an explicit --all-versions / --version / --time supplied by the user.
+            if (!options.ContainsKey("all-versions") && !options.ContainsKey("version") && !options.ContainsKey("time"))
+                options["all-versions"] = "true";
+
+            return List(outwriter, setup, args, options, filter);
+        }
+
         public static int List(TextWriter outwriter, Action<Duplicati.Library.Main.Controller> setup, List<string> args, Dictionary<string, string> options, Library.Utility.IFilter filter)
         {
             filter = filter ?? new Duplicati.Library.Utility.FilterExpression();

--- a/Duplicati/CommandLine/CLI/Program.cs
+++ b/Duplicati/CommandLine/CLI/Program.cs
@@ -76,7 +76,7 @@ namespace Duplicati.CommandLine
                         ["help"] = Commands.Help,
                         ["example"] = Commands.Examples,
                         ["examples"] = Commands.Examples,
-                        ["find"] = Commands.List,
+                        ["find"] = Commands.Find,
                         ["list"] = Commands.List,
                         ["list-filesets"] = Commands.ListFilesets,
                         ["list-folder-content"] = Commands.ListFolderContent,

--- a/Duplicati/CommandLine/CLI/help.txt
+++ b/Duplicati/CommandLine/CLI/help.txt
@@ -103,7 +103,7 @@ Usage: %CLI_EXE% backup <storage-URL> "<source-path>" [<options>]
 
 Usage: %CLI_EXE% find <storage-URL> ["<filename>"] [<options>]
 
-  Finds specific files in specific backups. If <filename> is specified, all occurrences of <filename> in the backup are listed. <filename> can contain * and ? as wildcards. File names in [brackets] are interpreted as regular expression. Latest backup is searched by default. If entire path is specified, all available versions of the file are listed. If no <filename> is specified, a list of all available backups is shown.
+  Finds specific files in specific backups. If <filename> is specified, all occurrences of <filename> in the backup are listed. <filename> can contain * and ? as wildcards. File names in [brackets] are interpreted as regular expression. The "find" command searches all backup versions by default, while "list" shows only the latest version by default (use --all-versions with "list" to search every version). If no <filename> is specified, a list of all available backups is shown.
 
   --time=<time>
     Shows what the files looked like at a specific time. Absolute and relative times can be specified.

--- a/Duplicati/UnitTest/Issue2287.cs
+++ b/Duplicati/UnitTest/Issue2287.cs
@@ -1,0 +1,100 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    public class Issue2287 : BasicSetupHelper
+    {
+        /// <summary>
+        /// https://github.com/duplicati/duplicati/issues/2287
+        /// The "find" command must locate a file in ANY backup version, not only the newest one.
+        /// A bare filename is turned into a wildcard filter (e.g. "*/target.txt"), which previously
+        /// searched only the newest version; the all-versions fallback only triggered when the newest
+        /// version had zero matches, so a file present only in an older version was silently missed
+        /// whenever the newest version still contained a same-named file. "find" now searches all
+        /// versions by default, while "list" keeps its newest-only default.
+        /// </summary>
+        [Test]
+        [Category("Targeted")]
+        public async Task FindSearchesAllVersionsAsync()
+        {
+            var testopts = TestOptions.Expand(new { no_encryption = true });
+
+            var subA = Path.Combine(DATAFOLDER, "sub_a");
+            var subB = Path.Combine(DATAFOLDER, "sub_b");
+            Directory.CreateDirectory(subA);
+            Directory.CreateDirectory(subB);
+            var fileA = Path.Combine(subA, "target.txt");
+            var fileB = Path.Combine(subB, "target.txt");
+            File.WriteAllText(fileA, "present in newest and old version");
+            File.WriteAllText(fileB, "present only in the old version");
+
+            // Version 1: both sub_a/target.txt and sub_b/target.txt exist.
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                var res = await c.BackupAsync(new[] { DATAFOLDER });
+                Assert.AreEqual(0, res.Errors.Count());
+            }
+
+            System.Threading.Thread.Sleep(TimeSpan.FromSeconds(3));
+
+            // Version 0 (newest): sub_b/target.txt is removed, so it now exists only in the old version.
+            File.Delete(fileB);
+            Directory.Delete(subB);
+            using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+            {
+                var res = await c.BackupAsync(new[] { DATAFOLDER });
+                Assert.AreEqual(0, res.Errors.Count());
+            }
+
+            // "find target.txt" must surface the older-only sub_b/target.txt as well as the newest one.
+            var findOutput = RunListCommand(Duplicati.CommandLine.Commands.Find, "target.txt", testopts);
+            Assert.IsTrue(findOutput.Contains("sub_a"), "find should list the newest match:" + Environment.NewLine + findOutput);
+            Assert.IsTrue(findOutput.Contains("sub_b"), "find should also list the older-only match:" + Environment.NewLine + findOutput);
+
+            // "list target.txt" keeps the newest-only behaviour, so it must NOT include the older-only file.
+            var listOutput = RunListCommand(Duplicati.CommandLine.Commands.List, "target.txt", testopts);
+            Assert.IsTrue(listOutput.Contains("sub_a"), "list should list the newest match:" + Environment.NewLine + listOutput);
+            Assert.IsFalse(listOutput.Contains("sub_b"), "list should not list the older-only match:" + Environment.NewLine + listOutput);
+        }
+
+        private string RunListCommand(
+            Func<TextWriter, Action<Library.Main.Controller>, List<string>, Dictionary<string, string>, Library.Utility.IFilter, int> command,
+            string filename,
+            Dictionary<string, string> baseopts)
+        {
+            using var sw = new StringWriter();
+            // The list/find commands mutate the args and options, so hand each invocation its own copies.
+            var args = new List<string> { "file://" + TARGETFOLDER, filename };
+            var opts = new Dictionary<string, string>(baseopts);
+            command(sw, _ => { }, args, opts, null);
+            return sw.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2287 — the CLI `find` command could silently miss a file that exists only in an older backup version. `find` now searches **all** backup versions by default, while `list` keeps its newest-only default.

## The bug

`find` and `list` share the same handler (`Commands.List`). A bare filename like `report.txt` is rewritten to `*/report.txt` by `PrefixArgWithAsterisk`, which makes it a **Wildcard** filter. `ListFilesHandler` only searches every version when the filter is `FilterType.Simple` or `--all-versions` is set, so a Wildcard filter is restricted to the **newest** fileset (`ListFilesHandler.cs` → `TakeFirstAsync`).

There is a fallback in `Commands.List` that retries with `all-versions=true`, but **only when the first (newest) pass returns zero files**. So if the newest version contains any other file matching the pattern, the fallback never runs and matches that exist only in an older version are silently dropped. This also produced a surprising inconsistency (noted by @ts678 on the issue): `find /full/path/report.txt` (a Simple filter) *does* search all versions, while `find report.txt` does not.

## The fix

Add a thin `Commands.Find` entry point and map `find` to it (`list` is unchanged):

```csharp
public static int Find(...)
{
    // "find" searches every backup version by default; "list" shows only the newest.
    // Respect an explicit --all-versions / --version / --time from the user.
    if (!options.ContainsKey("all-versions") && !options.ContainsKey("version") && !options.ContainsKey("time"))
        options["all-versions"] = "true";
    return List(...);
}
```

- `find <filename>` now reliably searches every version, matching what users expect from a "find" command.
- `list` keeps the documented newest-only default (use `--all-versions` to search all).
- An explicit `--version` / `--time` / `--all-versions` from the user is respected.
- The help text for `find` is updated accordingly.

This changes `find`'s documented default ("latest by default" → "all versions"); happy to adjust the approach if you'd prefer to keep the newest-only default and instead make the zero-match fallback complete.

## Test

Adds `Duplicati/UnitTest/Issue2287.cs`: backs up two versions where `sub_b/target.txt` exists only in the older version (the newest still contains `sub_a/target.txt`), then asserts `Commands.Find("target.txt")` lists the older-only file while `Commands.List("target.txt")` does not. Verified locally on .NET 10 that the test fails without the fix and passes with it.

## Scope

- `Duplicati/CommandLine/CLI/Commands.cs` (new `Find`), `Program.cs` (command map), `help.txt` (find description), and a new regression test. `list` behaviour is untouched.
