### PR TITLE
Do not attach stack traces to known-problem path warnings (#6426)

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/LogExceptionHelper.cs
+++ b/Duplicati/Library/Main/Operation/Backup/LogExceptionHelper.cs
@@ -42,14 +42,18 @@ public static class LogExceptionHelper
     /// <param name="message">The message to log</param>
     public static void LogCommonWarning(Exception? ex, string logtag, string id, string path, string message = "Failed to process path: {0}")
     {
+        // For known, expected path problems the warning message already describes the cause,
+        // so the exception (and its stack trace) is not attached: it would only bloat the logs
+        // (issue #6426). The fallback below keeps the exception so genuinely unexpected failures
+        // remain fully debuggable.
         if (ex.IsPermissionDeniedException())
-            Log.WriteWarningMessage(logtag, "PermissionDenied", ex, "Excluding path due to permission denied: {0}", path);
+            Log.WriteWarningMessage(logtag, "PermissionDenied", null, "Excluding path due to permission denied: {0}", path);
         else if (ex.IsFileLockedException())
-            Log.WriteWarningMessage(logtag, "FileLocked", ex, "Excluding path due to file locked: {0}", path);
+            Log.WriteWarningMessage(logtag, "FileLocked", null, "Excluding path due to file locked: {0}", path);
         else if (ex.IsPathNotFoundException())
-            Log.WriteWarningMessage(logtag, "PathNotFound", ex, "Excluding path due to path not found: {0}", path);
+            Log.WriteWarningMessage(logtag, "PathNotFound", null, "Excluding path due to path not found: {0}", path);
         else if (ex.IsPathTooLongException())
-            Log.WriteWarningMessage(logtag, "PathTooLong", ex, "Excluding path due to path too long: {0}", path);
+            Log.WriteWarningMessage(logtag, "PathTooLong", null, "Excluding path due to path too long: {0}", path);
         else
             Log.WriteWarningMessage(logtag, id, ex, message, path);
 

--- a/Duplicati/UnitTest/Issue6426.cs
+++ b/Duplicati/UnitTest/Issue6426.cs
@@ -1,0 +1,82 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Duplicati.Library.Logging;
+using Duplicati.Library.Main.Operation.Backup;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// https://github.com/duplicati/duplicati/issues/6426
+    /// Warnings for known, expected path problems (permission denied, locked file, path not
+    /// found, path too long) must not carry the exception, so their (large) stack traces do not
+    /// bloat the log. Genuinely unexpected errors still keep the exception for debugging.
+    /// </summary>
+    public class Issue6426
+    {
+        private static List<LogEntry> CaptureWarnings(Exception ex, string callerId)
+        {
+            var captured = new List<LogEntry>();
+            using (Log.StartScope(e => captured.Add(e)))
+                LogExceptionHelper.LogCommonWarning(ex, "TestTag", callerId, "/some/path");
+            return captured.Where(e => e.Level == LogMessageType.Warning).ToList();
+        }
+
+        [Test]
+        [Category("Targeted")]
+        public void KnownPathWarningsCarryNoException()
+        {
+            // These exception types are recognised as "known problems" on every platform.
+            var cases = new (Exception Exception, string ExpectedId)[]
+            {
+                (new UnauthorizedAccessException("denied"), "PermissionDenied"),
+                (new FileNotFoundException("missing"), "PathNotFound"),
+                (new PathTooLongException("too long"), "PathTooLong"),
+            };
+
+            foreach (var c in cases)
+            {
+                var warnings = CaptureWarnings(c.Exception, "SomeCallerId");
+                Assert.AreEqual(1, warnings.Count, "Expected exactly one warning for " + c.ExpectedId);
+                Assert.AreEqual(c.ExpectedId, warnings[0].Id, "Unexpected warning id");
+                Assert.IsNull(warnings[0].Exception,
+                    c.ExpectedId + " is a known problem and must not attach the exception (no stack trace)");
+            }
+        }
+
+        [Test]
+        [Category("Targeted")]
+        public void UnknownPathWarningKeepsExceptionForDebugging()
+        {
+            var ex = new InvalidOperationException("unexpected");
+            var warnings = CaptureWarnings(ex, "CustomId");
+            Assert.AreEqual(1, warnings.Count);
+            Assert.AreEqual("CustomId", warnings[0].Id, "Unknown errors should use the caller-supplied id");
+            Assert.AreSame(ex, warnings[0].Exception, "Unknown errors must keep the exception for debugging");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #6426. During a backup, warnings for **known, expected** path problems (permission denied, locked file, path not found, path too long) were logged with the full exception, so their stack traces bloated the log with no diagnostic value.

## Root cause

`LogExceptionHelper.LogCommonWarning` (`Duplicati/Library/Main/Operation/Backup/LogExceptionHelper.cs`) is the shared helper used by ~16 enumeration/metadata sites (`FileEnumerationProcess`, `MetadataPreProcess`, `MetadataGenerator`, `FilePreFilterProcess`, `StreamBlockSplitter`). For the four known categories it passed the exception to `Log.WriteWarningMessage`, and when an exception is attached the file log, console, and report modules render it via `LogEntry.AsString(true)` → `Exception.ToString()`, i.e. the full stack trace. (Result warnings use `AsString(false)` and were already trace-free.)

## Change

The known-category branches now log **without** attaching the exception, so no stack trace is stored/rendered. The self-describing warning message (e.g. `Excluding path due to permission denied: <path>`) remains. The fallback branch (unknown/unexpected errors) still passes the exception, so genuinely unexpected failures remain fully debuggable.

## Tests / verification

- New `Issue6426` tests call `LogCommonWarning` while capturing log entries and assert that known problems (`UnauthorizedAccessException` → PermissionDenied, `FileNotFoundException` → PathNotFound, `PathTooLongException` → PathTooLong) produce a warning with **no** exception attached, while an unknown exception is **retained**.
- Verified locally (.NET 10): the new tests **pass** with the fix and the known-problem test **fails** without it (the exception is still attached). Build is clean.
