### PR TITLE
Fix broken date-time format strings

### DIFF
--- a/Duplicati/CommandLine/DatabaseTool/Helper.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Helper.cs
@@ -27,7 +27,7 @@ public static class Helper
         var dir = Path.GetDirectoryName(path) ?? "";
         var filename = Path.GetFileNameWithoutExtension(path);
 
-        var newname = $"{filename}-{DateTime.Now:yyyMMddhhmmss}.bak";
+        var newname = $"{filename}-{DateTime.Now:yyyyMMddHHmmss}.bak";
         var backup = Path.Combine(dir, newname);
         var retry = 0;
         while (File.Exists(backup))
@@ -36,7 +36,7 @@ public static class Helper
                 throw new IOException($"Cannot create backup file {backup} - too many retries");
 
             retry++;
-            newname = $"{filename}-{DateTime.Now:yyyMMddhhmmss}-{retry}.bak";
+            newname = $"{filename}-{DateTime.Now:yyyyMMddHHmmss}-{retry}.bak";
             backup = Path.Combine(dir, newname);
         }
 

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -79,10 +79,6 @@ namespace Duplicati.Library.AutoUpdater
         public static event Action<Exception>? OnError;
 
         /// <summary>
-        /// Common formatting string for date-time values
-        /// </summary>
-        private const string DATETIME_FORMAT = "yyyymmddhhMMss";
-        /// <summary>
         /// The template for the environment variable that toggles disabling updates
         /// </summary>
         public const string SKIPUPDATE_ENVNAME_TEMPLATE = "AUTOUPDATER_{0}_SKIP_UPDATE";

--- a/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
+++ b/Duplicati/Library/SQLiteHelper/DatabaseUpgrader.cs
@@ -265,7 +265,7 @@ namespace Duplicati.Library.SQLiteHelper
                     {
                         backupfile = System.IO.Path.Combine(
                             System.IO.Path.GetDirectoryName(sourcefile),
-                            Strings.DatabaseUpgrader.BackupFilenamePrefix + " " + System.IO.Path.GetFileNameWithoutExtension(sourcefile) + " " + (DateTime.Now + TimeSpan.FromSeconds(i * 1.5)).ToString("yyyyMMddhhmmss", System.Globalization.CultureInfo.InvariantCulture) + ".sqlite");
+                            Strings.DatabaseUpgrader.BackupFilenamePrefix + " " + System.IO.Path.GetFileNameWithoutExtension(sourcefile) + " " + (DateTime.Now + TimeSpan.FromSeconds(i * 1.5)).ToString("yyyyMMddHHmmss", System.Globalization.CultureInfo.InvariantCulture) + ".sqlite");
 
                         if (!System.IO.File.Exists(backupfile))
                             break;

--- a/Duplicati/UnitTest/DatabaseToolTests.cs
+++ b/Duplicati/UnitTest/DatabaseToolTests.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -53,6 +54,55 @@ namespace Duplicati.UnitTest
             Assert.AreEqual(0, await Program.MainAsync(["list", dbfile, "RemoteVolume"]));
             Assert.AreEqual(0, await Program.MainAsync(["list", dbfile, "RemoteVolume", "--output-json"]));
             Assert.AreEqual(0, await Program.MainAsync(["execute", dbfile, "SELECT * FROM RemoteVolume", "--output-json"]));
+        }
+
+        /// <summary>
+        /// The backup taken before an upgrade must carry an unambiguous timestamp.
+        /// The format string used to specify <c>hh</c> (12-hour clock) without an
+        /// AM/PM designator, so a backup taken at 13:30 was named as if it had been
+        /// taken at 01:30 and collided with one taken in the morning.
+        ///
+        /// Note that the 12/24-hour part of this test only discriminates when the
+        /// local time is 13:00 or later; before noon the two formats agree. It never
+        /// fails spuriously, and a month/minute mix-up is caught at any time of day.
+        /// </summary>
+        [Test]
+        [Category("DatabaseTool")]
+        public async Task UpgradeBackupFileNameUsesUnambiguousTimestampAsync()
+        {
+            using var dbfile = new TempFile();
+            using (var db = await SQLiteLoader.LoadConnectionAsync(dbfile))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            var folder = Path.GetDirectoryName(Path.GetFullPath(dbfile))!;
+            var prefix = Path.GetFileNameWithoutExtension(dbfile) + "-";
+
+            // Deliberately omit --no-backups so that Helper.CreateFileBackup runs.
+            var before = DateTime.Now;
+            Assert.AreEqual(0, await Program.MainAsync(["upgrade", dbfile]));
+            var after = DateTime.Now;
+
+            var backups = Directory.GetFiles(folder, prefix + "*.bak");
+            Assert.AreEqual(1, backups.Length, "The upgrade should have created exactly one backup file.");
+
+            try
+            {
+                var stamp = Path.GetFileNameWithoutExtension(backups[0]).Substring(prefix.Length);
+                Assert.IsTrue(
+                    DateTime.TryParseExact(stamp, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed),
+                    $"The backup timestamp \"{stamp}\" is not a valid yyyyMMddHHmmss value.");
+
+                Assert.IsTrue(parsed >= before.AddSeconds(-5) && parsed <= after.AddSeconds(5),
+                    $"The backup timestamp \"{stamp}\" does not match the time the backup was taken ({before:yyyyMMddHHmmss}).");
+            }
+            finally
+            {
+                File.Delete(backups[0]);
+            }
         }
 
         [Test]

--- a/Duplicati/UnitTest/DatabaseUpgraderTests.cs
+++ b/Duplicati/UnitTest/DatabaseUpgraderTests.cs
@@ -20,6 +20,9 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Duplicati.Library.Main.Database.Local;
 using Duplicati.Library.SQLiteHelper;
@@ -136,6 +139,78 @@ namespace Duplicati.UnitTest
                 Assert.IsTrue(await ColumnExistsAsync(db, "Metadataset", "Content"),
                     "The Metadataset.Content column (added by the final upgrade script) should exist after the upgrade.");
             }
+        }
+
+        /// <summary>
+        /// The backup taken before the numbered upgrade scripts run must carry an
+        /// unambiguous timestamp. The format string used to specify <c>hh</c> (12-hour
+        /// clock) without an AM/PM designator, so a backup taken at 13:30 was named as
+        /// if it had been taken at 01:30 and collided with one taken in the morning,
+        /// forcing the surrounding retry loop to shift the timestamp for no reason.
+        ///
+        /// Note that the 12/24-hour part of this test only discriminates when the local
+        /// time is 13:00 or later; before noon the two formats agree. It never fails
+        /// spuriously, and a month/minute mix-up is caught at any time of day.
+        /// </summary>
+        [Test]
+        public async Task UpgradeDatabase_BackupFileName_UsesUnambiguousTimestampAsync()
+        {
+            using var dbfile = new TempFile();
+            await RewindToPreviousVersionAsync(dbfile);
+
+            var folder = Path.GetDirectoryName(Path.GetFullPath(dbfile))!;
+            var name = Path.GetFileNameWithoutExtension(dbfile);
+
+            var before = DateTime.Now;
+            using (var db = await SQLiteLoader.LoadConnectionAsync(dbfile))
+                DatabaseUpgrader.UpgradeDatabase(db, dbfile, typeof(DatabaseSchemaMarker));
+            var after = DateTime.Now;
+
+            // The backup is named "<prefix> <database name> <timestamp>.sqlite". Match on
+            // the database name so the test does not depend on the prefix, which is a
+            // localized string internal to Duplicati.Library.SQLiteHelper.
+            var backups = Directory.GetFiles(folder, "* " + name + " *.sqlite");
+            Assert.AreEqual(1, backups.Length, "The upgrade should have created exactly one backup file.");
+
+            try
+            {
+                var stamp = Path.GetFileNameWithoutExtension(backups[0]).Split(' ').Last();
+                Assert.IsTrue(
+                    DateTime.TryParseExact(stamp, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed),
+                    $"The backup timestamp \"{stamp}\" is not a valid yyyyMMddHHmmss value.");
+
+                // The upgrader may add up to 15 seconds to dodge a name collision.
+                Assert.IsTrue(parsed >= before.AddSeconds(-5) && parsed <= after.AddSeconds(20),
+                    $"The backup timestamp \"{stamp}\" does not match the time the backup was taken ({before:yyyyMMddHHmmss}).");
+            }
+            finally
+            {
+                File.Delete(backups[0]);
+            }
+        }
+
+        /// <summary>
+        /// Brings the database to the latest schema and then rewinds it to the previous
+        /// version, so that the upgrader has exactly one outstanding upgrade script to
+        /// apply. This mirrors the setup used by
+        /// <see cref="UpgradeDatabase_OnOldVersion_AppliesNumberedUpgradeScriptsAsync"/>.
+        /// </summary>
+        private static async Task RewindToPreviousVersionAsync(string dbfile)
+        {
+            using var db = await SQLiteLoader.LoadConnectionAsync(dbfile);
+            using var cmd = db.CreateCommand();
+
+            DatabaseUpgrader.UpgradeDatabase(db, dbfile, typeof(DatabaseSchemaMarker));
+
+            // Drop the column the most recent upgrade script introduces, so that
+            // re-applying that script is valid.
+            cmd.CommandText = @"ALTER TABLE ""Metadataset"" DROP COLUMN ""Content""";
+            await cmd.ExecuteNonQueryAsync();
+
+            cmd.CommandText = @"UPDATE ""Version"" SET ""Version"" = @ver";
+            cmd.Parameters.AddWithValue("@ver", EXPECTED_LATEST_SCHEMA_VERSION - 1);
+            await cmd.ExecuteNonQueryAsync();
+            await db.CloseAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it.** I found these while sweeping the repository for malformed date-time format strings; searching open and closed issues, PRs and discussions turned up no mention of any of them.

In a .NET custom date-time format string, `MM` is the month and `mm` is the minute; `HH` is the 24-hour clock and `hh` is the 12-hour clock. Three places got this wrong.

| Where | Format | Problem |
|---|---|---|
| `UpdaterManager.DATETIME_FORMAT` | `yyyymmddhhMMss` | minute in the month position, month in the minute position, **and** 12-hour clock — unused |
| `DatabaseUpgrader` backup name | `yyyyMMddhhmmss` | 12-hour clock |
| `DatabaseTool` `.bak` name (×2) | `yyyMMddhhmmss` | 12-hour clock, plus a three-`y` year |

### 1. `UpdaterManager.DATETIME_FORMAT` — removed

It is `private` and has **no remaining references** anywhere in the repository, so it is deleted rather than corrected.

It was introduced already malformed in [`671548bd9646`](https://github.com/duplicati/duplicati/commit/671548bd964693813ab66b40c52137acfdc4f7d1) (2014-06-26). It did briefly name the folder that updates were installed into, but that was replaced with version-numbered folders ten days later in [`4dab922c85be`](https://github.com/duplicati/duplicati/commit/4dab922c85be8ff18fe1fc99b5b9b599bf6f3f58), so I do not think any user ever saw a mangled folder name. The last remaining use — a probe file name — was removed in [`27f0bb4ea093`](https://github.com/duplicati/duplicati/commit/27f0bb4ea093a99594b712241adcaada6d2ace9a) (2025-01-27), leaving the constant dead.

Nothing warns about this: C# does not report unused `private const` (`CS0414` covers *fields*, and `IDE0051` is IDE-only), and the repository has no `Directory.Build.props`, no analyzer settings and no `TreatWarningsAsErrors`.

### 2–3. The two live `hh` uses

Both name a backup file taken before a potentially destructive operation:

- `DatabaseUpgrader` — the `.sqlite` copied before the numbered upgrade scripts run.
- `DatabaseTool`'s `Helper.CreateFileBackup` — the `.bak` taken before `upgrade`, `downgrade` or `execute`.

`hh` drops the AM/PM distinction, so a backup taken at 13:30 is named as if it had been taken at 01:30. **Neither can lose data** — both retry on a name collision (`i * 1.5` second offset, and a `-{retry}` suffix respectively) — but the collision is needless and the recorded time is misleading. Both now use `HH`.

The `yyy` in the DatabaseTool format is a separate typo; it happens to render identically to `yyyy`, so fixing it changes no output.

## Testing

A regression test for each of the two live paths, asserting that the generated backup name parses as `yyyyMMddHHmmss` and matches the time the backup was actually taken. **Both fail before this change and pass after it:**

```
The backup timestamp "20260719100340" does not match the time the backup was taken (20260719220339).
```

Worth stating plainly: the 12/24-hour half of these tests **only discriminates when the local time is 13:00 or later**, because `hh` and `HH` agree before noon. They never fail spuriously, and a month/minute mix-up — the `DATETIME_FORMAT` class of error — is caught at any time of day. I ran them at 22:00 local, which is why they went red above.

The `DatabaseTool` test also fills a small gap: every existing test of that command passes `--no-backups`, so `CreateFileBackup` was not covered at all.

`TestCategory=Database|TestCategory=DatabaseTool`: 28/28 pass.

## Scope

I swept the whole repository and found **no other malformed date-time format strings**. `TimeSpan` format strings, where `hh` and `mm` are correct, were excluded as false positives, as was `HH:mm:ss` in the JavaScript.

## Note on overlap

#7063 (open) also touches `Duplicati/CommandLine/DatabaseTool/Helper.cs`, but only the `<param>` tag on line 23; this PR changes lines 30 and 39. The hunks do not overlap, so the two should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
