### PR TITLE
Fix secure-datafolder for service

### DIFF
--- a/Duplicati/CommandLine/ConfigureTool/Commands/SecureDataFolderCommand.cs
+++ b/Duplicati/CommandLine/ConfigureTool/Commands/SecureDataFolderCommand.cs
@@ -43,9 +43,10 @@ public static class SecureDataFolderCommand
         {
             new Option<string>("--data-folder", "Path to the Duplicati data folder (defaults to standard location)"),
             new Option<bool>("--apply", "Apply the restricted permissions without prompting. By default a warning is shown and the user must confirm."),
+            new Option<bool>("--for-service", "Apply the restricted permissions for use with a service"),
         };
 
-        cmd.Handler = CommandHandler.Create<string?, bool>(HandleSecureDataFolder);
+        cmd.Handler = CommandHandler.Create<string?, bool, bool>(HandleSecureDataFolder);
         return cmd;
     }
 
@@ -77,7 +78,7 @@ public static class SecureDataFolderCommand
     /// Checks the current permissions on the data folder and, if they are not already restricted,
     /// applies the restricted permissions (current user, SYSTEM and Administrators only).
     /// </summary>
-    private static int HandleSecureDataFolder(string? dataFolder, bool apply)
+    private static int HandleSecureDataFolder(string? dataFolder, bool apply, bool forService)
     {
         var dataFolderPath = GetDataFolder(dataFolder);
 
@@ -92,7 +93,7 @@ public static class SecureDataFolderCommand
         }
 
         // Check if the permissions are already set as expected
-        var alreadySecure = SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolderPath, out var detail);
+        var alreadySecure = SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolderPath, forService, out var detail);
 
         if (alreadySecure)
         {
@@ -123,8 +124,8 @@ public static class SecureDataFolderCommand
 
         try
         {
-            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolderPath);
-            if (!SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolderPath, out var checkDetail))
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolderPath, forService);
+            if (!SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolderPath, forService, out var checkDetail))
             {
                 Console.WriteLine($"Warning: failed to verify that permissions were applied correctly: {checkDetail}");
                 return 1;

--- a/Duplicati/Library/AutoUpdater/DataFolderManager.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderManager.cs
@@ -246,7 +246,7 @@ public static class DataFolderManager
     {
         try
         {
-            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolder);
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolder, false);
         }
         catch (Exception ex)
         {
@@ -277,7 +277,7 @@ public static class DataFolderManager
             return;
 
         // The folder is acceptable only if it is in the canonical locked-down form.
-        if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolder, out var detail))
+        if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolder, false, out var detail))
             return;
 
         // Tailor the guidance based on whether the folder pre-existed. A pre-existing folder

--- a/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
+++ b/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
@@ -375,7 +375,7 @@ public static class PreloadSettingsLoader
             if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
                 return;
 
-            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, out var dirDetail))
+            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out var dirDetail))
                 return;
 
             if (!Util.AllowInsecureDataFolder())

--- a/Duplicati/Library/Common/IO/ISystemIO.cs
+++ b/Duplicati/Library/Common/IO/ISystemIO.cs
@@ -88,19 +88,21 @@ namespace Duplicati.Library.Common.IO
         /// <param name="path">The file to set permissions on.</param>
         void FileSetPermissionUserRWOnly(string path);
         /// <summary>
-        /// Sets the permission to read-write only for the current user.
+        /// Sets the permission to read-write only for the desired user.
         /// </summary>
         /// <param name="path">The directory to set permissions on.</param>
-        void DirectorySetPermissionUserRWOnly(string path);
+        /// <param name="excludeCurrentUser">Do not accept the current user as part of the security check</param>
+        void DirectorySetPermissionUserRWOnly(string path, bool excludeCurrentUser);
 
         /// <summary>
-        /// Checks whether the directory has the read-write only permission for the current user,
+        /// Checks whether the directory has the correct read-write only permissions,
         /// i.e. the same permissions that <see cref="DirectorySetPermissionUserRWOnly"/> would apply.
         /// </summary>
         /// <param name="path">The directory to check permissions on.</param>
+        /// <param name="excludeCurrentUser">Do not accept the current user as part of the security check</param>
         /// <param name="detail">A human-readable description of why the check failed, if it did; otherwise <see cref="string.Empty"/>.</param>
         /// <returns><c>true</c> if the directory has the expected permissions; otherwise <c>false</c>.</returns>
-        bool DirectoryHasPermissionUserRWOnly(string path, out string detail);
+        bool DirectoryHasPermissionUserRWOnly(string path, bool excludeCurrentUser, out string detail);
 
         /// <summary>
         /// Gets a value indicating whether the operating system supports alternate data streams.

--- a/Duplicati/Library/Common/IO/SystemIOLinux.cs
+++ b/Duplicati/Library/Common/IO/SystemIOLinux.cs
@@ -457,11 +457,12 @@ namespace Duplicati.Library.Common.IO
         /// Sets the permission to read-write only for the current user.
         /// </summary>
         /// <param name="path">The directory to set permissions on.</param>
-        public void DirectorySetPermissionUserRWOnly(string path)
+        /// <param name="excludeCurrentUser">Do not use the current user for the permissions</param>
+        public void DirectorySetPermissionUserRWOnly(string path, bool excludeCurrentUser)
         {
             PosixFile.SetUserGroupAndPermissions(
                 path,
-                PInvoke.getuid(),
+                excludeCurrentUser ? RootUid : PInvoke.getuid(),
                 PInvoke.getgid(),
                 Convert.ToInt32("700", 8) /* FilePermissions.S_IRUSR | FilePermissions.S_IWUSR | FilePermissions.S_IXUSR */
             );
@@ -472,10 +473,11 @@ namespace Duplicati.Library.Common.IO
         /// matching the permissions applied by <see cref="DirectorySetPermissionUserRWOnly"/>.
         /// </summary>
         /// <param name="path">The directory to check permissions on.</param>
+        /// <param name="excludeCurrentUser">Do not include the current user when checking permissions</param>
         /// <param name="detail">A human-readable description of why the check failed, if it did; otherwise <see cref="string.Empty"/>.</param>
         /// <returns><c>true</c> if the directory has the expected permissions; otherwise <c>false</c>.</returns>
-        public bool DirectoryHasPermissionUserRWOnly(string path, out string detail)
-            => HasPermissionUserRWOnly(path, Convert.ToInt32("700", 8), out detail);
+        public bool DirectoryHasPermissionUserRWOnly(string path, bool excludeCurrentUser, out string detail)
+            => HasPermissionUserRWOnly(path, excludeCurrentUser, Convert.ToInt32("700", 8), out detail);
 
         /// <summary>
         /// The root user id, which is always considered a trusted owner.
@@ -491,10 +493,11 @@ namespace Duplicati.Library.Common.IO
         /// bits are set; the exact owning uid/gid beyond "current user or root" is not required.
         /// </summary>
         /// <param name="path">The path to check permissions on.</param>
+        /// <param name="excludeCurrentUser">Do not include the current user in the permission check</param>
         /// <param name="expectedMode">The expected octal mode (e.g. 0700 for directories).</param>
         /// <param name="detail">A human-readable description of why the check failed, if it did; otherwise <see cref="string.Empty"/>.</param>
         /// <returns><c>true</c> if the expected permissions are set; otherwise <c>false</c>.</returns>
-        private static bool HasPermissionUserRWOnly(string path, int expectedMode, out string detail)
+        private static bool HasPermissionUserRWOnly(string path, bool excludeCurrentUser, int expectedMode, out string detail)
         {
             detail = string.Empty;
             try
@@ -519,7 +522,7 @@ namespace Duplicati.Library.Common.IO
                 // The owner must be the current user or root. A root-owned folder is trusted
                 // because only root (a fully privileged principal) could have created it, and
                 // an unprivileged attacker cannot own a folder as root.
-                var uid = PInvoke.getuid();
+                var uid = excludeCurrentUser ? RootUid : PInvoke.getuid();
                 if (info.UID != uid && info.UID != RootUid)
                 {
                     detail = $"owner is uid {info.UID} but expected the current user (uid {uid}) or root";

--- a/Duplicati/Library/Common/IO/SystemIOWindows.cs
+++ b/Duplicati/Library/Common/IO/SystemIOWindows.cs
@@ -776,7 +776,7 @@ namespace Duplicati.Library.Common.IO
             // HasPermissionUserRWOnly verifies. Without this, the owner is whatever the
             // filesystem assigned at creation (e.g. the Administrators group or a different
             // account), which could cause the verification to reject a file we just locked down.
-            TrySetOwner(security);
+            TrySetOwner(security, CURRENT_USER_SID);
 
             // Adjust with the new security settings
             new FileInfo(path).SetAccessControl(security);
@@ -791,11 +791,12 @@ namespace Duplicati.Library.Common.IO
         /// already be a trusted principal (SYSTEM or Administrators), which verification accepts.
         /// </summary>
         /// <param name="security">The security descriptor to update.</param>
-        private static void TrySetOwner(FileSystemSecurity security)
+        /// <param name="userId">The id of the user to set as owner</param>
+        private static void TrySetOwner(FileSystemSecurity security, SecurityIdentifier userId)
         {
             try
             {
-                security.SetOwner(CURRENT_USER_SID);
+                security.SetOwner(userId);
             }
             catch
             {
@@ -808,7 +809,8 @@ namespace Duplicati.Library.Common.IO
         /// Sets the directory permissions to read-write only for the current user.
         /// </summary>
         /// <param name="path">The directory to set permissions on.</param>
-        public void DirectorySetPermissionUserRWOnly(string path)
+        /// <param name="excludeCurrentUser">Do not include the current user.</param>
+        public void DirectorySetPermissionUserRWOnly(string path, bool excludeCurrentUser)
         {
             // Create directory security settings
             var security = new DirectorySecurity();
@@ -816,8 +818,10 @@ namespace Duplicati.Library.Common.IO
             // Remove inherited permissions to ensure only the current user has access
             security.SetAccessRuleProtection(true, false);
 
+            var self = excludeCurrentUser ? ADMINISTRATORS_SID : CURRENT_USER_SID;
+
             var users = new[] {
-                CURRENT_USER_SID,
+                self,
                 LOCAL_SYSTEM_SID,
                 ADMINISTRATORS_SID
             }.ToHashSet();
@@ -836,7 +840,7 @@ namespace Duplicati.Library.Common.IO
             // HasPermissionUserRWOnly verifies. Without this, the owner is whatever the
             // filesystem assigned at creation (e.g. the Administrators group or a different
             // account), which could cause the verification to reject a folder we just locked down.
-            TrySetOwner(security);
+            TrySetOwner(security, self);
 
             // Adjust with the new security settings
             new DirectoryInfo(path).SetAccessControl(security);
@@ -848,10 +852,11 @@ namespace Duplicati.Library.Common.IO
         /// matching the permissions applied by <see cref="DirectorySetPermissionUserRWOnly"/>.
         /// </summary>
         /// <param name="path">The directory to check permissions on.</param>
+        /// <param name="excludeCurrentUser">Do not accept the current user as part of the security check</param>
         /// <param name="detail">A human-readable description of why the check failed, if it did; otherwise <see cref="string.Empty"/>.</param>
         /// <returns><c>true</c> if the directory has the expected permissions; otherwise <c>false</c>.</returns>
-        public bool DirectoryHasPermissionUserRWOnly(string path, out string detail)
-            => HasPermissionUserRWOnly(new DirectoryInfo(path).GetAccessControl(), "folder", out detail);
+        public bool DirectoryHasPermissionUserRWOnly(string path, bool excludeCurrentUser, out string detail)
+            => HasPermissionUserRWOnly(new DirectoryInfo(path).GetAccessControl(), excludeCurrentUser, "folder", out detail);
 
         /// <summary>
         /// Verifies that a file or directory access control object grants full control to
@@ -859,10 +864,11 @@ namespace Duplicati.Library.Common.IO
         /// owned by one of those principals.
         /// </summary>
         /// <param name="security">The access control object for the file or directory.</param>
+        /// <param name="excludeCurrentUser">Do not accept the current user as part of the security check</param>
         /// <param name="kind">A label such as "file" or "folder" used in detail messages.</param>
         /// <param name="detail">A human-readable description of why the check failed, if it did; otherwise <see cref="string.Empty"/>.</param>
         /// <returns><c>true</c> if the expected permissions are set; otherwise <c>false</c>.</returns>
-        private static bool HasPermissionUserRWOnly(FileSystemSecurity security, string kind, out string detail)
+        private static bool HasPermissionUserRWOnly(FileSystemSecurity security, bool excludeCurrentUser, string kind, out string detail)
         {
             detail = string.Empty;
             try
@@ -873,7 +879,7 @@ namespace Duplicati.Library.Common.IO
                 // is privileged and cannot be impersonated by an unprivileged attacker, so all
                 // three are accepted. DirectorySetPermissionUserRWOnly explicitly sets the owner
                 // to the current user, so a folder we lock down always satisfies this check.
-                var expected = new[] { CURRENT_USER_SID, LOCAL_SYSTEM_SID, ADMINISTRATORS_SID }.ToHashSet();
+                var expected = new[] { excludeCurrentUser ? ADMINISTRATORS_SID : CURRENT_USER_SID, LOCAL_SYSTEM_SID, ADMINISTRATORS_SID }.ToHashSet();
                 var ownerRef = security.GetOwner(typeof(SecurityIdentifier));
                 var owner = ownerRef as SecurityIdentifier;
                 if (owner == null || !expected.Contains(owner))

--- a/Duplicati/UnitTest/DataFolderSecurityTests.cs
+++ b/Duplicati/UnitTest/DataFolderSecurityTests.cs
@@ -21,12 +21,15 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Interface;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
 
 namespace Duplicati.UnitTest
 {
@@ -93,6 +96,37 @@ namespace Duplicati.UnitTest
         }
 
         /// <summary>
+        /// Returns the effective user id of the current process on POSIX, or 0 on Windows
+        /// (where the concept does not apply; callers gate on <see cref="OperatingSystem.IsWindows"/>).
+        /// </summary>
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        [DllImport("libc")]
+        private static extern uint geteuid();
+
+        /// <summary>
+        /// Returns <c>true</c> if the current process is privileged with respect to the
+        /// for-service lockdown: root on POSIX, or a member of the Administrators group on Windows.
+        /// On POSIX the for-service set step chowns to root and therefore requires root, so tests
+        /// that exercise the set step skip when this returns false on POSIX. On Windows the
+        /// Administrators principal is one of the trusted SIDs the for-service lockdown grants
+        /// access to, so a member of Administrators is effectively the service principal.
+        /// </summary>
+        private static bool IsCurrentUserPrivilegedForService()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                using var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+                return new System.Security.Principal.WindowsPrincipal(identity)
+                    .IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+            }
+
+            return OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()
+                ? geteuid() == 0
+                : false;
+        }
+
+        /// <summary>
         /// Creates a child directory inside the temp dir and returns its path.
         /// </summary>
         private string NewChild(string name)
@@ -105,10 +139,31 @@ namespace Duplicati.UnitTest
             var dir = NewChild("roundtrip");
             Directory.CreateDirectory(dir);
 
-            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir);
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, false);
 
-            Assert.IsTrue(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, out var detail),
+            Assert.IsTrue(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out var detail),
                 $"A locked-down folder should pass the canonical permission check, but: {detail}");
+        }
+
+        [Test]
+        [Category("DataFolderSecurity")]
+        public void LockDownThenVerifyRoundTrips_ForService()
+        {
+            var dir = NewChild("roundtrip-service");
+            Directory.CreateDirectory(dir);
+
+            // The "for service" mode excludes the current user as a trusted principal and
+            // locks the folder down to root (POSIX) or SYSTEM/Administrators (Windows).
+            // On POSIX this requires running as root to be able to chown to root, so skip
+            // the set step there when not root; verification of an already-root-owned
+            // folder is covered by the canonical check on the service path elsewhere.
+            if (!OperatingSystem.IsWindows() && !IsCurrentUserPrivilegedForService())
+                Assert.Ignore("The for-service lockdown on POSIX requires running as root");
+
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, true);
+
+            Assert.IsTrue(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, true, out var detail),
+                $"A folder locked down for service should pass the canonical permission check, but: {detail}");
         }
 
         [Test]
@@ -123,8 +178,52 @@ namespace Duplicati.UnitTest
 
             // On Windows, a freshly created dir inherits its parent ACL (not protected) and so is
             // not canonical; on POSIX we made it 0777 above. Either way it must fail.
-            Assert.IsFalse(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, out _),
+            Assert.IsFalse(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _),
                 "A non-canonical folder must not pass the canonical permission check");
+        }
+
+        [Test]
+        [Category("DataFolderSecurity")]
+        public void ForServiceLockdown_AcceptsForServiceCheck()
+        {
+            var dir = NewChild("service-accepted");
+            Directory.CreateDirectory(dir);
+
+            if (!OperatingSystem.IsWindows() && !IsCurrentUserPrivilegedForService())
+                Assert.Ignore("The for-service lockdown on POSIX requires running as root");
+
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, true);
+
+            // The folder locked down for service must pass the for-service verification.
+            Assert.IsTrue(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, true, out var detail),
+                $"A folder locked down for service should pass the for-service check, but: {detail}");
+        }
+
+        [Test]
+        [Category("DataFolderSecurity")]
+        public void ForServiceLockdown_RejectsNonServiceCheck()
+        {
+            var dir = NewChild("service-rejects-non-service");
+            Directory.CreateDirectory(dir);
+
+            if (!OperatingSystem.IsWindows() && !IsCurrentUserPrivilegedForService())
+                Assert.Ignore("The for-service lockdown on POSIX requires running as root");
+
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, true);
+
+            // A folder locked down for service excludes the current user as a trusted principal.
+            // The non-service check (which requires the current user to be trusted) must reject it,
+            // unless the current user happens to be an Administrator (Windows) or root (POSIX),
+            // in which case the current user is indistinguishable from the service principal and
+            // the non-service check would also accept it. Assert accordingly.
+            var isPrivileged = IsCurrentUserPrivilegedForService();
+            var result = SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _);
+            if (isPrivileged)
+                Assert.IsTrue(result,
+                    "When the current user is the service principal, both checks should accept the folder");
+            else
+                Assert.IsFalse(result,
+                    "A folder locked down for service must not pass the non-service check");
         }
 
         [Test]
@@ -137,7 +236,7 @@ namespace Duplicati.UnitTest
             DataFolderManager.PrepareSecureDataFolder(dir, createIfMissing: true);
 
             Assert.IsTrue(Directory.Exists(dir), "The folder should have been created");
-            Assert.IsTrue(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, out var detail),
+            Assert.IsTrue(SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out var detail),
                 $"A created folder should be locked down, but: {detail}");
         }
 
@@ -158,7 +257,7 @@ namespace Duplicati.UnitTest
         {
             var dir = NewChild("existing-ok");
             Directory.CreateDirectory(dir);
-            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir);
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, false);
 
             // A pre-existing, already-canonical folder must be accepted without modification or error.
             Assert.DoesNotThrow(() => DataFolderManager.PrepareSecureDataFolder(dir, createIfMissing: true));
@@ -174,7 +273,7 @@ namespace Duplicati.UnitTest
                 MakeInsecure(dir);
 
             // Sanity: the folder must actually be non-canonical for this test to be meaningful.
-            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, out _))
+            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _))
                 Assert.Ignore("Could not produce a non-canonical folder on this platform/filesystem");
 
             var ex = Assert.Throws<UserInformationException>(
@@ -192,7 +291,7 @@ namespace Duplicati.UnitTest
             if (!OperatingSystem.IsWindows())
                 MakeInsecure(dir);
 
-            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, out _))
+            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _))
                 Assert.Ignore("Could not produce a non-canonical folder on this platform/filesystem");
 
             Environment.SetEnvironmentVariable(Util.AllowInsecureDatafolderEnvVar, "true");
@@ -210,7 +309,7 @@ namespace Duplicati.UnitTest
             if (!OperatingSystem.IsWindows())
                 MakeInsecure(dir);
 
-            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, out _))
+            if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _))
                 Assert.Ignore("Could not produce a non-canonical folder on this platform/filesystem");
 
             var ex = Assert.Throws<UserInformationException>(
@@ -239,7 +338,7 @@ namespace Duplicati.UnitTest
         {
             var dir = NewChild("readonly-ok");
             Directory.CreateDirectory(dir);
-            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir);
+            SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, false);
 
             Assert.DoesNotThrow(() => DataFolderManager.VerifyDataFolderSecurityReadOnly(dir));
         }

--- a/Duplicati/UnitTest/DataFolderSecurityTests.cs
+++ b/Duplicati/UnitTest/DataFolderSecurityTests.cs
@@ -212,18 +212,26 @@ namespace Duplicati.UnitTest
             SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, true);
 
             // A folder locked down for service excludes the current user as a trusted principal.
-            // The non-service check (which requires the current user to be trusted) must reject it,
-            // unless the current user happens to be an Administrator (Windows) or root (POSIX),
-            // in which case the current user is indistinguishable from the service principal and
-            // the non-service check would also accept it. Assert accordingly.
-            var isPrivileged = IsCurrentUserPrivilegedForService();
+            // How the non-service check treats it differs by platform:
+            //
+            // - Windows: the for-service lockdown grants the Administrators *group* SID, never
+            //   the current user's individual SID. The non-service check requires an explicit
+            //   rule for the current user's individual SID, which is distinct from the group SID
+            //   even when the current user is a member of Administrators. So the non-service
+            //   check always rejects a for-service folder here.
+            //
+            // - POSIX: the for-service lockdown chowns to root, and root ownership is always
+            //   trusted by the non-service check (an unprivileged attacker cannot own a folder
+            //   as root). So the non-service check always accepts a for-service folder here.
+            //   This test only runs as root on POSIX (it is ignored otherwise, above).
             var result = SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _);
-            if (isPrivileged)
-                Assert.IsTrue(result,
-                    "When the current user is the service principal, both checks should accept the folder");
-            else
+            if (OperatingSystem.IsWindows())
                 Assert.IsFalse(result,
-                    "A folder locked down for service must not pass the non-service check");
+                    "On Windows a folder locked down for service must not pass the non-service check, " +
+                    "because it grants the Administrators group SID rather than the current user's individual SID");
+            else
+                Assert.IsTrue(result,
+                    "On POSIX a folder locked down for service is root-owned, which the non-service check always trusts");
         }
 
         [Test]

--- a/Duplicati/WindowsService/ServiceControl.cs
+++ b/Duplicati/WindowsService/ServiceControl.cs
@@ -429,10 +429,10 @@ namespace Duplicati.WindowsService
 
                     try
                     {
-                        SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolder);
+                        SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dataFolder, false);
 
                         // Verify the permissions were actually set correctly
-                        if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolder, out var detail))
+                        if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dataFolder, false, out var detail))
                             m_eventLog.WriteEntry("Data folder permissions restricted to SYSTEM and Administrators only.", System.Diagnostics.EventLogEntryType.Information);
                         else
                             m_eventLog.WriteEntry($"Data folder permissions could not be verified after applying: {detail}", System.Diagnostics.EventLogEntryType.Warning);


### PR DESCRIPTION
The new command to fix the datafolder permissions was not working correctly when attempting to secure the datafolder for service use. The reason is that the elevated user (which is usually an Administrator) would be added to the permissions, but then when running the service, this user would not be in the set of allowed users.

This PR updates the command such that the `--for-service` option is added, which will ignore the current user and only grant access to Administrators (group) and SYSTEM.