### PR TITLE
Fail the backend test when verification finds a problem

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -31,6 +31,8 @@ using Duplicati.Library.Utility;
 using Duplicati.StreamUtil;
 using System.Threading.Tasks;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.CommandLine.BackendTester
 {
     public class Program
@@ -41,7 +43,6 @@ namespace Duplicati.CommandLine.BackendTester
             public readonly string localfilename;
             public readonly byte[] hash;
             public readonly long length;
-            public bool found = false;
 
             public TempFile(string remotefilename, string localfilename, byte[] hash, long length)
             {
@@ -286,6 +287,10 @@ namespace Duplicati.CommandLine.BackendTester
                 if (options.ContainsKey("wait-after-delete"))
                     waitAfterDelete = Timeparser.ParseTimeSpan(options["wait-after-delete"]);
 
+                var verificationRetries = 3;
+                if (options.ContainsKey("verification-retries"))
+                    verificationRetries = int.Parse(options["verification-retries"]);
+
                 var rnd = new Random();
                 var sha = System.Security.Cryptography.SHA256.Create();
 
@@ -351,42 +356,27 @@ namespace Duplicati.CommandLine.BackendTester
 
                     Console.WriteLine($"{LogTimeStamp}Verifying file list ...");
 
-                    curlist = Retry(() => backend.ListAsync(CancellationToken.None).ToBlockingEnumerable().ToList(), retries);
-                    foreach (var fe in curlist)
-                        if (!fe.IsFolder)
-                        {
-                            bool found = false;
-                            for (var i = 0; i < files.Count; i++)
-                            {
-                                var tx = files[i];
-                                if (tx.remotefilename == fe.Name)
-                                {
-                                    if (tx.found)
-                                        Console.WriteLine($"{LogTimeStamp}*** File {i}) with name {tx.remotefilename} was found more than once");
-                                    found = true;
-                                    tx.found = true;
+                    // The listing can lag behind the operations that were just performed, so a
+                    // mismatch is re-checked a number of times before it is reported as a problem.
+                    var expectedFiles = files.Select(x => (x.remotefilename, x.length)).ToList();
+                    List<string> listProblems;
+                    for (var attempt = 0; ; attempt++)
+                    {
+                        curlist = Retry(() => backend.ListAsync(CancellationToken.None).ToBlockingEnumerable().ToList(), retries);
+                        listProblems = VerifyFileList(curlist, expectedFiles, originalRenamedFile?.remotefilename, renamedFileNewName);
+                        if (listProblems.Count == 0 || attempt >= verificationRetries)
+                            break;
 
-                                    if (fe.Size > 0 && tx.length != fe.Size)
-                                        Console.WriteLine($"{LogTimeStamp}*** File {i} with name {tx.remotefilename} has size {tx.length} but the size was reported as {fe.Size}");
+                        var delay = Utility.GetRetryDelay(TimeSpan.FromSeconds(1), attempt + 1, true);
+                        Console.WriteLine($"{LogTimeStamp}File listing does not match yet ({listProblems.Count} problem(s)), re-checking in {delay.TotalMilliseconds} ms");
+                        Thread.Sleep(delay);
+                    }
 
-                                    break;
-                                }
-                            }
-
-                            if (!found)
-                                if (originalRenamedFile != null && renamedFileNewName != null && originalRenamedFile.remotefilename == fe.Name)
-                                {
-                                    Console.WriteLine($"{LogTimeStamp}*** File with name {fe.Name} was found on server but was supposed to have been renamed to {renamedFileNewName}!");
-                                }
-                                else
-                                {
-                                    Console.WriteLine($"{LogTimeStamp}*** File with name {fe.Name} was found on server but not uploaded!");
-                                }
-                        }
-
-                    for (var i = 0; i < files.Count; i++)
-                        if (!files[i].found)
-                            Console.WriteLine($"{LogTimeStamp}*** File {i} with name {files[i].remotefilename} was uploaded but not found afterwards");
+                    foreach (var problem in listProblems)
+                    {
+                        failAfterFinished = true;
+                        Console.WriteLine($"{LogTimeStamp}*** {problem}");
+                    }
 
                     Console.WriteLine($"{LogTimeStamp}Downloading files");
 
@@ -439,7 +429,10 @@ namespace Duplicati.CommandLine.BackendTester
                                 if (Convert.ToBase64String(sha.ComputeHash(fs)) != Convert.ToBase64String(files[i].hash))
                                 {
                                     if (dummyFileHash != null && Convert.ToBase64String(sha.ComputeHash(fs)) == Convert.ToBase64String(dummyFileHash))
-                                        Console.WriteLine($"{LogTimeStamp}failed\n*** Downloaded file was the dummy file"); // Should this be failed?
+                                    {
+                                        failAfterFinished = true;
+                                        Console.WriteLine($"{LogTimeStamp}failed\n*** Downloaded file was the dummy file");
+                                    }
                                     else
                                     {
                                         failAfterFinished = true;
@@ -471,12 +464,25 @@ namespace Duplicati.CommandLine.BackendTester
                         Thread.Sleep(waitAfterDelete);
                     }
 
-                    curlist = Retry(() => backend.ListAsync(CancellationToken.None).ToBlockingEnumerable().ToList(), retries);
-                    foreach (var fe in curlist)
-                        if (!fe.IsFolder)
-                        {
-                            Console.WriteLine($"{LogTimeStamp}*** Remote folder contains {fe.Name} after cleanup");
-                        }
+                    // As with the upload verification, the listing can lag behind the deletes
+                    List<string> leftovers;
+                    for (var attempt = 0; ; attempt++)
+                    {
+                        curlist = Retry(() => backend.ListAsync(CancellationToken.None).ToBlockingEnumerable().ToList(), retries);
+                        leftovers = curlist.Where(x => !x.IsFolder).Select(x => x.Name).ToList();
+                        if (leftovers.Count == 0 || attempt >= verificationRetries)
+                            break;
+
+                        var delay = Utility.GetRetryDelay(TimeSpan.FromSeconds(1), attempt + 1, true);
+                        Console.WriteLine($"{LogTimeStamp}Remote folder is not empty yet ({leftovers.Count} file(s)), re-checking in {delay.TotalMilliseconds} ms");
+                        Thread.Sleep(delay);
+                    }
+
+                    foreach (var name in leftovers)
+                    {
+                        failAfterFinished = true;
+                        Console.WriteLine($"{LogTimeStamp}*** Remote folder contains {name} after cleanup");
+                    }
 
                     // Test some error cases
                     Console.WriteLine($"{LogTimeStamp}Checking retrieval of non-existent file...");
@@ -677,6 +683,56 @@ namespace Duplicati.CommandLine.BackendTester
         private static T Retry<T>(Func<T> action, int retries)
             => Retry(() => Task.FromResult(action()), retries).Result;
 
+        /// <summary>
+        /// Compares the file listing reported by the backend with the files that were uploaded.
+        /// </summary>
+        /// <param name="remoteList">The listing reported by the backend.</param>
+        /// <param name="expected">The files that are expected to be present, in upload order.</param>
+        /// <param name="renamedFrom">The name a file was renamed away from, or null if no rename was performed.</param>
+        /// <param name="renamedTo">The name the file was renamed to, or null if no rename was performed.</param>
+        /// <returns>One message for each problem found; empty if the listing matches what was uploaded.</returns>
+        internal static List<string> VerifyFileList(IEnumerable<IFileEntry> remoteList, IReadOnlyList<(string Name, long Length)> expected, string renamedFrom, string renamedTo)
+        {
+            var problems = new List<string>();
+            var found = new bool[expected.Count];
+
+            foreach (var fe in remoteList)
+            {
+                if (fe.IsFolder)
+                    continue;
+
+                var matched = false;
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    if (expected[i].Name != fe.Name)
+                        continue;
+
+                    if (found[i])
+                        problems.Add($"File {i}) with name {expected[i].Name} was found more than once");
+                    matched = true;
+                    found[i] = true;
+
+                    // A size of zero means the backend does not report sizes, so it cannot be compared
+                    if (fe.Size > 0 && expected[i].Length != fe.Size)
+                        problems.Add($"File {i} with name {expected[i].Name} has size {expected[i].Length} but the size was reported as {fe.Size}");
+
+                    break;
+                }
+
+                if (!matched)
+                    if (renamedFrom != null && renamedTo != null && renamedFrom == fe.Name)
+                        problems.Add($"File with name {fe.Name} was found on server but was supposed to have been renamed to {renamedTo}!");
+                    else
+                        problems.Add($"File with name {fe.Name} was found on server but not uploaded!");
+            }
+
+            for (var i = 0; i < expected.Count; i++)
+                if (!found[i])
+                    problems.Add($"File {i} with name {expected[i].Name} was uploaded but not found afterwards");
+
+            return problems;
+        }
+
         private static string LogTimeStamp => $"[{DateTime.Now:HH:mm:ss fff}] ";
 
         public static IList<ICommandLineArgument> SupportedCommands => [
@@ -696,6 +752,7 @@ namespace Duplicati.CommandLine.BackendTester
             new CommandLineArgument("wait-after-upload", CommandLineArgument.ArgumentType.Timespan, "Wait after all uploads", "A value that indicates how long to wait after all files are uploaded, to account for the backends eventual consistency", "0s"),
             new CommandLineArgument("wait-after-delete", CommandLineArgument.ArgumentType.Timespan, "Wait after all deletes", "A value that indicates how long to wait after each delete operation, to account for the backends eventual consistency", "0s"),
             new CommandLineArgument("failure-retries", CommandLineArgument.ArgumentType.Integer, "The number of retries for each operation", "An integer that indicates how many times an operation should be retried before giving up", "0"),
+            new CommandLineArgument("verification-retries", CommandLineArgument.ArgumentType.Integer, "The number of re-checks of the remote file listing", "An integer that indicates how many times the remote file listing is re-checked before a mismatch is reported as a problem, to account for the backends eventual consistency", "3"),
         ];
     }
 }

--- a/Duplicati/UnitTest/BackendTesterVerificationTests.cs
+++ b/Duplicati/UnitTest/BackendTesterVerificationTests.cs
@@ -1,0 +1,167 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Duplicati.CommandLine.BackendTester;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using StringAssert = NUnit.Framework.Legacy.StringAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Tests the comparison of the backend's file listing against the files the backend
+    /// tester uploaded. Every problem reported here makes the tester exit non-zero, which
+    /// is what the live backend tests assert on, so a mistake in this comparison either
+    /// hides a broken backend or fails a working one.
+    /// </summary>
+    [TestFixture]
+    [Category("BackendTesterVerification")]
+    public class BackendTesterVerificationTests
+    {
+        /// <summary>
+        /// Builds a listing entry; only the name, the size and the folder flag take part
+        /// in the comparison.
+        /// </summary>
+        private static IFileEntry Entry(string name, long size, bool isFolder = false)
+            => new Duplicati.Library.Common.IO.FileEntry(name, size, isFolder: isFolder);
+
+        private static readonly (string Name, long Length)[] TwoFiles =
+        [
+            ("file-a", 100),
+            ("file-b", 200)
+        ];
+
+        [Test]
+        public void MatchingListingReportsNoProblems()
+        {
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 100), Entry("file-b", 200)],
+                TwoFiles, null, null);
+
+            Assert.IsEmpty(problems, "A listing that matches the uploaded files must not report anything.");
+        }
+
+        [Test]
+        public void FoldersAreIgnored()
+        {
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 100), Entry("file-b", 200), Entry("a-subfolder", 0, isFolder: true)],
+                TwoFiles, null, null);
+
+            Assert.IsEmpty(problems, "A folder in the listing is not an unexpected file.");
+        }
+
+        [Test]
+        public void DuplicateEntryIsReported()
+        {
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 100), Entry("file-a", 100), Entry("file-b", 200)],
+                TwoFiles, null, null);
+
+            Assert.AreEqual(1, problems.Count);
+            StringAssert.Contains("was found more than once", problems[0]);
+        }
+
+        [Test]
+        public void SizeMismatchIsReported()
+        {
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 999), Entry("file-b", 200)],
+                TwoFiles, null, null);
+
+            Assert.AreEqual(1, problems.Count);
+            StringAssert.Contains("has size 100 but the size was reported as 999", problems[0]);
+        }
+
+        /// <summary>
+        /// Backends that do not report a size list everything as zero. Comparing against
+        /// that would report every single file as a size mismatch.
+        /// </summary>
+        [Test]
+        public void UnreportedSizeIsNotAMismatch()
+        {
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 0), Entry("file-b", 0)],
+                TwoFiles, null, null);
+
+            Assert.IsEmpty(problems, "A size of zero means the backend does not report sizes.");
+        }
+
+        [Test]
+        public void MissingFileIsReported()
+        {
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 100)],
+                TwoFiles, null, null);
+
+            Assert.AreEqual(1, problems.Count);
+            StringAssert.Contains("was uploaded but not found afterwards", problems[0]);
+        }
+
+        [Test]
+        public void UnexpectedFileIsReported()
+        {
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 100), Entry("file-b", 200), Entry("a-stranger", 50)],
+                TwoFiles, null, null);
+
+            Assert.AreEqual(1, problems.Count);
+            StringAssert.Contains("a-stranger was found on server but not uploaded", problems[0]);
+        }
+
+        /// <summary>
+        /// After a rename the old name must be gone and the new name must be present. A
+        /// backend that copies instead of renaming, or that does nothing at all, is caught
+        /// here; this is the condition behind #4126.
+        /// </summary>
+        [Test]
+        public void RenameThatDidNotTakeEffectIsReported()
+        {
+            var expected = new[] { ("file-a", 100L), ("renamed-b", 200L) };
+
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 100), Entry("file-b", 200)],
+                expected, "file-b", "renamed-b");
+
+            Assert.AreEqual(2, problems.Count, "Both the lingering old name and the missing new name are problems.");
+            Assert.IsTrue(problems.Any(x => x.Contains("was supposed to have been renamed to renamed-b")),
+                $"Expected the lingering old name to be reported, got: {string.Join(" | ", problems)}");
+            Assert.IsTrue(problems.Any(x => x.Contains("renamed-b was uploaded but not found afterwards")),
+                $"Expected the missing new name to be reported, got: {string.Join(" | ", problems)}");
+        }
+
+        [Test]
+        public void CompletedRenameReportsNoProblems()
+        {
+            var expected = new[] { ("file-a", 100L), ("renamed-b", 200L) };
+
+            var problems = Program.VerifyFileList(
+                [Entry("file-a", 100), Entry("renamed-b", 200)],
+                expected, "file-b", "renamed-b");
+
+            Assert.IsEmpty(problems, "A rename that took effect must not report anything.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it.** (#4538 "Verify functionality of BackendTester" is the closest thing, and this fills in part of it.)

BackendTester detects **seven** kinds of problem while verifying a backend and only *prints* them — it never sets `failAfterFinished`, so `Run` returns `true` and the process exits 0:

| Detected | Line |
|---|---|
| A file was uploaded but is not in the listing afterwards | `Program.cs:389` |
| The reported size differs from the uploaded size | `:370` |
| The same name appears more than once | `:365` |
| A rename did not take effect — the old name is still there | `:379` |
| The downloaded file is the dummy file, i.e. the overwrite did not stick | `:442` |
| A file is on the server that this run did not upload | `:383` |
| Files remain after the cleanup deletes | `:478` |

Every live backend test asserts on nothing but the exit code:

```csharp
if (exitCode != 0) Assert.Fail("BackendTester is returning non-zero exit code, check logs for details");
```

So a backend that **loses a file, reports a wrong size, ignores a rename or serves stale content passes CI**, with the reason sitting unread in the log.

## This finishes work that was started but not completed

[`adc4bfa650fa`](https://github.com/duplicati/duplicati/commit/adc4bfa650fab62c7faa1c91e9fe0c673ef9deaf) introduced `failAfterFinished` and says in its own commit message:

> Also changed logic around test result, **ensuring it fails when any unexpected behavior happens.**

Only four branches were actually wired up. One of the branches left behind still carries the author's open question inline — `// Should this be failed?` — which this PR answers. Nothing in the file's history ever made these fatal and reverted it.

## Why they could not simply be made fatal

The verification takes **one** listing immediately after the uploads and treats it as the truth. That listing can lag behind the operations that just happened.

In Backend Live Tests run [`29688083494`](https://github.com/duplicati/duplicati/actions/runs/29688083494) — **reported green** — 4 of 50 jobs already printed these messages:

| Job | runs | renames | rename problem | missing file |
|---|---|---|---|---|
| SFTP (macos) | 5 | 5 | 2 | 2 |
| SFTP (windows) | 5 | 5 | 2 | 2 |
| SSH (macos) | 5 | 5 | 1 | 1 |
| CloudStack (windows) | 5 | 5 | 0 | 1 |

It is **intermittent** — all 5 runs perform the same rename, but only 1–2 report a problem, and in the SSH case the rename and the listing share a millisecond. That is the shape of propagation lag, not of a broken backend. Making the checks fatal as they stood would have produced flaky red.

**So the listing is now re-checked before a mismatch is reported.** The comparison moved into `VerifyFileList`, which is pure and returns the problems it found; the caller re-lists with the existing `Utility.GetRetryDelay` backoff until the problems clear or the attempts run out. The leftover check after the deletes gets the same treatment.

This is also, I think, a proper answer to #5781, where the same messages were treated as noise to be worked around with added delays.

New option, defaulting to **3**:

```
--verification-retries   The number of re-checks of the remote file listing
```

It cannot default to 0: `LiveTests/Duplicati.Backend.Tests/Parameters.cs` passes no extra options, so an inactive default would leave CI exactly as flaky as before.

**The messages themselves are unchanged** — only their effect on the exit code is.

## The trade-off I want to flag

Two of the seven — *an unexpected file on the server* and *files left after cleanup* — can be caused by the **service** rather than by Duplicati. An upload that times out client-side may still land minutes later, and re-checking cannot clear that, because the file really is there. I saw exactly this on pCloud yesterday: an abandoned upload materialised **4½ minutes** after the client gave up, during a different test.

I still made them fatal, because today that straggler makes the *next* run abort with a generic `*** Remote folder contains 1 file(s), aborting` — the test still fails, just in the wrong place with a message that says nothing about what happened. Failing where it happened, with the reason attached, seems strictly better. **Happy to downgrade those two to warnings if you would rather not have service hiccups fail a run.**

## What this would have caught

Real bugs that shipped while this verification was advisory: **#4126** (FTP rename leaves the old name — exactly the rename check), **#4486** and **#4964** (size disagreements), **#772** (uploaded but not found), **#6438**.

## Testing

Nine tests for `VerifyFileList`: matching listing, folders ignored, duplicates, size mismatch, sizes the backend does not report (`Size == 0` must **not** be a mismatch — this guard is load-bearing for backends that do not report sizes), a missing file, an unexpected file, and both outcomes of a rename.

I sanity-checked that they actually bite by breaking the size comparison on purpose — `SizeMismatchIsReported` fails, the other 8 stay green.

**Being upfront about a gap:** these test the newly extracted helper, so they are not a red-to-green demonstration of the *exit-code* change. Verifying that end-to-end needs a live backend, and I did not want to fake it. The refactor is intended to be behaviour-preserving for the message text; the fatal wiring is a four-line change reviewable by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
