### PR TITLE
Stabilize TestMultiExceptionOnDlistAsync

### DIFF
--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -1092,6 +1092,9 @@ namespace Duplicati.UnitTest
             var testopts = TestOptions;
             testopts["number-of-retries"] = "0";
             testopts["dblock-size"] = "10mb";
+            // Keep unchanged-source cases independent of platform-specific metadata changes.
+            // ModifySourceFiles updates the file timestamps for cases that expect new versions.
+            testopts["check-filetime-only"] = "true";
             // We always have at least 1 backup at the end
             var expectedFilesets = 1;
             // If the files are modified, this will create multiple versions


### PR DESCRIPTION
## Summary

- make unchanged-source cases in `TestMultiExceptionOnDlistAsync` rely only on file timestamps
- avoid platform-specific metadata changes creating an unexpected extra fileset
- preserve modified-source coverage because `ModifySourceFiles` updates file timestamps

## Context

The macOS unit-test job in https://github.com/duplicati/duplicati/actions/runs/29542790738/job/87768294517 intermittently reported 2 filesets instead of 1 for `TestMultiExceptionOnDlistAsync(False,False,3,True)`. The PR under test did not touch disruption or backup behavior, and the same test had passed in earlier runs.

The unchanged-source variants are intended to exercise dlist upload failures, not filesystem metadata detection. Enabling `check-filetime-only` keeps that setup deterministic while the variants that call `ModifySourceFiles` still produce new versions.

## Testing

- `dotnet test Duplicati/UnitTest/Duplicati.UnitTest.csproj --filter FullyQualifiedName~Duplicati.UnitTest.DisruptionTests.TestMultiExceptionOnDlistAsync`
- repeated the complete 8-case parameter matrix 5 times: 40/40 passed