### PR TITLE
Update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/backendtests.yml
+++ b/.github/workflows/backendtests.yml
@@ -269,11 +269,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -309,11 +309,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -347,11 +347,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -386,11 +386,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -424,11 +424,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -463,11 +463,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -500,11 +500,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -540,11 +540,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -579,11 +579,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -613,11 +613,11 @@ jobs:
           - ubuntu-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -646,11 +646,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -684,11 +684,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -720,11 +720,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -758,11 +758,11 @@ jobs:
   #         - macos-latest
   #   steps:
   #     - name: Set up .NET
-  #       uses: actions/setup-dotnet@v4
+  #       uses: actions/setup-dotnet@v5
   #       with:
   #         dotnet-version: 10.x
   #     - name: Checkout source
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v7
   #     - name: Restore NuGet dependencies
   #       run: >-
   #         dotnet restore
@@ -794,11 +794,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -831,11 +831,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -869,11 +869,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -910,11 +910,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Create dummy changelog file
         working-directory: ./ReleaseBuilder
@@ -41,6 +41,6 @@ jobs:
   # selenium:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v7
   #     - name: Selenium
   #       run: pipeline/selenium/test.sh

--- a/.github/workflows/secretprovidertests.yml
+++ b/.github/workflows/secretprovidertests.yml
@@ -89,11 +89,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -122,11 +122,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -157,11 +157,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -192,11 +192,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -227,11 +227,11 @@ jobs:
           - macos-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore
@@ -252,11 +252,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Restore NuGet dependencies
         run: >-
           dotnet restore

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       actions: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 15
           days-before-issue-close: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore NuGet dependencies
         run: dotnet restore Duplicati.slnx
@@ -49,12 +49,12 @@ jobs:
 
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore NuGet dependencies
         run: dotnet restore Duplicati.slnx
@@ -71,13 +71,13 @@ jobs:
     name: Playwright UI tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install NPM dependencies
         run: npm ci
       - name: Install Playwright browsers
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload Playwright test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-test-results
           path: |
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Playwright HTML report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-html-report
           path: playwright-report/


### PR DESCRIPTION
## Summary

Updates the GitHub Actions used in CI to their current major versions. This clears the recurring `Node.js 20 is deprecated … actions/checkout@v4, actions/setup-dotnet@v4` warnings on every run (the pinned actions bundled Node.js 20, which GitHub is retiring on runners).

## Version bumps

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-dotnet` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/setup-node` | v4 | **v6** |
| `actions/stale` | v9 | **v10** |
| `atomicjar/testcontainers-cloud-setup-action` | v1 | v1 (already the latest major — unchanged) |

Only the `uses:` version tags change; no workflow logic, inputs, or triggers are touched.

## Compatibility review (release notes)

All of these majors moved to Node.js 24 and require **Actions Runner ≥ v2.327.1**. This repo uses only GitHub-hosted runners (`ubuntu-latest` / `windows-latest` / `macos-latest`), which always satisfy that, and there are no self-hosted runners.

- **checkout v7** — the notable v7 change ("block checking out fork PRs for `pull_request_target` / `workflow_run`") does **not** affect these workflows: they only trigger on `pull_request`, `workflow_dispatch`, and `schedule`, and no `checkout` step overrides `ref:`/`repository:`. v6's "persist credentials to a separate file" is transparent (no step reads the token from `.git/config`; no `persist-credentials` override is used).
- **setup-dotnet v5** — drops installing older/EOL .NET SDKs; irrelevant here since the workflows install `dotnet-version: 10.x` (current).
- **setup-node v6** — v5+ auto-enables package-manager caching only when `package.json` has a `packageManager` field; this repo's `package.json` has none, so behavior is unchanged. The existing `node-version: 20` input is left as-is.
- **upload-artifact v7** — the new direct/unzipped upload is opt-in (`archive: false`, default keeps zipping); the two existing uses (`name` + `path` + `retention-days`) are unaffected.
- **stale v10** — Node.js 24 plus an additive `sort-by` option; no change to existing config.

## Verification

- `actionlint` passes on all workflow files.
- The new action versions are exercised by this PR's own CI (`pull_request` runs use the workflow definitions from the PR).
