### PR TITLE
Fix flaky temp-file name collision in debug builds

### DIFF
--- a/Duplicati/Library/Utility/TempFile.cs
+++ b/Duplicati/Library/Utility/TempFile.cs
@@ -44,6 +44,13 @@ namespace Duplicati.Library.Utility
         private static readonly object m_lock = new object();
         private static readonly Dictionary<string, System.Diagnostics.StackTrace> m_fileTrace = new Dictionary<string, System.Diagnostics.StackTrace>();
 
+        // Process-wide monotonic counter appended to each generated name to guarantee
+        // uniqueness. The timestamp is only second-precision and the Guid is truncated to
+        // 8 characters, so under load (many temp files created in the same second by the
+        // same caller) those alone can collide, which would produce duplicate file paths
+        // and throw from the m_fileTrace.Add below.
+        private static long m_uniqueCounter;
+
         public static System.Diagnostics.StackTrace GetStackTraceForTempFile(string filename)
         {
             lock (m_lock)
@@ -53,17 +60,20 @@ namespace Duplicati.Library.Utility
                     return null;
         }
 
-        private static string GenerateUniqueName()
+        internal static string GenerateUniqueName()
         {
+            // The trailing sequence number guarantees a unique name even when the caller,
+            // second-precision timestamp, and truncated Guid all coincide.
+            var seq = System.Threading.Interlocked.Increment(ref m_uniqueCounter);
             var st = new System.Diagnostics.StackTrace();
             foreach (var f in st.GetFrames())
             {
                 var asm = f.GetMethod()?.DeclaringType?.Assembly;
                 if (asm != null && asm != typeof(TempFile).Assembly)
                 {
-                    var n = string.Format("{0}_{1}_{2}_{3}", f.GetMethod().DeclaringType.FullName, f.GetMethod().Name, Library.Utility.Utility.SerializeDateTime(DateTime.UtcNow), Guid.NewGuid().ToString().Substring(0, 8));
+                    var n = string.Format("{0}_{1}_{2}_{3}_{4}", f.GetMethod().DeclaringType.FullName, f.GetMethod().Name, Library.Utility.Utility.SerializeDateTime(DateTime.UtcNow), Guid.NewGuid().ToString().Substring(0, 8), seq);
                     if (n.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) >= 0)
-                        n = string.Format("{0}_{1}_{2}_{3}", f.GetMethod().DeclaringType.Name, f.GetMethod().Name, Library.Utility.Utility.SerializeDateTime(DateTime.UtcNow), Guid.NewGuid().ToString().Substring(0, 8));
+                        n = string.Format("{0}_{1}_{2}_{3}_{4}", f.GetMethod().DeclaringType.Name, f.GetMethod().Name, Library.Utility.Utility.SerializeDateTime(DateTime.UtcNow), Guid.NewGuid().ToString().Substring(0, 8), seq);
                     if (n.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) < 0)
                     {
                         lock (m_lock)
@@ -73,13 +83,13 @@ namespace Duplicati.Library.Utility
                 }
             }
 
-            var s = Guid.NewGuid().ToString();
+            var s = string.Format("{0}_{1}", Guid.NewGuid(), seq);
             lock (m_lock)
                 m_fileTrace.Add(s, st);
             return s;
         }
 #else
-        private static string GenerateUniqueName()
+        internal static string GenerateUniqueName()
         {
             return APPLICATION_PREFIX + Guid.NewGuid().ToString();
         }

--- a/Duplicati/UnitTest/TempFileUniqueNameTests.cs
+++ b/Duplicati/UnitTest/TempFileUniqueNameTests.cs
@@ -1,0 +1,82 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Regression tests for <see cref="TempFile"/> unique-name generation. In DEBUG builds
+    /// the name is built from the caller, a second-precision timestamp and a truncated Guid,
+    /// which could collide when many temp files are created in the same second by the same
+    /// caller — producing duplicate paths and throwing from the internal tracking dictionary.
+    /// The generator now appends a process-wide counter to guarantee uniqueness.
+    /// </summary>
+    public class TempFileUniqueNameTests
+    {
+        [Test]
+        [Category("Utility")]
+        public void GeneratedNamesAreUniqueUnderConcurrentLoad()
+        {
+            const int threads = 8;
+            const int perThread = 12500;
+            const int expected = threads * perThread;
+
+            var names = new ConcurrentBag<string>();
+            var errors = new ConcurrentQueue<Exception>();
+
+            var work = new Task[threads];
+            for (var t = 0; t < threads; t++)
+            {
+                work[t] = Task.Run(() =>
+                {
+                    try
+                    {
+                        for (var i = 0; i < perThread; i++)
+                            names.Add(TempFile.GenerateUniqueName());
+                    }
+                    catch (Exception ex)
+                    {
+                        // Before the fix, a name collision throws ArgumentException from the
+                        // tracking dictionary's Add; capture it rather than faulting the task.
+                        errors.Enqueue(ex);
+                    }
+                });
+            }
+
+            Task.WaitAll(work);
+
+            Assert.IsEmpty(errors, "Generating unique temp names must not throw: " + (errors.IsEmpty ? "" : errors.ToArray()[0].ToString()));
+
+            var all = names.ToArray();
+            Assert.AreEqual(expected, all.Length, "Every generation should have produced a name");
+
+            var distinct = new HashSet<string>(all, StringComparer.Ordinal);
+            Assert.AreEqual(all.Length, distinct.Count, "Generated temp file names must all be unique");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure in **DEBUG** unit-test builds where `BorderTests.Run10kTzstdCompressionAsync` (and any other test that creates a large number of temp files quickly) fails with:

```
System.ArgumentException : An item with the same key has already been added.
  Key: ...FileArchiveTarBased+PendingEntryStream_.ctor_20260710T160450Z_72d2af1a
  at Duplicati.Library.Utility.TempFile.GenerateUniqueName()   TempFile.cs:70
```

## Root cause

In DEBUG builds, `TempFile.GenerateUniqueName()` builds each temp-file name from `{callerType}_{method}_{timestamp}_{guid8}` and registers it in a static `Dictionary<string, StackTrace>` for debugging.

- The timestamp is **second-precision** (`SERIALIZED_DATE_TIME_FORMAT = "yyyyMMdd'T'HHmmssK"`).
- So for a single caller within one second, names differ only by the **first 8 hex characters of a Guid** (a 2³² space).
- A stress test like `Run10k…` creates ~10k temp files from the same `PendingEntryStream..ctor` in a short window, so the truncated Guid collides (birthday paradox). The repeated name makes `Dictionary.Add` throw — and, more importantly, two `TempFile` instances would resolve to the **same path**.

Release builds are unaffected (they use a full Guid and no tracking dictionary).

## Fix

Append a process-wide monotonic counter (`Interlocked.Increment`) to the generated name, so it is unique regardless of timestamp granularity or Guid-prefix collisions. The `Dictionary.Add` invariant check is kept.

`GenerateUniqueName` is made `internal` (Library.Utility already has `[InternalsVisibleTo("Duplicati.UnitTest")]`) so it can be exercised directly.

## Tests / verification

- New `TempFileUniqueNameTests`: 8 threads generate 100k names concurrently and assert none throw and all are unique.
- Verified locally (.NET 10, DEBUG): the new test **passes** with the fix; temporarily removing the counter makes it **fail** with the exact `ArgumentException` above, confirming it is a genuine regression test.
- Re-ran `BorderTests.Run10kTzstdCompressionAsync` — passes.

Independent of #7020 / #7033; branches off `master`.
