### PR TITLE
Support native $VAR/${VAR} environment variable syntax (#2838)

### DIFF
--- a/Duplicati/CommandLine/CLI/help.txt
+++ b/Duplicati/CommandLine/CLI/help.txt
@@ -562,6 +562,8 @@ Duplicati can apply globbing and regex filter rules to backup and restore specif
   Globbing: *.txt
   Regex: [.*test\.txt]
 
+Environment variables are expanded in filter values, source paths, and the restore path. On any platform you can use the Windows form %VAR%; on Linux and macOS you can also use the native forms $VAR and ${VAR}. An undefined $VAR or ${VAR} is left unchanged.
+
   --include=<filter>
     Adds an include filter
   --exclude=<filter>

--- a/Duplicati/Library/RestAPI/SpecialFolders.cs
+++ b/Duplicati/Library/RestAPI/SpecialFolders.cs
@@ -40,7 +40,10 @@ namespace Duplicati.Server
             foreach (var n in Nodes)
                 if (path.StartsWith(n.id, StringComparison.Ordinal))
                     path = path.Replace(n.id, n.resolvedpath);
-            return Environment.ExpandEnvironmentVariables(path);
+            // Expand Windows %VAR% (undefined is left literal - unchanged legacy behavior)
+            path = Environment.ExpandEnvironmentVariables(path);
+            // Additionally expand native $VAR / ${VAR} on non-Windows platforms
+            return Library.Utility.Utility.ExpandEnvironmentVariablesNative(path);
         }
 
         public static string ExpandEnvironmentVariablesRegexp(string path)

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -970,28 +970,92 @@ namespace Duplicati.Library.Utility
         /// <summary>
         /// Regexp for matching environment variables on Windows (%VAR%)
         /// </summary>
-        private static readonly Regex ENVIRONMENT_VARIABLE_MATCHER_WINDOWS = new Regex(@"\%(?<name>\w+)\%");
+        private static readonly Regex ENVIRONMENT_VARIABLE_MATCHER_WINDOWS = new Regex(@"\%(?<win>\w+)\%");
 
         /// <summary>
-        /// Expands environment variables in a RegExp safe format
+        /// Regexp for matching Windows (%VAR%) and native ($VAR or ${VAR}) environment variables in a single pass
+        /// </summary>
+        private static readonly Regex ENVIRONMENT_VARIABLE_MATCHER_COMBINED = new Regex(@"\%(?<win>\w+)\%|\$\{(?<braced>[^}]+)\}|\$(?<bare>\w+)");
+
+        /// <summary>
+        /// Regexp for matching native ($VAR or ${VAR}) environment variables only
+        /// </summary>
+        private static readonly Regex ENVIRONMENT_VARIABLE_MATCHER_NATIVE_ONLY = new Regex(@"\$\{(?<braced>[^}]+)\}|\$(?<bare>\w+)");
+
+        /// <summary>
+        /// Expands environment variables in a RegExp safe format.
+        /// Windows-style %VAR% is expanded on all platforms; native $VAR and ${VAR} are
+        /// additionally expanded on non-Windows platforms.
         /// </summary>
         /// <returns>The expanded string.</returns>
         /// <param name="str">The string to expand.</param>
         /// <param name="lookup">A lookup method that converts an environment key to an expanded string</param>
         public static string? ExpandEnvironmentVariablesRegexp(string? str, Func<string?, string?>? lookup = null)
+            => ExpandEnvironmentVariablesRegexp(str, lookup, !OperatingSystem.IsWindows());
+
+        /// <summary>
+        /// Expands environment variables in a RegExp safe format, with explicit control over native syntax.
+        /// </summary>
+        /// <returns>The expanded string.</returns>
+        /// <param name="str">The string to expand.</param>
+        /// <param name="lookup">A lookup method that converts an environment key to an expanded string</param>
+        /// <param name="expandNativeSyntax">True to also expand native $VAR and ${VAR} syntax (in addition to %VAR%)</param>
+        internal static string? ExpandEnvironmentVariablesRegexp(string? str, Func<string?, string?>? lookup, bool expandNativeSyntax)
         {
             if (string.IsNullOrWhiteSpace(str))
                 return str;
 
-            if (lookup == null)
-                lookup = x => Environment.GetEnvironmentVariable(x ?? string.Empty);
+            lookup ??= x => Environment.GetEnvironmentVariable(x ?? string.Empty);
 
-            return
+            var matcher = expandNativeSyntax ? ENVIRONMENT_VARIABLE_MATCHER_COMBINED : ENVIRONMENT_VARIABLE_MATCHER_WINDOWS;
 
-                // TODO: Should we switch to using the native format ($VAR or ${VAR}), instead of following the Windows scheme?
-                // IsClientLinux ? new Regex(@"\$(?<name>\w+)|(\{(?<name>[^\}]+)\})") : ENVIRONMENT_VARIABLE_MATCHER_WINDOWS
+            // Single pass, so a value that itself contains the other syntax is not re-expanded
+            return matcher.Replace(str, m =>
+            {
+                if (m.Groups["win"].Success)
+                    // Windows %VAR%: preserve legacy behavior - an undefined variable expands to an empty string
+                    return Regex.Escape(lookup(m.Groups["win"].Value) ?? string.Empty);
 
-                ENVIRONMENT_VARIABLE_MATCHER_WINDOWS.Replace(str, m => Regex.Escape(lookup(m.Groups["name"].Value) ?? string.Empty));
+                // Native $VAR / ${VAR}
+                var name = m.Groups["braced"].Success ? m.Groups["braced"].Value : m.Groups["bare"].Value;
+                var value = lookup(name);
+
+                // An undefined native variable is left untouched, so a literal '$'-containing
+                // string is never blanked or mangled
+                return value == null ? m.Value : Regex.Escape(value);
+            });
+        }
+
+        /// <summary>
+        /// Expands native ($VAR or ${VAR}) environment variables in a literal (non-RegExp) string.
+        /// Windows %VAR% is not touched by this method; native syntax is only expanded on non-Windows platforms.
+        /// </summary>
+        /// <returns>The expanded string.</returns>
+        /// <param name="str">The string to expand.</param>
+        /// <param name="lookup">A lookup method that converts an environment key to an expanded string</param>
+        public static string ExpandEnvironmentVariablesNative(string str, Func<string?, string?>? lookup = null)
+            => ExpandEnvironmentVariablesNative(str, lookup, !OperatingSystem.IsWindows());
+
+        /// <summary>
+        /// Expands native ($VAR or ${VAR}) environment variables in a literal string, with explicit control over native syntax.
+        /// </summary>
+        /// <returns>The expanded string.</returns>
+        /// <param name="str">The string to expand.</param>
+        /// <param name="lookup">A lookup method that converts an environment key to an expanded string</param>
+        /// <param name="expandNativeSyntax">True to expand native $VAR and ${VAR} syntax</param>
+        internal static string ExpandEnvironmentVariablesNative(string str, Func<string?, string?>? lookup, bool expandNativeSyntax)
+        {
+            if (!expandNativeSyntax || string.IsNullOrEmpty(str))
+                return str;
+
+            lookup ??= x => Environment.GetEnvironmentVariable(x ?? string.Empty);
+
+            return ENVIRONMENT_VARIABLE_MATCHER_NATIVE_ONLY.Replace(str, m =>
+            {
+                var name = m.Groups["braced"].Success ? m.Groups["braced"].Value : m.Groups["bare"].Value;
+                // An undefined native variable is left untouched (no regex escaping - this is a literal path/glob)
+                return lookup(name) ?? m.Value;
+            });
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -441,6 +441,68 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Utility")]
+        public void ExpandEnvironmentVariablesRegexp()
+        {
+            // Values with regex metacharacters, to prove the substituted value is Regex.Escape'd
+            var env = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["FOO"] = "a.b",
+                ["BAR"] = "a+b(c)",
+            };
+            Func<string, string> lookup = k => (k != null && env.TryGetValue(k, out var v)) ? v : null;
+
+            // %VAR% behaves identically whether or not native syntax is enabled
+            foreach (var native in new[] { true, false })
+            {
+                Assert.AreEqual(@"xa\.by", Utility.ExpandEnvironmentVariablesRegexp("x%FOO%y", lookup, native));
+                Assert.AreEqual(@"a\+b\(c\)", Utility.ExpandEnvironmentVariablesRegexp("%BAR%", lookup, native));
+                // Undefined %VAR% expands to an empty string (unchanged legacy behavior)
+                Assert.AreEqual("", Utility.ExpandEnvironmentVariablesRegexp("%NOPE%", lookup, native));
+            }
+
+            // Native ON: $VAR and ${VAR} expand and are Regex.Escape'd
+            Assert.AreEqual(@"a\.b/bar", Utility.ExpandEnvironmentVariablesRegexp("$FOO/bar", lookup, true));
+            Assert.AreEqual(@"a\.bbar", Utility.ExpandEnvironmentVariablesRegexp("${FOO}bar", lookup, true));
+            // Undefined native variable is left as the original literal
+            Assert.AreEqual("$NOPE/x", Utility.ExpandEnvironmentVariablesRegexp("$NOPE/x", lookup, true));
+            Assert.AreEqual("${NOPE}", Utility.ExpandEnvironmentVariablesRegexp("${NOPE}", lookup, true));
+            // A brace group without a leading '$' (e.g. Duplicati {group} filters) is not matched
+            Assert.AreEqual("{FOO}", Utility.ExpandEnvironmentVariablesRegexp("{FOO}", lookup, true));
+            // A '$' regex anchor not followed by a word character is left alone
+            Assert.AreEqual(@".*\.log$", Utility.ExpandEnvironmentVariablesRegexp(@".*\.log$", lookup, true));
+
+            // Native OFF (Windows path): $VAR / ${VAR} are left untouched
+            Assert.AreEqual("$FOO/bar", Utility.ExpandEnvironmentVariablesRegexp("$FOO/bar", lookup, false));
+            Assert.AreEqual("${FOO}bar", Utility.ExpandEnvironmentVariablesRegexp("${FOO}bar", lookup, false));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public void ExpandEnvironmentVariablesNative()
+        {
+            // Space in the value proves the result is NOT regex-escaped
+            var env = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["FOO"] = "a b",
+            };
+            Func<string, string> lookup = k => (k != null && env.TryGetValue(k, out var v)) ? v : null;
+
+            // Native ON: expands, unescaped
+            Assert.AreEqual("a b/x", Utility.ExpandEnvironmentVariablesNative("$FOO/x", lookup, true));
+            Assert.AreEqual("a b", Utility.ExpandEnvironmentVariablesNative("${FOO}", lookup, true));
+            // Undefined native variable is left as the original literal
+            Assert.AreEqual("$NOPE", Utility.ExpandEnvironmentVariablesNative("$NOPE", lookup, true));
+            // %VAR% is not this helper's concern and is left untouched
+            Assert.AreEqual("%FOO%", Utility.ExpandEnvironmentVariablesNative("%FOO%", lookup, true));
+            // A brace group without a leading '$' is not matched
+            Assert.AreEqual("{FOO}", Utility.ExpandEnvironmentVariablesNative("{FOO}", lookup, true));
+
+            // Native OFF (Windows path): no-op
+            Assert.AreEqual("$FOO/x", Utility.ExpandEnvironmentVariablesNative("$FOO/x", lookup, false));
+        }
+
+        [Test]
+        [Category("Utility")]
         public static void ThrottledStreamRead()
         {
             byte[] sourceBuffer = [0x10, 0x20, 0x30, 0x40, 0x50];


### PR DESCRIPTION
## Summary

Fixes #2838 — Duplicati only expanded Windows-style `%VAR%` environment variables in paths and filters (both `Environment.ExpandEnvironmentVariables` and the Duplicati regexp expander understand only `%VAR%`), so the native `$VAR` / `${VAR}` forms — most notably `$HOME` — were never expanded on Linux or macOS.

## Approach

Native `$VAR` / `${VAR}` expansion is added **additively** and **only on non-Windows** (`!OperatingSystem.IsWindows()`):

- `%VAR%` keeps working on every platform exactly as before, so existing configurations are not affected. This addresses the backward-compatibility concern raised in the issue thread (dropping `%VAR%` on non-Windows could break current users).
- The two Duplicati-owned expanders now support native syntax:
  - `Utility.ExpandEnvironmentVariablesRegexp` — used for `[...]` regex filters.
  - `SpecialFolders.ExpandEnvironmentVariables` — used for backup source paths, the restore path, and glob/simple filters.
- An **undefined** native variable is left as the original literal, so a literal `$`-containing path is never blanked or mangled. `%VAR%` handling (including its existing undefined-variable semantics) is unchanged.

The scattered raw `Environment.ExpandEnvironmentVariables` call sites (parameters-file names, data-folder paths, global/CLI filter collectors) are intentionally left as-is.

## Notes

- The combined matcher runs in a **single pass**, so a value that itself contains the other syntax is not re-expanded.
- The braced form **requires a leading `$`** (`\$\{...\}`). This is deliberate: matching bare `{...}` would collide with Duplicati's `{group}` filter syntax and regex quantifiers like `a{2}`.
- Inside `[...]` regex filters, the native matcher only matches `$` immediately followed by a word char (`$name`) or `${...}`, so a regex end-anchor such as `[.*\.log$]` is unaffected.

## Testing

- Added `UtilityTests.ExpandEnvironmentVariablesRegexp` and `UtilityTests.ExpandEnvironmentVariablesNative` (`[Category("Utility")]`), covering `%VAR%` (unchanged, escaped), `$VAR`/`${VAR}` expansion, value Regex-escaping, undefined → literal, `{group}` not matched, the `$`-anchor edge case, and the Windows/native-disabled path. The native branch is exercised via an explicit flag so it is covered regardless of host OS.
- Full `Utility` test category passes (101 tests, 0 failures) on `net10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
