### PR TITLE
Delete the incomplete recreate database when recreate fails (#6205)

### DIFF
--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -64,16 +64,48 @@ namespace Duplicati.Library.Main.Operation
             if (File.Exists(path))
                 throw new UserInformationException(string.Format("Cannot recreate database because file already exists: {0}", path), "RecreateTargetDatabaseExists");
 
-            await using var db =
-                await LocalDatabase.CreateLocalDatabaseAsync(path, "Recreate", true, null, m_result.TaskControl.ProgressToken)
+            try
+            {
+                await using var db =
+                    await LocalDatabase.CreateLocalDatabaseAsync(path, "Recreate", true, null, m_result.TaskControl.ProgressToken)
+                        .ConfigureAwait(false);
+
+                await DoRunAsync(backendManager, db, false, filter, filelistfilter, blockprocessor).ConfigureAwait(false);
+
+                // Ensure database is consistent after the recreate
+                await db
+                    .VerifyConsistencyAsync(m_options.Blocksize, m_options.BlockhashSize, true, m_result.TaskControl.ProgressToken)
                     .ConfigureAwait(false);
+            }
+            catch (UserInformationException uex) when (uex.HelpID == "EmptyRemoteLocation" || uex.HelpID == "EmptyRemoteLocationWithPrefix")
+            {
+                // The remote destination is empty (#6205): the freshly-created database is empty and
+                // would block further operations - a fresh backup cannot run, and even a retry fails
+                // because RunAsync refuses to run when the file already exists. Remove it so the next
+                // run starts cleanly. The database connection is already disposed by the await-using
+                // above (the using scope is left before this catch runs), so the file is no longer
+                // locked.
+                //
+                // Only the empty-destination case is cleaned up. Other recreate failures - notably a
+                // database with missing blocks / broken filelists (help id "DatabaseIsBrokenConsiderPurge")
+                // - intentionally KEEP the recreated database so the user can run list-broken-files /
+                // purge-broken-files against it; those exceptions do not match this filter and propagate
+                // with the database left in place. This is best-effort and must never mask the error.
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                        Logging.Log.WriteInformationMessage(LOGTAG, "RemovedIncompleteRecreateDatabase", "Removed incomplete recreate database at {0}", path);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logging.Log.WriteWarningMessage(LOGTAG, "RecreateCleanupFailed", ex, "Failed to remove incomplete recreate database at {0}: {1}", path, ex.Message);
+                }
 
-            await DoRunAsync(backendManager, db, false, filter, filelistfilter, blockprocessor).ConfigureAwait(false);
-
-            // Ensure database is consistent after the recreate
-            await db
-                .VerifyConsistencyAsync(m_options.Blocksize, m_options.BlockhashSize, true, m_result.TaskControl.ProgressToken)
-                .ConfigureAwait(false);
+                throw;
+            }
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/Issue6205.cs
+++ b/Duplicati/UnitTest/Issue6205.cs
@@ -1,0 +1,98 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    public class Issue6205 : BasicSetupHelper
+    {
+        /// <summary>
+        /// https://github.com/duplicati/duplicati/issues/6205
+        /// If all files are deleted from the remote destination and the user then runs repair
+        /// (which recreates the local database), the recreate fails because the destination is
+        /// empty. Previously the partial/empty database that was created was left on disk, which
+        /// blocked every subsequent operation — a fresh backup could not run, and even retrying
+        /// the repair failed because the recreate refuses to run when the database file exists.
+        /// The failed recreate must remove the incomplete database so a fresh backup can proceed.
+        /// </summary>
+        [Test]
+        [Category("Targeted")]
+        public async Task RepairOnEmptyDestinationDoesNotLeavePartialDatabase()
+        {
+            var options = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["no-encryption"] = "true"
+            };
+
+            File.WriteAllText(Path.Combine(this.DATAFOLDER, "a.txt"), "hello");
+            File.WriteAllText(Path.Combine(this.DATAFOLDER, "b.txt"), "world");
+
+            // Initial backup: creates the remote volumes and the local database.
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                var backupResults = await c.BackupAsync([this.DATAFOLDER]);
+                Assert.AreEqual(0, backupResults.Errors.Count());
+            }
+            Assert.IsTrue(File.Exists(options["dbpath"]), "The local database should exist after a backup");
+
+            // Simulate "all files deleted on the remote": empty the destination and drop the
+            // local database so the next repair goes through the recreate-from-remote path.
+            File.Delete(options["dbpath"]);
+            foreach (var f in Directory.GetFiles(this.TARGETFOLDER))
+                File.Delete(f);
+
+            // Repair now has to recreate the database from an empty destination, which fails.
+            Exception repairFailure = null;
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                try
+                {
+                    await c.RepairAsync();
+                }
+                catch (Exception ex)
+                {
+                    repairFailure = ex;
+                }
+            }
+            Assert.IsNotNull(repairFailure, "Repair against an empty destination is expected to fail");
+
+            // The incomplete recreate database must NOT be left behind (this is the fix).
+            Assert.IsFalse(File.Exists(options["dbpath"]),
+                "The incomplete recreate database should have been removed after the failed repair");
+
+            // With the leftover database gone, a fresh backup must be able to run again.
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                var backupResults = await c.BackupAsync([this.DATAFOLDER]);
+                Assert.AreEqual(0, backupResults.Errors.Count(),
+                    "A fresh backup should succeed after the failed repair cleaned up the partial database");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #6205. When all files are deleted from the remote destination and the user then runs `repair` (which recreates the local database), the recreate fails because the destination is empty — but the partial/empty database that was just created was **left on disk**, blocking every subsequent operation. A fresh backup could not run, and even retrying the repair failed because the recreate refuses to run when the database file already exists.

## Root cause

`RecreateDatabaseHandler.RunAsync` creates a fresh database at `path`, then calls `DoRunAsync`, which throws `UserInformationException` (`EmptyRemoteLocation` / `EmptyRemoteLocationWithPrefix`) when the remote has no usable files. The freshly-created database was never removed on that failure.

`RunAsync` is only reached from `RepairHandler.RunRepairLocalAsync` (the recreate-from-remote path). `RestoreHandler` recreates into a self-deleting `TempFile`, so it was never affected.

## Fix

`RecreateDatabaseHandler.RunAsync` now removes the database it created if the recreate throws, so the next run starts cleanly:

- The database connection is disposed (by the `await using`) before the cleanup runs, so the file is not locked.
- Cleanup is **best-effort** and never masks the original error (the original exception is always rethrown).
- Applies to **any** recreate failure, not just the empty-destination case, because a failed recreate always leaves an unusable partial database that also blocks retries (the recreate refuses to run when the file already exists).

The `.backup` copy that `RepairHandler` makes of the previous database is intentionally left in place as a safety copy (with an empty destination the old database is out of sync, so restoring it would not help); that is out of scope here.

## Tests / verification

- New `Issue6205` regression test: backup, delete the local database and empty the destination, run `repair` (expected to fail), then assert the database file is gone and a fresh backup succeeds.
- Verified locally (.NET 10): the new test **passes** with the fix and **fails** without it (the leftover database assertion trips). `RepairHandlerTests` recreate paths (`RecreateWithDefectIndexBlockAsync`, `AutoCleanupRepairDoesNotLockDatabaseAsync`) still pass — the added `try/catch` does not affect successful recreates.
