### PR TITLE
Make the Service delay-start

### DIFF
--- a/ReleaseBuilder/Resources/Windows/Agent/Duplicati.wxs
+++ b/ReleaseBuilder/Resources/Windows/Agent/Duplicati.wxs
@@ -71,7 +71,15 @@
                             Start="auto"
                             ErrorControl="normal"
                             Arguments="AGENT run"
-                            Vital="yes" />
+                            Vital="yes">
+              <!-- Register the service as Automatic (Delayed Start). Only the
+                   real WiX toolchain (Windows build) understands ServiceConfig;
+                   wixl builds get the equivalent MsiServiceConfig row injected
+                   from InstallTables.sql instead. -->
+<?if $(var.BuildEnv) = "Windows" ?>
+              <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall="yes" />
+<?endif?>
+            </ServiceInstall>
 
             <ServiceControl Id="DuplicatiAgentServiceControl"
                             Name="Duplicati.Agent"

--- a/ReleaseBuilder/Resources/Windows/Agent/InstallTables.sql
+++ b/ReleaseBuilder/Resources/Windows/Agent/InstallTables.sql
@@ -58,3 +58,32 @@ INSERT INTO `RemoveFile` (`FileKey`, `Component_`, `FileName`, `DirProperty`, `I
 -- ---------------------------------------------------------------------------
 INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('ResolveSource', 'INSTALL_PRELOAD="true" AND NOT Installed', 850)
 INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MoveFiles', 'INSTALL_PRELOAD="true"', 3700)
+
+-- ---------------------------------------------------------------------------
+-- MsiServiceConfig: register the Agent service as Automatic (Delayed Start).
+-- Replaces the WiX <ServiceConfig DelayedAutoStart="yes"/> element (a child of
+-- <ServiceInstall>) that wixl 0.106 cannot parse. On Windows the real WiX
+-- toolchain emits this table natively from the WXS <ServiceConfig> element.
+--
+--   Name        - the service name (matches ServiceInstall/@Name in the WXS).
+--   Event       - 7 = msidbServiceConfigEventInstall (1) | ...Reinstall (2) |
+--                 ...Uninstall (4); apply the config on install and reinstall
+--                 (the uninstall bit is harmless as there is nothing to undo).
+--   ConfigType  - 3 = SERVICE_CONFIG_DELAYED_AUTO_START_INFO.
+--   Argument    - '1' enables delayed auto-start (only affects auto services).
+--   Component_  - keyed to the always-installed service component so the
+--                 config is applied whenever the service is installed.
+--
+-- The standard MsiConfigureServices action that processes this table is
+-- scheduled below.
+-- ---------------------------------------------------------------------------
+CREATE TABLE `MsiServiceConfig` (`MsiServiceConfig` CHAR(72) NOT NULL, `Name` CHAR(255) NOT NULL, `Event` INT NOT NULL, `ConfigType` INT NOT NULL, `Argument` CHAR(255), `Component_` CHAR(72) NOT NULL PRIMARY KEY `MsiServiceConfig`)
+INSERT INTO `MsiServiceConfig` (`MsiServiceConfig`, `Name`, `Event`, `ConfigType`, `Argument`, `Component_`) VALUES ('DelayStartAgentSvc', 'Duplicati.Agent', 7, 3, '1', 'DuplicatiAgentServiceComponent')
+
+-- ---------------------------------------------------------------------------
+-- InstallExecuteSequence: schedule the standard MsiConfigureServices action so
+-- the MsiServiceConfig row above is processed. wixl does not auto-insert it
+-- because the table is empty at wixl build time. 5850 is just after the
+-- standard InstallServices (5800), so the service exists when it is configured.
+-- ---------------------------------------------------------------------------
+INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MsiConfigureServices', '', 5850)

--- a/ReleaseBuilder/Resources/Windows/Agent/InstallTables.sql
+++ b/ReleaseBuilder/Resources/Windows/Agent/InstallTables.sql
@@ -66,9 +66,8 @@ INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES 
 -- toolchain emits this table natively from the WXS <ServiceConfig> element.
 --
 --   Name        - the service name (matches ServiceInstall/@Name in the WXS).
---   Event       - 7 = msidbServiceConfigEventInstall (1) | ...Reinstall (2) |
---                 ...Uninstall (4); apply the config on install and reinstall
---                 (the uninstall bit is harmless as there is nothing to undo).
+--   Event       - 3 = msidbServiceConfigEventInstall (1) | ...Reinstall (2).
+--                 The uninstall bit (4) is not set.
 --   ConfigType  - 3 = SERVICE_CONFIG_DELAYED_AUTO_START_INFO.
 --   Argument    - '1' enables delayed auto-start (only affects auto services).
 --   Component_  - keyed to the always-installed service component so the
@@ -78,12 +77,21 @@ INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES 
 -- scheduled below.
 -- ---------------------------------------------------------------------------
 CREATE TABLE `MsiServiceConfig` (`MsiServiceConfig` CHAR(72) NOT NULL, `Name` CHAR(255) NOT NULL, `Event` INT NOT NULL, `ConfigType` INT NOT NULL, `Argument` CHAR(255), `Component_` CHAR(72) NOT NULL PRIMARY KEY `MsiServiceConfig`)
-INSERT INTO `MsiServiceConfig` (`MsiServiceConfig`, `Name`, `Event`, `ConfigType`, `Argument`, `Component_`) VALUES ('DelayStartAgentSvc', 'Duplicati.Agent', 7, 3, '1', 'DuplicatiAgentServiceComponent')
+INSERT INTO `MsiServiceConfig` (`MsiServiceConfig`, `Name`, `Event`, `ConfigType`, `Argument`, `Component_`) VALUES ('DelayStartAgentSvc', 'Duplicati.Agent', 3, 3, '1', 'DuplicatiAgentServiceComponent')
 
 -- ---------------------------------------------------------------------------
 -- InstallExecuteSequence: schedule the standard MsiConfigureServices action so
 -- the MsiServiceConfig row above is processed. wixl does not auto-insert it
 -- because the table is empty at wixl build time. 5850 is just after the
 -- standard InstallServices (5800), so the service exists when it is configured.
+--
+-- Condition 'NOT REMOVE~="ALL"': despite Event=3 (install/reinstall only),
+-- Windows Installer still emits a ServiceConfigure op for the component's
+-- uninstall transition. Because MsiConfigureServices (5850) runs AFTER
+-- DeleteServices (5680) removes the service, that op fails with Error
+-- 1060/1939 ("handle to the service could [not] be obtained") and aborts the
+-- uninstall with 1603. Gating the action off REMOVE="ALL" skips it entirely on
+-- uninstall (and on the major-upgrade removal of the old product), while still
+-- running it on install/reinstall of the new product.
 -- ---------------------------------------------------------------------------
-INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MsiConfigureServices', '', 5850)
+INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MsiConfigureServices', 'NOT REMOVE~="ALL"', 5850)

--- a/ReleaseBuilder/Resources/Windows/TrayIcon/Duplicati.wxs
+++ b/ReleaseBuilder/Resources/Windows/TrayIcon/Duplicati.wxs
@@ -242,7 +242,15 @@
                             Start="auto"
                             ErrorControl="normal"
                             Arguments="SERVER"
-                            Vital="yes" />
+                            Vital="yes">
+              <!-- Register the service as Automatic (Delayed Start). Only the
+                   real WiX toolchain (Windows build) understands ServiceConfig;
+                   wixl builds get the equivalent MsiServiceConfig row injected
+                   from InstallTables.sql instead. -->
+<?if $(var.BuildEnv) = "Windows" ?>
+              <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall="yes" />
+<?endif?>
+            </ServiceInstall>
 
             <ServiceControl Id="DuplicatiServiceControl"
                             Name="Duplicati"

--- a/ReleaseBuilder/Resources/Windows/TrayIcon/InstallTables.sql
+++ b/ReleaseBuilder/Resources/Windows/TrayIcon/InstallTables.sql
@@ -70,9 +70,8 @@ INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES 
 -- WiX toolchain emits this table natively from the WXS <ServiceConfig> element.
 --
 --   Name        - the service name (matches ServiceInstall/@Name in the WXS).
---   Event       - 7 = msidbServiceConfigEventInstall (1) | ...Reinstall (2) |
---                 ...Uninstall (4); apply the config on install and reinstall
---                 (the uninstall bit is harmless as there is nothing to undo).
+--   Event       - 3 = msidbServiceConfigEventInstall (1) | ...Reinstall (2).
+--                 The uninstall bit (4) is not set.
 --   ConfigType  - 3 = SERVICE_CONFIG_DELAYED_AUTO_START_INFO.
 --   Argument    - '1' enables delayed auto-start (only affects auto services).
 --   Component_  - keyed to DuplicatiWindowsServiceComponent, which is only
@@ -85,12 +84,21 @@ INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES 
 -- scheduled below.
 -- ---------------------------------------------------------------------------
 CREATE TABLE `MsiServiceConfig` (`MsiServiceConfig` CHAR(72) NOT NULL, `Name` CHAR(255) NOT NULL, `Event` INT NOT NULL, `ConfigType` INT NOT NULL, `Argument` CHAR(255), `Component_` CHAR(72) NOT NULL PRIMARY KEY `MsiServiceConfig`)
-INSERT INTO `MsiServiceConfig` (`MsiServiceConfig`, `Name`, `Event`, `ConfigType`, `Argument`, `Component_`) VALUES ('DelayStartSvc', 'Duplicati', 7, 3, '1', 'DuplicatiWindowsServiceComponent')
+INSERT INTO `MsiServiceConfig` (`MsiServiceConfig`, `Name`, `Event`, `ConfigType`, `Argument`, `Component_`) VALUES ('DelayStartSvc', 'Duplicati', 3, 3, '1', 'DuplicatiWindowsServiceComponent')
 
 -- ---------------------------------------------------------------------------
 -- InstallExecuteSequence: schedule the standard MsiConfigureServices action so
 -- the MsiServiceConfig row above is processed. wixl does not auto-insert it
 -- because the table is empty at wixl build time. 5850 is just after the
 -- standard InstallServices (5800), so the service exists when it is configured.
+--
+-- Condition 'NOT REMOVE~="ALL"': despite Event=3 (install/reinstall only),
+-- Windows Installer still emits a ServiceConfigure op for the component's
+-- uninstall transition. Because MsiConfigureServices (5850) runs AFTER
+-- DeleteServices (5680) removes the service, that op fails with Error
+-- 1060/1939 ("handle to the service could [not] be obtained") and aborts the
+-- uninstall with 1603. Gating the action off REMOVE="ALL" skips it entirely on
+-- uninstall (and on the major-upgrade removal of the old product), while still
+-- running it on install/reinstall of the new product.
 -- ---------------------------------------------------------------------------
-INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MsiConfigureServices', '', 5850)
+INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MsiConfigureServices', 'NOT REMOVE~="ALL"', 5850)

--- a/ReleaseBuilder/Resources/Windows/TrayIcon/InstallTables.sql
+++ b/ReleaseBuilder/Resources/Windows/TrayIcon/InstallTables.sql
@@ -62,3 +62,35 @@ INSERT INTO `RemoveFile` (`FileKey`, `Component_`, `FileName`, `DirProperty`, `I
 -- ---------------------------------------------------------------------------
 INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('ResolveSource', 'INSTALL_PRELOAD="true" AND NOT Installed', 850)
 INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MoveFiles', 'INSTALL_PRELOAD="true"', 3700)
+
+-- ---------------------------------------------------------------------------
+-- MsiServiceConfig: register the Duplicati service as Automatic (Delayed
+-- Start). Replaces the WiX <ServiceConfig DelayedAutoStart="yes"/> element (a
+-- child of <ServiceInstall>) that wixl 0.106 cannot parse. On Windows the real
+-- WiX toolchain emits this table natively from the WXS <ServiceConfig> element.
+--
+--   Name        - the service name (matches ServiceInstall/@Name in the WXS).
+--   Event       - 7 = msidbServiceConfigEventInstall (1) | ...Reinstall (2) |
+--                 ...Uninstall (4); apply the config on install and reinstall
+--                 (the uninstall bit is harmless as there is nothing to undo).
+--   ConfigType  - 3 = SERVICE_CONFIG_DELAYED_AUTO_START_INFO.
+--   Argument    - '1' enables delayed auto-start (only affects auto services).
+--   Component_  - keyed to DuplicatiWindowsServiceComponent, which is only
+--                 installed when the service feature is selected
+--                 (DUPLICATI_SERVICE_SELECTED). MsiConfigureServices only acts
+--                 on rows whose component is being installed, so the delayed
+--                 start config applies exactly when the service is installed.
+--
+-- The standard MsiConfigureServices action that processes this table is
+-- scheduled below.
+-- ---------------------------------------------------------------------------
+CREATE TABLE `MsiServiceConfig` (`MsiServiceConfig` CHAR(72) NOT NULL, `Name` CHAR(255) NOT NULL, `Event` INT NOT NULL, `ConfigType` INT NOT NULL, `Argument` CHAR(255), `Component_` CHAR(72) NOT NULL PRIMARY KEY `MsiServiceConfig`)
+INSERT INTO `MsiServiceConfig` (`MsiServiceConfig`, `Name`, `Event`, `ConfigType`, `Argument`, `Component_`) VALUES ('DelayStartSvc', 'Duplicati', 7, 3, '1', 'DuplicatiWindowsServiceComponent')
+
+-- ---------------------------------------------------------------------------
+-- InstallExecuteSequence: schedule the standard MsiConfigureServices action so
+-- the MsiServiceConfig row above is processed. wixl does not auto-insert it
+-- because the table is empty at wixl build time. 5850 is just after the
+-- standard InstallServices (5800), so the service exists when it is configured.
+-- ---------------------------------------------------------------------------
+INSERT INTO `InstallExecuteSequence` (`Action`, `Condition`, `Sequence`) VALUES ('MsiConfigureServices', '', 5850)


### PR DESCRIPTION
When installing a service from the MSI, make sure the service is delay-started.

This is a follow-up to #7045