### PR TITLE
Use effective dbpath for show-log and delete-db endpoints (fixes #1698)

### DIFF
--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -1412,6 +1412,19 @@ namespace Duplicati.Server
             options["remote-sync-json-config"] = JsonSerializer.Serialize(config, jsonOptions);
         }
 
+        /// <summary>
+        /// Returns the effective local database path for a backup: the "--dbpath" advanced option if
+        /// it is set, otherwise the stored <see cref="Serialization.Interface.IBackup.DBPath"/>. This
+        /// mirrors the precedence applied by <see cref="ApplyOptions"/> so that every operation agrees
+        /// on which database file to use (see issue #1698).
+        /// </summary>
+        public static string GetEffectiveDBPath(Serialization.Interface.IBackup backup)
+        {
+            var dbpath = backup.Settings?
+                .FirstOrDefault(s => s.Name.Equals("--dbpath", StringComparison.OrdinalIgnoreCase))?.Value;
+            return string.IsNullOrWhiteSpace(dbpath) ? backup.DBPath : dbpath;
+        }
+
         internal static Dictionary<string, string?> ApplyOptions(Connection databaseConnection, Serialization.Interface.IBackup backup, Dictionary<string, string?> options, out string url)
         {
             url = backup.TargetURL;

--- a/Duplicati/UnitTest/Issue1698.cs
+++ b/Duplicati/UnitTest/Issue1698.cs
@@ -1,0 +1,91 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Duplicati.Server.Database;
+using Duplicati.Server.Serialization.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// https://github.com/duplicati/duplicati/issues/1698
+    /// "Show log" and "Database delete" read/deleted the stored <c>Backup.DBPath</c> directly, while
+    /// most operations honor a "--dbpath" advanced option. When those disagreed, Show log opened the
+    /// wrong/empty database ("no such table: LogData"). <see cref="Duplicati.Server.Runner.GetEffectiveDBPath"/>
+    /// reconciles them with the same precedence as the runner; these tests cover that precedence.
+    /// </summary>
+    [TestFixture]
+    public class Issue1698
+    {
+        private static Backup CreateBackup(string? storedDbPath, params (string Name, string Value)[] settings)
+        {
+            var backup = new Backup
+            {
+                ID = null,
+                Name = "Test Backup",
+                Description = "",
+                Tags = new string[0],
+                TargetURL = "file:///test",
+                Sources = new string[0],
+                Settings = settings.Select(s => (ISetting)new Setting { Name = s.Name, Value = s.Value }).ToArray(),
+                Filters = new IFilter[0],
+                Metadata = new Dictionary<string, string>()
+            };
+            if (storedDbPath != null)
+                backup.SetDBPath(storedDbPath);
+            return backup;
+        }
+
+        [Test]
+        public void UsesStoredDbPathWhenNoAdvancedOption()
+        {
+            var backup = CreateBackup("/stored/path.sqlite");
+            Assert.AreEqual("/stored/path.sqlite", Duplicati.Server.Runner.GetEffectiveDBPath(backup));
+        }
+
+        [Test]
+        public void AdvancedDbPathOptionOverridesStoredDbPath()
+        {
+            var backup = CreateBackup("/stored/path.sqlite", ("--dbpath", "/override/path.sqlite"));
+            Assert.AreEqual("/override/path.sqlite", Duplicati.Server.Runner.GetEffectiveDBPath(backup));
+        }
+
+        [Test]
+        public void AdvancedDbPathMatchIsCaseInsensitiveOnName()
+        {
+            var backup = CreateBackup("/stored/path.sqlite", ("--DBPath", "/override/path.sqlite"));
+            Assert.AreEqual("/override/path.sqlite", Duplicati.Server.Runner.GetEffectiveDBPath(backup));
+        }
+
+        [Test]
+        public void BlankAdvancedDbPathFallsBackToStoredDbPath()
+        {
+            var backup = CreateBackup("/stored/path.sqlite", ("--dbpath", "   "));
+            Assert.AreEqual("/stored/path.sqlite", Duplicati.Server.Runner.GetEffectiveDBPath(backup));
+        }
+    }
+}

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupGet.cs
@@ -187,20 +187,24 @@ public class BackupGet : IEndpointV1
 
     private static List<Dictionary<string, object>> ExecuteGetLog(Connection connection, IBackup bk, long? offset, long pagesize)
     {
-        if (!File.Exists(bk.DBPath))
+        // Use the effective database path (honoring a "--dbpath" advanced option) so that the log is
+        // read from the same database the backup actually uses (see issue #1698).
+        var dbpath = Runner.GetEffectiveDBPath(bk);
+        if (!File.Exists(dbpath))
             return new List<Dictionary<string, object>>();
 
-        using (var con = Library.SQLiteHelper.SQLiteLoader.LoadConnection(bk.DBPath))
+        using (var con = Library.SQLiteHelper.SQLiteLoader.LoadConnection(dbpath))
         using (var cmd = con.CreateCommand())
             return LogData.DumpTable(cmd, "LogData", "ID", offset, pagesize);
     }
 
     private static List<Dictionary<string, object>> ExecuteGetRemotelog(Connection connection, IBackup bk, long? offset, long pagesize)
     {
-        if (!File.Exists(bk.DBPath))
+        var dbpath = Runner.GetEffectiveDBPath(bk);
+        if (!File.Exists(dbpath))
             return new List<Dictionary<string, object>>();
 
-        using (var con = Library.SQLiteHelper.SQLiteLoader.LoadConnection(bk.DBPath))
+        using (var con = Library.SQLiteHelper.SQLiteLoader.LoadConnection(dbpath))
         using (var cmd = con.CreateCommand())
         {
             var dt = LogData.DumpTable(cmd, "RemoteOperation", "ID", offset, pagesize);

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
@@ -105,7 +105,9 @@ public class BackupPost : IEndpointV1
         => connection.GetBackup(id) ?? throw new NotFoundException("Backup not found");
 
     private static void ExecuteDeleteDb(IBackup backup)
-        => File.Delete(backup.DBPath);
+        // Delete the effective database (honoring a "--dbpath" advanced option) so the database the
+        // backup actually uses is removed, not a stale DBPath that may not exist (see issue #1698).
+        => File.Delete(Runner.GetEffectiveDBPath(backup));
 
     private static void UpdateDatabasePath(Connection connection, IBackup backup, string targetpath, bool move)
     {


### PR DESCRIPTION
## Summary

Fixes #1698 — "Show log", "Show remote log", and "Delete database" ignored a `--dbpath` advanced option and operated on the stored `Backup.DBPath` instead, so they opened/deleted the wrong database. With a `--dbpath` that differs from `Backup.DBPath`, "Show log" fails with `SQL logic error: no such table: LogData`.

## Root cause

A backup has two notions of its local DB path:
- the stored `Backup.DBPath` field (set via the **Database** screen), and
- a `--dbpath` advanced option stored in the backup's settings.

The only place that computes the **effective** path (honoring `--dbpath`) is `Runner.ApplyOptions` (`Runner.cs`: it seeds `options["dbpath"] = backup.DBPath`, then lets a `--dbpath` setting override it). Every runner-dispatched operation (Run, Restore, Verify, Compact, Repair, Commandline, Export, and the "delete entire backup + local DB" task) therefore honors `--dbpath`. But three endpoints bypass the runner and read `backup.DBPath` directly:

- `GET /backup/{id}/log` — `BackupGet.ExecuteGetLog`
- `GET /backup/{id}/remotelog` — `BackupGet.ExecuteGetRemotelog`
- `POST /backup/{id}/deletedb` — `BackupPost.ExecuteDeleteDb`

So they disagree with everything else (as @ts678 observed on the issue: most buttons follow `--dbpath`, but Show log / Database Delete follow `Backup.DBPath`).

## Fix

Add a small shared helper `Runner.GetEffectiveDBPath(IBackup)` that returns the `--dbpath` advanced option if present, otherwise `Backup.DBPath` (the same precedence as `ApplyOptions`), and use it in the three endpoints so every operation agrees on the database file.

## Scope / notes

- Deliberately does **not** touch the DB **move/update** endpoints (`movedb`/`updatedb`, `BackupPost.UpdateDatabasePath`) — those manage the `DBPath` field itself and interact with `--dbpath` differently; that's a separate concern.
- @kenkendk suggested (on the issue) reconciling `--dbpath` into the `DBPath` field with a prompt on save. That's complementary and would need UI work; this change fixes the immediate inconsistency entirely server-side. Happy to align with the prompt-on-save approach instead/as well if you'd prefer.

## Test

Adds `Duplicati/UnitTest/Issue1698.cs` covering `Runner.GetEffectiveDBPath` precedence: a `--dbpath` setting overrides the stored `DBPath` (case-insensitive on the option name), while a missing/blank setting falls back to `DBPath`.

Verified locally on .NET 10: build clean; `Issue1698` (4) + `RelativeDbPathTests` (6) + `ServerApiIntegrationTests` (4) all pass.
