### PR TITLE
Log errors when user-supplied settings fail to parse

### DIFF
--- a/Duplicati/Library/RestAPI/LiveControls.cs
+++ b/Duplicati/Library/RestAPI/LiveControls.cs
@@ -179,7 +179,7 @@ namespace Duplicati.Server
             {
                 var startupDelay = new TimeSpan(0);
                 try { startupDelay = Library.Utility.Timeparser.ParseTimeSpan(settings.StartupDelayDuration); }
-                catch { }
+                catch (Exception ex) { Library.Logging.Log.WriteWarningMessage(LOGTAG, "ParseStartupDelayError", ex, "Failed to parse startup delay, continuing without it: {0}", settings.StartupDelayDuration); }
 
                 if (startupDelay.Ticks > 0)
                 {
@@ -235,7 +235,10 @@ namespace Duplicati.Server
                     m_powerModeProvider.OnSuspend = OnSuspend;
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Library.Logging.Log.WriteWarningMessage(LOGTAG, "PowerModeProviderError", ex, "Failed to set up the power mode provider, suspend and resume events will not be handled: {0}", ex.Message);
+            }
         }
 
         /// <summary>
@@ -428,7 +431,7 @@ namespace Duplicati.Server
                 var appset = m_connection.ApplicationSettings;
                 if (!string.IsNullOrEmpty(appset.StartupDelayDuration) && appset.StartupDelayDuration != "0")
                     try { delayTicks = Math.Max(delayTicks, Library.Utility.Timeparser.ParseTimeSpan(appset.StartupDelayDuration).Ticks); }
-                    catch { }
+                    catch (Exception ex) { Library.Logging.Log.WriteWarningMessage(LOGTAG, "ParseStartupDelayError", ex, "Failed to parse startup delay, continuing without it: {0}", appset.StartupDelayDuration); }
 
                 if (delayTicks > 0)
                 {

--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -42,6 +42,11 @@ namespace Duplicati.Server
 {
     public static class Runner
     {
+        /// <summary>
+        /// The tag used for logging
+        /// </summary>
+        private static readonly string LOGTAG = Library.Logging.Log.LogTagFromType(typeof(Runner));
+
         public const string TaskSetupFilename = "task-setup.json";
 
         public interface IRunnerData : Serialization.Interface.IQueuedTask
@@ -140,14 +145,20 @@ namespace Duplicati.Server
                     if (!string.IsNullOrWhiteSpace(uploadSpeed))
                         server_upload_throttle = Sizeparser.ParseSize(uploadSpeed, "kb");
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Library.Logging.Log.WriteErrorMessage(LOGTAG, "ParseUploadLimitError", ex, "Failed to parse upload limit: {0}", uploadSpeed);
+                }
 
                 try
                 {
                     if (!string.IsNullOrWhiteSpace(downloadSpeed))
                         server_download_throttle = Sizeparser.ParseSize(downloadSpeed, "kb");
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Library.Logging.Log.WriteErrorMessage(LOGTAG, "ParseDownloadLimitError", ex, "Failed to parse download limit: {0}", downloadSpeed);
+                }
 
                 var upload_throttle = Math.Min(job_upload_throttle, server_upload_throttle);
                 var download_throttle = Math.Min(job_download_throttle, server_download_throttle);
@@ -833,14 +844,20 @@ namespace Duplicati.Server
                         if (options.ContainsKey("throttle-upload"))
                             ((RunnerData)data).OriginalUploadSpeed = Duplicati.Library.Utility.Sizeparser.ParseSize(options["throttle-upload"], "kb");
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Library.Logging.Log.WriteWarningMessage(LOGTAG, "ParseUploadThrottleError", ex, "Failed to parse throttle-upload, continuing without it: {0}", options["throttle-upload"]);
+                    }
 
                     try
                     {
                         if (options.ContainsKey("throttle-download"))
                             ((RunnerData)data).OriginalDownloadSpeed = Duplicati.Library.Utility.Sizeparser.ParseSize(options["throttle-download"], "kb");
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Library.Logging.Log.WriteWarningMessage(LOGTAG, "ParseDownloadThrottleError", ex, "Failed to parse throttle-download, continuing without it: {0}", options["throttle-download"]);
+                    }
 
                     ((RunnerData)data).Controller = controller;
                     var appSettings = databaseConnection.ApplicationSettings;

--- a/Duplicati/UnitTest/LiveControlsLoggingTests.cs
+++ b/Duplicati/UnitTest/LiveControlsLoggingTests.cs
@@ -1,0 +1,108 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.AutoUpdater;
+using Duplicati.Library.Logging;
+using Duplicati.Library.SQLiteHelper;
+using Duplicati.Server.Database;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// A malformed value in the server settings is ignored by design, but it must not be
+    /// ignored <em>silently</em>: the user has to be able to find out from the log why the
+    /// setting they typed had no effect.
+    /// </summary>
+    [TestFixture]
+    [Category("LiveControls")]
+    public class LiveControlsLoggingTests
+    {
+        private string _tempDataFolder = null!;
+        private string _databasePath = null!;
+        private Connection _connection = null!;
+
+        [SetUp]
+        public async Task SetUpAsync()
+        {
+            _tempDataFolder = Path.Combine(Path.GetTempPath(), $"duplicati-livecontrols-test-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_tempDataFolder);
+
+            _databasePath = Path.Combine(_tempDataFolder, DataFolderManager.SERVER_DATABASE_FILENAME);
+
+            var dbConnection = await SQLiteLoader.LoadConnectionAsync(_databasePath);
+            DatabaseUpgrader.UpgradeDatabase(dbConnection, _databasePath, typeof(Library.RestAPI.Database.DatabaseSchemaMarker));
+
+            _connection = new Connection(dbConnection, true, null, _tempDataFolder, () => { });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _connection?.Dispose();
+
+            if (Directory.Exists(_tempDataFolder))
+            {
+                try
+                {
+                    Directory.Delete(_tempDataFolder, true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        /// <summary>
+        /// The startup delay is parsed while LiveControls is being constructed. An unparsable
+        /// value leaves the delay at zero, which is the correct fallback, but the failure has
+        /// to reach the log so the setting does not appear to be honoured when it is not.
+        /// </summary>
+        [Test]
+        [Category("LiveControls")]
+        public void MalformedStartupDelayIsReportedAsync()
+        {
+            const string badValue = "not-a-duration";
+            _connection.ApplicationSettings.StartupDelayDuration = badValue;
+
+            var captured = new List<LogEntry>();
+            using (Log.StartScope(e => captured.Add(e)))
+                _ = new Duplicati.Server.LiveControls(_connection);
+
+            var entry = captured.FirstOrDefault(x => x.Id == "ParseStartupDelayError");
+            Assert.IsNotNull(entry,
+                "A startup delay that cannot be parsed must be reported in the log instead of being discarded silently.");
+            Assert.AreEqual(LogMessageType.Warning, entry!.Level);
+            Assert.IsTrue(entry.FormattedMessage.Contains(badValue),
+                $"The log message should quote the offending value; got: {entry.FormattedMessage}");
+            Assert.IsNotNull(entry.Exception,
+                "The parse exception should be attached so the reason for the failure is visible.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it.** It is the follow-up I offered in #7069, where I deliberately left `LiveControls`' unused `LOGTAG` in place rather than deleting it.

Seven `catch { }` blocks in `LiveControls` and `Runner` threw away the exception from parsing a **user-supplied setting**. A malformed value is ignored by design — that is the right fallback — but it was ignored *silently*, so the setting looked accepted in the UI while having no effect, and nothing in the log explained why.

### Two of them are a regression

[`ff1b2b7990c0`](https://github.com/duplicati/duplicati/commit/ff1b2b7990c0c96fe2b7fd44d7e6271f6d8bee63) (*Simplified task control (#5753)*, 2024-12-18) moved speed-limit parsing out of `LiveControls` into `Runner.UpdateThrottleSpeedsAsync`, but the logging did not come along:

```diff
-                catch (Exception ex)
-                    Log.WriteErrorMessage(LOGTAG, "ParseUploadLimitError", ex, "Failed to parse upload limit: {0}", settings.UploadSpeedLimit);
-                catch (Exception ex)
-                    Log.WriteErrorMessage(LOGTAG, "ParseDownloadLimitError", ex, "Failed to parse download limit: {0}", settings.DownloadSpeedLimit);
```

The destination already had silent `catch { }` blocks, so the two messages were simply dropped. Since then a malformed `UploadSpeedLimit`/`DownloadSpeedLimit` has been discarded without a word.

**Restored with their original message ids and their original `Error` level**, deliberately — those ids are the pre-regression contract. One consequence worth calling out: because the code moved, they are now emitted under `Runner`'s log tag instead of `LiveControls`'.

### The other five never logged at all

Added as **warnings**, since they are new messages rather than restored ones:

| Location | Setting | Id |
|---|---|---|
| `LiveControls.Init` / `OnResume` | startup delay (parsed at startup **and** on resume from suspend) | `ParseStartupDelayError` |
| `LiveControls.UpdatePowerModeProvider` | failure here silently disables suspend/resume handling entirely | `PowerModeProviderError` |
| `Runner` (job start) | per-job `throttle-upload` / `throttle-download` | `ParseUploadThrottleError` / `ParseDownloadThrottleError` |

**Control flow is unchanged at every site** — each one still falls back to its previous default and carries on. The only difference is that the failure is now visible.

`Runner` gains a `LOGTAG` (it had none), and `LiveControls`' existing-but-unused one is in use again, which resolves the exception I made in #7069.

## Will this add log noise?

No — I checked every caller. `UpdateThrottleSpeedsAsync` runs on settings save (`Connection.cs:445`) and at job start (`Runner.cs:847`); `UpdatePowerModeProvider` runs at init and on settings save; the startup delay is parsed at server start and on resume from suspend. These messages appear only when a setting is genuinely malformed.

## Will the messages actually reach the log?

Yes. `Program.cs:241` establishes a server-wide scope via `Log.StartScope(logWriteHandler, null)` before `LiveControls` is constructed, and `Log` uses `AsyncLocal<LogScope>`, so it flows. `Scheduler.cs` in the same folder already logs this way.

## Testing

New `LiveControlsLoggingTests` constructs `LiveControls` with an unparsable startup delay and asserts the warning is written — reusing the log-capture scope from `Issue6426.cs:44` and the server-database setup from `RelativeDbPathTests.cs:57`. **It fails before this change and passes after it:**

```
A startup delay that cannot be parsed must be reported in the log instead of being discarded silently.
  Expected: not null
  But was:  null
```

**The two restored messages are not covered by a test, and I want to be upfront about that.** They live in the private nested `RunnerData` class, and `UpdateThrottleSpeedsAsync` returns early unless a live backup controller is attached, so the parse is unreachable from a unit test without restructuring production code — which seemed disproportionate for restoring two log lines. They were verified by reading the path.

Build 0 errors; `LiveControlsLoggingTests` + `RelativeDbPath` 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
