### PR TITLE
Recompute the next scheduled run when weekdays or interval change

### DIFF
--- a/Duplicati/Library/RestAPI/Scheduler.cs
+++ b/Duplicati/Library/RestAPI/Scheduler.cs
@@ -253,11 +253,30 @@ namespace Duplicati.Server
         }
 
         /// <summary>
+        /// Returns a fingerprint of the schedule fields that determine the next run time.
+        /// The cached next-run computed by <see cref="Runner"/> is invalidated when this
+        /// changes, so that editing the time, the repetition interval or the allowed
+        /// weekdays all cause the next run to be recomputed.
+        /// </summary>
+        /// <param name="schedule">The schedule to compute the fingerprint for</param>
+        /// <returns>The fingerprint of the schedule</returns>
+        public static string GetScheduleFingerprint(ISchedule schedule)
+        {
+            // Fold the days into a bitmask so ordering and duplicates do not matter
+            var daysMask = 0;
+            if (schedule.AllowedDays != null)
+                foreach (var d in schedule.AllowedDays)
+                    daysMask |= 1 << (int)d;
+
+            return FormattableString.Invariant($"{schedule.Time.Ticks}:{daysMask}:{schedule.Repeat}");
+        }
+
+        /// <summary>
         /// The actual scheduling procedure
         /// </summary>
         private void Runner()
         {
-            var scheduled = new Dictionary<long, KeyValuePair<long, DateTime>>();
+            var scheduled = new Dictionary<long, KeyValuePair<string, DateTime>>();
             while (!m_terminate)
             {
                 //TODO: As this is executed repeatedly we should cache it
@@ -270,16 +289,18 @@ namespace Duplicati.Server
                 {
                     if (!string.IsNullOrEmpty(sc.Repeat))
                     {
-                        KeyValuePair<long, DateTime> startkey;
+                        KeyValuePair<string, DateTime> startkey;
 
-                        DateTime last = new DateTime(0, DateTimeKind.Utc);
+                        // The last run is applied on both paths so the timedrift recovery
+                        // below also works on a cached entry; a last run in the future
+                        // would otherwise keep the stale cached time until a restart
+                        DateTime last = sc.LastRun;
                         DateTime start;
-                        var scticks = sc.Time.Ticks;
+                        var scfingerprint = GetScheduleFingerprint(sc);
 
-                        if (!scheduled.TryGetValue(sc.ID, out startkey) || startkey.Key != scticks)
+                        if (!scheduled.TryGetValue(sc.ID, out startkey) || startkey.Key != scfingerprint)
                         {
-                            start = new DateTime(scticks, DateTimeKind.Utc);
-                            last = sc.LastRun;
+                            start = new DateTime(sc.Time.Ticks, DateTimeKind.Utc);
                         }
                         else
                         {
@@ -402,7 +423,7 @@ namespace Duplicati.Server
                             }
                         }
 
-                        scheduled[sc.ID] = new KeyValuePair<long, DateTime>(scticks, start);
+                        scheduled[sc.ID] = new KeyValuePair<string, DateTime>(scfingerprint, start);
                     }
                 }
 

--- a/Duplicati/UnitTest/SchedulerTests.cs
+++ b/Duplicati/UnitTest/SchedulerTests.cs
@@ -1,0 +1,159 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using Duplicati.Server;
+using Duplicati.Server.Serialization.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Tests for the scheduler's next-run computation. The scheduler caches the
+    /// computed next run per schedule and only recomputes when the schedule
+    /// fingerprint changes, so the fingerprint must change for every field that
+    /// affects the next run time — otherwise editing that field has no effect
+    /// until the server restarts (issue #2487).
+    /// </summary>
+    [TestFixture]
+    [Category("Scheduler")]
+    public class SchedulerTests
+    {
+        /// <summary>
+        /// A minimal schedule holder for fingerprint tests.
+        /// </summary>
+        private sealed class FakeSchedule : ISchedule
+        {
+            public long ID { get; set; }
+            public string[] Tags { get; set; } = [];
+            public DateTime Time { get; set; }
+            public string Repeat { get; set; } = "1D";
+            public DateTime LastRun { get; set; }
+            public string Rule { get; set; } = "";
+            public DayOfWeek[] AllowedDays { get; set; } = [];
+        }
+
+        private static FakeSchedule MakeSchedule()
+            => new FakeSchedule
+            {
+                Time = new DateTime(2030, 1, 1, 13, 0, 0, DateTimeKind.Utc),
+                Repeat = "1D",
+                AllowedDays = [DayOfWeek.Friday],
+            };
+
+        [Test]
+        public void FingerprintIsStableForEqualSchedules()
+        {
+            Assert.AreEqual(
+                Scheduler.GetScheduleFingerprint(MakeSchedule()),
+                Scheduler.GetScheduleFingerprint(MakeSchedule()));
+        }
+
+        [Test]
+        public void FingerprintIgnoresDayOrderAndDuplicates()
+        {
+            var a = MakeSchedule();
+            a.AllowedDays = [DayOfWeek.Monday, DayOfWeek.Friday];
+            var b = MakeSchedule();
+            b.AllowedDays = [DayOfWeek.Friday, DayOfWeek.Monday, DayOfWeek.Friday];
+
+            Assert.AreEqual(Scheduler.GetScheduleFingerprint(a), Scheduler.GetScheduleFingerprint(b));
+        }
+
+        [Test]
+        public void FingerprintChangesWhenDaysChange()
+        {
+            var a = MakeSchedule();
+            var b = MakeSchedule();
+            b.AllowedDays = [DayOfWeek.Friday, DayOfWeek.Wednesday];
+
+            Assert.AreNotEqual(Scheduler.GetScheduleFingerprint(a), Scheduler.GetScheduleFingerprint(b),
+                "Adding an allowed day must invalidate the cached next run (issue #2487)");
+        }
+
+        [Test]
+        public void FingerprintChangesWhenRepeatChanges()
+        {
+            var a = MakeSchedule();
+            var b = MakeSchedule();
+            b.Repeat = "1W";
+
+            Assert.AreNotEqual(Scheduler.GetScheduleFingerprint(a), Scheduler.GetScheduleFingerprint(b),
+                "Changing the repetition interval must invalidate the cached next run");
+        }
+
+        [Test]
+        public void FingerprintChangesWhenTimeChanges()
+        {
+            var a = MakeSchedule();
+            var b = MakeSchedule();
+            b.Time = b.Time.AddMinutes(30);
+
+            Assert.AreNotEqual(Scheduler.GetScheduleFingerprint(a), Scheduler.GetScheduleFingerprint(b));
+        }
+
+        [Test]
+        public void FingerprintTreatsNullAndEmptyDaysTheSame()
+        {
+            var a = MakeSchedule();
+            a.AllowedDays = null!;
+            var b = MakeSchedule();
+            b.AllowedDays = [];
+
+            Assert.AreEqual(Scheduler.GetScheduleFingerprint(a), Scheduler.GetScheduleFingerprint(b));
+        }
+
+        /// <summary>
+        /// Documents why the cache must be invalidated when the allowed days change:
+        /// <see cref="Scheduler.GetNextValidTime"/> can only move a time forward, so a
+        /// cached next-run computed under the old day set can never move to an earlier
+        /// (newly allowed) day. Only recomputing from the schedule's base time can.
+        /// </summary>
+        [Test]
+        public void CachedNextRunCannotMoveEarlierWhenDaysAreAdded()
+        {
+            var tz = TimeZoneInfo.Utc;
+
+            // A daily schedule, base time Tuesday 2030-01-01 13:00, allowed: Friday only.
+            var baseTime = new DateTime(2030, 1, 1, 13, 0, 0, DateTimeKind.Utc);
+            var lastRun = new DateTime(2029, 12, 25, 13, 0, 0, DateTimeKind.Utc);
+
+            var nextUnderFridayOnly = Scheduler.GetNextValidTime(baseTime, lastRun, "1D", [DayOfWeek.Friday], tz);
+            Assert.AreEqual(new DateTime(2030, 1, 4, 13, 0, 0, DateTimeKind.Utc), nextUnderFridayOnly,
+                "Sanity: the first allowed run is Friday 2030-01-04");
+
+            // The user now ALSO allows Wednesday. The correct next run is Wednesday
+            // 2030-01-02, as a fresh computation from the base time shows:
+            var freshRecompute = Scheduler.GetNextValidTime(baseTime, lastRun, "1D", [DayOfWeek.Wednesday, DayOfWeek.Friday], tz);
+            Assert.AreEqual(new DateTime(2030, 1, 2, 13, 0, 0, DateTimeKind.Utc), freshRecompute,
+                "A recomputation from the base time picks up the newly allowed earlier day");
+
+            // But feeding the CACHED next run (Friday) back in, as the scheduler does on
+            // a cache hit, cannot move backwards to Wednesday:
+            var fromStaleCache = Scheduler.GetNextValidTime(nextUnderFridayOnly, lastRun, "1D", [DayOfWeek.Wednesday, DayOfWeek.Friday], tz);
+            Assert.AreEqual(nextUnderFridayOnly, fromStaleCache,
+                "The forward-only fix-up keeps the stale Friday, which is why the cache must be invalidated");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2487
Fixes #2904

## Summary

Editing a schedule's **allowed weekdays** — or its **repetition interval** — does not update the next scheduled run. Only editing the *time* does. The stale next-run is both displayed on the home screen and used as the actual trigger; it corrects itself only when the cached time passes, the time field is edited, or the server restarts. Exactly as #2487 reported in 2017 (*"If I change the weekday of the schedule the next execution will not be updated but the change will be saved"*).

## Mechanism

The scheduler caches the computed next run per schedule and invalidates it by comparing **only `Schedule.Time.Ticks`**:

```csharp
if (!scheduled.TryGetValue(sc.ID, out startkey) || startkey.Key != scticks)
{
    start = new DateTime(scticks, DateTimeKind.Utc);   // full recompute — only when Time changed
    last = sc.LastRun;
}
else
    start = startkey.Value;                            // weekday/interval edits reuse the cached value
```

Three things make this land exactly as reported:

1. The data-change event *does* fire `Reschedule()` on every edit, so the loop re-runs promptly — the stale cache is the only thing blocking the recompute.
2. The subsequent `GetNextValidTime` fix-up is **forward-only**: removing a day happens to correct itself (the cached day becomes disallowed and gets pushed forward), but *allowing an additional day* or *shortening the interval* can never move the next run **earlier**.
3. `GetProposedSchedule()` serves the cached value, so the UI display and the actual trigger are both stale.

## Fix

The cache key is now a fingerprint of every field the computation depends on — time, repetition, allowed weekdays (folded into a bitmask, so day order/duplicates don't matter). A fingerprint change enters the **same recompute path a time-edit used before**; no new behavior is introduced for the recompute itself.

### Second hunk: the #2983 timedrift recovery never ran on the cached path (this is what fixes #2904)

#2904 is the timedrift variant: a clock excursion left a schedule stuck proposing a next run in the far future (October 2018), and it stayed stuck. PR #2983 added a recovery for precisely this — `if (last > DateTime.UtcNow) { start = last = UtcNow; }` — but the cached branch always passed a **zeroed** `last`, so **the recovery is unreachable in steady state**: a drifted schedule stays stuck until a restart or a time edit.

`last = sc.LastRun` is now applied on both paths, so a drifted schedule self-heals on the next scheduler pass, with no user action. For a normal schedule this is a no-op: the last run lies in the past, and the forward-only computation ignores a `firstdate` that is earlier than the base time. Combined with the fingerprint (edits now also recompute), all facets reported in #2904 are covered.

## Verified end-to-end on a real server

Local server, REST API (`/api/v1/backups`, `/api/v1/serverstate` — the same data the home screen shows). Daily schedule, base time today +2h, allowing **Thursday only**, then edited (time unchanged) to allow **Wednesday + Thursday**:

**Unpatched server:**
```
initial allowed    : [thu]      -> proposed next run: 2026-07-23T15:24:01Z (Thursday)
edited allowed     : [wed,thu]  (Time unchanged)
proposed after edit: 2026-07-23T15:24:01Z   ← still Thursday
RESULT: STALE (next run did NOT move to tomorrow)
```

**Patched server, same steps:**
```
initial allowed    : [thu]      -> proposed next run: 2026-07-23T15:29:42Z (Thursday)
edited allowed     : [wed,thu]  (Time unchanged)
proposed after edit: 2026-07-22T15:29:42Z   ← Wednesday, recomputed immediately
RESULT: RESCHEDULED-CORRECTLY (next run moved to tomorrow)
```

## Tests

First tests for `Scheduler` (there were none): fingerprint stability, day-order/duplicate invariance, null-vs-empty days, and a change in each field; plus a test documenting *why* invalidation is required — feeding a cached next-run back into `GetNextValidTime` cannot move it to an earlier, newly-allowed day, while a fresh computation from the base time can. 7/7 pass. The threaded `Runner()` loop itself is deliberately not unit-tested (it would need a test-only restructuring of threaded code); the E2E run above covers the wiring.

## Related issues deliberately not closed by this PR

Searched open+closed via timeline traversal from #2487/#2904 plus ~20 keyword queries. Scheduling-adjacent but different mechanisms: #1226 (edit moves the next run one day *earlier* — opposite direction, old date math), #6761 (AllowedDays skip in the *display* layer, already fixed), #2324 (AllowedDays not *saved* — UI/persistence layer), #1935/#2028 (old "even time edits don't apply" pair, closed), DST/timezone family (#1364, #2069, #1168, #1200), wake-from-sleep family (#2925, #6759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
