### PR TITLE
Fix loading of locale files with hyphenated culture names

### DIFF
--- a/Duplicati/Library/Localization/MoLocalizationService.cs
+++ b/Duplicati/Library/Localization/MoLocalizationService.cs
@@ -82,14 +82,7 @@ namespace Duplicati.Library.Localization
         public MoLocalizationService(CultureInfo ci)
         {
             Culture = ci;
-            var filenames = new string[] { 
-                // Load the specialized version first
-                string.Format("localization-{0}.mo", ci.Name.Replace('-', '_')), 
-                // Then try the generic language version
-                string.Format("localization-{0}.mo", ci.TwoLetterISOLanguageName)
-            };
-
-            foreach (var fn in filenames)
+            foreach (var fn in GetCandidateFilenames(ci))
             {
                 // search first in external files
                 foreach (var sp in SearchPaths)
@@ -123,6 +116,24 @@ namespace Duplicati.Library.Localization
                 }
             }
         }
+
+        /// <summary>
+        /// Returns the catalog filenames probed for a culture, most specific first.
+        /// Catalog files exist under two naming conventions: the underscored form
+        /// produced by older Transifex language codes (e.g. <c>localization-zh_CN.mo</c>)
+        /// and the hyphenated BCP 47 form produced by current ones
+        /// (e.g. <c>localization-zh-Hans.mo</c>), so both are probed.
+        /// </summary>
+        /// <param name="ci">The culture to find catalog files for.</param>
+        /// <returns>The candidate filenames, in probing order.</returns>
+        public static IEnumerable<string> GetCandidateFilenames(CultureInfo ci)
+            => new string[] {
+                // Load the specialized version first, under either naming convention
+                string.Format("localization-{0}.mo", ci.Name),
+                string.Format("localization-{0}.mo", ci.Name.Replace('-', '_')),
+                // Then try the generic language version
+                string.Format("localization-{0}.mo", ci.TwoLetterISOLanguageName)
+            }.Distinct();
 
         /// <summary>
         /// Gets the culture of the localization

--- a/Duplicati/UnitTest/LocalizationLoaderTests.cs
+++ b/Duplicati/UnitTest/LocalizationLoaderTests.cs
@@ -1,0 +1,132 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Duplicati.Library.Localization;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Tests that the culture discovery and the catalog loading of
+    /// <see cref="MoLocalizationService"/> agree with each other. Discovery accepts both
+    /// hyphenated and underscored culture segments in a filename, so every catalog that
+    /// is advertised as a supported culture must also be loadable by the filename
+    /// candidates of that culture — otherwise the language shows up in the picker but
+    /// silently falls back to another catalog.
+    /// </summary>
+    [TestFixture]
+    [Category("LocalizationLoader")]
+    public class LocalizationLoaderTests
+    {
+        /// <summary>
+        /// The same filename pattern the service uses for discovery.
+        /// </summary>
+        private static readonly Regex MoFileMatcher = new Regex(@"localization-(?<culture>" + LocalizationService.CI_MATCHER + @")\.mo");
+
+        /// <summary>
+        /// Lists the embedded catalog filenames (e.g. <c>localization-zh-Hans.mo</c>)
+        /// together with the culture the discovery parses out of them.
+        /// </summary>
+        private static IEnumerable<(string Filename, CultureInfo Culture)> EmbeddedCatalogs()
+        {
+            foreach (var name in MoLocalizationService.SearchAssembly.GetManifestResourceNames())
+            {
+                var m = MoFileMatcher.Match(name);
+                if (!m.Success)
+                    continue;
+
+                var ci = LocalizationService.ParseCulture(m.Groups["culture"].Value);
+                if (ci != null)
+                    yield return (m.Value, ci);
+            }
+        }
+
+        /// <summary>
+        /// Every culture that discovery reports must be able to load its own catalog
+        /// file. A mismatch means the language is offered in the UI but the load falls
+        /// through to a more generic catalog (or none), which is exactly what happened
+        /// to zh-Hans: it was discovered from <c>localization-zh-Hans.mo</c>, but the
+        /// loader only probed the underscored form and fell back to the generic
+        /// <c>localization-zh.mo</c>.
+        /// </summary>
+        [Test]
+        public void EveryEmbeddedCatalogIsLoadableByItsOwnCulture()
+        {
+            var catalogs = EmbeddedCatalogs().ToList();
+            Assert.IsNotEmpty(catalogs, "The localization assembly should embed at least one catalog");
+
+            var unloadable = catalogs
+                .Where(x => !MoLocalizationService.GetCandidateFilenames(x.Culture).Contains(x.Filename))
+                .Select(x => $"{x.Filename} (culture {x.Culture.Name})")
+                .ToList();
+
+            Assert.IsEmpty(unloadable,
+                "Every discovered catalog must be loadable by its own culture, but these are not: " + string.Join(", ", unloadable));
+        }
+
+        /// <summary>
+        /// A hyphenated culture must probe the catalog named exactly after it before any
+        /// fallback, so zh-Hans loads Simplified Chinese and not the generic zh catalog.
+        /// </summary>
+        [Test]
+        public void HyphenatedCultureProbesItsExactNameFirst()
+        {
+            var candidates = MoLocalizationService.GetCandidateFilenames(new CultureInfo("zh-Hans")).ToList();
+
+            Assert.AreEqual("localization-zh-Hans.mo", candidates.First(),
+                "The exact culture name must be probed first");
+            Assert.Contains("localization-zh.mo", candidates,
+                "The generic language catalog must remain as a fallback");
+        }
+
+        /// <summary>
+        /// The legacy underscored filenames (as produced by older Transifex language
+        /// codes, e.g. <c>localization-zh_CN.mo</c>) must keep resolving for their
+        /// culture, which is parsed with a hyphen.
+        /// </summary>
+        [Test]
+        public void UnderscoredLegacyNamesStillResolve()
+        {
+            var ci = LocalizationService.ParseCulture("zh_CN");
+            Assert.IsNotNull(ci);
+            Assert.AreEqual("zh-CN", ci.Name);
+
+            Assert.Contains("localization-zh_CN.mo", MoLocalizationService.GetCandidateFilenames(ci).ToList(),
+                "The underscored legacy filename must remain a candidate");
+        }
+
+        /// <summary>
+        /// A culture without a region or script produces no duplicate probes.
+        /// </summary>
+        [Test]
+        public void PlainLanguageCultureProducesSingleCandidate()
+        {
+            var candidates = MoLocalizationService.GetCandidateFilenames(new CultureInfo("de")).ToList();
+            Assert.AreEqual(1, candidates.Count, $"Expected a single candidate, got: {string.Join(", ", candidates)}");
+            Assert.AreEqual("localization-de.mo", candidates[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it** (searched open and closed for `zh-Hans`, Simplified/Traditional Chinese: nothing about loading; #6881 was about translation content and is closed).

**Selecting 简体中文 (zh-Hans) in the language list currently displays Traditional Chinese.**

The mechanism is a naming-convention mismatch between discovery and loading in `MoLocalizationService`:

- **Discovery** (`CI_MATCHER`) accepts both underscored and hyphenated culture segments in `localization-*.mo` filenames, so the catalogs added by #7070 under the current Transifex BCP 47 codes — `localization-zh-Hans.mo`, `localization-zh-Hant.mo` — are found and both languages appear in the language list.
- **Loading** probes only the underscored form (`ci.Name.Replace('-', '_')` → `localization-zh_Hans.mo`), which does not exist, and then falls back to the generic `localization-zh.mo` — whose content is the **Traditional** Chinese catalog.

So zh-Hans silently loads zh-Hant's content, and zh-Hant itself works only because the fallback happens to match.

## Why fix the loader and not rename the files

Renaming the pulled files to the underscored form would not stick: `.tx/config` maps files with a raw `<lang>` placeholder and Transifex returns hyphenated codes, so the next `tx pull` recreates the hyphenated names. The loader now probes the culture name as-is *before* the underscored form:

```csharp
$"localization-{ci.Name}.mo",                    // hyphenated BCP 47 form (zh-Hans)
$"localization-{ci.Name.Replace('-', '_')}.mo",  // underscored legacy form (zh_CN)
$"localization-{ci.TwoLetterISOLanguageName}.mo" // generic language fallback
```

Existing catalogs are unaffected (for cultures without a hyphen the first two candidates are identical and de-duplicated), and future pulls of other script-tagged languages work without further changes.

## Testing

The candidate list moves into a testable `GetCandidateFilenames`. Four new tests, including an **invariant over the real embedded catalogs**: every catalog that discovery reports as a supported culture must be loadable by that culture's own candidates — i.e. no language can appear in the picker and then silently load a different catalog. Before the fix it fails naming the exact two files:

```
Every discovered catalog must be loadable by its own culture, but these are not:
  localization-zh-Hans.mo (culture zh-Hans), localization-zh-Hant.mo (culture zh-Hant)
```

After the fix: 4/4 pass. The other tests pin exact-name-first probing for zh-Hans, the underscored legacy names (`zh_CN`), and single-candidate plain cultures (`de`).

**Scope note:** this covers the server-side .mo catalogs (the path used at runtime via `LocalizationService.Get`). The Angular webroot catalogs are a separate mechanism (`gettextCatalog.setStrings`) and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
