### PR TITLE
Retain profiling logs only for failed tests

### DIFF
--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -25,7 +25,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Collections.Generic;
 using System.IO.Compression;
+using System.Linq;
 using Duplicati.Library.Common.IO;
+using NUnit.Framework.Interfaces;
 using System.Timers;
 
 namespace Duplicati.UnitTest
@@ -98,7 +100,8 @@ namespace Duplicati.UnitTest
             this.BasicHelperTearDown();
         }
 
-        private static int count = 1;
+        private const int RetainedFailedTestLogs = 10;
+        private static int logArchiveSequence;
 
 
         private static Timer SetupTimer()
@@ -162,15 +165,44 @@ namespace Duplicati.UnitTest
             }
             if (systemIO.FileExists(this.LOGFILE))
             {
-                var source = new System.IO.FileStream(this.LOGFILE, System.IO.FileMode.Open, System.IO.FileAccess.Read);
-                var dest = new System.IO.FileStream($"{this.LOGFILE}.{count++}.gz", System.IO.FileMode.Create, System.IO.FileAccess.Write);
-                var gzip = new System.IO.Compression.GZipStream(dest, System.IO.Compression.CompressionMode.Compress);
-                source.CopyTo(gzip);
-                gzip.Flush();
-                source.Close();
-                gzip.Close();
-                dest.Close();
-                systemIO.FileDelete(this.LOGFILE);
+                CleanupLogFile(
+                    this.LOGFILE,
+                    TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed,
+                    RetainedFailedTestLogs
+                );
+            }
+        }
+
+        internal static string CleanupLogFile(string logfile, bool retain, int retainedLogCount)
+        {
+            if (!File.Exists(logfile))
+                return null;
+
+            string archivePath = null;
+            try
+            {
+                if (!retain)
+                    return null;
+
+                var archiveSequence = System.Threading.Interlocked.Increment(ref logArchiveSequence);
+                archivePath = $"{logfile}.{DateTime.UtcNow:yyyyMMddHHmmssfffffff}.{archiveSequence:D10}.gz";
+                using (var source = new FileStream(logfile, FileMode.Open, FileAccess.Read))
+                using (var destination = new FileStream(archivePath, FileMode.Create, FileAccess.Write))
+                using (var gzip = new GZipStream(destination, CompressionMode.Compress))
+                    source.CopyTo(gzip);
+
+                var logDirectory = Path.GetDirectoryName(logfile);
+                var logPattern = $"{Path.GetFileName(logfile)}.*.gz";
+                foreach (var expiredArchive in Directory.GetFiles(logDirectory, logPattern)
+                    .OrderByDescending(x => x, StringComparer.Ordinal)
+                    .Skip(retainedLogCount))
+                    File.Delete(expiredArchive);
+
+                return archivePath;
+            }
+            finally
+            {
+                File.Delete(logfile);
             }
         }
 

--- a/Duplicati/UnitTest/BasicSetupHelperTests.cs
+++ b/Duplicati/UnitTest/BasicSetupHelperTests.cs
@@ -1,0 +1,95 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    public class BasicSetupHelperTests
+    {
+        private string testFolder;
+        private string logFile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            testFolder = Path.Combine(Path.GetTempPath(), $"duplicati-log-cleanup-{Path.GetRandomFileName()}");
+            Directory.CreateDirectory(testFolder);
+            logFile = Path.Combine(testFolder, "logfile.log");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(testFolder))
+                Directory.Delete(testFolder, true);
+        }
+
+        [Test]
+        public void SuccessfulTestLogIsDeleted()
+        {
+            File.WriteAllText(logFile, "successful test log");
+
+            var archivePath = BasicSetupHelper.CleanupLogFile(logFile, false, 10);
+
+            Assert.IsNull(archivePath);
+            Assert.IsFalse(File.Exists(logFile));
+            Assert.IsEmpty(Directory.GetFiles(testFolder));
+        }
+
+        [Test]
+        public void FailedTestLogIsCompressed()
+        {
+            const string contents = "failed test log";
+            File.WriteAllText(logFile, contents);
+
+            var archivePath = BasicSetupHelper.CleanupLogFile(logFile, true, 10);
+
+            Assert.IsFalse(File.Exists(logFile));
+            Assert.IsTrue(File.Exists(archivePath));
+            using var source = File.OpenRead(archivePath);
+            using var gzip = new GZipStream(source, CompressionMode.Decompress);
+            using var reader = new StreamReader(gzip);
+            Assert.AreEqual(contents, reader.ReadToEnd());
+        }
+
+        [Test]
+        public void FailedTestLogsAreLimitedToMostRecentTen()
+        {
+            var archivePaths = new List<string>();
+            for (var i = 0; i < 12; i++)
+            {
+                File.WriteAllText(logFile, $"failed test log {i}");
+                archivePaths.Add(BasicSetupHelper.CleanupLogFile(logFile, true, 10));
+            }
+
+            Assert.AreEqual(10, Directory.GetFiles(testFolder, "logfile.log.*.gz").Length);
+            Assert.IsFalse(File.Exists(archivePaths[0]));
+            Assert.IsFalse(File.Exists(archivePaths[1]));
+            Assert.IsTrue(archivePaths.Skip(2).All(File.Exists));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- delete profiling logs from successful unit tests instead of archiving every log
- retain compressed logs for failed tests to preserve diagnostics
- cap retained failure logs at the 10 most recent archives

## Context

The unit-test helper currently compresses every per-test profiling log and never removes the archives. These files accumulate throughout the roughly 1,400-test run. This is consistent with the runner storage failures seen in:

- https://github.com/duplicati/duplicati/actions/runs/29542770690/job/87768238194 (`No space left on device`)
- https://github.com/duplicati/duplicati/actions/runs/29542827012/job/87768402167 (cascading SQLite `disk I/O error` failures)

Running the eight `TestMultiExceptionOnDlistAsync` cases locally left 8 archives totaling about 22 MB before this change. The same matrix leaves no archives and a 0-byte log directory after this change.

## Testing

- `BasicSetupHelperTests`: 3/3 passed
  - successful logs are deleted
  - failed logs are compressed with their contents intact
  - 12 failed logs are pruned to the 10 most recent archives
- `TestMultiExceptionOnDlistAsync` parameter matrix: 8/8 passed
- log storage after the 8-case matrix: 0 archives, 0 bytes