### PR TITLE
Allow machine-id override

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -500,7 +500,7 @@ namespace Duplicati.Library.Main
             new CommandLineArgument("exclude-files-attributes", CommandLineArgument.ArgumentType.Flags, Strings.Options.ExcludefilesattributesShort, Strings.Options.ExcludefilesattributesLong, null, null, Common.IO.ExtendedFileAttributes.GetNames(false).ToArray()),
             new CommandLineArgument("compression-extension-file", CommandLineArgument.ArgumentType.Path, Strings.Options.CompressionextensionfileShort, Strings.Options.CompressionextensionfileLong(DEFAULT_COMPRESSED_EXTENSION_FILE), DEFAULT_COMPRESSED_EXTENSION_FILE),
 
-            new CommandLineArgument("machine-id", CommandLineArgument.ArgumentType.String, Strings.Options.MachineidShort, Strings.Options.MachineidLong, Library.AutoUpdater.DataFolderManager.InstallID),
+            new CommandLineArgument("machine-id", CommandLineArgument.ArgumentType.String, Strings.Options.MachineidShort, Strings.Options.MachineidLong, Library.AutoUpdater.DataFolderManager.MachineID),
             new CommandLineArgument("machine-name", CommandLineArgument.ArgumentType.String, Strings.Options.MachinenameShort, Strings.Options.MachinenameLong, Library.AutoUpdater.DataFolderManager.MachineName),
             new CommandLineArgument("backup-id", CommandLineArgument.ArgumentType.String, Strings.Options.BackupidShort, Strings.Options.BackupidLong, ""),
             new CommandLineArgument("backup-name", CommandLineArgument.ArgumentType.String, Strings.Options.BackupnameShort, Strings.Options.BackupnameLong, DefaultBackupName),

--- a/Duplicati/WebserverCore/Services/RemoteControllerHandler.cs
+++ b/Duplicati/WebserverCore/Services/RemoteControllerHandler.cs
@@ -47,6 +47,19 @@ public class RemoteControllerHandler(Connection connection, IHttpClientFactory h
     {
         metadata["feature:additional-report-url"] = connection.ApplicationSettings.AdditionalReportUrl;
         metadata["feature:additional-activity-url"] = connection.ApplicationSettings.AdditionalActivityUrl;
+        if (connection.Settings != null)
+        {
+            var lookup = connection.Settings
+                .GroupBy(k => k.Name.StartsWith("--", StringComparison.Ordinal) ? k.Name.Substring(2) : k.Name, k => k.Value)
+                .ToDictionary(x => x.Key, x => x.FirstOrDefault(), StringComparer.OrdinalIgnoreCase);
+
+            var machineId = lookup.GetValueOrDefault("machine-id");
+            var machineName = lookup.GetValueOrDefault("machine-name");
+            if (!string.IsNullOrWhiteSpace(machineId))
+                metadata["machine-id"] = machineId;
+            if (!string.IsNullOrWhiteSpace(machineName))
+                metadata["machine-name"] = machineName;
+        }
         return Task.FromResult(metadata);
     }
 


### PR DESCRIPTION
This fixes an issue where the machineId could be set in the global advanced options, but would not be applied when connecting to the console.

Setting the option would cause the machine to have one id for the connection and another id for the backup reports.

This also fixes an incorrectly reported default value for the machineId. Previously it would report `InstallId` but actually use `MachineId` for the default value.