### PR TITLE
Stabilize ZipFallback database cleanup on Windows

### DIFF
--- a/Duplicati/UnitTest/ZipFallbackTest.cs
+++ b/Duplicati/UnitTest/ZipFallbackTest.cs
@@ -31,6 +31,27 @@ namespace Duplicati.UnitTest
 {
     public class ZipFallbackTest : BasicSetupHelper
     {
+        private static async Task DeleteDatabaseWithRetryAsync(string path)
+        {
+            const int maxAttempts = 10;
+
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    File.Delete(path);
+                    return;
+                }
+                catch (IOException) when (OperatingSystem.IsWindows() && attempt < maxAttempts)
+                {
+                    // Windows can retain SQLite file handles until pending finalizers complete.
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                }
+            }
+        }
+
         [Test]
         [Category("Targeted")]
         public async Task FallbackToSharpCompressOnDecompressLzmaStreamsAsync()
@@ -50,7 +71,7 @@ namespace Duplicati.UnitTest
             }
 
             // Delete the local database
-            File.Delete(DBFILE);
+            await DeleteDatabaseWithRetryAsync(DBFILE);
 
             // Switch back to built-in compression
             testopts.Remove("zip-compression-method");
@@ -116,7 +137,7 @@ namespace Duplicati.UnitTest
             }
 
             // Delete the local database
-            File.Delete(DBFILE);
+            await DeleteDatabaseWithRetryAsync(DBFILE);
 
             // Recreate the database
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))


### PR DESCRIPTION
## Summary
- retry local database deletion when Windows temporarily retains a SQLite file handle
- force collection and wait for pending finalizers before each retry
- keep non-Windows behavior and final failure reporting unchanged

## Background
The Windows unit test in [this CI job](https://github.com/duplicati/duplicati/actions/runs/29166311247/job/86579902453) intermittently failed when `ZipFallbackTest` deleted `autotest.sqlite` immediately after a backup. This follows the existing Windows cleanup approach in `VacuumAndBugReportTests`, while limiting retries to `IOException` on Windows and allowing the final exception to propagate.

Both database deletion points in `ZipFallbackTest` use the helper, including the Zip64 path. Production SQLite settings and behavior are unchanged.

## Validation
- `dotnet restore Duplicati\UnitTest\Duplicati.UnitTest.csproj --force --verbosity minimal`
- `dotnet build Duplicati\UnitTest\Duplicati.UnitTest.csproj --no-restore --verbosity minimal -p:UseSharedCompilation=false -nr:false` (0 warnings, 0 errors)
- `FallbackToSharpCompressOnDecompressLzmaStreamsAsync` passed 10 consecutive Windows runs
- final post-build focused run passed

A local coverage-enabled full suite was attempted during investigation but was stopped after 3 hours 34 minutes while still progressing. The complete suite is left to GitHub Actions, where the same workflow normally completes in about 55 minutes.