### PR TITLE
Improve MS365 shared mailbox handling

### DIFF
--- a/proprietary/Office365/APIHelper.cs
+++ b/proprietary/Office365/APIHelper.cs
@@ -259,7 +259,8 @@ internal class APIHelper : IDisposable
             // Ignore failures when reading the response body; we'll throw with status code regardless.
         }
 
-        var message = TryExtractOfficeApiErrorMessage(responseBody)
+        var (errorCode, errorMessage) = TryExtractOfficeApiError(responseBody);
+        var message = errorMessage
             ?? responseBody
             ?? response.ReasonPhrase
             ?? "Request failed.";
@@ -269,37 +270,89 @@ internal class APIHelper : IDisposable
         var detailedMessage = $"{message} (HTTP {(int)statusCode} {statusCode}) - Request URI: {response.RequestMessage?.RequestUri}";
         if (response?.Headers?.TryGetValues("Location", out var location) == true)
             detailedMessage += $" - Location: {location.First()}";
-        throw new HttpRequestException(detailedMessage, inner: null, statusCode);
+        var ex = new HttpRequestException(detailedMessage, inner: null, statusCode);
+
+        // Expose the machine-readable Graph error code so callers can react to specific
+        // conditions (e.g. a user without a provisioned mailbox) without matching on the
+        // localized human-readable message.
+        if (!string.IsNullOrWhiteSpace(errorCode))
+            ex.Data[GraphErrorCodeKey] = errorCode;
+
+        throw ex;
     }
 
     /// <summary>
-    /// Attempts to extract the error message from the Office API response.
+    /// The <see cref="System.Exception.Data"/> key used to store the Graph API error code
+    /// on thrown <see cref="HttpRequestException"/> instances.
+    /// </summary>
+    internal const string GraphErrorCodeKey = "GraphErrorCode";
+
+    /// <summary>
+    /// Gets the Graph API error code stored on an exception, if any.
+    /// </summary>
+    /// <param name="ex">The exception to inspect.</param>
+    /// <returns>The Graph error code, or null if none is present.</returns>
+    internal static string? GetGraphErrorCode(Exception ex)
+        => ex.Data.Contains(GraphErrorCodeKey) ? ex.Data[GraphErrorCodeKey] as string : null;
+
+    /// <summary>
+    /// Determines whether the exception indicates that the target user does not have an
+    /// accessible Exchange Online mailbox (no license, disabled, soft-deleted, or on-premise).
+    /// Graph returns HTTP 404 with an error code of <c>MailboxNotEnabledForRESTAPI</c> or
+    /// <c>MailboxNotSupportedForRESTAPI</c> in these cases.
+    /// </summary>
+    /// <param name="ex">The exception to inspect.</param>
+    /// <returns><c>true</c> if the exception indicates an unavailable mailbox; otherwise <c>false</c>.</returns>
+    internal static bool IsMailboxNotEnabled(Exception ex)
+    {
+        if (ex is not HttpRequestException httpEx || httpEx.StatusCode != HttpStatusCode.NotFound)
+            return false;
+
+        var code = GetGraphErrorCode(ex);
+        return string.Equals(code, "MailboxNotEnabledForRESTAPI", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(code, "MailboxNotSupportedForRESTAPI", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Attempts to extract the error code and message from the Office API response.
     /// </summary>
     /// <param name="responseBody">The response body</param>
-    /// <returns>The extracted error message, or null if none could be found</returns>
-    private static string? TryExtractOfficeApiErrorMessage(string? responseBody)
+    /// <returns>The extracted error code and message; either may be null if not found.</returns>
+    private static (string? Code, string? Message) TryExtractOfficeApiError(string? responseBody)
     {
         if (string.IsNullOrWhiteSpace(responseBody))
-            return null;
+            return (null, null);
 
         // Fast filter: if it doesn't look like JSON, don't attempt to parse.
         var trimmed = responseBody.AsSpan().TrimStart();
         if (trimmed.Length == 0 || (trimmed[0] != '{' && trimmed[0] != '['))
-            return null;
+            return (null, null);
 
         try
         {
             using var doc = JsonDocument.Parse(responseBody);
             if (doc.RootElement.ValueKind != JsonValueKind.Object)
-                return null;
+                return (null, null);
 
             if (doc.RootElement.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.Object)
             {
+                string? code = null;
+                if (error.TryGetProperty("code", out var codeElement) && codeElement.ValueKind == JsonValueKind.String)
+                {
+                    code = codeElement.GetString();
+                    if (string.IsNullOrWhiteSpace(code))
+                        code = null;
+                }
+
+                string? message = null;
                 if (error.TryGetProperty("message", out var messageElement) && messageElement.ValueKind == JsonValueKind.String)
                 {
-                    var message = messageElement.GetString();
-                    return string.IsNullOrWhiteSpace(message) ? null : message;
+                    message = messageElement.GetString();
+                    if (string.IsNullOrWhiteSpace(message))
+                        message = null;
                 }
+
+                return (code, message);
             }
         }
         catch (JsonException)
@@ -307,7 +360,7 @@ internal class APIHelper : IDisposable
             // Not JSON (or invalid JSON) - fall back to entire response body.
         }
 
-        return null;
+        return (null, null);
     }
 
     /// <summary>

--- a/proprietary/Office365/DTOs.cs
+++ b/proprietary/Office365/DTOs.cs
@@ -22,6 +22,32 @@ internal sealed class GraphUser
     [JsonPropertyName("createdDateTime")]
     public DateTimeOffset? CreatedDateTime { get; set; }
 
+    /// <summary>
+    /// The licenses assigned to the user. A shared mailbox with additional storage
+    /// (i.e. an assigned Exchange Online license) will have one or more entries here.
+    /// </summary>
+    [JsonPropertyName("assignedLicenses")]
+    public List<GraphAssignedLicense>? AssignedLicenses { get; set; }
+}
+
+internal sealed class GraphAssignedLicense
+{
+    [JsonPropertyName("skuId")]
+    public string? SkuId { get; set; }
+
+    [JsonPropertyName("disabledPlans")]
+    public List<string>? DisabledPlans { get; set; }
+}
+
+/// <summary>
+/// Represents the <c>userPurpose</c> value returned by
+/// <c>GET /users/{id}/mailboxSettings/userPurpose</c>.
+/// Differentiates a regular user mailbox from shared, room and equipment mailboxes.
+/// </summary>
+internal sealed class GraphMailboxUserPurpose
+{
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
 }
 
 internal sealed class GraphSite

--- a/proprietary/Office365/OptionsHelper.cs
+++ b/proprietary/Office365/OptionsHelper.cs
@@ -19,6 +19,9 @@ internal static class OptionsHelper
     internal const string OFFICE_INCLUDED_ROOT_TYPES_OPTION = "office365-included-root-types";
     internal const string OFFICE_INCLUDED_USER_TYPES_OPTION = "office365-included-user-types";
     internal const string OFFICE_INCLUDED_GROUP_TYPES_OPTION = "office365-included-group-types";
+    internal const string OFFICE_INCLUDED_USER_CLASSIFICATIONS_OPTION = "office365-included-user-classifications";
+    internal const string OFFICE_INCLUDED_GROUP_CLASSIFICATIONS_OPTION = "office365-included-group-classifications";
+    internal const string OFFICE_INCLUDED_SITE_CLASSIFICATIONS_OPTION = "office365-included-site-classifications";
 
     /// <summary>
     /// User types that require delegated permissions, default disabled.
@@ -61,6 +64,24 @@ internal static class OptionsHelper
             .Except(DELEGATED_USER_TYPES)
             .ToArray();
 
+    /// <summary>
+    /// All user classifications, i.e. the default include filter (everything included).
+    /// </summary>
+    internal static readonly Office365UserClassification ALL_USER_CLASSIFICATIONS =
+        Enum.GetValues<Office365UserClassification>().Aggregate((Office365UserClassification)0, (acc, v) => acc | v);
+
+    /// <summary>
+    /// All group classifications, i.e. the default include filter (everything included).
+    /// </summary>
+    internal static readonly Office365GroupClassification ALL_GROUP_CLASSIFICATIONS =
+        Enum.GetValues<Office365GroupClassification>().Aggregate((Office365GroupClassification)0, (acc, v) => acc | v);
+
+    /// <summary>
+    /// All site classifications, i.e. the default include filter (everything included).
+    /// </summary>
+    internal static readonly Office365SiteClassification ALL_SITE_CLASSIFICATIONS =
+        Enum.GetValues<Office365SiteClassification>().Aggregate((Office365SiteClassification)0, (acc, v) => acc | v);
+
     internal const string DEFAULT_GRAPH_BASE_URL = "https://graph.microsoft.com";
 
     internal sealed record ParsedOptions(
@@ -72,7 +93,10 @@ internal static class OptionsHelper
         string Scope,
         Office365MetaType[] IncludedRootTypes,
         Office365UserType[] IncludedUserTypes,
-        Office365GroupType[] IncludedGroupTypes
+        Office365GroupType[] IncludedGroupTypes,
+        Office365UserClassification IncludedUserClassifications,
+        Office365GroupClassification IncludedGroupClassifications,
+        Office365SiteClassification IncludedSiteClassifications
     );
 
     internal static ParsedOptions ParseAndValidateOptions(string url, Dictionary<string, string?> options)
@@ -98,6 +122,11 @@ internal static class OptionsHelper
         var includedUserTypes = Library.Utility.Utility.ParseFlagsOption(options, OFFICE_INCLUDED_USER_TYPES_OPTION, (Office365UserType)DEFAULT_INCLUDED_USER_TYPES.Aggregate(0, (acc, type) => acc | (int)type));
         var includedGroupTypes = Library.Utility.Utility.ParseFlagsOption(options, OFFICE_INCLUDED_GROUP_TYPES_OPTION, (Office365GroupType)DEFAULT_INCLUDED_GROUP_TYPES.Aggregate(0, (acc, type) => acc | (int)type));
 
+        // Classification include filters default to all classifications included.
+        var includedUserClassifications = Library.Utility.Utility.ParseFlagsOption(options, OFFICE_INCLUDED_USER_CLASSIFICATIONS_OPTION, ALL_USER_CLASSIFICATIONS);
+        var includedGroupClassifications = Library.Utility.Utility.ParseFlagsOption(options, OFFICE_INCLUDED_GROUP_CLASSIFICATIONS_OPTION, ALL_GROUP_CLASSIFICATIONS);
+        var includedSiteClassifications = Library.Utility.Utility.ParseFlagsOption(options, OFFICE_INCLUDED_SITE_CLASSIFICATIONS_OPTION, ALL_SITE_CLASSIFICATIONS);
+
         return new ParsedOptions(
             TenantId: _tenantId,
             AuthOptions: _authOptions,
@@ -107,7 +136,10 @@ internal static class OptionsHelper
             Scope: _scope,
             IncludedRootTypes: Enum.GetValues<Office365MetaType>().Where(n => includedRootTypes.HasFlag(n)).ToArray(),
             IncludedUserTypes: Enum.GetValues<Office365UserType>().Where(n => includedUserTypes.HasFlag(n)).ToArray(),
-            IncludedGroupTypes: Enum.GetValues<Office365GroupType>().Where(n => includedGroupTypes.HasFlag(n)).ToArray()
+            IncludedGroupTypes: Enum.GetValues<Office365GroupType>().Where(n => includedGroupTypes.HasFlag(n)).ToArray(),
+            IncludedUserClassifications: includedUserClassifications,
+            IncludedGroupClassifications: includedGroupClassifications,
+            IncludedSiteClassifications: includedSiteClassifications
         );
     }
 
@@ -122,6 +154,9 @@ internal static class OptionsHelper
         new CommandLineArgument(OFFICE_SCOPE_OPTION, CommandLineArgument.ArgumentType.String, Strings.OfficeScopeOptionShort, Strings.OfficeScopeOptionLong, OFFICE_SCOPE_OPTION_DEFAULT),
         new CommandLineArgument(OFFICE_INCLUDED_ROOT_TYPES_OPTION, CommandLineArgument.ArgumentType.Flags, Strings.OfficeIncludedRootTypesShort, Strings.OfficeIncludedRootTypesLong, string.Join(",", DEFAULT_INCLUDED_ROOT_TYPES.Select(n => n.ToString()).ToArray()), null, Enum.GetNames<Office365MetaType>()),
         new CommandLineArgument(OFFICE_INCLUDED_USER_TYPES_OPTION, CommandLineArgument.ArgumentType.Flags, Strings.OfficeIncludedUserTypesShort, Strings.OfficeIncludedUserTypesLong, string.Join(",", DEFAULT_INCLUDED_USER_TYPES.Select(n => n.ToString()).ToArray()), null, Enum.GetNames<Office365UserType>()),
-        new CommandLineArgument(OFFICE_INCLUDED_GROUP_TYPES_OPTION, CommandLineArgument.ArgumentType.Flags, Strings.OfficeIncludedGroupTypesShort, Strings.OfficeIncludedGroupTypesLong, string.Join(",", DEFAULT_INCLUDED_GROUP_TYPES.Select(n => n.ToString()).ToArray()), null, Enum.GetNames<Office365GroupType>())
+        new CommandLineArgument(OFFICE_INCLUDED_GROUP_TYPES_OPTION, CommandLineArgument.ArgumentType.Flags, Strings.OfficeIncludedGroupTypesShort, Strings.OfficeIncludedGroupTypesLong, string.Join(",", DEFAULT_INCLUDED_GROUP_TYPES.Select(n => n.ToString()).ToArray()), null, Enum.GetNames<Office365GroupType>()),
+        new CommandLineArgument(OFFICE_INCLUDED_USER_CLASSIFICATIONS_OPTION, CommandLineArgument.ArgumentType.Flags, Strings.OfficeIncludedUserClassificationsShort, Strings.OfficeIncludedUserClassificationsLong, string.Join(",", Enum.GetNames<Office365UserClassification>()), null, Enum.GetNames<Office365UserClassification>()),
+        new CommandLineArgument(OFFICE_INCLUDED_GROUP_CLASSIFICATIONS_OPTION, CommandLineArgument.ArgumentType.Flags, Strings.OfficeIncludedGroupClassificationsShort, Strings.OfficeIncludedGroupClassificationsLong, string.Join(",", Enum.GetNames<Office365GroupClassification>()), null, Enum.GetNames<Office365GroupClassification>()),
+        new CommandLineArgument(OFFICE_INCLUDED_SITE_CLASSIFICATIONS_OPTION, CommandLineArgument.ArgumentType.Flags, Strings.OfficeIncludedSiteClassificationsShort, Strings.OfficeIncludedSiteClassificationsLong, string.Join(",", Enum.GetNames<Office365SiteClassification>()), null, Enum.GetNames<Office365SiteClassification>())
     ];
 }

--- a/proprietary/Office365/SourceItems/GroupSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/GroupSourceEntry.cs
@@ -25,7 +25,11 @@ internal class GroupSourceEntry(SourceProvider provider, string parentPath, Grap
 {
     public override async IAsyncEnumerable<ISourceProviderEntry> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        if (!provider.LicenseApprovedForEntry(parentPath, Office365MetaType.Groups, group.Id, true))
+        // Security groups and distribution lists do not consume a seat; only Microsoft 365
+        // (Unified) groups count.
+        var groupCountsAsSeat = SourceProvider.GroupCountsAsSeat(group);
+
+        if (!provider.LicenseApprovedForEntry(parentPath, Office365MetaType.Groups, group.Id, true, groupCountsAsSeat))
             yield break;
 
         await foreach (var entry in MetadataEntries(cancellationToken))
@@ -111,6 +115,7 @@ internal class GroupSourceEntry(SourceProvider provider, string parentPath, Grap
                 { "o365:Visibility", group.Visibility },
                 { "o365:MailEnabled", group.MailEnabled.ToString() },
                 { "o365:SecurityEnabled", group.SecurityEnabled.ToString() },
+                { "o365:Classification", SourceProvider.ClassifyGroupFromDirectory(group) },
             }
             .WhereNotNull()
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value));

--- a/proprietary/Office365/SourceItems/MetaRootSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/MetaRootSourceEntry.cs
@@ -57,7 +57,16 @@ internal class MetaRootSourceEntry(SourceProvider provider, string mountPoint, O
                     if (cancellationToken.IsCancellationRequested)
                         yield break;
 
-                    if (provider.LicenseApprovedForEntry(Path, type, user.Id, false))
+                    // Skip users whose classification is excluded by the include filter.
+                    // This uses the cached classification, so no extra Graph call is made
+                    // beyond the one already performed for seat counting.
+                    if (!await provider.IsUserClassificationIncludedAsync(user, cancellationToken).ConfigureAwait(false))
+                        continue;
+
+                    // Shared mailboxes without additional storage do not consume a seat.
+                    var countsAsSeat = await provider.UserCountsAsSeatAsync(user, cancellationToken).ConfigureAwait(false);
+
+                    if (provider.LicenseApprovedForEntry(Path, type, user.Id, false, countsAsSeat))
                         yield return new UserSourceEntry(provider, Path, user);
                 }
                 break;
@@ -67,7 +76,15 @@ internal class MetaRootSourceEntry(SourceProvider provider, string mountPoint, O
                     if (cancellationToken.IsCancellationRequested)
                         yield break;
 
-                    if (provider.LicenseApprovedForEntry(Path, type, group.Id, false))
+                    // Skip groups whose classification is excluded by the include filter.
+                    if (!provider.IsGroupClassificationIncluded(group))
+                        continue;
+
+                    // Security groups and distribution lists do not consume a seat;
+                    // only Microsoft 365 (Unified) groups count.
+                    var groupCountsAsSeat = SourceProvider.GroupCountsAsSeat(group);
+
+                    if (provider.LicenseApprovedForEntry(Path, type, group.Id, false, groupCountsAsSeat))
                         yield return new GroupSourceEntry(provider, this.Path, group);
                 }
                 break;
@@ -76,6 +93,10 @@ internal class MetaRootSourceEntry(SourceProvider provider, string mountPoint, O
                 {
                     if (cancellationToken.IsCancellationRequested)
                         yield break;
+
+                    // Skip sites whose classification is excluded by the include filter.
+                    if (!provider.IsSiteClassificationIncluded(site))
+                        continue;
 
                     if (provider.LicenseApprovedForEntry(Path, type, site.Id, false))
                         yield return new SiteSourceEntry(provider, this.Path, site);

--- a/proprietary/Office365/SourceItems/Office365Classifications.cs
+++ b/proprietary/Office365/SourceItems/Office365Classifications.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+namespace Duplicati.Proprietary.Office365.SourceItems;
+
+/// <summary>
+/// The user classifications that can be included or excluded from the backup.
+/// Mirrors <see cref="SourceProvider.UserSeatCategory"/>.
+/// </summary>
+[Flags]
+internal enum Office365UserClassification
+{
+    /// <summary>A regular user mailbox with one or more assigned licenses.</summary>
+    Licensed = 1,
+    /// <summary>A regular user mailbox with no assigned license.</summary>
+    Unlicensed = 2,
+    /// <summary>A shared/room/equipment mailbox with additional (licensed) storage.</summary>
+    SharedMailboxWithStorage = 4,
+    /// <summary>A shared/room/equipment mailbox without additional storage.</summary>
+    SharedMailboxWithoutStorage = 8
+}
+
+/// <summary>
+/// The group classifications that can be included or excluded from the backup.
+/// </summary>
+[Flags]
+internal enum Office365GroupClassification
+{
+    /// <summary>A Microsoft 365 (Unified) group.</summary>
+    Unified = 1,
+    /// <summary>A security group or distribution list (non-Unified group).</summary>
+    NotUnified = 2
+}
+
+/// <summary>
+/// The site classifications that can be included or excluded from the backup.
+/// Mirrors <see cref="SourceProvider.SiteCategory"/>.
+/// </summary>
+[Flags]
+internal enum Office365SiteClassification
+{
+    /// <summary>A Microsoft 365 group-connected team site.</summary>
+    Group = 1,
+    /// <summary>A classic (non-group) team site.</summary>
+    Classic = 2,
+    /// <summary>A modern communication site.</summary>
+    Communication = 4,
+    /// <summary>A personal (OneDrive for Business) site.</summary>
+    Personal = 8,
+    /// <summary>Any other or undetermined site type.</summary>
+    Other = 16
+}

--- a/proprietary/Office365/SourceItems/SiteSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/SiteSourceEntry.cs
@@ -19,7 +19,8 @@ internal class SiteSourceEntry(SourceProvider provider, string parentPath, Graph
             { "o365:DisplayName", site.DisplayName },
             { "o365:WebUrl", site.WebUrl },
             { "o365:Hostname", site.SiteCollection?.Hostname },
-            { "o365:PersonalSite", site.SiteCollection?.PersonalSite?.ToString() }
+            { "o365:PersonalSite", site.SiteCollection?.PersonalSite?.ToString() },
+            { "o365:Classification", SourceProvider.ClassifySite(site).ToString() }
         }
         .Where(kv => !string.IsNullOrEmpty(kv.Value))
         .ToDictionary(kv => kv.Key, kv => kv.Value));

--- a/proprietary/Office365/SourceItems/UserSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/UserSourceEntry.cs
@@ -24,7 +24,10 @@ internal class UserSourceEntry(SourceProvider provider, string parentPath, Graph
 {
     public override async IAsyncEnumerable<ISourceProviderEntry> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        if (!provider.LicenseApprovedForEntry(parentPath, Office365MetaType.Users, user.Id, true))
+        // Shared mailboxes without additional storage do not consume a seat.
+        var countsAsSeat = await provider.UserCountsAsSeatAsync(user, cancellationToken).ConfigureAwait(false);
+
+        if (!provider.LicenseApprovedForEntry(parentPath, Office365MetaType.Users, user.Id, true, countsAsSeat))
             yield break;
 
         foreach (var type in provider.IncludedUserTypes)
@@ -46,9 +49,21 @@ internal class UserSourceEntry(SourceProvider provider, string parentPath, Graph
                 { "o365:DisplayName", user.DisplayName ?? "" },
                 { "o365:UserPrincipalName", user.UserPrincipalName ?? "" },
                 { "o365:AccountEnabled", user.AccountEnabled?.ToString() ?? "" },
+                { "o365:Classification", GetUserClassification() },
             }
             .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+
+    /// <summary>
+    /// Gets the classification string for treeview display, preferring the already-resolved
+    /// seat classification (which includes the shared-mailbox distinction) and never
+    /// triggering an extra API call.
+    /// </summary>
+    private string GetUserClassification()
+    {
+        var cached = provider.TryGetCachedUserSeatCategory(user.Id);
+        return cached?.ToString() ?? SourceProvider.ClassifyUserFromDirectory(user);
+    }
 
     public override Task<bool> FileExists(string filename, CancellationToken cancellationToken)
         => Task.FromResult(provider.IncludedUserTypes.Any(x => x.ToString() == filename));

--- a/proprietary/Office365/SourceProvider/SourceProvider.UserProfile.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.UserProfile.cs
@@ -8,6 +8,31 @@ partial class SourceProvider
 
     internal class UserProfileImpl(APIHelper provider)
     {
+        /// <summary>
+        /// Gets the mailbox <c>userPurpose</c> for a user, which differentiates a regular
+        /// user mailbox from a shared, room or equipment mailbox.
+        /// Returns <c>null</c> if the user has no accessible mailbox (unlicensed, disabled,
+        /// soft-deleted, or hosted on-premise) or if the value cannot be determined.
+        /// </summary>
+        /// <param name="userIdOrUpn">The user id or user principal name.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>The mailbox purpose (e.g. <c>user</c>, <c>shared</c>, <c>room</c>, <c>equipment</c>), or null.</returns>
+        public async Task<string?> GetMailboxUserPurposeAsync(string userIdOrUpn, CancellationToken ct)
+        {
+            // MailboxSettings.Read (application) is required to read another user's mailbox purpose.
+            var url = $"{provider.GraphBaseUrl.TrimEnd('/')}/v1.0/users/{Uri.EscapeDataString(userIdOrUpn)}/mailboxSettings/userPurpose";
+            try
+            {
+                var purpose = await provider.GetGraphItemAsync<GraphMailboxUserPurpose>(url, ct).ConfigureAwait(false);
+                return string.IsNullOrWhiteSpace(purpose.Value) ? null : purpose.Value;
+            }
+            catch (Exception ex) when (APIHelper.IsMailboxNotEnabled(ex))
+            {
+                // No accessible mailbox; treat as unknown purpose.
+                return null;
+            }
+        }
+
         // /users/{id}
         public Task<Stream> GetUserObjectStreamAsync(string userIdOrUpn, CancellationToken ct)
         {

--- a/proprietary/Office365/SourceProvider/SourceProvider.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.cs
@@ -49,6 +49,14 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     private readonly ConcurrentDictionary<string, bool> _enumerationCounter = new();
 
     /// <summary>
+    /// Cache of the resolved seat classification for a given user (by id). This is resolved
+    /// once per user and reused across the non-incrementing (gate) and incrementing (count)
+    /// license checks, as well as for item metadata, so that the shared-mailbox lookup is
+    /// performed at most once per user.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, Task<UserSeatCategory>> _userSeatCache = new();
+
+    /// <summary>
     /// The current number of users that has been enumerated.
     /// </summary>
     private int _userCount = 0;
@@ -90,6 +98,21 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     private readonly Office365GroupType[] _includedGroupTypes;
 
     /// <summary>
+    /// The included user classifications.
+    /// </summary>
+    private readonly SourceItems.Office365UserClassification _includedUserClassifications;
+
+    /// <summary>
+    /// The included group classifications.
+    /// </summary>
+    private readonly SourceItems.Office365GroupClassification _includedGroupClassifications;
+
+    /// <summary>
+    /// The included site classifications.
+    /// </summary>
+    private readonly SourceItems.Office365SiteClassification _includedSiteClassifications;
+
+    /// <summary>
     /// Whether this provider is being used for a restore operation.
     /// </summary>
     internal bool UsedForRestoreOperation { get; set; } = false;
@@ -107,6 +130,9 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
         _includedRootTypes = null!;
         _includedUserTypes = null!;
         _includedGroupTypes = null!;
+        _includedUserClassifications = OptionsHelper.ALL_USER_CLASSIFICATIONS;
+        _includedGroupClassifications = OptionsHelper.ALL_GROUP_CLASSIFICATIONS;
+        _includedSiteClassifications = OptionsHelper.ALL_SITE_CLASSIFICATIONS;
         _hasSetMetadataStorageOption = false;
     }
 
@@ -126,6 +152,9 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
         _includedRootTypes = parsedOptions.IncludedRootTypes;
         _includedUserTypes = parsedOptions.IncludedUserTypes;
         _includedGroupTypes = parsedOptions.IncludedGroupTypes;
+        _includedUserClassifications = parsedOptions.IncludedUserClassifications;
+        _includedGroupClassifications = parsedOptions.IncludedGroupClassifications;
+        _includedSiteClassifications = parsedOptions.IncludedSiteClassifications;
         _apiHelper = APIHelper.Create(
             tenantId: parsedOptions.TenantId,
             authOptions: parsedOptions.AuthOptions,
@@ -240,17 +269,284 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     }
 
     /// <summary>
+    /// Determines whether the given user consumes a Duplicati user seat.
+    /// Regular user mailboxes always count. Shared, room and equipment mailboxes only
+    /// count when they have additional storage, i.e. an assigned Exchange Online license.
+    /// </summary>
+    /// <param name="user">The user to classify.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><c>true</c> if the user should count as a seat; otherwise <c>false</c>.</returns>
+    internal async Task<bool> UserCountsAsSeatAsync(GraphUser user, CancellationToken cancellationToken)
+    {
+        // Restores are unlimited; avoid any extra Graph calls for classification.
+        if (UsedForRestoreOperation)
+            return true;
+
+        var category = await ClassifyUserAsync(user, cancellationToken).ConfigureAwait(false);
+        return SeatCategoryCountsAsSeat(category);
+    }
+
+    /// <summary>
+    /// Determines whether the given seat category consumes a licensed seat. Only shared,
+    /// room and equipment mailboxes without additional storage do not consume a seat; every
+    /// other category (including unlicensed and undetermined regular mailboxes) counts, so
+    /// real user seats are never under-counted.
+    /// </summary>
+    private static bool SeatCategoryCountsAsSeat(UserSeatCategory category)
+        => category != UserSeatCategory.SharedMailboxWithoutStorage;
+
+    /// <summary>
+    /// Returns the cached seat classification for a user if it has already been resolved,
+    /// without triggering any Graph API call. Returns <c>null</c> when the classification has
+    /// not been resolved yet (or has not completed successfully).
+    /// </summary>
+    /// <param name="userId">The user id.</param>
+    /// <returns>The resolved seat category, or <c>null</c> if not yet available.</returns>
+    internal UserSeatCategory? TryGetCachedUserSeatCategory(string userId)
+        => _userSeatCache.TryGetValue(userId, out var task) && task.IsCompletedSuccessfully
+            ? task.Result
+            : null;
+
+    /// <summary>
+    /// Determines whether the given group consumes a Duplicati group seat.
+    /// Only Microsoft 365 (Unified) groups have backable content and count as a seat.
+    /// Security groups and distribution lists (mail-enabled security groups included) do
+    /// not consume a group seat.
+    /// </summary>
+    /// <param name="group">The group to classify.</param>
+    /// <returns><c>true</c> if the group should count as a seat; otherwise <c>false</c>.</returns>
+    internal static bool GroupCountsAsSeat(GraphGroup group)
+        => group.GroupTypes?.Any(t => t.Equals("Unified", StringComparison.OrdinalIgnoreCase)) == true;
+
+    /// <summary>
+    /// Determines whether the given mailbox <c>userPurpose</c> value denotes a mailbox that
+    /// is not a regular user mailbox (shared, room, equipment or other).
+    /// </summary>
+    /// <param name="purpose">The mailbox purpose value.</param>
+    /// <returns><c>true</c> if the mailbox is not a regular user mailbox; otherwise <c>false</c>.</returns>
+    private static bool IsNonUserMailboxPurpose(string purpose)
+        => purpose.Equals("shared", StringComparison.OrdinalIgnoreCase)
+            || purpose.Equals("room", StringComparison.OrdinalIgnoreCase)
+            || purpose.Equals("equipment", StringComparison.OrdinalIgnoreCase)
+            || purpose.Equals("others", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The seat classification of a user, used for reporting item counts.
+    /// </summary>
+    internal enum UserSeatCategory
+    {
+        /// <summary>A regular user mailbox with one or more assigned licenses.</summary>
+        Licensed,
+        /// <summary>A regular user mailbox with no assigned license.</summary>
+        Unlicensed,
+        /// <summary>A shared/room/equipment mailbox with additional (licensed) storage.</summary>
+        SharedMailboxWithStorage,
+        /// <summary>A shared/room/equipment mailbox without additional storage.</summary>
+        SharedMailboxWithoutStorage,
+    }
+
+    /// <summary>
+    /// The classification of a SharePoint site, used for reporting item counts.
+    /// Determined on a best-effort basis from the Microsoft Graph <c>site</c> object only.
+    /// </summary>
+    internal enum SiteCategory
+    {
+        /// <summary>A Microsoft 365 group-connected team site.</summary>
+        Group,
+        /// <summary>A classic (non-group) team site.</summary>
+        Classic,
+        /// <summary>A modern communication site.</summary>
+        Communication,
+        /// <summary>A personal (OneDrive for Business) site.</summary>
+        Personal,
+        /// <summary>Any other or undetermined site type.</summary>
+        Other,
+    }
+
+    /// <summary>
+    /// Maps a <see cref="UserSeatCategory"/> to its corresponding include-filter flag.
+    /// </summary>
+    private static SourceItems.Office365UserClassification ToClassificationFlag(UserSeatCategory category)
+        => category switch
+        {
+            UserSeatCategory.Licensed => SourceItems.Office365UserClassification.Licensed,
+            UserSeatCategory.Unlicensed => SourceItems.Office365UserClassification.Unlicensed,
+            UserSeatCategory.SharedMailboxWithStorage => SourceItems.Office365UserClassification.SharedMailboxWithStorage,
+            UserSeatCategory.SharedMailboxWithoutStorage => SourceItems.Office365UserClassification.SharedMailboxWithoutStorage,
+            _ => SourceItems.Office365UserClassification.Licensed
+        };
+
+    /// <summary>
+    /// Maps a <see cref="SiteCategory"/> to its corresponding include-filter flag.
+    /// </summary>
+    private static SourceItems.Office365SiteClassification ToClassificationFlag(SiteCategory category)
+        => category switch
+        {
+            SiteCategory.Group => SourceItems.Office365SiteClassification.Group,
+            SiteCategory.Classic => SourceItems.Office365SiteClassification.Classic,
+            SiteCategory.Communication => SourceItems.Office365SiteClassification.Communication,
+            SiteCategory.Personal => SourceItems.Office365SiteClassification.Personal,
+            _ => SourceItems.Office365SiteClassification.Other
+        };
+
+    /// <summary>
+    /// Determines whether a user should be included based on its classification and the
+    /// configured user-classification include filter. Uses the cached classification, so no
+    /// extra Graph API call is made beyond the one already performed for seat counting.
+    /// </summary>
+    /// <param name="user">The user to test.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><c>true</c> if the user should be included; otherwise <c>false</c>.</returns>
+    internal async Task<bool> IsUserClassificationIncludedAsync(GraphUser user, CancellationToken cancellationToken)
+    {
+        var category = await ClassifyUserAsync(user, cancellationToken).ConfigureAwait(false);
+        return _includedUserClassifications.HasFlag(ToClassificationFlag(category));
+    }
+
+    /// <summary>
+    /// Determines whether a group should be included based on its classification and the
+    /// configured group-classification include filter.
+    /// </summary>
+    /// <param name="group">The group to test.</param>
+    /// <returns><c>true</c> if the group should be included; otherwise <c>false</c>.</returns>
+    internal bool IsGroupClassificationIncluded(GraphGroup group)
+    {
+        var flag = GroupCountsAsSeat(group)
+            ? SourceItems.Office365GroupClassification.Unified
+            : SourceItems.Office365GroupClassification.NotUnified;
+        return _includedGroupClassifications.HasFlag(flag);
+    }
+
+    /// <summary>
+    /// Determines whether a site should be included based on its classification and the
+    /// configured site-classification include filter.
+    /// </summary>
+    /// <param name="site">The site to test.</param>
+    /// <returns><c>true</c> if the site should be included; otherwise <c>false</c>.</returns>
+    internal bool IsSiteClassificationIncluded(GraphSite site)
+        => _includedSiteClassifications.HasFlag(ToClassificationFlag(ClassifySite(site)));
+
+    /// <summary>
+    /// Classifies a user into one of the <see cref="UserSeatCategory"/> buckets.
+    /// A licensed user (with assigned licenses) is <see cref="UserSeatCategory.Licensed"/>,
+    /// unless it is a shared/room/equipment mailbox, in which case it is
+    /// <see cref="UserSeatCategory.SharedMailboxWithStorage"/>. Unlicensed regular mailboxes
+    /// are <see cref="UserSeatCategory.Unlicensed"/>, and unlicensed shared mailboxes are
+    /// <see cref="UserSeatCategory.SharedMailboxWithoutStorage"/>.
+    /// </summary>
+    /// <param name="user">The user to classify.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The user seat category.</returns>
+    /// <remarks>
+    /// The result is resolved once per user and cached, so the underlying
+    /// <c>mailboxSettings/userPurpose</c> lookup is performed at most once per user and is
+    /// shared between seat counting, the count operation and item metadata.
+    /// </remarks>
+    internal Task<UserSeatCategory> ClassifyUserAsync(GraphUser user, CancellationToken cancellationToken)
+        => _userSeatCache.GetOrAdd(user.Id, _ => ResolveUserSeatCategoryAsync(user, cancellationToken));
+
+    /// <summary>
+    /// Resolves the seat classification for a user. See <see cref="ClassifyUserAsync"/>.
+    /// </summary>
+    private async Task<UserSeatCategory> ResolveUserSeatCategoryAsync(GraphUser user, CancellationToken cancellationToken)
+    {
+        var hasStorage = user.AssignedLicenses is { Count: > 0 };
+
+        string? purpose = null;
+        try
+        {
+            purpose = await UserProfileApi.GetMailboxUserPurposeAsync(user.Id, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // If the purpose cannot be determined, treat it as a regular user mailbox.
+            Library.Logging.Log.WriteVerboseMessage(LOGTAG, "MailboxPurposeLookupFailed", ex, $"Failed to determine mailbox purpose for user '{user.Id}'; treating it as a regular user mailbox.");
+        }
+
+        var isShared = !string.IsNullOrWhiteSpace(purpose) && IsNonUserMailboxPurpose(purpose);
+
+        if (isShared)
+            return hasStorage
+                ? UserSeatCategory.SharedMailboxWithStorage
+                : UserSeatCategory.SharedMailboxWithoutStorage;
+
+        return hasStorage
+            ? UserSeatCategory.Licensed
+            : UserSeatCategory.Unlicensed;
+    }
+
+    /// <summary>
+    /// Classifies a SharePoint site into one of the <see cref="SiteCategory"/> buckets,
+    /// on a best-effort basis using only the Microsoft Graph <c>site</c> object.
+    /// Personal (OneDrive) sites are detected reliably. The Graph <c>site</c> object does
+    /// not expose the SharePoint web template, so group, classic and communication sites
+    /// cannot be reliably distinguished from Graph alone and are reported as
+    /// <see cref="SiteCategory.Other"/>.
+    /// </summary>
+    /// <param name="site">The site to classify.</param>
+    /// <returns>The site category.</returns>
+    internal static SiteCategory ClassifySite(GraphSite site)
+    {
+        if (site.SiteCollection?.PersonalSite == true)
+            return SiteCategory.Personal;
+
+        // OneDrive personal sites are hosted on the "-my" SharePoint host.
+        var host = site.SiteCollection?.Hostname;
+        if (!string.IsNullOrWhiteSpace(host) && host.Contains("-my.", StringComparison.OrdinalIgnoreCase))
+            return SiteCategory.Personal;
+
+        if (!string.IsNullOrWhiteSpace(site.WebUrl)
+            && (site.WebUrl.Contains("-my.", StringComparison.OrdinalIgnoreCase)
+                || site.WebUrl.Contains("/personal/", StringComparison.OrdinalIgnoreCase)))
+            return SiteCategory.Personal;
+
+        // The Graph site object does not expose the web template, so group/classic/
+        // communication cannot be distinguished reliably from Graph alone.
+        return SiteCategory.Other;
+    }
+
+    /// <summary>
+    /// Classifies a user using only the data already present on the directory object,
+    /// without any additional Graph API call. This can only determine whether the user is
+    /// licensed or unlicensed; it cannot distinguish shared/room/equipment mailboxes, which
+    /// would require an extra <c>mailboxSettings/userPurpose</c> call.
+    /// </summary>
+    /// <param name="user">The user to classify.</param>
+    /// <returns>The classification string suitable for item metadata.</returns>
+    internal static string ClassifyUserFromDirectory(GraphUser user)
+        => user.AssignedLicenses is { Count: > 0 } ? "Licensed" : "Unlicensed";
+
+    /// <summary>
+    /// Classifies a group using only the data already present on the directory object,
+    /// without any additional Graph API call.
+    /// </summary>
+    /// <param name="group">The group to classify.</param>
+    /// <returns>The classification string suitable for item metadata.</returns>
+    internal static string ClassifyGroupFromDirectory(GraphGroup group)
+        => GroupCountsAsSeat(group) ? "Unified" : "NotUnified";
+
+    /// <summary>
     /// Determines whether the license is approved for the given entry.
     /// </summary>
     /// <param name="path">The path to verify.</param>
     /// <param name="type">The type of entry.</param>
     /// <param name="id">The ID of the entry.</param>
     /// <param name="increment">Whether to increment the counter if the license is approved.</param>
+    /// <param name="countsAsSeat">
+    /// Whether this entry consumes a licensed seat. When <c>false</c>, the entry is always
+    /// approved and never counted against the seat limit (used for shared mailboxes without
+    /// additional storage).
+    /// </param>
     /// <returns><c>true</c> if the license is approved; otherwise, <c>false</c>.</returns>
-    internal bool LicenseApprovedForEntry(string path, Office365MetaType type, string id, bool increment)
+    internal bool LicenseApprovedForEntry(string path, Office365MetaType type, string id, bool increment, bool countsAsSeat = true)
     {
         // We do not limit restores
         if (UsedForRestoreOperation)
+            return true;
+
+        // Entries that do not consume a seat (e.g. shared mailboxes without extra storage)
+        // are always approved and never counted against the seat limit.
+        if (!countsAsSeat)
             return true;
 
         // Make a unique target path for the type and id, just for counting purposes, not matching actual paths

--- a/proprietary/Office365/Strings.cs
+++ b/proprietary/Office365/Strings.cs
@@ -71,5 +71,14 @@ internal static class Strings
     public static string OfficeIncludedGroupTypesShort => LC.L("Included group types.");
     public static string OfficeIncludedGroupTypesLong => LC.L("The group types to include in the backup (e.g. Mailbox, OneDrive, Calendar).");
 
+    public static string OfficeIncludedUserClassificationsShort => LC.L("Included user classifications.");
+    public static string OfficeIncludedUserClassificationsLong => LC.L("The user classifications to include in the backup: Licensed, Unlicensed, SharedMailboxWithStorage, SharedMailboxWithoutStorage. Defaults to all.");
+
+    public static string OfficeIncludedGroupClassificationsShort => LC.L("Included group classifications.");
+    public static string OfficeIncludedGroupClassificationsLong => LC.L("The group classifications to include in the backup: Unified (Microsoft 365 groups), NotUnified (security groups and distribution lists). Defaults to all.");
+
+    public static string OfficeIncludedSiteClassificationsShort => LC.L("Included site classifications.");
+    public static string OfficeIncludedSiteClassificationsLong => LC.L("The site classifications to include in the backup: Group, Classic, Communication, Personal, Other. Defaults to all.");
+
     public static string LicenseWarning(SourceItems.Office365MetaType type, int approved) => LC.L($"Licensed Microsoft 365 feature seats exceeded for {type} ({approved}). Some items will not be backed up, and some folders may be empty.");
 }

--- a/proprietary/Office365/WebModule/WebModule.cs
+++ b/proprietary/Office365/WebModule/WebModule.cs
@@ -16,7 +16,8 @@ public class WebModule : IWebModule
     public enum Operation
     {
         ListDestination,
-        ListDestinationRestoreTargets
+        ListDestinationRestoreTargets,
+        CountItems
     }
 
     private static readonly Operation DEFAULT_OPERATION = Operation.ListDestination;
@@ -74,7 +75,7 @@ public class WebModule : IWebModule
         options.TryGetValue(KEY_URL, out var url);
         options.TryGetValue(KEY_PATH, out var path);
 
-        if (op != Operation.ListDestination && op != Operation.ListDestinationRestoreTargets)
+        if (!Enum.IsDefined(op))
             throw new UserInformationException($"Unsupported operation: {op}", "UnsupportedOperation");
 
         if (string.IsNullOrWhiteSpace(url))
@@ -91,6 +92,9 @@ public class WebModule : IWebModule
 
         using var client = new SourceProvider(url, "", forwardoptions);
         await client.InitializeAsync(cancellationToken);
+
+        if (op == Operation.CountItems)
+            return await CountItemsAsync(client, cancellationToken).ConfigureAwait(false);
 
         var targetEntry = await client.GetEntryAsync((path ?? "").TrimStart('/'), isFolder: true, cancellationToken).ConfigureAwait(false);
         if (targetEntry == null)
@@ -138,6 +142,166 @@ public class WebModule : IWebModule
 
     }
 
+    /// <summary>
+    /// The result key under which the item-count breakdown JSON is returned.
+    /// </summary>
+    private const string COUNT_RESULT_KEY = "counts";
+
+    /// <summary>
+    /// Counts the number of top-level items (users, groups, sites) and, within each
+    /// top-level type, breaks the items down by whether they consume a Duplicati license
+    /// seat and by sub-type.
+    /// </summary>
+    /// <param name="client">The initialized source provider.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A dictionary containing a single JSON-serialized <see cref="CountResult"/>.</returns>
+    private static async Task<IDictionary<string, string>> CountItemsAsync(SourceProvider client, CancellationToken cancellationToken)
+    {
+        var result = new CountResult();
+
+        // Users
+        await foreach (var user in client.RootApi.ListAllUsersAsync(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result.Users.Total++;
+
+            switch (await client.ClassifyUserAsync(user, cancellationToken).ConfigureAwait(false))
+            {
+                case SourceProvider.UserSeatCategory.Licensed:
+                    result.Users.Licensed++;
+                    break;
+                case SourceProvider.UserSeatCategory.Unlicensed:
+                    result.Users.Unlicensed++;
+                    break;
+                case SourceProvider.UserSeatCategory.SharedMailboxWithStorage:
+                    result.Users.SharedMailboxWithStorage++;
+                    break;
+                case SourceProvider.UserSeatCategory.SharedMailboxWithoutStorage:
+                    result.Users.SharedMailboxWithoutStorage++;
+                    break;
+            }
+        }
+
+        // Groups
+        await foreach (var group in client.RootApi.ListAllGroupsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result.Groups.Total++;
+
+            if (SourceProvider.GroupCountsAsSeat(group))
+                result.Groups.Unified++;
+            else
+                result.Groups.NotUnified++;
+        }
+
+        // Sites
+        await foreach (var site in client.RootApi.ListAllSitesAsync(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result.Sites.Total++;
+
+            switch (SourceProvider.ClassifySite(site))
+            {
+                case SourceProvider.SiteCategory.Group:
+                    result.Sites.Group++;
+                    break;
+                case SourceProvider.SiteCategory.Classic:
+                    result.Sites.Classic++;
+                    break;
+                case SourceProvider.SiteCategory.Communication:
+                    result.Sites.Communication++;
+                    break;
+                case SourceProvider.SiteCategory.Personal:
+                    result.Sites.Personal++;
+                    break;
+                default:
+                    result.Sites.Other++;
+                    break;
+            }
+        }
+
+        return new Dictionary<string, string>
+        {
+            [COUNT_RESULT_KEY] = JsonSerializer.Serialize(result)
+        };
+    }
+
     public IDictionary<string, IDictionary<string, string>> GetLookups()
         => new Dictionary<string, IDictionary<string, string>>();
+
+    /// <summary>
+    /// The item-count breakdown returned by <see cref="Operation.CountItems"/>.
+    /// </summary>
+    private sealed class CountResult
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("users")]
+        public UserCounts Users { get; } = new();
+
+        [System.Text.Json.Serialization.JsonPropertyName("groups")]
+        public GroupCounts Groups { get; } = new();
+
+        [System.Text.Json.Serialization.JsonPropertyName("sites")]
+        public SiteCounts Sites { get; } = new();
+    }
+
+    /// <summary>
+    /// The user item-count breakdown. <see cref="Licensed"/> and
+    /// <see cref="SharedMailboxWithStorage"/> require a license seat; the remainder do not.
+    /// </summary>
+    private sealed class UserCounts
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("total")]
+        public int Total { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("licensed")]
+        public int Licensed { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("unlicensed")]
+        public int Unlicensed { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("sharedMailboxWithStorage")]
+        public int SharedMailboxWithStorage { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("sharedMailboxWithoutStorage")]
+        public int SharedMailboxWithoutStorage { get; set; }
+    }
+
+    /// <summary>
+    /// The group item-count breakdown. Only <see cref="Unified"/> groups require a seat.
+    /// </summary>
+    private sealed class GroupCounts
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("total")]
+        public int Total { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("unified")]
+        public int Unified { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("notUnified")]
+        public int NotUnified { get; set; }
+    }
+
+    /// <summary>
+    /// The site item-count breakdown.
+    /// </summary>
+    private sealed class SiteCounts
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("total")]
+        public int Total { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("group")]
+        public int Group { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("classic")]
+        public int Classic { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("communication")]
+        public int Communication { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("personal")]
+        public int Personal { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("other")]
+        public int Other { get; set; }
+    }
 }


### PR DESCRIPTION
This updates the MS365 backups to not treat regular shared mailboxes as needing a license. Similarly, non-Unified groups no longer requires a license.

With this is also an API for counting the number of different top-level items in the backup. With this new classification, it is now also possible to exclude items from the backup based on their type.