### PR TITLE
Remove unused declarations and stale doc parameters

### DIFF
--- a/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
@@ -34,11 +34,6 @@ namespace Duplicati.Library.AutoUpdater;
 public static class DataFolderLocator
 {
     /// <summary>
-    /// The log tag for this class
-    /// </summary>
-    private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(DataFolderLocator));
-
-    /// <summary>
     /// Finds a default storage folder, using the operating system specific locations.
     /// The targetfilename is used to detect locations that are used in previous versions.
     /// If the targetfilename is found in an old location, but not the current, the old location is used.

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -36,7 +36,6 @@ namespace Duplicati.Library.Backend.Box
     public class BoxBackend : IStreamingBackend, IRenameEnabledBackend, IFolderEnabledBackend
     {
         private static readonly string TOKEN_URL = AuthIdOptionsHelper.GetOAuthLoginUrl("box.com", null);
-        private const string AUTHID_OPTION = "authid";
         private const string REALLY_DELETE_OPTION = "box-delete-from-trash";
 
         private const string BOX_API_URL = "https://api.box.com/2.0";

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -30,8 +30,6 @@ namespace Duplicati.Library.Backend
 {
     public class S3 : IBackend, IStreamingBackend, IRenameEnabledBackend, IFolderEnabledBackend, ILockingBackend
     {
-        private static readonly string LOGTAG = Logging.Log.LogTagFromType<S3>();
-
         private const string AUTH_USERNAME_OPTION = "aws-access-key-id";
         private const string AUTH_PASSWORD_OPTION = "aws-secret-access-key";
 

--- a/Duplicati/Library/Main/Operation/Restore/DeadlockTimer.cs
+++ b/Duplicati/Library/Main/Operation/Restore/DeadlockTimer.cs
@@ -45,12 +45,6 @@ namespace Duplicati.Library.Main.Operation.Restore
     internal class DeadlockTimer
     {
         /// <summary>
-        /// The log tag for this class.
-        /// </summary>
-        private static readonly string LOGTAG =
-            Logging.Log.LogTagFromType<DeadlockTimer>();
-
-        /// <summary>
         /// Initial threshold (in milliseconds) for detecting deadlocks.
         /// </summary>
         public static int initial_threshold =

--- a/Duplicati/Library/Snapshots/MacOS/MacOSPhotosLibraryEntry.cs
+++ b/Duplicati/Library/Snapshots/MacOS/MacOSPhotosLibraryEntry.cs
@@ -30,15 +30,12 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Interface;
-using Duplicati.Library.Logging;
 
 namespace Duplicati.Library.Snapshots.MacOS;
 
 [SupportedOSPlatform("macOS")]
 internal sealed class MacOSPhotosLibraryEntry : ISourceProviderEntry
 {
-    private static readonly string LOGTAG = Log.LogTagFromType<MacOSPhotosLibraryEntry>();
-
     private readonly ISourceProviderEntry inner;
     private readonly MacOSPhotosLibrary photosLibrary;
     private readonly SemaphoreSlim cacheLock = new(1, 1);

--- a/Duplicati/Library/Utility/FilterGroups.cs
+++ b/Duplicati/Library/Utility/FilterGroups.cs
@@ -120,16 +120,6 @@ namespace Duplicati.Library.Utility
             };
 
         /// <summary>
-        /// Regex escaped string for the AltDirectorySeparatorChar
-        /// </summary>
-        private static readonly string RegexEscapedAltDirectorySeparatorChar = System.Text.RegularExpressions.Regex.Escape(Common.IO.Util.AltDirectorySeparatorString);
-
-        /// <summary>
-        /// Regex escaped string for the DirectorySeparatorChar
-        /// </summary>
-        private static readonly string RegexEscapedDirectorySeparatorChar = System.Text.RegularExpressions.Regex.Escape(Common.IO.Util.DirectorySeparatorString);
-
-        /// <summary>
         /// Gets the list of alternate aliases which can refer to this group.
         /// </summary>
         /// <param name="group">Filter group</param>

--- a/Tools/AutoTune/Program.cs
+++ b/Tools/AutoTune/Program.cs
@@ -420,10 +420,6 @@ public class Program
     /// Core tuning loop for restore performance. Measures a baseline, then iteratively adjusts
     /// concurrency parameters to find the fastest configuration.
     /// </summary>
-    /// <param name="source">Path to the source folder to back up.</param>
-    /// <param name="destination">Backup destination URI (e.g. file:///tmp/backup).</param>
-    /// <param name="restoretarget">Path where restores are performed during measurement.</param>
-    /// <param name="tempfolder">Path for temporary files such as the database.</param>
     /// <param name="cfg">User-supplied tuning options.</param>
     /// <param name="options">Parsed Duplicati key-value options passed to the controller.</param>
     /// <returns>A process exit code: 0 on success, -1 on error.</returns>


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for any of it.**

Everything here is a declaration or a documentation tag that refers to something which **no longer exists or was never used**. Pure deletion, 31 lines, no behavior change.

### 1. Stale `<param>` tags in AutoTune

`RunCoreAsync` documents `source`, `destination`, `restoretarget` and `tempfolder`, but those four were folded into the `ConfigAutoTune` parameter — the signature is `(cfg, options)`, and both of those are already documented on the next two lines.

This one is **a miss on my part in #7063**: it was in that audit's output and I simply left it out of the PR, while mentioning the two `Win32USN.cs` false positives in the same run. Correcting it here.

### 2. Six never-referenced private members

Found by extending the sweep that turned up `DATETIME_FORMAT` in #7067: all 1143 `private const` / `private static readonly` declarations in the repository, keeping those whose identifier appears exactly once repo-wide.

| Member | Note |
|---|---|
| `Box.AUTHID_OPTION` | The `authid` option is still registered — via `AuthIdOptionsHelper.GetOptions()`. Only the constant is left over. |
| `FilterGroups.RegexEscapedDirectorySeparatorChar` (+ `Alt` variant) | |
| `LOGTAG` in `DataFolderLocator`, `S3`, `DeadlockTimer`, `MacOSPhotosLibraryEntry` | See below |

An unused `LOGTAG` can mean two very different things, so I checked each against the history to confirm it is residue and not a sign that logging went missing:

- **`DataFolderLocator`** — the last use moved to `DataFolderManager` in [`a7ef8e42f275`](https://github.com/duplicati/duplicati/commit/a7ef8e42f2759edb149288eb1673172eb6aecabc) (*Lock permissions on datafolder*), where the same `FailedToSetPermissions` warning is still emitted under that class's own tag. Nothing was lost.
- **`S3`** — the last use was a deprecation warning **deliberately** retired in [`b11c558ba2cb`](https://github.com/duplicati/duplicati/commit/b11c558ba2cb67e2f20c487c067e0a6d47b6ba76) (*Removed options that have been deprecated for years.*).
- **`DeadlockTimer`** — never used, from its creating commit [`4e5d015e0cce`](https://github.com/duplicati/duplicati/commit/4e5d015e0cce2691ac44cfef8ef85dd1a290fc01) onward. It is a stateless data holder; the corresponding deadlock warning already lives in `BlockManager`, which has the context to emit it.
- **`MacOSPhotosLibraryEntry`** — never used, from its creating commit [`3b695cf065f2`](https://github.com/duplicati/duplicati/commit/3b695cf065f2800bcff0e31fc43cc56cdac6e4aa) onward. Its `using Duplicati.Library.Logging;` existed solely for that field and is removed with it.

## Deliberately **not** included

**`LiveControls` also has an unused `LOGTAG`, and I left it alone on purpose.** [`ff1b2b7990c0`](https://github.com/duplicati/duplicati/commit/ff1b2b7990c0c96fe2b7fd44d7e6271f6d8bee63) (*Simplified task control (#5753)*) removed its two `WriteErrorMessage` calls:

```
- Log.WriteErrorMessage(LOGTAG, "ParseUploadLimitError", ex, "Failed to parse upload limit: {0}", ...);
- Log.WriteErrorMessage(LOGTAG, "ParseDownloadLimitError", ex, "Failed to parse download limit: {0}", ...);
```

Speed-limit parsing moved to `Runner.UpdateThrottleSpeedsAsync`, but the destination's `catch { }` blocks were already silent, so the messages were simply dropped. Since then a malformed `UploadSpeedLimit`/`DownloadSpeedLimit` appears to be **silently ignored**, and `LiveControls` has three more silent `catch { }` on user-supplied settings (lines 182, 238, 431). Deleting the tag would cement that; restoring the logging is a behavior change and deserves its own PR. **Happy to open one if you'd like it** — I did not want to smuggle a behavioral fix into a deletion-only PR.

Also excluded: five unused constants under `proprietary/DiskImage/` (`ATTR_FILE_NAME`, `ENTRY_CREATION_DATE_OFFSET`, …). Those document NTFS/FAT32 on-disk layout and arguably earn their keep as a spec reference.

## Why a compiler doesn't catch these

Unused `private const` is not reported: `CS0414` covers *fields*, and `IDE0051` is IDE-only. The repository has no `Directory.Build.props`, no analyzer configuration and no `TreatWarningsAsErrors`, so nothing flags them during a build.

## Verification

- Builds with **0 errors**: `Duplicati.UnitTest` (covers Main/Utility/AutoUpdater/Snapshots), plus `Backend.Box`, `Backend.S3` and `AutoTune` explicitly, since the backends are loaded dynamically and are not referenced by the test project. A clean build is itself the proof that nothing referenced these.
- Both sweeps re-run afterwards: stale `<param>` **3 → 2** (only the two known `Win32USN.cs` false positives remain), unused private members **7 → 1** in the non-proprietary tree (`DATETIME_FORMAT`, which is #7067).
- No tests added: there is no behavior to pin.
- `FullyQualifiedName~Filter|~Snapshot` (25 tests): 20 pass, 5 fail locally, and the identical 5 fail on unmodified master — **but this is a stale-artifact problem in my own working copy, not anything wrong with master.** They throw `TypeLoadException: Could not load type 'Duplicati.Library.Interface.IParity'`, and my checkout has pre-`IParity` copies of `Duplicati.Library.Interface.dll` in the consumer `bin` folders. `IParity` is present in the source, master's own CI is green, and this PR's Integration/Playwright jobs pass. Noting it only so the local numbers above are not misread — there is nothing here for you to act on.

## Related precedent

Same class of change as the 49 merged "remove unused" PRs (#6547, #6106, #5833, #3908, …), and a direct follow-on from #7062 / #7063 / #7064 / #7067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
