### PR TITLE
Show tray notifications as Windows toasts with click-to-open

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
@@ -48,6 +48,10 @@ namespace Duplicati.GUI.TrayIcon
         private AvaloniaApp? application;
         private bool closed = false;
         private ProcessBasedActionDelay actionDelayer = new ProcessBasedActionDelay();
+        /// <summary>
+        /// The native notification support, if available; created on first use
+        /// </summary>
+        private Library.Interface.INativeNotifier notifier = null;
         private IEnumerable<AvaloniaMenuItem> menuItems = Enumerable.Empty<AvaloniaMenuItem>();
         private int _disposed;
         private int _exitCalled;
@@ -240,19 +244,38 @@ namespace Duplicati.GUI.TrayIcon
 
         public override void NotifyUser(string title, string message, NotificationType type)
         {
-            //var icon = Win32NativeNotifyIcon.InfoFlags.NIIF_INFO;
+            // Avalonia's TrayIcon has no notification support of its own, so the
+            // notification is shown with platform code; currently only Windows
+            // toast notifications are implemented
+            if (!OperatingSystem.IsWindows())
+                return;
 
-            switch (type)
+            try
             {
-                case NotificationType.Information:
-                    //icon = Win32NativeNotifyIcon.InfoFlags.NIIF_INFO;
-                    break;
-                case NotificationType.Warning:
-                    //icon = Win32NativeNotifyIcon.InfoFlags.NIIF_WARNING;
-                    break;
-                case NotificationType.Error:
-                    //icon = Win32NativeNotifyIcon.InfoFlags.NIIF_ERROR;
-                    break;
+                if (this.notifier == null)
+                {
+                    this.notifier = Library.Snapshots.Windows.WindowsShimLoader.NewNativeNotifier();
+                    // Clicking the notification opens the status window, same as
+                    // clicking the tray icon. ShowStatusWindow only performs an HTTP
+                    // request and launches the browser, so it is safe to call from
+                    // the activation callback's COM thread.
+                    this.notifier.NotificationClicked = () => ShowStatusWindow();
+                }
+
+                var level = type switch
+                {
+                    NotificationType.Warning => Library.Interface.NativeNotificationLevel.Warning,
+                    NotificationType.Error => Library.Interface.NativeNotificationLevel.Error,
+                    _ => Library.Interface.NativeNotificationLevel.Information,
+                };
+
+                this.notifier.Notify(level, title, message);
+            }
+            catch (Exception ex)
+            {
+                // Never let a failed notification take down the tray icon; toasts can
+                // be unavailable (e.g. notifications disabled, missing WinRT support)
+                Log.WriteWarningMessage(LOGTAG, "NotificationFailed", ex, "Failed to show notification: {0}", title);
             }
         }
 

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
@@ -51,7 +51,7 @@ namespace Duplicati.GUI.TrayIcon
         /// <summary>
         /// The native notification support, if available; created on first use
         /// </summary>
-        private Library.Interface.INativeNotifier notifier = null;
+        private Library.Interface.INativeNotifier? notifier = null;
         private IEnumerable<AvaloniaMenuItem> menuItems = Enumerable.Empty<AvaloniaMenuItem>();
         private int _disposed;
         private int _exitCalled;
@@ -248,6 +248,10 @@ namespace Duplicati.GUI.TrayIcon
             // notification is shown with platform code; currently only Windows
             // toast notifications are implemented
             if (!OperatingSystem.IsWindows())
+                return;
+
+            // The Windows toast notifications require Windows 10 or later
+            if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763))
                 return;
 
             try

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/AvaloniaRunner.cs
@@ -51,7 +51,11 @@ namespace Duplicati.GUI.TrayIcon
         /// <summary>
         /// The native notification support, if available; created on first use
         /// </summary>
-        private Library.Interface.INativeNotifier? notifier = null;
+        private Library.Interface.INativeNotifier? notifierInstance = null;
+        /// <summary>
+        /// Only attempt to load the notifier once
+        /// </summary>
+        private bool hasAttemptedNotifierLoad = false;
         private IEnumerable<AvaloniaMenuItem> menuItems = Enumerable.Empty<AvaloniaMenuItem>();
         private int _disposed;
         private int _exitCalled;
@@ -242,29 +246,45 @@ namespace Duplicati.GUI.TrayIcon
             return new AvaloniaMenuItem(this, text, icon, callback, subitems);
         }
 
-        public override void NotifyUser(string title, string message, NotificationType type)
+        private Library.Interface.INativeNotifier? TryLoadNotifier()
         {
+            if (hasAttemptedNotifierLoad)
+                return notifierInstance;
+
+            // Only try to load the notifier once
+            hasAttemptedNotifierLoad = true;
+
             // Avalonia's TrayIcon has no notification support of its own, so the
             // notification is shown with platform code; currently only Windows
             // toast notifications are implemented
-            if (!OperatingSystem.IsWindows())
-                return;
-
-            // The Windows toast notifications require Windows 10 or later
-            if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763))
-                return;
-
-            try
+            // The Toast implementation requires Windows 10 build 17763 or later
+            if (OperatingSystem.IsWindows() && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763))
             {
-                if (this.notifier == null)
+                try
                 {
-                    this.notifier = Library.Snapshots.Windows.WindowsShimLoader.NewNativeNotifier();
+                    this.notifierInstance = Library.Snapshots.Windows.WindowsShimLoader.NewNativeNotifier();
                     // Clicking the notification opens the status window, same as
                     // clicking the tray icon. ShowStatusWindow only performs an HTTP
                     // request and launches the browser, so it is safe to call from
                     // the activation callback's COM thread.
-                    this.notifier.NotificationClicked = () => ShowStatusWindow();
+                    this.notifierInstance.NotificationClicked = () => ShowStatusWindow();
                 }
+                catch (Exception ex)
+                {
+                    Log.WriteWarningMessage(LOGTAG, "NotificationLoadFailed", ex, "Failed to load notification implementation");                    
+                }
+            }
+
+            return notifierInstance;
+        }
+
+        public override void NotifyUser(string title, string message, NotificationType type)
+        {
+            try
+            {
+                var notifier = TryLoadNotifier();
+                if (notifier == null)
+                    return;
 
                 var level = type switch
                 {
@@ -273,7 +293,7 @@ namespace Duplicati.GUI.TrayIcon
                     _ => Library.Interface.NativeNotificationLevel.Information,
                 };
 
-                this.notifier.Notify(level, title, message);
+                notifier.Notify(level, title, message);
             }
             catch (Exception ex)
             {

--- a/Duplicati/Library/Interface/INativeNotifier.cs
+++ b/Duplicati/Library/Interface/INativeNotifier.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+
+namespace Duplicati.Library.Interface
+{
+    /// <summary>
+    /// The severity of a native notification
+    /// </summary>
+    public enum NativeNotificationLevel
+    {
+        /// <summary>An informational message</summary>
+        Information,
+        /// <summary>A warning message</summary>
+        Warning,
+        /// <summary>An error message</summary>
+        Error
+    }
+
+    /// <summary>
+    /// Shows notifications through the operating system's notification facility
+    /// </summary>
+    public interface INativeNotifier
+    {
+        /// <summary>
+        /// Invoked when the user clicks or otherwise activates a notification.
+        /// May be invoked on a non-UI thread.
+        /// </summary>
+        Action? NotificationClicked { get; set; }
+
+        /// <summary>
+        /// Shows a notification to the user
+        /// </summary>
+        /// <param name="level">The severity of the notification</param>
+        /// <param name="title">The notification title</param>
+        /// <param name="message">The notification message</param>
+        void Notify(NativeNotificationLevel level, string title, string message);
+    }
+}

--- a/Duplicati/Library/Snapshots/Windows/WindowsShimLoader.cs
+++ b/Duplicati/Library/Snapshots/Windows/WindowsShimLoader.cs
@@ -169,6 +169,13 @@ public static class WindowsShimLoader
         => LoadWithReflection<Stream>("BackupDataStream", path);
 
     /// <summary>
+    /// Creates a new NativeNotifier that shows Windows toast notifications
+    /// </summary>
+    /// <returns>A new NativeNotifier</returns>
+    public static INativeNotifier NewNativeNotifier()
+        => LoadWithReflection<INativeNotifier>("WindowsToastNotifier");
+
+    /// <summary>
     /// Loads the chosen snapshot provider
     /// </summary>
     /// <param name="provider">The provider to load</param>

--- a/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
+++ b/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
@@ -1,13 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <!-- The toast notification support requires the 10.0.17763 API surface;
+         .NET 10 itself requires Windows 10 or later, so this does not narrow
+         the set of supported systems -->
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <!-- Allows compiling this Windows-targeted assembly on Linux/macOS build hosts;
+         it is only ever loaded at runtime on Windows -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Copyright>Copyright © 2026 Team Duplicati, MIT license</Copyright>
     <RootNamespace>Duplicati.Library.WindowsModules</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <!-- Overrides the vulnerable 4.7.0 pulled in transitively by the notifications toolkit -->
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
     <PackageReference Include="Vanara.PInvoke.VssApi" Version="5.0.0" />
     <PackageReference Include="Vanara.PInvoke.Kernel32" Version="5.0.0" />
     <PackageReference Include="Vanara.PInvoke.Security" Version="5.0.0" />

--- a/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
+++ b/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- The toast notification support requires the 10.0.17763 API surface;
-         .NET 10 itself requires Windows 10 or later, so this does not narrow
-         the set of supported systems -->
+    <!-- The toast notification support requires the 10.0.17763 API surface -->
     <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
-    <!-- Allows compiling this Windows-targeted assembly on Linux/macOS build hosts;
-         it is only ever loaded at runtime on Windows -->
+    <!-- Allows compiling this Windows-targeted assembly on Linux/macOS build hosts -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <!-- Support older Windows versions -->
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <Copyright>Copyright © 2026 Team Duplicati, MIT license</Copyright>
     <RootNamespace>Duplicati.Library.WindowsModules</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Duplicati/Library/WindowsModules/WindowsToastNotifier.cs
+++ b/Duplicati/Library/WindowsModules/WindowsToastNotifier.cs
@@ -1,0 +1,60 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Runtime.Versioning;
+using Duplicati.Library.Interface;
+using Microsoft.Toolkit.Uwp.Notifications;
+
+namespace Duplicati.Library.WindowsModules;
+
+/// <summary>
+/// Shows notifications as Windows toast notifications.
+/// The compat layer in the toolkit handles the AppUserModelID and COM activator
+/// registration required for an unpackaged desktop application.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsToastNotifier : INativeNotifier
+{
+    /// <inheritdoc/>
+    public Action? NotificationClicked { get; set; }
+
+    /// <summary>
+    /// Creates a new toast notifier and hooks up activation handling.
+    /// </summary>
+    public WindowsToastNotifier()
+    {
+        // The activation handler must be registered before the first toast is
+        // shown. The callback arrives on a COM thread, not the UI thread.
+        ToastNotificationManagerCompat.OnActivated += _ => NotificationClicked?.Invoke();
+    }
+
+    /// <inheritdoc/>
+    public void Notify(NativeNotificationLevel level, string title, string message)
+    {
+        new ToastContentBuilder()
+            .AddText(title)
+            .AddText(message)
+            .Show();
+    }
+}

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -52,7 +52,7 @@
   <!-- Copy in WindowsModules for easier debug, or if we are targeting Windows -->
   <Target Name="CopyWindowsModulesRuntime" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
     <ItemGroup>
-      <_WinMods Include="..\Library\WindowsModules\bin\$(Configuration)\net10.0-windows7.0\**\*.dll" />
+      <_WinMods Include="..\Library\WindowsModules\bin\$(Configuration)\net10.0-windows10.0.17763.0\**\*.dll" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_WinMods)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />

--- a/Duplicati/UnitTest/NativeNotifierTests.cs
+++ b/Duplicati/UnitTest/NativeNotifierTests.cs
@@ -1,0 +1,58 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using Duplicati.Library.Snapshots.Windows;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Smoke test for the Windows toast notifier shim. Only the loading and the
+    /// callback wiring are exercised; no toast is shown, because notification
+    /// display depends on the session/OS configuration of the machine running
+    /// the tests.
+    /// </summary>
+    [TestFixture]
+    [Category("NativeNotifier")]
+    public class NativeNotifierTests
+    {
+        [Test]
+        public void NativeNotifierLoadsThroughTheShim()
+        {
+            if (!OperatingSystem.IsWindows())
+                Assert.Ignore("The native notifier is only implemented for Windows");
+
+            var notifier = WindowsShimLoader.NewNativeNotifier();
+            Assert.IsNotNull(notifier, "The shim should produce a notifier instance on Windows");
+
+            var clicked = false;
+            notifier.NotificationClicked = () => clicked = true;
+            Assert.IsNotNull(notifier.NotificationClicked, "The click callback must be storable");
+
+            notifier.NotificationClicked.Invoke();
+            Assert.IsTrue(clicked, "The stored callback must be invocable");
+        }
+    }
+}

--- a/Executables/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
+++ b/Executables/Duplicati.GUI.TrayIcon/Duplicati.GUI.TrayIcon.csproj
@@ -23,7 +23,7 @@
   <!-- Copy in WindowsModules for easier debug, or if we are targeting Windows -->
   <Target Name="CopyWindowsModulesRuntime" AfterTargets="Build" Condition="'$(_CopyWinModules)' == 'True'">
     <ItemGroup>
-      <_WinMods Include="..\..\Duplicati\Library\WindowsModules\bin\$(Configuration)\net10.0-windows7.0\**\*.dll" />
+      <_WinMods Include="..\..\Duplicati\Library\WindowsModules\bin\$(Configuration)\net10.0-windows10.0.17763.0\**\*.dll" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_WinMods)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />

--- a/Executables/Duplicati.WindowsModulesLoader/Duplicati.WindowsModulesLoader.csproj
+++ b/Executables/Duplicati.WindowsModulesLoader/Duplicati.WindowsModulesLoader.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0-windows7.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <!-- Allows compiling this Windows-targeted executable on Linux/macOS build hosts -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Description>WindowsModulesLoader for Duplicati</Description>
     <AssemblyName>Duplicati.WindowsModulesLoader</AssemblyName>
     <Copyright>Copyright © 2026 Team Duplicati, MIT license</Copyright>

--- a/Executables/Duplicati.WindowsModulesLoader/Duplicati.WindowsModulesLoader.csproj
+++ b/Executables/Duplicati.WindowsModulesLoader/Duplicati.WindowsModulesLoader.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <!-- Allows compiling this Windows-targeted executable on Linux/macOS build hosts -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <!-- Support older Windows versions -->
+    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <Description>WindowsModulesLoader for Duplicati</Description>
     <AssemblyName>Duplicati.WindowsModulesLoader</AssemblyName>
     <Copyright>Copyright © 2026 Team Duplicati, MIT license</Copyright>


### PR DESCRIPTION
Fixes #2612

## Summary

Since the Avalonia rewrite the tray icon has shown **no notifications at all**: `AvaloniaRunner.NotifyUser` was an empty stub carrying the remains of the old WinForms balloon code in comments, and Avalonia's `TrayIcon` has no notification API of its own. The click-to-open intent survived the rewrite — `TrayIconBase` still wires `m_onNotificationClick = ShowStatusWindow` — but nothing ever displayed a notification to click.

This implements the stub for Windows: server notifications (backup warnings/errors, update available, bug report ready) are shown as **Windows toast notifications**, and activating a toast opens the Web UI in the browser — the same `ShowStatusWindow()` path as clicking the tray icon.

## Why a package, and why this one

Producing a toast requires platform code: Avalonia exposes neither a toast API nor the native handle of its tray icon (so the old `Shell_NotifyIcon` balloon route is not available without owning a second tray icon). The alternatives were hand-rolled WinRT/COM interop — a significant maintenance liability — or [`Microsoft.Toolkit.Uwp.Notifications`](https://www.nuget.org/packages/Microsoft.Toolkit.Uwp.Notifications), Microsoft's own toolkit whose compat layer handles exactly the painful parts for an **unpackaged** desktop app: AppUserModelID registration and the COM activator for click activation. That is what this PR uses.

Two dependency notes, being upfront:

- The toolkit transitively references `System.Drawing.Common 4.7.0`, which has a known critical advisory (GHSA-rxg9-xrhp-64gj). It is **overridden to 10.0.0**, the version already used by `Duplicati.Server` and `Modules.Builtin`, so no vulnerable package lands in the output.
- The toolkit requires the 10.0.17763 API surface, so `Duplicati.Library.WindowsModules` moves from `net10.0-windows7.0` to `net10.0-windows10.0.17763.0` (the three hardcoded copy-path references are updated). .NET 10 itself requires Windows 10+, so no supported system is dropped.
- Raising the platform version means the Windows SDK targeting pack is now resolved at build time, which non-Windows build hosts reject by default (`NETSDK1100`) — so the two Windows-targeted projects set `EnableWindowsTargeting`, the documented mechanism for cross-compiling Windows-targeted assemblies on Linux/macOS. Verified by building both projects in a Linux (.NET 10 SDK) container.

## Why the code lives in WindowsModules

The tray project is the primary GUI project, ships identically on all three OSes, and stays on plain `net10.0` — untouched. The toast code follows the **established Windows-only pattern**: implementation in `Duplicati.Library.WindowsModules`, loaded via the existing `WindowsShimLoader` reflection mechanism (same as VSS, `SeBackupPrivilege`, power events). The pieces already in place made this the low-friction option: the tray executable already copies the WindowsModules assembly next to itself on Windows, and ReleaseBuilder already verifies it ships **only** in Windows packages — macOS/Linux artifacts are byte-for-byte unaffected.

New surface: `INativeNotifier` (+ `NativeNotificationLevel`) in `Duplicati.Library.Interface`, `WindowsToastNotifier` in WindowsModules, `WindowsShimLoader.NewNativeNotifier()`, and the `NotifyUser` implementation (OS-guarded, lazy, exception-safe — a failed toast logs a warning rather than taking down the tray).

## Verified end-to-end on Windows 11

Against a running tray instance (hosting its own server) with a backup configured to produce warnings:

1. **Delivery**: each backup run produced a server notification, the tray received it and called the notifier — four runs left **four entries in the AUMID's `ToastNotificationHistory`**, and the toolkit auto-registered the AUMID (`DisplayName=Duplicati.GUI.TrayIcon`). The full chain (server → long-poll → `NotifyUser` → shim → toolkit → WinRT) works.
2. **Click-to-open**: invoking the registered COM activator — the exact code path a user's click takes (`INotificationActivationCallback.Activate`) — made the running tray open the **Web UI in the default browser** (signin URL, same as the tray menu).
3. **Banner display**: the toast banners were observed on screen during the runs, and the notification center afterwards showed the delivered test toast ("Duplicati direct test / If you can see this, toasts work"). An earlier automated screenshot attempt missed the ~5-second banner window, which was a capture-timing issue, not suppression.

A smoke test covers loading the notifier through the shim and the callback wiring on Windows (ignored elsewhere). It deliberately does not call `Show()` — whether a banner appears depends on the test machine's notification settings.

## Known limitations (deliberate scope)

- Clicking a toast always opens the dashboard. The notification's `Action`/`BackupID` fields are dropped in `TrayIconBase.OnNotification` today, so per-backup deep-linking would be a follow-up.
- There is no option to disable tray notifications (none existed before either — nothing was shown at all). Easy to add if wanted.
- The toolkit's auto-registration writes the AUMID/activator under HKCU; uninstall cleanup (`ToastNotificationManagerCompat.Uninstall()`) would be an installer follow-up.
- Non-Windows platforms remain without notifications, as before (the issue is Windows-specific; Avalonia offers nothing cross-platform here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
