### PR TITLE
Fix restore-preallocate-size option having no effect

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -1870,7 +1870,7 @@ namespace Duplicati.Library.Main
         /// <summary>
         /// Gets whether to preallocate files during restore
         /// </summary>
-        public bool RestorePreAllocate => GetBool("restore-pre-allocate");
+        public bool RestorePreAllocate => GetBool("restore-preallocate-size");
 
         /// <summary>
         /// Gets whether to handle MacOS Photo Libraries specially

--- a/Duplicati/UnitTest/OptionsTests.cs
+++ b/Duplicati/UnitTest/OptionsTests.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Duplicati.Library.Main;
 using NUnit.Framework;
 
@@ -258,6 +259,52 @@ namespace Duplicati.UnitTest
             });
 
             Assert.That(options.RestoreVolumeCacheMinFree, Is.EqualTo(2L * 1024 * 1024 * 1024));
+        }
+
+        [Test]
+        [Category("Options")]
+        public void RestorePreAllocateDefaultsToFalse()
+        {
+            var options = CreateOptions();
+
+            Assert.That(options.RestorePreAllocate, Is.False);
+        }
+
+        [Test]
+        [Category("Options")]
+        public void RestorePreAllocateReadsTheRegisteredOptionName()
+        {
+            var options = CreateOptions(new Dictionary<string, string?>
+            {
+                { "restore-preallocate-size", "true" }
+            });
+
+            Assert.That(options.RestorePreAllocate, Is.True);
+        }
+
+        [Test]
+        [Category("Options")]
+        public void RestorePreAllocateCanBeDisabledExplicitly()
+        {
+            var options = CreateOptions(new Dictionary<string, string?>
+            {
+                { "restore-preallocate-size", "false" }
+            });
+
+            Assert.That(options.RestorePreAllocate, Is.False);
+        }
+
+        [Test]
+        [Category("Options")]
+        public void RestorePreAllocateOptionIsRegistered()
+        {
+            // Guards against the accessor reading a key that is not a registered option name,
+            // which silently makes the option a no-op.
+            var options = CreateOptions();
+
+            Assert.That(
+                options.SupportedCommands.Any(x => x.Name == "restore-preallocate-size"),
+                Is.True);
         }
     }
 }


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it.** I found this while auditing `Options.cs`, and a search of open and closed issues, PRs and discussions turned up no mention of `restore-preallocate-size`, `restore-pre-allocate` or `RestorePreAllocate`.

The option is registered under one name but read under another:

```csharp
new CommandLineArgument("restore-preallocate-size", ArgumentType.Boolean, ...)   // Options.cs:602
public bool RestorePreAllocate => GetBool("restore-pre-allocate");               // Options.cs:1873
```

Because the two names never matched, **the option cannot be reached from either spelling**:

| What the user types | What happens |
|---|---|
| `--restore-preallocate-size=true` | Silently ignored — the accessor looks up `restore-pre-allocate`, which is never set, so `GetBool` returns `false`. |
| `--restore-pre-allocate=true` | Rejected by the option validation in `Controller.cs` with an *"unsupported option"* warning, because that name isn't registered. |

So the only consumer of the flag — the `fs.SetLength(file.Length)` call in `Operation/Restore/FileProcessor.cs`, which preallocates the file to reduce fragmentation — **has never executed**. The feature looks implemented but is unreachable.

## Fix

Point the accessor at the registered option name (one line).

**No alias is added** for the misspelled key. Duplicati's alias mechanism exists to keep names that *used to work* working (`dry-run`/`dryrun` and friends); `restore-pre-allocate` never worked, so nothing can depend on it, and adding it would only widen the public surface.

## Origin

The mismatch has been there since the option was introduced in [`76240550ed34`](https://github.com/duplicati/duplicati/commit/76240550ed34607ad571d8651552f82553e50b65) (#5728, the restore rewrite) — it is **not** the result of a later rename; both halves were added in that one commit, already inconsistent. The `restore-legacy` option added on the *adjacent line* of the same commit is wired correctly, so this was an isolated typo that slipped through a 144-commit PR without being reviewed on its own.

## Testing

Regression tests added to `OptionsTests`:
- default is `false`
- **`restore-preallocate-size=true` yields `true`** — this test **fails before this change** (`Expected: True, But was: False`) and passes after it
- explicit `false` yields `false`
- `restore-preallocate-size` is a registered option name — guards against an accessor drifting away from its registration again, which is exactly the failure mode here

Full `Options` category passes. I also swept `Options.cs`, comparing all registered option names against every key read by the accessors: after this change there is **no other mismatch** (the other keys that looked unregistered are all legitimate — registered aliases, a commented-out accessor, and one internal-only key).

## Note on scope

Related to #3733 ("Large file restore causes large fragmentation and unnecessary IO"), which appears to be the motivation for the option — `ts678` twice raised preallocating the file to its final size there, and it's still open. This PR does **not** claim to resolve that issue; it only makes the existing option actually work, so the idea can finally be evaluated in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

