### PR TITLE
Fix corrupted target URL for local paths containing @ (#2681)

### DIFF
--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -156,6 +156,34 @@ namespace Duplicati.Library.Utility
             m_queryParams = null;
             this.OriginalUri = url;
 
+            // A file:// URL whose remainder is a Windows drive path (e.g. file://c:\@folder\)
+            // must not go through the generic parser: an '@' or ':' in the path would be
+            // misread as user:password@host. Treat it as a local path directly. This
+            // generalizes the file://c:\test / file:///C:\test handling below so it also
+            // works when the path contains '@' or other userinfo-confusing characters.
+            // Decode first so the encoded forms (e.g. %40 for @, %5C for \) that ToString()
+            // produces are recognized as the same Windows path and round-trip cleanly.
+            if (url.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+            {
+                var candidate = UrlDecode(url.Substring("file://".Length));
+                // also accept the correctly-encoded file:///C:\ triple-slash form
+                if (candidate.StartsWith("/", StringComparison.Ordinal) && WINDOWS_PATH.IsMatch(candidate))
+                    candidate = candidate.Substring(1);
+
+                if (WINDOWS_PATH.IsMatch(candidate) && candidate.IndexOfAny(System.IO.Path.GetInvalidPathChars()) < 0)
+                {
+                    this.Scheme = "file";
+                    this.Host = null;
+                    this.Path = System.IO.Path.GetFullPath(candidate);
+                    this.Port = -1;
+                    this.Query = null;
+                    this.Username = null;
+                    this.Password = null;
+                    return;
+                }
+                // otherwise fall through to the generic parser (unchanged behavior)
+            }
+
             var m = URL_PARSER.Match(url);
             if (!m.Success || m.Length != url.Length)
             {

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -159,5 +159,38 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(a.Path, b.Path);
             }
         }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestUriParseWindowsPathWithAtSign()
+        {
+            // Regression for #2681: an '@' in a local (file://) Windows drive path must
+            // not be parsed as user:password@host.
+            if (!System.OperatingSystem.IsWindows())
+                return;
+
+            var a = new Library.Utility.Uri("file://c:\\@folder\\");
+            Assert.AreEqual("file", a.Scheme);
+            Assert.IsNull(a.Host, "Host should be null for a local path");
+            Assert.IsNull(a.Username, "Username should be null");
+            Assert.IsNull(a.Password, "Password should be null");
+            Assert.IsTrue(a.Path.Contains("@folder"), "Path should keep the @ folder name");
+            Assert.IsTrue(System.IO.Path.IsPathRooted(a.Path), "Path should be a rooted local path");
+
+            // The file:// form must parse the same as the raw path form
+            var b = new Library.Utility.Uri("c:\\@folder\\");
+            Assert.AreEqual(b.Path, a.Path);
+            Assert.AreEqual(b.ToString(), a.ToString());
+
+            // Re-parsing ToString() round-trips to the same path (no corruption)
+            var roundtrip = new Library.Utility.Uri(a.ToString());
+            Assert.AreEqual(a.Path, roundtrip.Path);
+            Assert.IsNull(roundtrip.Host);
+            Assert.IsNull(roundtrip.Username);
+
+            // The url-encoded form (%40) resolves to the same path
+            var encoded = new Library.Utility.Uri("file://c:\\%40folder\\");
+            Assert.AreEqual(a.Path, encoded.Path);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2681 — a `file://` (Local folder or drive) destination whose Windows path contains an `@`, e.g. `file://c:\@folder\`, gets corrupted when a job is edited/saved.

Duplicati's relaxed URL parser (`Duplicati/Library/Utility/Uri.cs`) runs the generic `URL_PARSER` regex, which reads the text before the `@` as `user:password@host` — so `c` becomes the username, `\` the password, and `folder` the host. The result is a garbled destination such as `file://folder\/?auth-username=C&auth-password=%5C` (exactly as reported). The triple-slash form `file:///c:\@folder\` already parsed correctly, but the folder picker emits the double-slash form.

## Fix

In the `Uri(string)` constructor, detect up front when the URL is a `file://` URL whose (decoded) remainder is a Windows drive path — using the parser's existing `WINDOWS_PATH` regex — and treat it as a local path directly, skipping the generic parser. An `@` or `:` in the path can then no longer be misread as userinfo.

- Decoding first means the encoded forms that `ToString()` emits (`%40` for `@`, `%5C` for `\`) are recognized as the same path and round-trip cleanly.
- This **generalizes** the existing `file://c:\test` / `file:///C:\test` handling further down the constructor, so it also covers paths containing `@`/`:`.
- Other schemes (e.g. `ftp://user@host`) and non-drive paths are unaffected, and normal `file://C:\...` destinations parse identically to before.

UNC paths (`\\server\share`) are out of scope here (they don't match `WINDOWS_PATH`).

## Testing

- Added `UriUtilityTests.TestUriParseWindowsPathWithAtSign` (`[Category("UriUtility")]`, Windows-gated) covering: the `@` path parses with null host/username/password and a rooted path; equivalence between the `file://` form and the raw path form (same `Path` and `ToString()`); round-tripping `ToString()` back through the parser; and the `%40`-encoded form resolving to the same path.
- Full `UriUtility` category passes (78 tests, 0 failures) on `net10.0`, including the existing `TestUriParsePaths` regression.
- Smoke-tested the `file://` backend end-to-end (a full backup + list + find over a Windows `file://` target) to confirm normal local destinations are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
