### PR TITLE
Unify `--datafolder` option name

### DIFF
--- a/Duplicati/CommandLine/ConfigureTool/Commands/HttpsCommand.cs
+++ b/Duplicati/CommandLine/ConfigureTool/Commands/HttpsCommand.cs
@@ -63,7 +63,7 @@ public static class HttpsCommand
     /// <returns>The command</returns>
     private static Command AddDatabaseOptions(Command cmd)
     {
-        cmd.AddOption(new Option<string>("--data-folder", "Path to the Duplicati data folder (defaults to standard location)"));
+        cmd.AddOption(new Option<string>("--datafolder", "Path to the Duplicati data folder (defaults to standard location)"));
         cmd.AddOption(new Option<string>("--settings-encryption-key", "Settings encryption key for the database (if settings are encrypted)"));
         return cmd;
     }
@@ -370,10 +370,10 @@ public static class HttpsCommand
     /// Handles the 'generate' command.
     /// Delegates certificate generation to <see cref="CertificateConfigurationHelper.GenerateCertificates"/>.
     /// </summary>
-    private static int HandleGenerate(string? hostnames, bool noTrust, string? dataFolder, string? settingsEncryptionKey, bool autoCreateDatabase, string? store, string? certDir, string? keychain)
+    private static int HandleGenerate(string? hostnames, bool noTrust, string? datafolder, string? settingsEncryptionKey, bool autoCreateDatabase, string? store, string? certDir, string? keychain)
     {
         var storeLocation = ParseStoreLocation(store);
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
 
         using var _ = StartConsoleLogScope();
         Console.WriteLine($"Using data folder: {dataFolderPath}");
@@ -426,9 +426,9 @@ public static class HttpsCommand
     /// Handles the 'renew' command.
     /// Delegates certificate renewal to <see cref="CertificateConfigurationHelper.RenewServerCertificate"/>.
     /// </summary>
-    private static int HandleRenew(string? dataFolder, string? settingsEncryptionKey)
+    private static int HandleRenew(string? datafolder, string? settingsEncryptionKey)
     {
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
 
         Console.WriteLine($"Using data folder: {dataFolderPath}");
         using var _ = StartConsoleLogScope();
@@ -466,10 +466,10 @@ public static class HttpsCommand
     /// Handles the 'regenerate-ca' command.
     /// Delegates to <see cref="CertificateConfigurationHelper.RegenerateCACertificates"/>.
     /// </summary>
-    private static int HandleRegenerateCa(string? hostnames, bool noTrust, string? dataFolder, string? settingsEncryptionKey, string? store, string? certDir, string? keychain)
+    private static int HandleRegenerateCa(string? hostnames, bool noTrust, string? datafolder, string? settingsEncryptionKey, string? store, string? certDir, string? keychain)
     {
         var storeLocation = ParseStoreLocation(store);
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
 
         Console.WriteLine($"Using data folder: {dataFolderPath}");
         using var _ = StartConsoleLogScope();
@@ -511,10 +511,10 @@ public static class HttpsCommand
     /// <summary>
     /// Handles the 'remove' command.
     /// </summary>
-    private static int HandleRemove(string? dataFolder, string? settingsEncryptionKey, string? store, string? certDir, string? keychain)
+    private static int HandleRemove(string? datafolder, string? settingsEncryptionKey, string? store, string? certDir, string? keychain)
     {
         var storeLocation = ParseStoreLocation(store);
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
 
         Console.WriteLine($"Using data folder: {dataFolderPath}");
         using var _ = StartConsoleLogScope();
@@ -577,10 +577,10 @@ public static class HttpsCommand
     /// Handles the 'show' command.
     /// Delegates status retrieval to <see cref="CertificateConfigurationHelper.GetCertificateStatus"/>.
     /// </summary>
-    private static int HandleShow(string? dataFolder, string? settingsEncryptionKey, string? store, string? certDir, string? keychain)
+    private static int HandleShow(string? datafolder, string? settingsEncryptionKey, string? store, string? certDir, string? keychain)
     {
         var storeLocation = ParseStoreLocation(store);
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
 
         Console.WriteLine($"Using data folder: {dataFolderPath}");
         Console.WriteLine();
@@ -671,9 +671,9 @@ public static class HttpsCommand
     /// <summary>
     /// Handles the 'export' command.
     /// </summary>
-    private static int HandleExport(string? file, string? dataFolder, string? settingsEncryptionKey)
+    private static int HandleExport(string? file, string? datafolder, string? settingsEncryptionKey)
     {
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
         var outputFile = string.IsNullOrWhiteSpace(file) ? "duplicati-server.crt" : file;
 
         Console.WriteLine($"Using data folder: {dataFolderPath}");
@@ -709,9 +709,9 @@ public static class HttpsCommand
     /// <summary>
     /// Handles the 'export-ca' command.
     /// </summary>
-    private static int HandleExportCa(string? file, string? dataFolder, string? settingsEncryptionKey)
+    private static int HandleExportCa(string? file, string? datafolder, string? settingsEncryptionKey)
     {
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
         var outputFile = string.IsNullOrWhiteSpace(file) ? "duplicati-ca.crt" : file;
 
         Console.WriteLine($"Using data folder: {dataFolderPath}");

--- a/Duplicati/CommandLine/ConfigureTool/Commands/SecureDataFolderCommand.cs
+++ b/Duplicati/CommandLine/ConfigureTool/Commands/SecureDataFolderCommand.cs
@@ -41,12 +41,13 @@ public static class SecureDataFolderCommand
             ? "Restrict the permissions on the data folder so only the current user, SYSTEM and Administrators can access it"
             : "Restrict the permissions on the data folder so only root and the current user can access it")
         {
-            new Option<string>("--data-folder", "Path to the Duplicati data folder (defaults to standard location)"),
+            new Option<string>("--datafolder", "Path to the Duplicati data folder (defaults to standard location)"),
             new Option<bool>("--apply", "Apply the restricted permissions without prompting. By default a warning is shown and the user must confirm."),
             new Option<bool>("--for-service", "Apply the restricted permissions for use with a service"),
+            new Option<bool>("--quiet", "Suppress all output except for minimum messages, such as errors"),
         };
 
-        cmd.Handler = CommandHandler.Create<string?, bool, bool>(HandleSecureDataFolder);
+        cmd.Handler = CommandHandler.Create<string?, bool, bool, bool>(HandleSecureDataFolder);
         return cmd;
     }
 
@@ -78,17 +79,19 @@ public static class SecureDataFolderCommand
     /// Checks the current permissions on the data folder and, if they are not already restricted,
     /// applies the restricted permissions (current user, SYSTEM and Administrators only).
     /// </summary>
-    private static int HandleSecureDataFolder(string? dataFolder, bool apply, bool forService)
+    private static int HandleSecureDataFolder(string? datafolder, bool apply, bool forService, bool quiet)
     {
-        var dataFolderPath = GetDataFolder(dataFolder);
+        var dataFolderPath = GetDataFolder(datafolder);
 
         using var _ = StartConsoleLogScope();
-        Console.WriteLine($"Using data folder: {dataFolderPath}");
+        if (!quiet)
+            Console.WriteLine($"Using data folder: {dataFolderPath}");
 
         if (!Directory.Exists(dataFolderPath))
         {
             Console.WriteLine($"The data folder does not exist: {dataFolderPath}");
-            Console.WriteLine("Create the folder first by starting the server or by creating it manually, then re-run this command.");
+            if (!quiet)
+                Console.WriteLine("Create the folder first by starting the server or by creating it manually, then re-run this command.");
             return 1;
         }
 
@@ -97,18 +100,24 @@ public static class SecureDataFolderCommand
 
         if (alreadySecure)
         {
-            Console.WriteLine("The data folder already has restricted permissions (only the current user, SYSTEM and Administrators can access it).");
-            Console.WriteLine("No changes are needed.");
+            if (!quiet)
+            {
+                Console.WriteLine("The data folder already has restricted permissions (only the current user, SYSTEM and Administrators can access it).");
+                Console.WriteLine("No changes are needed.");
+            }
             return 0;
         }
 
-        Console.WriteLine("The data folder does not have restricted permissions.");
-        Console.WriteLine($"Current state: {detail}");
-        Console.WriteLine();
-        Console.WriteLine("Warning: if someone created this folder, running this command may inadvertently give unwanted access to this system.");
-        Console.WriteLine("Before proceeding, verify that the data folder was created by Duplicati and not by an attacker,");
-        Console.WriteLine("as restricting the permissions will grant the current user, SYSTEM and Administrators full control over the folder.");
-        Console.WriteLine();
+        if (!quiet)
+        {
+            Console.WriteLine("The data folder does not have restricted permissions.");
+            Console.WriteLine($"Current state: {detail}");
+            Console.WriteLine();
+            Console.WriteLine("Warning: if someone created this folder, running this command may inadvertently give unwanted access to this system.");
+            Console.WriteLine("Before proceeding, verify that the data folder was created by Duplicati and not by an attacker,");
+            Console.WriteLine("as restricting the permissions will grant the current user, SYSTEM and Administrators full control over the folder.");
+            Console.WriteLine();
+        }
 
         if (!apply)
         {
@@ -117,7 +126,8 @@ public static class SecureDataFolderCommand
             if (!string.Equals(response?.Trim(), "y", StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(response?.Trim(), "yes", StringComparison.OrdinalIgnoreCase))
             {
-                Console.WriteLine("Aborted. No changes were made.");
+                if (!quiet)
+                    Console.WriteLine("Aborted. No changes were made.");
                 return 1;
             }
         }
@@ -131,8 +141,11 @@ public static class SecureDataFolderCommand
                 return 1;
             }
 
-            Console.WriteLine("Restricted permissions applied to the data folder.");
-            Console.WriteLine("Only the current user, SYSTEM and Administrators can now access the folder.");
+            if (!quiet)
+            {
+                Console.WriteLine("Restricted permissions applied to the data folder.");
+                Console.WriteLine("Only the current user, SYSTEM and Administrators can now access the folder.");
+            }
             return 0;
         }
         catch (Exception ex)


### PR DESCRIPTION
This makes `--datafolder` the common name for the datafolder in the configuretool to match the other tools (was `--data-folder`).