### PR TITLE
Do not drop a pre-existing stash in tx-sync.sh

### DIFF
--- a/Localizations/tx-sync.sh
+++ b/Localizations/tx-sync.sh
@@ -12,8 +12,15 @@ fi
 ./extract_all.sh
 ./push_source_files_to_transifex.sh
 
+# Discard the extract/push artifacts, but only drop what was actually stashed:
+# "git stash push" saves nothing (and still exits 0) when there are no changes,
+# and an unconditional drop would then delete a pre-existing stash entry.
+STASH_BEFORE=$(git -C "$REPO_ROOT" rev-parse -q --verify refs/stash || true)
 git -C "$REPO_ROOT" stash push -m "tx-sync: discard extract/push artifacts"
-git -C "$REPO_ROOT" stash drop
+STASH_AFTER=$(git -C "$REPO_ROOT" rev-parse -q --verify refs/stash || true)
+if [ "$STASH_AFTER" != "$STASH_BEFORE" ]; then
+    git -C "$REPO_ROOT" stash drop
+fi
 
 ./pull_from_transifex.sh
 ./compile_all.sh


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it** (searched open and closed; the two keyword hits are unrelated).

`tx-sync.sh` (added in #7070) discards the extract/push artifacts with an unconditional pair:

```bash
git -C "$REPO_ROOT" stash push -m "tx-sync: discard extract/push artifacts"
git -C "$REPO_ROOT" stash drop
```

**When there is nothing to save, `git stash push` creates no entry and still exits 0 — so the `drop` deletes whatever was at `stash@{0}` before the script ran.** A stash the developer was keeping is silently destroyed.

The no-op case is easy to hit: the script has no `set -e`, so when the extract step produces no tracked changes — missing gettext tooling, or simply no string changes since the last sync — execution continues straight into the stash/drop pair. The clean-working-tree guard at the top protects the working tree, but not the stash stack. And since the script runs fine *up to that point* without any Transifex credentials, a curious contributor without the toolchain is actually the most likely victim.

## Fix

Drop only what was actually stashed, by comparing the stash ref before and after the push:

```bash
STASH_BEFORE=$(git -C "$REPO_ROOT" rev-parse -q --verify refs/stash || true)
git -C "$REPO_ROOT" stash push -m "tx-sync: discard extract/push artifacts"
STASH_AFTER=$(git -C "$REPO_ROOT" rev-parse -q --verify refs/stash || true)
if [ "$STASH_AFTER" != "$STASH_BEFORE" ]; then
    git -C "$REPO_ROOT" stash drop
fi
```

## Verification

Reproduced and verified in a scratch repository (I cannot run the script end-to-end — that needs Transifex maintainer credentials — but the stash logic is exercised exactly):

**Old pattern, pre-existing stash, nothing to save — the developer's stash is destroyed:**

```
$ git stash list
stash@{0}: On main: developers-precious-stash
$ git stash push -m "tx-sync: discard extract/push artifacts"
No local changes to save
$ git stash drop
Dropped refs/stash@{0} (0f1ca47...)
$ git stash list
(empty)
```

**Guarded version, same scenario — the stash survives:**

```
No local changes to save
(guard: nothing was stashed, not dropping)
$ git stash list
stash@{0}: On main: developers-precious-stash
```

**Guarded version, with artifacts present — artifacts are stashed and dropped, the pre-existing stash survives, tree is clean.**

`bash -n` passes.

## Out of scope, deliberately

`set -e` (a failed `tx push` currently continues into pull/compile) and `stash push -u` for untracked artifacts would both be reasonable hardening, but they change the script's behavior more broadly; this PR is the minimal fix for the destructive case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
