### PR TITLE
Fix XML doc parameter names that no longer match the code

### DIFF
--- a/Duplicati/CommandLine/DatabaseTool/Helper.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Helper.cs
@@ -20,7 +20,7 @@ public static class Helper
     /// <summary>
     /// Creates a backup of the file
     /// </summary>
-    /// <param name="filename">The filename to backup</param>
+    /// <param name="path">The path of the file to backup</param>
     public static void CreateFileBackup(string path)
     {
         path = Path.GetFullPath(path);

--- a/Duplicati/CommandLine/ServerUtil/Connection.cs
+++ b/Duplicati/CommandLine/ServerUtil/Connection.cs
@@ -366,7 +366,7 @@ public class Connection
     /// <summary>
     /// Parses the authentication response
     /// </summary>
-    /// <param name="response">The response to parse</param>
+    /// <param name="responseTask">The task producing the response to parse</param>
     /// <returns>The access and refresh tokens</returns>
     private static async Task<(string AccessToken, string? RefreshToken, string? RefreshNonce)> ParseAuthResponseAsync(Task<HttpResponseMessage> responseTask)
     {

--- a/Duplicati/CommandLine/ServerUtil/Settings.cs
+++ b/Duplicati/CommandLine/ServerUtil/Settings.cs
@@ -165,7 +165,6 @@ public sealed record Settings(
     /// <summary>
     /// Replaces secrets inside arguments and options
     /// </summary>
-    /// <param name="args">The arguments to replace</param>
     /// <param name="options">The options to replace</param>
     /// <returns>The task to await</returns>
     public Task ReplaceSecretsAsync(Dictionary<string, string?> options)

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/PasswordPrompt.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/PasswordPrompt.cs
@@ -40,10 +40,8 @@ internal static class PasswordPrompt
     /// Shows a password prompt dialog within an already-running Avalonia application.
     /// Must be called from the UI thread or will dispatch to it.
     /// </summary>
-    /// <param name="hostUrl">The host URL to show in the prompt</param>
-    /// <param name="password">The current password to pre-fill, if any</param
     /// <param name="isChangePassword">Whether this is a change password prompt</param>
-    /// <returns>A task that completes with the password, or null if cancelled</returns>
+    /// <returns>A task that completes with <c>true</c> if the password was submitted, or <c>false</c> if cancelled</returns>
     public static Task<bool> ShowPasswordDialogAsync(bool isChangePassword)
     {
         if (IsShowingDialog)

--- a/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
+++ b/Duplicati/Library/AutoUpdater/PreloadSettingsLoader.cs
@@ -137,7 +137,6 @@ public static class PreloadSettingsLoader
     /// Gets the merged settings for the given executable
     /// </summary>
     /// <param name="executable">The executable to get settings for</param>
-    /// <param name="sourceargs">The source commandline arguments</param>
     /// <param name="portableMode">The portable mode flag</param>
     /// <returns>The merged settings</returns>
     private static (Dictionary<string, string> env, List<string> args, Dictionary<string, string?> db) GetExecutableMergedSettings(PackageHelper.NamedExecutable executable, bool portableMode)

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -416,7 +416,7 @@ namespace Duplicati.Library.AutoUpdater
         /// <summary>
         /// Helper method to create a signed manifest file
         /// </summary>
-        /// <param name="key">The key used for signing the manifest</param>
+        /// <param name="keys">The keys used for signing the manifest</param>
         /// <param name="sourcedata">The template content in JSON format</param>
         /// <param name="outputfolder">The folder where the signed manifest will be written to</param>
         /// <param name="version">The version of the manifest</param>

--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -294,7 +294,7 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
     /// Download files from remote
     /// </summary>
     /// <param name="remotename">Filename at remote location</param>
-    /// <param name="output">Destination stream to write to</param>
+    /// <param name="localname">Destination file path to write to</param>
     /// <param name="cancellationToken">CancellationToken that is combined with internal timeout token</param>
     /// <exception cref="FileMissingException">FileMissingException when file is not found</exception>
     /// <exception cref="Exception">Exceptions arising from either code execution or FileMissingException</exception>

--- a/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
+++ b/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
@@ -174,7 +174,6 @@ namespace Duplicati.Library.DynamicLoader
         /// <param name="url">The url to create the instance for</param>
         /// <param name="mountPoint">The mount point to use</param>
         /// <param name="options">The options to pass to the instance constructor</param>
-        /// <param name="getForTesting">Whether the SourceProvider is requested for testing purposes</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The instanciated SourceProvider or null if the url is not supported</returns>
         public static async Task<ISourceProviderModule> GetSourceProvider(string url, string mountPoint, Dictionary<string, string> options, CancellationToken cancellationToken)

--- a/Duplicati/Library/Main/Backend/BackendManager.PutOperation.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.PutOperation.cs
@@ -119,7 +119,6 @@ partial class BackendManager
         /// <summary>
         /// Starts the encryption of the file
         /// </summary>
-        /// <param name="options">The options to use</param>
         public void StartEncryptionAndHashing()
         {
             if (encryptionAndHashingTask != null)

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -252,8 +252,8 @@ internal partial class BackendManager : IBackendManager
     /// <summary>
     /// Decrypts a file using the specified options
     /// </summary>
-    /// <param name="tmpfile">The file to decrypt</param>
-    /// <param name="filename">The name of the file. Used for detecting encryption algorithm if not specified in options or if it differs from the options</param>
+    /// <param name="volume">The file to decrypt</param>
+    /// <param name="volume_name">The name of the file. Used for detecting encryption algorithm if not specified in options or if it differs from the options</param>
     /// <param name="options">The Duplicati options</param>
     /// <param name="dispose">True if the input file should be disposed after decryption</param>
     /// <returns>The decrypted file</returns>
@@ -521,7 +521,6 @@ internal partial class BackendManager : IBackendManager
     /// Waits for the backend queue to be empty and flushes the database messages
     /// </summary>
     /// <param name="database">The database to write to</param>
-    /// <param name="transaction">The transaction to use</param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>An awaitable task</returns>
     public async Task WaitForEmptyAsync(IBackendManagerDatabase database, CancellationToken cancellationToken)

--- a/Duplicati/Library/Main/Database/ExtensionMethods.cs
+++ b/Duplicati/Library/Main/Database/ExtensionMethods.cs
@@ -848,7 +848,6 @@ public static partial class ExtensionMethods
     /// </summary>
     /// <param name="self">The command instance to execute on</param>
     /// <param name="cmd">The command string to execute</param>
-    /// <param name="values">The values to use as parameters. The parameters must already be added.</param>
     /// <returns>The number of rows affected</returns>
     public static int ExecuteNonQuery(this IDbCommand self, string cmd)
         => ExecuteNonQuery(self, true, cmd);
@@ -1134,7 +1133,7 @@ public static partial class ExtensionMethods
     /// </summary>
     /// <param name="self">The connection to create the command on.</param>
     /// <param name="transaction">The transaction to use for the command.</param>
-    /// <param name="cmd">The command string to create the command with.</param>
+    /// <param name="cmdtext">The command string to create the command with.</param>
     /// <returns>A new command with the given transaction.</returns>
     public static IDbCommand CreateCommand(this IDbConnection self, IDbTransaction? transaction, string? cmdtext = null)
     {

--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -3085,7 +3085,6 @@ namespace Duplicati.Library.Main.Database.Local
         /// <summary>
         /// Gets the last previous fileset that was incomplete.
         /// </summary>
-        /// <param name="transaction">The transaction to use.</param>
         /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
         /// <returns>A task that when awaited returns the last incomplete fileset or default</returns>
         public async Task<RemoteVolumeEntry> GetLastIncompleteFilesetVolumeAsync(CancellationToken token)

--- a/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
@@ -1179,7 +1179,7 @@ namespace Duplicati.Library.Main.Database.Local
         /// Extends folder entries with additional metadata from the Metadataset table.
         /// Note that this modifies the input entries in-place.
         /// </summary>
-        /// <param name="entries">The folder entries to extend.</param>
+        /// <param name="filesetIds">The file IDs to fetch metadata for.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <returns>A task that when awaited returns the extended folder entries.</returns>
         public async Task<Dictionary<long, Dictionary<string, string?>>> GetMetadataForFilesetIdsAsync(IEnumerable<long> filesetIds, CancellationToken token)

--- a/Duplicati/Library/Main/Operation/Backup/FileEnumerationProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FileEnumerationProcess.cs
@@ -524,7 +524,6 @@ namespace Duplicati.Library.Main.Operation.Backup
         /// Evaluates a single entry for inclusion in the backup
         /// </summary>
         /// <param name="entry">The current entry.</param>
-        /// <param name="snapshot">The snapshot service.</param>
         /// <param name="blacklistPaths">The blacklist paths.</param>
         /// <param name="hardlinkPolicy">The hardlink policy.</param>
         /// <param name="symlinkPolicy">The symlink policy.</param>

--- a/Duplicati/Library/Main/Operation/ReadLockInfoHandler.cs
+++ b/Duplicati/Library/Main/Operation/ReadLockInfoHandler.cs
@@ -44,8 +44,7 @@ namespace Duplicati.Library.Main.Operation
         /// Creates a new instance of the <see cref="ReadLockInfoHandler"/> class.
         /// </summary>
         /// <param name="options">The options for the operation.</param>
-        /// <param name="backendWriter">The backend writer for logging.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="result">The result object for the operation.</param>
         public ReadLockInfoHandler(Options options, ReadLockInfoResults result)
         {
             m_options = options;

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -1420,7 +1420,6 @@ namespace Duplicati.Library.Main.Operation
         /// Runs the refresh lock info operation to update lock expiration times from the backend.
         /// </summary>
         /// <param name="backendManager">The backend manager to use for reading lock info.</param>
-        /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
         /// <returns>A task that completes when the operation is finished.</returns>
         private async Task RunRefreshLockInfoAsync(IBackendManager backendManager)
         {

--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -349,7 +349,7 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// removed, the requester will be given a `Task` that will be
             /// completed when the block is available.
             /// </summary>
-            /// <param name="blockRequest">The block request related to the value.</param>
+            /// <param name="blockID">The ID of the block related to the value.</param>
             /// <param name="value">The byte[] buffer holding the block data.</param>
             public void Set(long blockID, DataBlock value)
             {

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -750,7 +750,7 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// <summary>
         /// Restores the metadata for a file.
         /// </summary>
-        /// <param name="cmd">The command to execute to retrieve the metadata blocks.</param>
+        /// <param name="db">The restore database, which is queried for the metadata blocks.</param>
         /// <param name="file">The file to restore.</param>
         /// <param name="restoreDestination">The restore destination provider.</param>
         /// <param name="block_request">The channel to request blocks from the block manager.</param>

--- a/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
+++ b/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
@@ -155,7 +155,7 @@ namespace Duplicati.Library.Main.Operation.Restore
     /// <param name="blockHash">The hash of the block.</param>
     /// <param name="blockSize">The size of the block.</param>
     /// <param name="volumeID">The ID of the volume in which the block is stored remotely.</param>
-    /// <param name="cacheDecrEvict">Flag indicating that this block request should either decrement the block counter for BlockID (for BlockManager) or evict the VolumeID (for VolumeDownloader).</param>
+    /// <param name="requestType">The type of request: a download, or a request to decrement the block counter for BlockID (for BlockManager) / evict the VolumeID (for VolumeDownloader).</param>
     public class BlockRequest(long blockID, long blockOffset, string blockHash, long blockSize, long volumeID, BlockRequestType requestType)
     { // Total = 81 bytes
         public long BlockID { get; } = blockID;

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -153,7 +153,6 @@ namespace Duplicati.Library.Main.Volumes
         /// Updates the options with data from the manifest file, but does not overwrite existing values
         /// </summary>
         /// <param name="compressor">The compressor to use</param>
-        /// <param name="file">The file to read the manifest from</param>
         /// <param name="options">The options to update</param>
         public static void UpdateOptionsFromManifest(ICompression compressor, Options options)
         {

--- a/Duplicati/Library/RemoteControl/ExchangeDataTypes.cs
+++ b/Duplicati/Library/RemoteControl/ExchangeDataTypes.cs
@@ -59,7 +59,7 @@ internal enum MessageType
 /// </summary>
 /// <param name="Token">The client token</param>
 /// <param name="PublicKey">The client public key</param>
-/// <param name="Version">The version of the client</param>
+/// <param name="ClientVersion">The version of the client</param>
 /// <param name="ProtocolVersion">The protocol version of the client</param>
 /// <param name="Metadata">The optional metadata to send</param>
 public record AuthMessage(string Token, string PublicKey, string ClientVersion, int ProtocolVersion, Dictionary<string, string?>? Metadata);
@@ -70,7 +70,6 @@ public record AuthMessage(string Token, string PublicKey, string ClientVersion, 
 /// <param name="Accepted">Whether the authentication was accepted</param>
 /// <param name="WillReplaceToken">Whether the token will be replaced</param>
 /// <param name="NewToken">The new token</param>
-/// <param name="SignedChallenge">The signed challenge</param>
 internal sealed record AuthResultMessage(bool? Accepted, bool? WillReplaceToken, string? NewToken);
 
 /// <summary>

--- a/Duplicati/Library/RemoteControl/SharedTypes.cs
+++ b/Duplicati/Library/RemoteControl/SharedTypes.cs
@@ -40,7 +40,6 @@ public sealed record RegisterClientData(
 /// <summary>
 /// Data returned when the machine is claimed
 /// </summary>
-/// <param name="Success">True if the claim was successful</param>
 /// <param name="StatusMessage">The status message for the claim</param>
 /// <param name="JWT">The JWT token for the machine</param>
 /// <param name="ServerUrl">The URL for the remote server</param>

--- a/Duplicati/Library/RemoteControl/TransportHelper.cs
+++ b/Duplicati/Library/RemoteControl/TransportHelper.cs
@@ -92,7 +92,7 @@ internal static class TransportHelper
     /// Parses an encrypted message using the provided key
     /// </summary>
     /// <param name="message">The encrypted message to parse</param>
-    /// <param name="privateKey">The private key to decrypt with</param>
+    /// <param name="key">The key to decrypt or verify with</param>
     /// <returns>The parsed message</returns>
     private static EnvelopedMessage ParsedFromEncodedMessage(string message, RSA key, bool isPrivateKey)
     {

--- a/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
+++ b/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
@@ -37,7 +37,7 @@ public static class QuerystringMasking
     /// <summary>
     /// Masks the values in the given URL for any properties listed in protectedProperties.
     /// </summary>
-    /// <param name="url">The URL to mask.</param>
+    /// <param name="urlstring">The URL to mask.</param>
     /// <param name="protectedProperties">The set of property names to mask (case-insensitive).</param>
     /// <returns>>The URL with sensitive properties masked.</returns>
     public static string Mask(string urlstring, IReadOnlySet<string> protectedProperties)

--- a/Duplicati/Library/SQLiteHelper/SQLiteRC4Decrypter.cs
+++ b/Duplicati/Library/SQLiteHelper/SQLiteRC4Decrypter.cs
@@ -86,8 +86,6 @@ public static class SQLiteRC4Decrypter
     /// </summary>
     /// <param name="databasePath">The path to the database file</param>
     /// <param name="password">The password to use for decryption</param>
-    /// <param name="errorMessage">The error message if decryption failed</param>
-    /// <returns><c>true</c> if the decryption was successful or the database was not encrypted; <c>false</c> otherwise</returns>
     public static void DecryptSQLiteFile(string databasePath, string password)
     {
         databasePath = Path.GetFullPath(databasePath);

--- a/Duplicati/Library/SecretProvider/MacOSKeyChainProvider.cs
+++ b/Duplicati/Library/SecretProvider/MacOSKeyChainProvider.cs
@@ -743,7 +743,7 @@ public class MacOSKeyChainProvider : ISecretProvider
     /// <summary>
     /// Core method to retrieve a password by label.
     /// </summary>
-    /// <param name="label">The label of the item.</param>
+    /// <param name="name">The label of the item.</param>
     /// <param name="isInternet">Whether it's an internet password.</param>
     /// <returns>The password value.</returns>
     private static string GetByLabelCore(string name, KeyChainSettings? settings, bool isInternet)

--- a/Duplicati/Library/Snapshots/USN/UsnJournalService.cs
+++ b/Duplicati/Library/Snapshots/USN/UsnJournalService.cs
@@ -428,7 +428,7 @@ namespace Duplicati.Library.Snapshots.USN
         /// <summary>
         /// Tests if specified folder, or any of its ancestors, is excluded by the filter
         /// </summary>
-        /// <param name="folder">Folder to test</param>
+        /// <param name="inputFolder">Folder to test</param>
         /// <param name="filter">Filter</param>
         /// <param name="cache">Cache of excluded folders (optional)</param>
         /// <returns>True if excluded, false otherwise</returns>

--- a/Duplicati/Library/Utility/BackendExtensions.cs
+++ b/Duplicati/Library/Utility/BackendExtensions.cs
@@ -61,7 +61,7 @@ public static class BackendExtensions
     /// Tests a backend by invoking the List() method, and attempting to write a small file on the destination.
     /// </summary>
     /// <param name="backend">Backend to test</param>
-    /// <param name="cancelToken">Cancellation token</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>An awaitable tasks</returns>
     public static async Task TestReadWritePermissionsAsync(this IBackend backend, CancellationToken cancellationToken)
     {
@@ -160,7 +160,7 @@ public static class BackendExtensions
     /// As long as the iteration can return one page, the test is considered successful.
     /// </summary>
     /// <param name="backend">Backend to test</param>
-    /// <param name="cancelToken">Cancellation token</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>An awaitable tasks</returns>
     public static async Task TestReadPermissionsAsync(this IBackend backend, CancellationToken cancellationToken)
     {

--- a/Duplicati/Library/Utility/CommandLineArgumentMapper.cs
+++ b/Duplicati/Library/Utility/CommandLineArgumentMapper.cs
@@ -110,7 +110,7 @@ public static class CommandLineArgumentMapper
     /// <summary>
     /// Extracts all primitive types from a class and maps them to command line arguments
     /// </summary>
-    /// <param name="type">The type to extract arguments from</param>
+    /// <param name="obj">The object to extract arguments from</param>
     /// <param name="prefix">The prefix to use for the arguments</param>
     /// <param name="exclude">A list of properties to exclude</param>
     /// <returns>A list of command line arguments</returns>

--- a/Duplicati/Library/Utility/Timeparser.cs
+++ b/Duplicati/Library/Utility/Timeparser.cs
@@ -175,7 +175,7 @@ namespace Duplicati.Library.Utility
         /// Parses a time interval string with a timezone offset, retaining the local time
         /// </summary>
         /// <param name="datestring">The repeating interval string</param>
-        /// <param name="offset">The base time to add the interval to</param>
+        /// <param name="rawoffset">The base time to add the interval to</param>
         /// <param name="timeZoneInfo">The timezone to use for the calculation</param>
         /// <param name="negate">True if the interval should be subtracted</param>
         /// <returns>The calculated time</returns>

--- a/Duplicati/UnitTest/DirectListHandlerTests.cs
+++ b/Duplicati/UnitTest/DirectListHandlerTests.cs
@@ -862,7 +862,7 @@ namespace Duplicati.UnitTest
 
         /// <summary>
         /// Tests that <see cref="LocalListDatabase.SearchEntriesAsync"/> can match values inside
-        /// metadata JSON when <paramref name="searchMetadata"/> is <c>true</c>.
+        /// metadata JSON when <c>searchMetadata</c> is <c>true</c>.
         /// </summary>
         [Test]
         [Category("Database")]


### PR DESCRIPTION
## Summary

A repository-wide scan comparing every `<param name="...">` tag against the actual parameter list of the member it documents found **35 tags naming parameters that do not exist**. These are broken as documentation — they don't resolve in IDE tooltips or generated docs, and they're what the compiler reports as **CS1572** when XML doc output is enabled.

Causes are the usual ones: parameters renamed without updating the doc, doc blocks copy-pasted between overloads, and parameters removed while their doc line stayed behind.

**All changes are inside `///` comments — no behavior change.** (Verified mechanically: every added/removed line in the diff starts with `///`.)

This is the third and last part of a doc audit; the earlier parts are #7062 (misleading/stale descriptions). `ReusableTransaction.cs` is deliberately excluded here because its fix is already in #7062, so the two PRs touch disjoint files.

## What changed

Each site was checked against the implementation before changing it. The fix is one of two kinds:

**Renamed** (parameter still exists under a new name, existing description still applies) — 20 tags, e.g.:

| Location | Change |
|---|---|
| `BackendManager.DecryptFile` | `tmpfile`→`volume`, `filename`→`volume_name` (copied from the delegate target, which is correct there) |
| `UpdaterManager.CreateSignedManifest` | `key`→`keys` (signing was made multi-key) |
| `BackendExtensions` ×2 | `cancelToken`→`cancellationToken` |
| `Timeparser.DSTAwareParseTimeInterval` | `offset`→`rawoffset` |
| `pCloudBackend.GetAsync` | `output`→`localname` (copied from the stream overload) |
| `AuthMessage` record | `Version`→`ClientVersion` |
| `ReadLockInfoHandler` ctor | `backendWriter`→`result` |

**Deleted** (parameter is gone, nothing corresponds to it) — 15 tags, e.g. the `transaction` parameters removed from `BackendManager.WaitForEmptyAsync` and `LocalDatabase.GetLastIncompleteFilesetVolumeAsync`, the `snapshot` parameter replaced by the source-provider entry in `FileEnumerationProcess`, and `SignedChallenge`/`Success` removed from the `AuthResultMessage`/`ClaimedClientData` records.

A few **descriptions** were also corrected where the parameter changed meaning, not just name:
- `BlockRequest.cacheDecrEvict` (bool flag) became the `BlockRequestType requestType` enum.
- `FileProcessor.RestoreMetadataAsync` now takes the database rather than a prepared `IDbCommand`.
- `CommandLineArgumentMapper.MapArguments` takes an object instance, not a type.

## Two related broken tags at the same sites

- **`PasswordPrompt.ShowPasswordDialogAsync`** — one of the stale tags was also **malformed XML** (`</param` with the closing bracket missing), and the `<returns>` described "the password, or null if cancelled" for a method that returns `Task<bool>`. Both fixed.
- **`DirectListHandlerTests`** — used `<paramref>` for a parameter of the `cref`'d method rather than of the test method itself, so it didn't resolve (CS1734 case). The prose was correct, so it's retagged to `<c>`.

## Verification

- Build of all affected projects: **0 errors**.
- **Re-ran the scan**: the 35 findings are gone. The three remaining hits are the one already fixed in #7062, plus **two false positives** in `Win32USN.cs` where the scan matched a capitalised name inside a *commented-out* signature — the real parameter (`[In] IntPtr overlapped`) and its doc agree, so those were deliberately left alone.
- Four edits needed line-scoped targeting because a byte-identical but **correct** line exists elsewhere in the same file (`ExtensionMethods.cs`, `VolumeReaderBase.cs`, `pCloudBackend.cs`, `TransportHelper.cs`). Confirmed after the fact that those correct lines are untouched.

## Out of scope

Adding docs for parameters that are simply undocumented (`releaseType`, `packages`, `settings`, `isPrivateKey`, …), and stale `<summary>`/`<returns>` text unrelated to parameter names — those are separate concerns from "tags that point at nothing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
