### PR TITLE
Fix race when no retries are enabled

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.Handler.cs
@@ -341,6 +341,12 @@ partial class BackendManager
             }
             finally
             {
+#if DEBUG
+                // Test hook: invoked right before we cancel all in-flight uploads during
+                // teardown. Tests use this to release a deliberately-held dindex upload so
+                // it is cancelled mid-flight here, making the teardown race deterministic.
+                DebugTestHooks.BeforeTeardownCancel?.Invoke();
+#endif
                 // Terminate any active uploads and downloads. Exceptions thrown by the downloads should be captured by the callers.
                 await tcs.CancelAsync();
 

--- a/Duplicati/Library/Main/Backend/BackendManager.PutOperation.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.PutOperation.cs
@@ -258,6 +258,14 @@ partial class BackendManager
             // Upload completed, prepare the index file if any
             if (indexOperation != null)
             {
+#if DEBUG
+                // Test hook: the block volume has now been uploaded to the destination and
+                // committed as Uploaded in the database, but the paired index volume has
+                // not been uploaded yet. Tests use this to keep the index upload in flight
+                // while a concurrent upload fails, reproducing the teardown-cancellation
+                // race between a block volume and its paired index volume.
+                DebugTestHooks.BeforeIndexUpload?.Invoke(indexOperation.Value.Operation.RemoteFilename);
+#endif
                 // TODO: It would be better if we encrypt the index file while uploading the block file
                 // since most operations work correctly. But if the upload of the block file fails
                 // we need to deal with decryption, or keep the unencrypted file around

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -26,6 +26,45 @@ internal partial class BackendManager : IBackendManager
     /// </summary>
     private static readonly string LOGTAG = Logging.Log.LogTagFromType<BackendManager>();
 
+#if DEBUG
+    /// <summary>
+    /// Test-only hooks used to make the concurrent-upload failure race deterministic.
+    /// These are only compiled in DEBUG builds and are no-ops unless a test assigns them.
+    /// See <c>DisruptionTests.TestUploadExceptionWithNoRetriesRaceAsync</c>.
+    /// </summary>
+    internal static class DebugTestHooks
+    {
+        /// <summary>
+        /// Invoked from a <see cref="PutOperation"/> just after the block (dblock) volume
+        /// has been uploaded to the destination but before the paired index (dindex)
+        /// volume is uploaded. The argument is the dindex remote filename. A test can
+        /// block here to keep the dindex upload in flight while another upload fails,
+        /// exercising the teardown/cancellation race between a block volume and its
+        /// paired index volume.
+        /// </summary>
+        public static Action<string>? BeforeIndexUpload;
+
+        /// <summary>
+        /// Invoked from the backend handler right before it cancels all in-flight uploads
+        /// during teardown (after an upload failed and the operation is aborting). A test
+        /// can use this to release an index (dindex) upload that has been deliberately held
+        /// in flight, so that the dindex is guaranteed to be cancelled mid-flight by the
+        /// teardown rather than completing beforehand. This makes the teardown/cancellation
+        /// race deterministic.
+        /// </summary>
+        public static Action? BeforeTeardownCancel;
+
+        /// <summary>
+        /// Resets all hooks. Should be called by tests in teardown.
+        /// </summary>
+        public static void Reset()
+        {
+            BeforeIndexUpload = null;
+            BeforeTeardownCancel = null;
+        }
+    }
+#endif
+
     /// <summary>
     /// The channel for issuing and handling requests.
     /// </summary>

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -845,6 +845,171 @@ namespace Duplicati.UnitTest
             }
         }
 
+        /// <summary>
+        /// Deterministic reproduction of the flaky <see cref="TestUploadExceptionWithNoRetriesAsync"/> failure.
+        ///
+        /// The backup uploads dblock+dindex pairs concurrently (asynchronous-upload-limit
+        /// defaults to 4). When one dblock upload fails and there are no retries, the
+        /// BackendManager handler tears down: it faults, and in its finally block it calls
+        /// <c>tcs.CancelAsync()</c> which cancels every other in-flight upload
+        /// (see BackendManager.Handler.RunAsync). If a second dblock has already uploaded
+        /// and been committed to the database as Uploaded (with its IndexBlockLink created),
+        /// but its paired dindex upload is still in-flight, the dindex upload is cancelled.
+        ///
+        /// This leaves the database believing the dindex exists (or leaves a partially
+        /// uploaded/inconsistent dindex on the destination) while the actual remote content
+        /// does not match. On the following backup this surfaces either as a
+        /// "Found 1 faulty index files, repairing now" warning during the post-backup Test
+        /// phase (the common CI symptom), or as a hard verification error listing
+        /// "[Missing, ...]" blocks for that dindex (the rarer CI symptom).
+        ///
+        /// The production test relies on a Thread.Sleep(1000) and hopes the second upload
+        /// fully completes before teardown; this test removes that timing dependency by
+        /// using the DeterministicErrorBackend's ErrorGenerator (invoked synchronously on
+        /// the upload worker threads) as a barrier: the failing dblock is held until a
+        /// second dblock's dindex upload has started, guaranteeing the dindex is in-flight
+        /// when teardown cancels it.
+        /// </summary>
+        [Test]
+        [Category("Disruption")]
+        public async Task TestUploadExceptionWithNoRetriesRaceAsync()
+        {
+#if !DEBUG
+            Assert.Ignore("This test requires DEBUG to be defined");
+#endif
+            var testopts = TestOptions;
+            testopts["number-of-retries"] = "0";
+            testopts["dblock-size"] = "10mb";
+            // Force concurrent uploads so a second dblock/dindex pair is in flight
+            // while the first upload fails.
+            testopts["asynchronous-upload-limit"] = "4";
+
+            // Make a base backup
+            using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(await c.BackupAsync(new string[] { DATAFOLDER }));
+
+            Assert.AreEqual(1, Directory.EnumerateFiles(TARGETFOLDER, "*.dlist.*").Count(), "There should be only one dlist file in the target folder");
+
+            // Make a new backup that fails uploading a dblock file
+            ModifySourceFiles();
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var failtarget = new DeterministicErrorBackend().ProtocolKey + "://" + TARGETFOLDER;
+
+            var hasFailed = false;
+            var lockobj = new object();
+
+            // Coordinates the deterministic race:
+            // - indexUploadHeld    : set when a completed dblock's paired dindex upload has
+            //                        started and is being held in flight.
+            // - releaseIndexUpload : set by the handler teardown to release the held dindex
+            //                        so it is cancelled mid-flight.
+            // The dindex is held in flight until the handler begins tearing down (after a
+            // concurrent dblock upload failed), guaranteeing the in-flight dindex is
+            // cancelled by the teardown rather than completing beforehand. This is what a
+            // correct fix must handle safely; without a fix, the following backup reports a
+            // faulty index file.
+            var indexUploadHeld = new ManualResetEventSlim(false);
+            var releaseIndexUpload = new ManualResetEventSlim(false);
+
+#if DEBUG
+            Library.Main.Backend.BackendManager.DebugTestHooks.BeforeIndexUpload = _ =>
+            {
+                // A dblock has been uploaded and committed as Uploaded in the database;
+                // its paired dindex is about to upload. Signal that it is in flight and
+                // hold it until the handler teardown releases it, so the dindex is
+                // guaranteed to still be in flight when the teardown cancels uploads.
+                indexUploadHeld.Set();
+                releaseIndexUpload.Wait(TimeSpan.FromSeconds(30));
+            };
+
+            Library.Main.Backend.BackendManager.DebugTestHooks.BeforeTeardownCancel = () =>
+            {
+                // The handler is about to cancel all in-flight uploads. Release the held
+                // dindex so it is cancelled here, deterministically leaving a dblock
+                // committed as Uploaded with an IndexBlockLink, but no matching dindex on
+                // the destination.
+                releaseIndexUpload.Set();
+            };
+#endif
+
+            DeterministicErrorBackend.ErrorGenerator = (DeterministicErrorBackend.BackendAction action, string remotename) =>
+            {
+                // Never interfere with downloads/verification reads.
+                if (action.IsGetOperation)
+                    return false;
+
+                var isBlock = remotename.Contains(".dblock.");
+
+                // Fail exactly one dblock upload, but only once a concurrent dindex
+                // upload is being held in flight. This guarantees the held dindex is
+                // cancelled by the handler teardown (tcs.CancelAsync) that follows.
+                if (action == DeterministicErrorBackend.BackendAction.PutBefore && isBlock)
+                {
+                    lock (lockobj)
+                    {
+                        if (!hasFailed)
+                        {
+                            // Wait until a dblock has uploaded and its dindex is held in
+                            // flight, then fail this (different) dblock upload.
+                            if (indexUploadHeld.Wait(TimeSpan.FromSeconds(30)))
+                            {
+                                hasFailed = true;
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                return false;
+            };
+
+            try
+            {
+                using (var c = new Controller(failtarget, testopts, null))
+                    Assert.ThrowsAsync<DeterministicErrorBackend.DeterministicErrorBackendException>(() => c.BackupAsync(new string[] { DATAFOLDER }));
+            }
+            finally
+            {
+                // Make sure a held dindex upload can never hang the test, and that the
+                // test hooks never leak into other tests.
+                releaseIndexUpload.Set();
+                DeterministicErrorBackend.ErrorGenerator = null;
+#if DEBUG
+                Library.Main.Backend.BackendManager.DebugTestHooks.Reset();
+#endif
+            }
+
+            Assert.That(hasFailed, Is.True, "Failed to fail the upload");
+
+            // Create a regular backup
+            using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(await c.BackupAsync(new string[] { DATAFOLDER }));
+
+            // Verify that all is in order. This is where the flaky failure surfaces:
+            // either a faulty-index-file warning or a [Missing, ...] verification error.
+            using (var c = new Controller("file://" + TARGETFOLDER, testopts.Expand(new { full_remote_verification = true }), null))
+            {
+                try
+                {
+                    TestUtils.AssertResults(await c.TestAsync(long.MaxValue));
+                }
+                catch (TestUtils.TestVerificationException e)
+                {
+                    using var db = await LocalDatabase.CreateLocalDatabaseAsync(testopts["dbpath"], "test", true, null, CancellationToken.None).ConfigureAwait(false);
+                    using var cmd = db.Connection.CreateCommand();
+
+                    var sb = new StringBuilder();
+                    sb.AppendLine(e.Message);
+                    sb.AppendLine(TestUtils.DumpTable(cmd, "Remotevolume", null));
+                    sb.AppendLine(TestUtils.DumpTable(cmd, "IndexBlockLink", null));
+                    sb.AppendLine(TestUtils.DumpTable(cmd, "Block", null));
+
+                    Assert.Fail(sb.ToString());
+                }
+            }
+        }
+
         [Test]
         [Category("Disruption")]
         [TestCase(true, false)]


### PR DESCRIPTION
This PR singles out a flaky issue in tests where the upload is set to have zero retries. In this case, a (simulated) failing uploaded can cause an in-flight index file to be incorrectly recorded in the database.

In the current version, no fix is present, but the issue is now reproducible.