### PR TITLE
Make BackendTester actually retry failed uploads

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -572,7 +572,6 @@ namespace Duplicati.CommandLine.BackendTester
         {
             var filesize = new System.IO.FileInfo(localfilename).Length;
             Console.Write($"{LogTimeStamp}Uploading file {i}, {Utility.FormatSizeString(filesize)} ... ");
-            Exception e = null;
 
             var sw = Stopwatch.StartNew();
             var throttleManager = new ThrottleManager() { Limit = throttle };
@@ -590,26 +589,21 @@ namespace Duplicati.CommandLine.BackendTester
                 else
                     backend.PutAsync(remotefilename, localfilename, CancellationToken.None).Await();
 
-                e = null;
+                sw.Stop();
+                Console.WriteLine($" done! in {sw.ElapsedMilliseconds} ms (~{Utility.FormatSizeString(filesize / sw.Elapsed.TotalSeconds)}/s)");
             }
             catch (Exception ex)
             {
-                e = ex;
-            }
-            sw.Stop();
-
-            if (e != null)
-            {
-                Console.WriteLine($"{LogTimeStamp}Failed to upload file {i}, error message: {e}, remote name: {remotefilename} after {sw.ElapsedMilliseconds} ms");
+                sw.Stop();
+                Console.WriteLine($"{LogTimeStamp}Failed to upload file {i}, error message: {ex}, remote name: {remotefilename} after {sw.ElapsedMilliseconds} ms");
+                var e = ex;
                 while (e.InnerException != null)
                 {
                     e = e.InnerException;
                     Console.WriteLine($"{LogTimeStamp}  Inner exception: {e}");
                 }
-            }
-            else
-            {
-                Console.WriteLine($" done! in {sw.ElapsedMilliseconds} ms (~{Utility.FormatSizeString(filesize / sw.Elapsed.TotalSeconds)}/s)");
+
+                throw;
             }
         }
 


### PR DESCRIPTION
## Summary

The backend tester's upload retry was effectively dead code. Every upload call site is wrapped in `Retry(...)` and the Backend Live Tests workflow passes `--failure-retries=3`, so uploads *look* retried — but `Uploadfile` caught every exception internally and only logged it, never rethrowing. The `Retry` wrapper therefore never fired, and uploads ran with **zero retries**, unlike list/download/delete/rename which all retry properly (their `Operation failed with exception, N retries left…` lines appear in CI logs; uploads never produce them).

A transiently failed upload was silently swallowed and only surfaced later in the verification phase as misleading cascades:

- `*** File X with name … was uploaded but not found afterwards`
- `*** Error: Duplicati.Library.Interface.FileMissingException: File not found: …`
- `*** Downloaded file was corrupt`

This pattern is visible in recent Backend Live Tests failures where a single one-shot error failed the whole job — e.g. an S3 `503 ServiceUnavailable` (Jun 27), and pCloud/Box/Google Drive single 5xx responses, as well as Drime `502/504/520` gateway errors (Jun 26, Jul 6, Jul 10, Jul 13).

## Change

Restructure `Uploadfile` to keep the exact same failure logging but **rethrow** the exception. The existing `Retry` helper (exponential backoff starting at 1s, rethrow on exhaustion) then applies to uploads like every other operation. No changes to `Retry`, the call sites, the workflow, or the exit-code contract (`Main` still catches, prints `Unittest failed: …` and returns 1).

This also aligns the tester with production behavior: `BackendManager` retries failed uploads during real backups (`number-of-retries` defaults to 5 with a 10s delay), so the tester was holding backends to a *stricter* standard than actual Duplicati operation.

Behavior changes:
1. Transient upload errors are absorbed by the configured `--failure-retries`.
2. A persistent failure aborts the run with the **actual upload error** as the cause, instead of the misleading downstream verification noise.

Scope note: this does not fix chronically unavailable services (e.g. the ongoing Drime gateway instability) — those still fail after retries, but now with the real error up front.

## Verification

Against a local `file://` target (Windows):

- **Normal run**: `--auto-clean --force --auto-create-folder --failure-retries=3 --number-of-files=5` → all uploads `done!`, `Unittest complete!`, exit 0.
- **Retry path**: started a throttled run, then denied file creation (`icacls … /deny user:(WD)`) mid-run. The log now shows the upload failing and being retried, then failing cleanly with the true cause:

```
Uploading file 0, 90.62 KiB ...  done! in 9090 ms
Uploading file 1, 95.29 KiB ... Failed to upload file 1, error message: System.UnauthorizedAccessException: …
Operation failed with exception, 1 retries left, delaying retry for 1000 ms
Retrying after error, 1 retries left
Uploading file 1, 95.29 KiB ... Failed to upload file 1, …
Unittest failed: System.AggregateException: … (Access to the path … is denied.)  →  exit 1
```

Before this change, the `retries left` lines never appeared for uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
