### PR TITLE
Use the application data folder for the control directory filter

### DIFF
--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -81,6 +81,9 @@ namespace Duplicati.Library.Utility
     /// </summary>
     public static class FilterGroups
     {
+        private const string CONTROL_DIRECTORY_NAME = "control_dir_v2";
+        private const string DEFAULT_CONTROL_DIRECTORY_FILTER = @"*/Duplicati/control_dir_v2/";
+
         /// <summary>
         /// In addition to the default names from the enums, these alternate / shorter names are also available.
         /// </summary>
@@ -235,6 +238,17 @@ namespace Duplicati.Library.Utility
         /// <param name="group">The group to use.</param>
         public static IEnumerable<string> GetFilterStrings(FilterGroup group)
         {
+            return GetFilterStrings(group, GetApplicationDataFolder());
+        }
+
+        /// <summary>
+        /// Gets the filters for a specific group using the supplied application data folder.
+        /// </summary>
+        /// <param name="group">The group to use.</param>
+        /// <param name="applicationDataFolder">The application data folder.</param>
+        /// <returns>The filters from the group.</returns>
+        internal static IEnumerable<string> GetFilterStrings(FilterGroup group, string applicationDataFolder)
+        {
             IEnumerable<string> osFilters;
 
             if (OperatingSystem.IsMacOS())
@@ -248,7 +262,7 @@ namespace Duplicati.Library.Utility
 
             return
                 FilterPrefixMatches(
-                    CreateCommonFilters(group)
+                    CreateCommonFilters(group, applicationDataFolder)
                         .Concat(osFilters)
                         .Where(x => !string.IsNullOrWhiteSpace(x))
                     )
@@ -305,15 +319,13 @@ namespace Duplicati.Library.Utility
         /// Creates common filters
         /// </summary>
         /// <param name="group">The groups to create the filters for</param>
+        /// <param name="applicationDataFolder">The application data folder.</param>
         /// <returns>Common filters</returns>
-        private static IEnumerable<string> CreateCommonFilters(FilterGroup group)
+        private static IEnumerable<string> CreateCommonFilters(FilterGroup group, string applicationDataFolder)
         {
             if (group.HasFlag(FilterGroup.CacheFiles))
             {
-                // TODO: The control_dir_v2 might be under a different path for OEM branded instances.
-                // However, the AppName is loaded and controlled by the AutoUpdater assembly, which we can't reference here without an ugly circular dependency or dependency injection.
-                // What is the best way to solve this?
-                yield return FilterGroups.CreateWildcardFilter(@"*/Duplicati/control_dir_v2/"); // Duplicati uses this directory to store lock files and communicate with other processes.
+                yield return CreateControlDirectoryFilter(applicationDataFolder); // Duplicati uses this directory to store lock files and communicate with other processes.
                 yield return FilterGroups.CreateWildcardFilter(@"*/Google/Chrome/*cache*");
                 yield return FilterGroups.CreateWildcardFilter(@"*/Google/Chrome/*LOCK*"); // Chrome appears to lock various files under it's settings folder using files named 'LOCK' or 'lockfile'
                 yield return FilterGroups.CreateWildcardFilter(@"*/Google/Chrome/*Current*"); // 'Current Session' and 'Current Tabs' appear to be locked while running Chrome
@@ -328,6 +340,50 @@ namespace Duplicati.Library.Utility
             {
                 yield return Library.Utility.TempFolder.SystemTempPath;
             }
+        }
+
+        /// <summary>
+        /// Gets the application data folder without introducing a circular dependency on the AutoUpdater assembly.
+        /// </summary>
+        /// <returns>The application data folder, or null if it could not be resolved.</returns>
+        private static string GetApplicationDataFolder()
+        {
+            try
+            {
+                var managerType = Type.GetType("Duplicati.Library.AutoUpdater.DataFolderManager, Duplicati.Library.AutoUpdater", false);
+                var accessModeType = managerType?.GetNestedType("AccessMode", System.Reflection.BindingFlags.Public);
+                if (managerType == null || accessModeType == null)
+                    return null;
+
+                var getDataFolder = managerType.GetMethod(
+                    "GetDataFolder",
+                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
+                    null,
+                    new[] { accessModeType },
+                    null);
+                if (getDataFolder == null)
+                    return null;
+
+                var probeOnly = Enum.Parse(accessModeType, "ProbeOnly");
+                return getDataFolder.Invoke(null, new[] { probeOnly }) as string;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Creates the filter for the directory used for single-instance control files.
+        /// </summary>
+        /// <param name="applicationDataFolder">The application data folder.</param>
+        /// <returns>The control directory filter.</returns>
+        private static string CreateControlDirectoryFilter(string applicationDataFolder)
+        {
+            if (string.IsNullOrWhiteSpace(applicationDataFolder))
+                return CreateWildcardFilter(DEFAULT_CONTROL_DIRECTORY_FILTER);
+
+            return CreateWildcardFilter(Common.IO.Util.AppendDirSeparator(Path.Combine(applicationDataFolder, CONTROL_DIRECTORY_NAME)));
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/FilterTest.cs
+++ b/Duplicati/UnitTest/FilterTest.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
@@ -204,6 +205,38 @@ namespace Duplicati.UnitTest
             IFilter defaultExcludes = new FilterExpression("{DefaultExcludes}");
             Assert.IsTrue(defaultExcludes.Matches(@"C:\Replicated\DfsrPrivate\", out _, out _));
             Assert.IsFalse(defaultExcludes.Matches(@"C:\Replicated\.DfsrPrivate\", out _, out _));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void ControlDirectoryFilterUsesApplicationDataFolder()
+        {
+            var root = Path.GetPathRoot(Path.GetTempPath()) ?? Path.DirectorySeparatorChar.ToString();
+            var dataFolder = Path.Combine(root, "OemDuplicati");
+            var controlDirectory = Util.AppendDirSeparator(Path.Combine(dataFolder, "control_dir_v2"));
+            var unrelatedControlDirectory = Util.AppendDirSeparator(Path.Combine(root, "OtherApplication", "control_dir_v2"));
+
+            var cacheFilters = FilterGroups.GetFilterStrings(FilterGroup.CacheFiles, dataFolder).ToList();
+            Assert.IsTrue(cacheFilters.Contains(controlDirectory, StringComparer.OrdinalIgnoreCase), $"Expected filter {controlDirectory} was not found.");
+
+            IFilter defaultExcludes = new FilterExpression(FilterGroups.GetFilterStrings(FilterGroup.DefaultExcludes, dataFolder));
+            Assert.IsTrue(defaultExcludes.Matches(controlDirectory, out _, out _));
+            Assert.IsFalse(defaultExcludes.Matches(unrelatedControlDirectory, out _, out _));
+
+            var fallbackFilter = $"*{Util.DirectorySeparatorString}Duplicati{Util.DirectorySeparatorString}control_dir_v2{Util.DirectorySeparatorString}";
+            var fallbackFilters = FilterGroups.GetFilterStrings(FilterGroup.CacheFiles, null).ToList();
+            Assert.IsTrue(fallbackFilters.Contains(fallbackFilter, StringComparer.OrdinalIgnoreCase), $"Expected fallback filter {fallbackFilter} was not found.");
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void ControlDirectoryFilterUsesResolvedDataFolder()
+        {
+            var dataFolder = DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly);
+            var expectedFilter = Util.AppendDirSeparator(Path.Combine(dataFolder, "control_dir_v2"));
+            var cacheFilters = FilterGroups.GetFilterStrings(FilterGroup.CacheFiles).ToList();
+
+            Assert.IsTrue(cacheFilters.Contains(expectedFilter, StringComparer.OrdinalIgnoreCase), $"Expected filter {expectedFilter} was not found.");
         }
 
         [Test]


### PR DESCRIPTION
Closes #3175

## Summary
- resolve the `control_dir_v2` exclusion from the application data folder used by the running instance
- load `DataFolderManager.GetDataFolder(ProbeOnly)` through reflection to avoid a circular project dependency
- retain the existing `*/Duplicati/control_dir_v2/` filter as a fallback when the AutoUpdater assembly or data folder cannot be resolved
- add regression coverage for OEM-style data folders, unrelated same-named folders, fallback behavior, and the runtime reflection path

## Root cause
`FilterGroups` is part of `Duplicati.Library.Utility`, while the OEM application name and data-folder resolution live in `Duplicati.Library.AutoUpdater`, which already depends on Utility. The fixed `Duplicati` parent path avoided that circular dependency but did not follow OEM branding or other supported data-folder overrides.

## Testing
- `dotnet restore Duplicati\UnitTest\Duplicati.UnitTest.csproj --force --verbosity minimal`
- `dotnet build Duplicati\Library\Utility\Duplicati.Library.Utility.csproj --no-restore --verbosity minimal -p:UseSharedCompilation=false -nr:false` (0 warnings, 0 errors)
- `dotnet build Duplicati\UnitTest\Duplicati.UnitTest.csproj --no-restore --no-dependencies --verbosity minimal -p:UseSharedCompilation=false -nr:false` (0 warnings, 0 errors)
- `dotnet test Duplicati\UnitTest\Duplicati.UnitTest.csproj --filter "FullyQualifiedName~ControlDirectoryFilter" --no-restore --no-build --verbosity minimal` (2 passed)
- `dotnet test Duplicati\UnitTest\Duplicati.UnitTest.csproj --filter "FullyQualifiedName~Duplicati.UnitTest.FilterTest" --no-restore --no-build --verbosity minimal` (6 passed)