### PR TITLE
Fix test-filters ignoring --source from a parameters file (#4812)

### DIFF
--- a/Duplicati/CommandLine/CLI/Program.cs
+++ b/Duplicati/CommandLine/CLI/Program.cs
@@ -393,15 +393,25 @@ namespace Duplicati.CommandLine
                 foreach (KeyValuePair<String, String> keyvalue in opt)
                     options[keyvalue.Key] = keyvalue.Value;
 
+                var command = cargs.Count >= 1 ? cargs[0] : string.Empty;
+                var isBackup = command.Equals("backup", StringComparison.OrdinalIgnoreCase);
+                var isTestFilters = command.Equals("test-filters", StringComparison.OrdinalIgnoreCase)
+                                 || command.Equals("test-filter", StringComparison.OrdinalIgnoreCase);
+
                 if (!string.IsNullOrEmpty(newtarget))
                 {
-                    if (cargs.Count <= 1)
+                    // test-filters takes source paths as positional arguments and has no target, so a
+                    // --target from the parameters file must not become a bogus positional source (#4812).
+                    if (isTestFilters)
+                        Library.Logging.Log.WriteVerboseMessage(LOGTAG, "NotUsingTarget", Strings.Program.SkippingTargetArgumentOnTestFilters);
+                    else if (cargs.Count <= 1)
                         cargs.Add(newtarget);
                     else
                         cargs[1] = newtarget;
                 }
 
-                if (cargs.Count >= 1 && cargs[0].Equals("backup", StringComparison.OrdinalIgnoreCase))
+                // backup and test-filters take source paths as positional arguments.
+                if (isBackup || isTestFilters)
                     cargs.AddRange(newsource);
                 else if (newsource.Count > 0)
                     Library.Logging.Log.WriteVerboseMessage(LOGTAG, "NotUsingBackupSources", Strings.Program.SkippingSourceArgumentsOnNonBackupOperation);

--- a/Duplicati/CommandLine/CLI/Strings.cs
+++ b/Duplicati/CommandLine/CLI/Strings.cs
@@ -54,6 +54,7 @@ namespace Duplicati.CommandLine.Strings
         public static string QuietConsoleOptionLong { get { return LC.L(@"If this option is set, progress reports and other messages that would normally go to the console will be redirected to the log."); } }
         public static string QuietConsoleOptionShort { get { return LC.L(@"Disable console output"); } }
         public static string SkippingSourceArgumentsOnNonBackupOperation { get { return @"The --source argument was specified in the parameter file, but the current operation is not a backup operation, so the argument is ignored."; } }
+        public static string SkippingTargetArgumentOnTestFilters { get { return @"The --target argument was specified in the parameter file, but the test-filters operation has no target, so the argument is ignored."; } }
         public static string AutoUpdateOptionShort { get { return LC.L(@"Toggle automatic updates"); } }
         public static string AutoUpdateOptionLong { get { return LC.L(@"Set this option if you prefer to have the commandline version automatically update"); } }
         public static string PortableModeOptionShort { get { return LC.L(@"Use portable mode"); } }

--- a/Duplicati/UnitTest/Issue4812.cs
+++ b/Duplicati/UnitTest/Issue4812.cs
@@ -1,0 +1,83 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    public class Issue4812 : BasicSetupHelper
+    {
+        /// <summary>
+        /// https://github.com/duplicati/duplicati/issues/4812
+        /// `test-filters --parameters-file=...` must test the --source paths listed in the
+        /// parameters file. Previously the parameters-file handling only appended --source for the
+        /// `backup` command and always injected --target as the first positional argument, so for
+        /// test-filters the --source entries were dropped and the --target was tested as the (bogus)
+        /// source path — matching zero files.
+        /// </summary>
+        [Test]
+        [Category("Targeted")]
+        public void TestFiltersUsesSourceFromParametersFile()
+        {
+            // A source folder with a known number of plain files.
+            var sourceFolder = Path.Combine(DATAFOLDER, "src");
+            Directory.CreateDirectory(sourceFolder);
+            const int fileCount = 3;
+            for (var i = 0; i < fileCount; i++)
+                File.WriteAllText(Path.Combine(sourceFolder, $"file{i}.txt"), "content " + i);
+
+            // A shared-style parameters file carrying both --target (used by backup) and --source.
+            var paramFile = Path.Combine(DATAFOLDER, "params.txt");
+            File.WriteAllLines(paramFile, new[]
+            {
+                "--source=" + sourceFolder,
+                "--target=file://" + TARGETFOLDER
+            });
+
+            var sb = new StringBuilder();
+            var err = new StringBuilder();
+            int exit;
+            using (var sw = new StringWriter(sb))
+            using (var ew = new StringWriter(err))
+                exit = Duplicati.CommandLine.Program.RunCommandLine(sw, ew, _ => { }, new[]
+                {
+                    "test-filters",
+                    "--parameters-file=" + paramFile
+                });
+
+            var output = sb.ToString();
+            Assert.AreEqual(0, exit, "test-filters should succeed" + Environment.NewLine + output + Environment.NewLine + err);
+
+            var m = Regex.Match(output, @"Matched (\d+) files");
+            Assert.IsTrue(m.Success, "Expected a 'Matched N files' summary" + Environment.NewLine + output);
+
+            var matched = int.Parse(m.Groups[1].Value);
+            // The --source folder's files must have been tested. Before the fix this was 0, because
+            // --target was injected as the tested path and --source was ignored.
+            Assert.AreEqual(fileCount, matched, "test-filters should have matched the --source files" + Environment.NewLine + output);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4812. Running `test-filters --parameters-file=<file>` ignored the file's `--source` entries and instead tested the `--target`, so filter testing ran against the backend URL rather than the real source paths — useless output, and confusing when a single shared parameters file is used for both `backup` and `test-filters`.

## Root cause

In `Program.ReadOptionsFromFile` (`Duplicati/CommandLine/CLI/Program.cs`), the parameters-file handling was backup-centric:

- `--target` was **always** injected as the first positional argument.
- `--source` was appended to the positional arguments **only** for the `backup` command; for every other command it was dropped (with a verbose log).

But `test-filters` / `test-filter` take **source paths as positional arguments** and have **no target** (`Commands.TestFilters` passes the positional args straight to `TestFilterAsync`). So the `--target` became the single (bogus) path to test and the `--source` entries were discarded.

## Fix

`test-filters` / `test-filter` now:
- **append `--source`** as positional arguments (like `backup`), and
- **do not inject `--target`** (it has no target); this is reported at verbose level, consistent with how a `--source` on a non-backup command is already reported.

`backup` and all other commands are unchanged.

`--target` on `test-filters` is **ignored** (not an error), so an existing shared/backup parameters file can be reused for filter testing. Happy to switch to a hard error instead if you'd prefer.

## Tests / verification

- New `Issue4812` regression test drives `Program.RunCommandLine` with a parameters file containing `--source` + `--target` and asserts `test-filters` matches the `--source` files.
- Verified locally (.NET 10): the new test **passes** with the fix; reverting the fix makes it **fail** (the injected `--target` path errors out). `CommandLineOperationsTests` (backup via parameters-file/target/source) still passes — no regression.
