### PR TITLE
Fixed restore-control-files

### DIFF
--- a/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreControlFilesHandler.cs
@@ -77,8 +77,14 @@ namespace Duplicati.Library.Main.Operation
                             .ConfigureAwait(false);
 
                         var res = new List<string>();
+
+                        // We do not want to match the manifest settings to the current settings,
+                        // as we only want to access the control files
+                        var readopts = new Options(m_options.RawOptions);
+                        readopts.RawOptions["dont-read-manifests"] = "true";
+
                         using (var tmpfile = await backendManager.GetAsync(file.Name, entry.Hash, entry.Size < 0 ? file.Size : entry.Size, allowParityRepair: true, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
-                        using (var tmp = new Volumes.FilesetVolumeReader(RestoreHandler.GetCompressionModule(file.Name), tmpfile, m_options))
+                        using (var tmp = new Volumes.FilesetVolumeReader(RestoreHandler.GetCompressionModule(file.Name), tmpfile, readopts))
                             foreach (var cf in tmp.ControlFiles)
                                 if (FilterExpression.Matches(filter, cf.Key))
                                 {


### PR DESCRIPTION
This fixes an error with restore-control-files where the local options would be validated against the remote manifest when restoring control files.

The would cause errors if the local settings differed from the control files settings (hash algorithm, blocksize, etc). But since we do not use any of that for restoring the control files, the code is updated to ignore control files in this case.