### PR TITLE
Fix options declared as Integer that are not integers

### DIFF
--- a/Duplicati/Library/Backend/SSHv2/KeyGenerator.cs
+++ b/Duplicati/Library/Backend/SSHv2/KeyGenerator.cs
@@ -209,7 +209,7 @@ namespace Duplicati.Library.Backend
         public IList<ICommandLineArgument> SupportedCommands => [
             new CommandLineArgument(KEY_KEYLEN, CommandLineArgument.ArgumentType.Integer, Strings.KeyGenerator.KeyLenShort, Strings.KeyGenerator.KeyLenLong, DEFAULT_KEYLEN.ToString(), null, new string[] {"1024", "2048"}),
             new CommandLineArgument(KEY_TYPE_NAME, CommandLineArgument.ArgumentType.Enumeration, Strings.KeyGenerator.KeyTypeShort, Strings.KeyGenerator.KeyTypeLong, DEFAULT_KEYTYPE, null, new string[] {KEYTYPE_DSA, KEYTYPE_RSA}),
-            new CommandLineArgument(KEY_USERNAME, CommandLineArgument.ArgumentType.Integer, Strings.KeyGenerator.KeyUsernameShort, Strings.KeyGenerator.KeyUsernameLong, DEFAULT_USERNAME),
+            new CommandLineArgument(KEY_USERNAME, CommandLineArgument.ArgumentType.String, Strings.KeyGenerator.KeyUsernameShort, Strings.KeyGenerator.KeyUsernameLong, DEFAULT_USERNAME),
         ];
 
         public IDictionary<string, IDictionary<string, string?>> GetLookups()

--- a/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
@@ -246,7 +246,7 @@ namespace Duplicati.Library.Modules.Builtin
             new CommandLineArgument(OPTION_IGNORE_REVOCATION_FAILURE, CommandLineArgument.ArgumentType.Boolean, Strings.SendHttpMessage.IgnoreRevocationFailureShort, Strings.SendHttpMessage.IgnoreRevocationFailureLong, "false"),
 
             new CommandLineArgument(OPTION_SEND_HTTP_RETRIES, CommandLineArgument.ArgumentType.Integer, Strings.SendHttpMessage.SendHttpRetriesShort, Strings.SendHttpMessage.SendHttpRetriesLong, DEFAULT_RETRIES.ToString()),
-            new CommandLineArgument(OPTION_SEND_HTTP_RETRY_DELAY, CommandLineArgument.ArgumentType.Integer, Strings.SendHttpMessage.SendHttpRetryDelayShort, Strings.SendHttpMessage.SendHttpRetryDelayLong, DEFAULT_RETRY_DELAY),
+            new CommandLineArgument(OPTION_SEND_HTTP_RETRY_DELAY, CommandLineArgument.ArgumentType.Timespan, Strings.SendHttpMessage.SendHttpRetryDelayShort, Strings.SendHttpMessage.SendHttpRetryDelayLong, DEFAULT_RETRY_DELAY),
         ];
 
         protected override string SubjectOptionName => OPTION_MESSAGE;

--- a/Duplicati/UnitTest/ModuleOptionTypeTests.cs
+++ b/Duplicati/UnitTest/ModuleOptionTypeTests.cs
@@ -1,0 +1,100 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
+using Duplicati.Library.DynamicLoader;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Verifies that module options are declared with an <see cref="CommandLineArgument.ArgumentType"/>
+    /// matching the values they actually accept. A wrong type is not just cosmetic: the option
+    /// validator rejects otherwise valid values, and the web UI renders the wrong editor for them.
+    /// Only metadata is read, so no external programs are required.
+    /// </summary>
+    public class ModuleOptionTypeTests : BasicSetupHelper
+    {
+        private static ICommandLineArgument GetWebModuleOption(string moduleKey, string optionName)
+        {
+            var module = WebLoader.Modules.FirstOrDefault(x => x.Key == moduleKey);
+            Assert.IsNotNull(module, $"The web module {moduleKey} should be registered");
+
+            var option = module!.SupportedCommands?.FirstOrDefault(x => x.Name == optionName);
+            Assert.IsNotNull(option, $"The module {moduleKey} should support the option {optionName}");
+            return option!;
+        }
+
+        private static ICommandLineArgument GetGenericModuleOption(string moduleKey, string optionName)
+        {
+            var module = GenericLoader.Modules.FirstOrDefault(x => x.Key == moduleKey);
+            Assert.IsNotNull(module, $"The generic module {moduleKey} should be registered");
+
+            var option = module!.SupportedCommands?.FirstOrDefault(x => x.Name == optionName);
+            Assert.IsNotNull(option, $"The module {moduleKey} should support the option {optionName}");
+            return option!;
+        }
+
+        [Test]
+        [Category("ModuleOptionType")]
+        public static void SshKeygenUsernameIsAStringOption()
+        {
+            // The value is a username appended to the public key, defaulting to
+            // "backup-user@<machinename>", so it must not be declared as an integer.
+            var option = GetWebModuleOption("ssh-keygen", "key-username");
+
+            Assert.AreEqual(CommandLineArgument.ArgumentType.String, option.Type);
+        }
+
+        [Test]
+        [Category("ModuleOptionType")]
+        public static void SshKeygenKeyLengthRemainsAnIntegerOption()
+        {
+            // Guards the neighbouring option, which is genuinely an integer.
+            var option = GetWebModuleOption("ssh-keygen", "key-bits");
+
+            Assert.AreEqual(CommandLineArgument.ArgumentType.Integer, option.Type);
+        }
+
+        [Test]
+        [Category("ModuleOptionType")]
+        public static void SendHttpRetryDelayIsATimespanOption()
+        {
+            // The value is parsed with ParseTimespanOption and defaults to "1s",
+            // so it must not be declared as an integer.
+            var option = GetGenericModuleOption("sendhttp", "send-http-retry-delay");
+
+            Assert.AreEqual(CommandLineArgument.ArgumentType.Timespan, option.Type);
+        }
+
+        [Test]
+        [Category("ModuleOptionType")]
+        public static void SendHttpRetriesRemainsAnIntegerOption()
+        {
+            // Guards the neighbouring option, which is genuinely an integer.
+            var option = GetGenericModuleOption("sendhttp", "send-http-retries");
+
+            Assert.AreEqual(CommandLineArgument.ArgumentType.Integer, option.Type);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it.** I found these while sweeping option registrations, and a search of open and closed issues, PRs and discussions turned up no mention of either option.

Two options are registered as `ArgumentType.Integer` although they accept non-integer values:

| Option | Declared | Actually | Evidence |
|---|---|---|---|
| `ssh-keygen` → `key-username` | `Integer` | **String** | Defaults to `"backup-user@" + MachineName`; described as *"A username to append to the public key"*; consumed as a string |
| `sendhttp` → `send-http-retry-delay` | `Integer` | **Timespan** | Defaults to `"1s"`; parsed with `ParseTimespanOption`; described as *"the delay between retries"* |

The declared type is metadata, so key generation and the retry delay still *behave* correctly — but the wrong type has two visible effects:

1. **The validator warns on correct input.** `CommandLineArgumentValidator` runs `long.TryParse` on `Integer` options and warns `The value "{1}" supplied to --{0} does not represent a valid integer`. Since neither option can ever hold an integer, the warning appears *precisely when the user supplies a valid value* like `user@host` or `5s`.
2. **The web UI mangles the value.** Both options are exposed in the UI, which maps `Integer` to a numeric editor (`advancedOptionsEditor.js`) and runs `parseInt()` on the value (`parseAdvancedOption.js`), so `backup-user@host` becomes `NaN`.

## Fix

Declare `key-username` as `String` and `send-http-retry-delay` as `Timespan`, matching how the values are actually parsed. One word each.

**These are isolated typos, not a convention:** in both cases the *adjacent* option in the same list is a genuine integer and is already correct (`key-bits`, `send-http-retries`), and the core `retry-delay` option is registered as `Timespan`.

## Origin

`key-username` has been wrong since [`421cba6f711e`](https://github.com/duplicati/duplicati/commit/421cba6f711ef94de4c78f94d4bf2443e5da3a04) (2014-03-12), the commit that added all three `ssh-keygen` options at once — it was never correct, most likely copied from the `key-bits` line directly above it. None of the later commits to that file touched the argument types, so it has stood for 12 years.

## Testing

New `ModuleOptionTypeTests` (metadata only, no external programs):
- `key-username` is `String` and `send-http-retry-delay` is `Timespan` — **both fail before this change** (`Expected: String, But was: Integer`) and pass after it
- `key-bits` and `send-http-retries` are still `Integer` — pins the neighbouring options so a future edit cannot swap them by accident

I also swept **every** `CommandLineArgument` registration in the repository, comparing the declared type against the default value it is given (resolving symbolic constants): after this change there is **no other mismatch**. One further candidate, `restore-volume-cache-hint` (`Size` with an empty default), was deliberately left alone — the validator only runs on user-supplied values, so an empty default is harmless.

Note: the `parseInt` → `NaN` behaviour above is read from the UI source; I have not exercised it in a running browser.

## Related precedent

Same class of fix as **#6662** (an option typed `Boolean` that was really a log name, *"caused a warning in the log that the option was incorrectly parsed"*), and #6980 / #5644 / #5343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

