### PR TITLE
Improve filter parsing

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -858,7 +858,7 @@ namespace Duplicati.Library.Main
 
                 // If the filters were changed by a module, read them back in
                 if (pristinefilter != m_options.RawOptions["filter"])
-                    filter = FilterExpression.Deserialize(m_options.RawOptions["filter"].Split(new string[] { Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries));
+                    filter = FilterExpression.Deserialize(m_options.RawOptions["filter"].Split([Path.PathSeparator.ToString()], StringSplitOptions.RemoveEmptyEntries));
             }
 
             if (!string.IsNullOrEmpty(m_options.Logfile))

--- a/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
@@ -534,7 +534,7 @@ namespace Duplicati.Library.Main.Database.Local
                         pathprefix = Util.AppendDirSeparator(pathprefix, dirsep);
 
                     await using var tmpnames = await FilteredFilenameTable
-                        .CreateFilteredFilenameTableAsync(m_db, new FilterExpression(new string[] { pathprefix + "*" }, true), token)
+                        .CreateFilteredFilenameTableAsync(m_db, new FilterExpression(pathprefix + "*", true), token)
                         .ConfigureAwait(false);
                     await using var cmd = m_db.Connection.CreateCommand();
                     //First we trim the filelist to exclude filenames not found in any of the filesets

--- a/Duplicati/Library/Utility/FilterCollector.cs
+++ b/Duplicati/Library/Utility/FilterCollector.cs
@@ -52,7 +52,13 @@ namespace Duplicati.Library.Utility
 
                     if (include || exclude)
                     {
-                        m_filters.Add(new FilterExpression(Environment.ExpandEnvironmentVariables(value), include));
+                        // Environment variable expansion is intentionally performed here rather than
+                        // inside FilterExpression: only command-line --include/--exclude arguments
+                        // are expanded, which mirrors how other options (e.g. --changed-files) are
+                        // pre-split by Options.cs before reaching the filter layer.
+                        var expanded = Environment.ExpandEnvironmentVariables(value);
+                        if (!string.IsNullOrWhiteSpace(expanded))
+                            m_filters.Add(new FilterExpression(expanded, include));
                         return false;
                     }
                 }

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -392,22 +392,24 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Creates a new <see cref="FilterExpression"/> instance.
+        /// Creates a new <see cref="FilterExpression"/> instance from a single filter string.
         /// </summary>
         /// <param name="filter">The filter string that represents the filter</param>
         public FilterExpression(string filter, bool result = true)
-            : this(Expand(filter), result)
+            : this([filter], result)
         {
         }
 
         /// <summary>
-        /// Creates a new <see cref="FilterExpression"/> instance.
+        /// Creates a new <see cref="FilterExpression"/> instance from one or more filter strings.
         /// </summary>
-        /// <param name="filter">The filter string that represents the filter</param>
+        /// <param name="filter">The filter strings that represent the filter</param>
         /// <param name="result">Return value of <see cref="Matches(string,out bool,out IFilter)"/> in case of match</param>
         public FilterExpression(IEnumerable<string>? filter, bool result = true)
         {
             this.Result = result;
+
+            filter = ExpandFilterGroups(filter);
 
             if (filter == null)
             {
@@ -427,24 +429,40 @@ namespace Duplicati.Library.Utility
                 this.Type = m_filters.Max((a) => a.Type);
         }
 
-        private static IEnumerable<string>? Expand(string filter)
+        /// <summary>
+        /// Expands any <c>{GroupName}</c> entries in <paramref name="filters"/> into the underlying
+        /// filter strings provided by <see cref="FilterGroups.GetFilterStrings(FilterGroup)"/>.
+        /// </summary>
+        /// <param name="filters">The raw filter strings to inspect. May be <see langword="null"/>.</param>
+        /// <returns>
+        /// A new sequence with group references replaced by their constituent filter strings, or
+        /// <see langword="null"/> when <paramref name="filters"/> is <see langword="null"/> or all
+        /// entries are empty/whitespace and/or reference unknown groups.
+        /// </returns>
+        private static IEnumerable<string>? ExpandFilterGroups(IEnumerable<string>? filters)
         {
-            if (string.IsNullOrWhiteSpace(filter))
+            if (filters == null)
                 return null;
 
-            if (filter.Length < 2 || (filter.StartsWith("[", StringComparison.Ordinal) && filter.EndsWith("]", StringComparison.Ordinal)))
+            var result = new List<string>();
+            foreach (var f in filters)
             {
-                return new string[] { filter };
-            }
+                if (string.IsNullOrWhiteSpace(f))
+                    continue;
 
-            if (filter.StartsWith("{", StringComparison.Ordinal) && filter.EndsWith("}", StringComparison.Ordinal))
-            {
-                string groupName = filter.Substring(1, filter.Length - 2);
-                FilterGroup filterGroup = FilterGroups.ParseFilterList(groupName, FilterGroup.None);
-                return (filterGroup == FilterGroup.None) ? null : FilterGroups.GetFilterStrings(filterGroup);
+                if (f.StartsWith("{", StringComparison.Ordinal) && f.EndsWith("}", StringComparison.Ordinal))
+                {
+                    string groupName = f.Substring(1, f.Length - 2);
+                    FilterGroup filterGroup = FilterGroups.ParseFilterList(groupName, FilterGroup.None);
+                    if (filterGroup != FilterGroup.None)
+                        result.AddRange(FilterGroups.GetFilterStrings(filterGroup));
+                }
+                else
+                {
+                    result.Add(f);
+                }
             }
-
-            return filter.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+            return result.Count > 0 ? result : null;
         }
 
         private static List<FilterEntry> Compact(IEnumerable<FilterEntry> items)

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -1668,13 +1668,13 @@ namespace Duplicati.Server
                     filter = newfilter;
 
                 if (!string.IsNullOrWhiteSpace(prependfilter))
-                    filter = FilterExpression.Combine(FilterExpression.Deserialize(prependfilter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries)), filter);
+                    filter = FilterExpression.Combine(FilterExpression.Deserialize(prependfilter.Split([System.IO.Path.PathSeparator.ToString()], StringSplitOptions.RemoveEmptyEntries)), filter);
 
                 if (!string.IsNullOrWhiteSpace(appendfilter))
-                    filter = FilterExpression.Combine(filter, FilterExpression.Deserialize(appendfilter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries)));
+                    filter = FilterExpression.Combine(filter, FilterExpression.Deserialize(appendfilter.Split([System.IO.Path.PathSeparator.ToString()], StringSplitOptions.RemoveEmptyEntries)));
 
                 if (!string.IsNullOrWhiteSpace(replacefilter))
-                    filter = FilterExpression.Deserialize(replacefilter.Split(new string[] { System.IO.Path.PathSeparator.ToString() }, StringSplitOptions.RemoveEmptyEntries));
+                    filter = FilterExpression.Deserialize(replacefilter.Split([System.IO.Path.PathSeparator.ToString()], StringSplitOptions.RemoveEmptyEntries));
 
                 foreach (var keyvalue in opt)
                     options[keyvalue.Key] = keyvalue.Value;

--- a/Duplicati/UnitTest/FilterTest.cs
+++ b/Duplicati/UnitTest/FilterTest.cs
@@ -304,5 +304,141 @@ namespace Duplicati.UnitTest
                 Assert.IsFalse(combined.Matches(s, out _, out _));
             }
         }
+
+        [Test]
+        [Category("Filter")]
+        public static void SingleStringConstructorDoesNotSplitOnPathSeparator()
+        {
+            // Regression guard: the single-string constructor must treat the input as a single
+            // filter entry and must NOT split it on System.IO.Path.PathSeparator. Previously the
+            // constructor split the input, which broke Windows paths that contain a colon (the
+            // platform's PathSeparator) or Unix paths that contain a semicolon.
+            var sep = System.IO.Path.PathSeparator.ToString();
+
+            // A path that contains the platform path separator should be matched as a single
+            // literal entry, not as two separate entries.
+            var literalWithSep = $"alpha{sep}beta";
+            var filter = new FilterExpression(literalWithSep);
+
+            Assert.IsFalse(filter.Empty, "Filter should not be empty");
+            Assert.AreEqual(FilterType.Simple, filter.Type, "Filter should be a simple/literal entry");
+
+            // The full string (including the separator) must match, proving it was not split.
+            Assert.IsTrue(filter.Matches(literalWithSep, out _, out _));
+            // Neither half should match on its own.
+            Assert.IsFalse(filter.Matches("alpha", out _, out _));
+            Assert.IsFalse(filter.Matches("beta", out _, out _));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void SingleStringConstructorHandlesEmptyAndWhitespace()
+        {
+            Assert.IsTrue(new FilterExpression(string.Empty).Empty, "Empty string should produce an empty filter");
+            Assert.IsTrue(new FilterExpression("   ").Empty, "Whitespace-only string should produce an empty filter");
+            Assert.IsTrue(new FilterExpression("\t\n").Empty, "Tab/newline string should produce an empty filter");
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void MultiStringConstructorDoesNotSplitEntries()
+        {
+            var sep = System.IO.Path.PathSeparator.ToString();
+
+            // When multiple entries are passed, each is treated as a distinct literal. Entries
+            // containing the platform path separator must not be split further.
+            var filter = new FilterExpression(new[] { $"foo{sep}bar", "baz" });
+
+            Assert.IsFalse(filter.Empty);
+            Assert.IsTrue(filter.Matches($"foo{sep}bar", out _, out _), "Composite entry should match as a whole");
+            Assert.IsTrue(filter.Matches("baz", out _, out _));
+            Assert.IsFalse(filter.Matches("foo", out _, out _), "Composite entry should not match its first half");
+            Assert.IsFalse(filter.Matches("bar", out _, out _), "Composite entry should not match its second half");
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void ExpandFilterGroupsResolvesValidGroup()
+        {
+            // {DefaultExcludes} should expand into the underlying System/Cache/etc. filter strings.
+            // Rather than asserting a specific platform-dependent path match, verify that the
+            // expanded filter is non-empty and matches at least one of the strings produced by
+            // FilterGroups.GetFilterStrings(FilterGroup.DefaultExcludes).
+            var groupStrings = FilterGroups.GetFilterStrings(FilterGroup.DefaultExcludes).ToList();
+            Assert.IsTrue(groupStrings.Count > 0, "DefaultExcludes group should produce filter strings");
+
+            var defaultExcludes = new FilterExpression("{DefaultExcludes}");
+            Assert.IsFalse(defaultExcludes.Empty, "DefaultExcludes group should expand to a non-empty filter");
+
+            var anyMatched = groupStrings.Any(s => defaultExcludes.Matches(s, out _, out _));
+            Assert.IsTrue(anyMatched, "Expanded filter should match at least one of the group's filter strings");
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void ExpandFilterGroupsDropsNoneResolvingGroup()
+        {
+            // DefaultIncludes resolves to FilterGroup.None, so the entry should be silently dropped
+            // rather than producing an empty/throwing filter. Combined with another literal, the
+            // literal must still match.
+            var filter = new FilterExpression(new[] { "{DefaultIncludes}", "keepme" });
+            Assert.IsFalse(filter.Empty, "Literal entry should survive even when a group entry is dropped");
+            Assert.IsTrue(filter.Matches("keepme", out _, out _));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void ExpandFilterGroupsThrowsOnUnknownGroup()
+        {
+            // An unknown group name is a user error; ParseFilterList throws ArgumentException,
+            // which must propagate out of the constructor.
+            Assert.Throws<ArgumentException>(() => new FilterExpression("{NoSuchGroup}"));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void ExpandFilterGroupsDropsEmptyAndWhitespaceEntries()
+        {
+            var filter = new FilterExpression(new[] { "", "   ", "real" });
+            Assert.IsFalse(filter.Empty);
+            Assert.IsTrue(filter.Matches("real", out _, out _));
+            Assert.IsFalse(filter.Matches("", out _, out _));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void ExpandFilterGroupsReturnsEmptyWhenAllEntriesDropped()
+        {
+            // When every entry resolves to nothing (empty strings plus a None-resolving group),
+            // the resulting filter should be Empty.
+            var filter = new FilterExpression(new[] { "", "{DefaultIncludes}", "   " });
+            Assert.IsTrue(filter.Empty, "Filter with only dropped entries should be empty");
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void FilterCollectorSkipsEmptyExpandedIncludeExclude()
+        {
+            // FilterCollector expands environment variables for --include/--exclude. If the
+            // expanded value is empty or whitespace, no filter entry should be added, and the
+            // resulting filter should be empty. Passing whitespace directly exercises the
+            // IsNullOrWhiteSpace guard without depending on platform-specific env var syntax.
+            var (_, filter) = FilterCollector.ExtractOptions(
+                new List<string> { "--include=   " });
+            Assert.IsTrue(filter.Empty, "Whitespace-only include should produce an empty filter");
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void FilterCollectorAcceptsNonWhitespaceInclude()
+        {
+            // A non-whitespace include value (with no env var references to expand) should
+            // produce a usable literal filter.
+            var (_, filter) = FilterCollector.ExtractOptions(
+                new List<string> { "--include=target-file.txt" });
+            Assert.IsFalse(filter.Empty);
+            Assert.IsTrue(filter.Matches("target-file.txt", out var result, out _));
+            Assert.IsTrue(result, "Include filter should report a positive match result");
+        }
     }
 }


### PR DESCRIPTION
This improves the filter parsing in a few places to not split on the path separator unless needed (';' on Windows, `:` on Linux/MacOS).

There are a few places where path separators are used to allow passing multiple filters when working with commandline input and scripts. These still cannot handle filters that target files or folders with embedded path separators.

Other places, notably when running a job from the server, we know the filters are single entry elements, so here we avoid splitting, which in turn allows targeting filters on paths with embedded path separators.