### PR TITLE
Fix the skip gate for the for-service data folder tests

### DIFF
--- a/Duplicati/UnitTest/DataFolderSecurityTests.cs
+++ b/Duplicati/UnitTest/DataFolderSecurityTests.cs
@@ -154,11 +154,13 @@ namespace Duplicati.UnitTest
 
             // The "for service" mode excludes the current user as a trusted principal and
             // locks the folder down to root (POSIX) or SYSTEM/Administrators (Windows).
-            // On POSIX this requires running as root to be able to chown to root, so skip
-            // the set step there when not root; verification of an already-root-owned
-            // folder is covered by the canonical check on the service path elsewhere.
-            if (!OperatingSystem.IsWindows() && !IsCurrentUserPrivilegedForService())
-                Assert.Ignore("The for-service lockdown on POSIX requires running as root");
+            // On POSIX this requires running as root to be able to chown to root, and on
+            // Windows it requires an elevated (Administrators) token to be able to assign
+            // Administrators as the owner, so skip the set step when not privileged;
+            // verification of an already-root-owned folder is covered by the canonical
+            // check on the service path elsewhere.
+            if (!IsCurrentUserPrivilegedForService())
+                Assert.Ignore("The for-service lockdown requires running as root on POSIX or as a member of Administrators on Windows");
 
             SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, true);
 
@@ -189,8 +191,8 @@ namespace Duplicati.UnitTest
             var dir = NewChild("service-accepted");
             Directory.CreateDirectory(dir);
 
-            if (!OperatingSystem.IsWindows() && !IsCurrentUserPrivilegedForService())
-                Assert.Ignore("The for-service lockdown on POSIX requires running as root");
+            if (!IsCurrentUserPrivilegedForService())
+                Assert.Ignore("The for-service lockdown requires running as root on POSIX or as a member of Administrators on Windows");
 
             SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, true);
 
@@ -206,8 +208,8 @@ namespace Duplicati.UnitTest
             var dir = NewChild("service-rejects-non-service");
             Directory.CreateDirectory(dir);
 
-            if (!OperatingSystem.IsWindows() && !IsCurrentUserPrivilegedForService())
-                Assert.Ignore("The for-service lockdown on POSIX requires running as root");
+            if (!IsCurrentUserPrivilegedForService())
+                Assert.Ignore("The for-service lockdown requires running as root on POSIX or as a member of Administrators on Windows");
 
             SystemIO.IO_OS.DirectorySetPermissionUserRWOnly(dir, true);
 


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it** (searched open and closed for `DataFolderSecurityTests` and for-service test failures: nothing).

The three for-service tests in `DataFolderSecurityTests` guard themselves with:

```csharp
if (!OperatingSystem.IsWindows() && !IsCurrentUserPrivilegedForService())
    Assert.Ignore("The for-service lockdown on POSIX requires running as root");
```

On Windows the first operand is always `false`, so the `&&` short-circuits and **`IsCurrentUserPrivilegedForService()` is never consulted on Windows at all**. That helper has a Windows branch checking membership in Administrators — with a doc comment explaining why that is the right privilege to require — so the intent is clear from the code itself; the branch is simply unreachable.

## Observed on a real machine

On a **non-elevated** Windows 11 session, the three tests fail instead of being skipped — the for-service lockdown assigns *Administrators* as the folder owner, which a filtered token cannot do:

```
Failed! - Failed: 3, Passed: 0, Skipped: 0
  LockDownThenVerifyRoundTrips_ForService
  ForServiceLockdown_AcceptsForServiceCheck
  ForServiceLockdown_RejectsNonServiceCheck
    → System.Security.AccessControl.NativeObjectSecurity.Persist(...)
```

After this change, same machine: **Failed: 0, Passed: 11, Skipped: 3.**

CI cannot catch this because the GitHub Windows runners run elevated — it only bites contributors running the suite locally.

## Why not just switch `&&` to `||`

That is the reflexive fix, and it would introduce the opposite bug: on POSIX the first operand is always `true`, so with `||` the tests would be ignored **even when running as root** and would never execute on POSIX again. The truth table only comes out right by dropping the `IsWindows` term and gating on the helper alone, since it already distinguishes the platforms internally (Administrators on Windows, root on POSIX, `false` elsewhere):

| Environment | Old `!Win && !Priv` | `!Win \|\| !Priv` | This PR: `!Priv` |
|---|---|---|---|
| Windows, elevated | runs ✅ | runs ✅ | runs ✅ |
| Windows, non-elevated | **fails ❌** | ignored ✅ | ignored ✅ |
| POSIX, root | runs ✅ | **ignored ❌** | runs ✅ |
| POSIX, non-root | ignored ✅ | ignored ✅ | ignored ✅ |

## Origin

The gates were introduced with the tests in [`3dd8c0ce3024`](https://github.com/duplicati/duplicati/commit/3dd8c0ce3024a6d1ec6a85fe23b6219574731385) (#7059). The later [`7b92a1de0c4b`](https://github.com/duplicati/duplicati/commit/7b92a1de0c4be915d28f35f07a7e321f590e5f75) (*Fixed failing test*) reworked the assertions in `ForServiceLockdown_RejectsNonServiceCheck` but did not touch the gates.

## Scope

Test-only — no production code is touched. The ignore message and the comment above the first gate are updated to describe both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
