### PR TITLE
Remove redundant cancel button from restore progress

### DIFF
--- a/Duplicati/Server/webroot/ngax/scripts/directives/waitArea.js
+++ b/Duplicati/Server/webroot/ngax/scripts/directives/waitArea.js
@@ -3,16 +3,12 @@ backupApp.directive('waitArea', function() {
     restrict: 'E',
     scope: {
         taskid: '=taskid',
-        text: '=text',
-        allowCancel: '=allowCancel'
+        text: '=text'
     },
     templateUrl: 'templates/waitarea.html',
-    controller: function($scope, ServerStatus, AppService) {
+    controller: function($scope, ServerStatus) {
         $scope.ServerStatus = ServerStatus;
         $scope.serverstate = ServerStatus.watch($scope);
-        $scope.cancelTask = function() {
-            AppService.post('/task/' + $scope.taskid + '/stop');
-        };
     }
   }
 });

--- a/Duplicati/Server/webroot/ngax/templates/restore.html
+++ b/Duplicati/Server/webroot/ngax/templates/restore.html
@@ -149,7 +149,7 @@
         </div>
 
         <div ng-show="connecting == true &amp;&amp; taskid != null">
-            <wait-area taskid="taskid" text="ConnectionProgress" allow-cancel="true"></wait-area>
+            <wait-area taskid="taskid" text="ConnectionProgress"></wait-area>
         </div>
 
         <div ng-show="connecting == true &amp;&amp; taskid == null">

--- a/Duplicati/Server/webroot/ngax/templates/waitarea.html
+++ b/Duplicati/Server/webroot/ngax/templates/waitarea.html
@@ -15,8 +15,4 @@
         {{'Server is currently paused,' | translate}} <a style="cursor: pointer" ng-click="ServerStatus.resume()" translate>resume now</a>
     </div>
 
-    <div ng-show="allowCancel">
-        <a href class="button" ng-click="cancelTask()" translate>Cancel</a>
-    </div>
-
 </div>


### PR DESCRIPTION
## Summary

Removes the redundant **Cancel** button from the restore progress view in the legacy **ngax** UI (`duplicati/duplicati`). Restore cancellation already works from the existing stop control in the top navigation bar; the extra Cancel button inside the restore-progress `wait-area` was redundant and confusing.

Fixes duplicati/duplicati#4453

## Root cause

The restore progress used `<wait-area ... allow-cancel="true">` (`restore.html`), which renders a second **Cancel** button (`waitarea.html`) whose handler (`waitArea.js` `cancelTask()`) posts `/task/{id}/stop`. This duplicates the top-navigation stop control (`StateController.stopDialog()`, which posts `/task/{id}/stop` or `/task/{id}/abort`), and the thread on #4453 agreed the extra button should simply be removed.

## Change

Legacy **ngax** UI only — the new **ngclient** UI does not have this button. No backend, REST API, `CancellationToken`, restore behavior, or handling of already-restored files is changed. "Cancel = delete partially restored files" is explicitly **not** implemented (the issue thread decided against it).

- `restore.html`: drop `allow-cancel="true"` from the wait-area.
- `waitarea.html`: remove the Cancel button block.
- `waitArea.js`: remove the `allowCancel` binding, `cancelTask()`, and the now-unused `AppService` dependency.

Restore cancellation continues to work via the existing top-navigation stop control, which is unchanged.

## Before / After

Legacy `/ngax/` restore-progress `wait-area`, captured against a locally-running server:

**Before** — redundant Cancel button present:

![before](https://raw.githubusercontent.com/JamBalaya56562/duplicati/pr-assets-4453/.pr-assets/restore-cancel-before.png)

**After** — Cancel button removed:

![after](https://raw.githubusercontent.com/JamBalaya56562/duplicati/pr-assets-4453/.pr-assets/restore-cancel-after.png)

## Verification

- `dotnet build` (Server project, .NET 10): **0 warnings, 0 errors**.
- Ran the server locally and loaded the legacy `/ngax/` UI; confirmed the restore-progress `wait-area` renders the Cancel button before the change and no longer renders it afterwards (screenshots above). The top-navigation stop control (`StateController.stopDialog`) is unchanged and still cancels restores.
- Searched the ngax tree: no remaining references to `allow-cancel`, `allowCancel`, or `cancelTask`.
