### PR TITLE
Fix wrong seek offset when copying verified local blocks during restore

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -601,8 +601,13 @@ namespace Duplicati.Library.Main.Operation.Restore
 
             foreach (var block in verified_blocks)
             {
-                fs_old.Seek(block.BlockOffset * block.BlockSize, SeekOrigin.Begin);
-                fs_new.Seek(block.BlockOffset * block.BlockSize, SeekOrigin.Begin);
+                // BlockOffset is the block index in the file, so the byte offset
+                // is the index multiplied by the fixed block size (buffer.Length,
+                // which equals options.Blocksize). Using block.BlockSize here would
+                // be wrong for the trailing partial block, where BlockSize is smaller
+                // than the fixed block size, placing the block at the wrong offset.
+                fs_old.Seek(block.BlockOffset * buffer.Length, SeekOrigin.Begin);
+                fs_new.Seek(block.BlockOffset * buffer.Length, SeekOrigin.Begin);
 
                 var length = await Library.Utility.Utility.ForceStreamReadAsync(fs_old, buffer, buffer.Length, cancellationToken).ConfigureAwait(false);
                 await fs_new.WriteAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -213,7 +213,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     {
                                         try
                                         {
-                                            await CopyOldTargetBlocksToNewTargetAsync(file, new_file, restoreDestination, buffer, verified_blocks, results.TaskControl.ProgressToken).ConfigureAwait(false);
+                                            await CopyOldTargetBlocksToNewTargetAsync(file, new_file, restoreDestination, buffer, options.Blocksize, verified_blocks, results.TaskControl.ProgressToken).ConfigureAwait(false);
                                         }
                                         catch (Exception ex)
                                         {
@@ -590,11 +590,12 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// </summary>
         /// <param name="old_file">The old target file.</param>
         /// <param name="new_file">The new target file.</param>
-        /// <param name="buffer">The buffer used for copying.</param>
         /// <param name="restoreDestination">The restore destination provider.</param>
+        /// <param name="buffer">The buffer used for copying (must be at least <paramref name="blocksize"/> bytes).</param>
+        /// <param name="blocksize">The fixed block size to used for calculating the byte offsets.</param>
         /// <param name="verified_blocks">The blocks in the old file that were verified.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        private static async Task CopyOldTargetBlocksToNewTargetAsync(FileRequest old_file, FileRequest new_file, IRestoreDestinationProvider restoreDestination, byte[] buffer, List<BlockRequest> verified_blocks, CancellationToken cancellationToken)
+        private static async Task CopyOldTargetBlocksToNewTargetAsync(FileRequest old_file, FileRequest new_file, IRestoreDestinationProvider restoreDestination, byte[] buffer, long blocksize, List<BlockRequest> verified_blocks, CancellationToken cancellationToken)
         {
             using var fs_old = await restoreDestination.OpenRead(old_file.TargetPath, cancellationToken).ConfigureAwait(false);
             using var fs_new = await restoreDestination.OpenWrite(new_file.TargetPath, cancellationToken).ConfigureAwait(false);
@@ -602,12 +603,11 @@ namespace Duplicati.Library.Main.Operation.Restore
             foreach (var block in verified_blocks)
             {
                 // BlockOffset is the block index in the file, so the byte offset
-                // is the index multiplied by the fixed block size (buffer.Length,
-                // which equals options.Blocksize). Using block.BlockSize here would
-                // be wrong for the trailing partial block, where BlockSize is smaller
-                // than the fixed block size, placing the block at the wrong offset.
-                fs_old.Seek(block.BlockOffset * buffer.Length, SeekOrigin.Begin);
-                fs_new.Seek(block.BlockOffset * buffer.Length, SeekOrigin.Begin);
+                // is the index multiplied by the fixed block size.
+                // Note that block.BlockSize is the size of the actual block, not the
+                // fixed block size.
+                fs_old.Seek(block.BlockOffset * blocksize, SeekOrigin.Begin);
+                fs_new.Seek(block.BlockOffset * blocksize, SeekOrigin.Begin);
 
                 var length = await Library.Utility.Utility.ForceStreamReadAsync(fs_old, buffer, buffer.Length, cancellationToken).ConfigureAwait(false);
                 await fs_new.WriteAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -64,6 +64,76 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("RestoreHandler")]
+        public async Task RestoreLocalBlocksRetargetPartialTrailingBlockAsync()
+        {
+            // Regression test for the byte-offset used when copying verified
+            // blocks from an existing target file into a retargeted file
+            // (CopyOldTargetBlocksToNewTargetAsync). The offset must be the
+            // block index times the fixed block size, not times the block's
+            // own size. This only mattered for a file's trailing partial block,
+            // where the block size is smaller than the fixed block size.
+
+            const int blocksize = 1024;
+            const string blocksizeArg = "1kb";
+            // Size the file to 2.5 blocks so the last block is partial (512 bytes).
+            var data = new byte[(blocksize * 2) + (blocksize / 2)];
+            new Random(42).NextBytes(data);
+
+            var filePath = Path.Combine(this.DATAFOLDER, "file");
+            File.WriteAllBytes(filePath, data);
+
+            var backupOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["blocksize"] = blocksizeArg,
+                ["restore-legacy"] = "false"
+            };
+            using (var c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            var restoreOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["blocksize"] = blocksizeArg,
+                ["restore-path"] = this.RESTOREFOLDER,
+                ["restore-legacy"] = "false",
+                ["restore-with-local-blocks"] = "true"
+            };
+            var restoredFilePath = Path.Combine(this.RESTOREFOLDER, "file");
+
+            // First restore so that a target file exists at the restore path.
+            using (var c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+                TestUtils.AssertResults(await c.RestoreAsync(new[] { filePath }));
+            Assert.IsTrue(File.Exists(restoredFilePath));
+
+            // Corrupt the first (full) block of the existing target while leaving
+            // the trailing partial block intact. VerifyTargetBlocks then marks the
+            // first block as missing and the last (partial) block as verified,
+            // which triggers retargeting to a new file and copies the verified
+            // blocks - including the partial one - into it.
+            var corrupted = (byte[])data.Clone();
+            for (var i = 0; i < blocksize; i++)
+                corrupted[i] ^= 0xFF;
+            File.WriteAllBytes(restoredFilePath, corrupted);
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+            {
+                var restoreResults = await c.RestoreAsync(new[] { filePath });
+                // With the wrong offset the partial block lands at the wrong
+                // position, the file hash no longer matches and the restore
+                // reports an error instead of producing the file.
+                Assert.AreEqual(0, restoreResults.Errors.Count());
+            }
+
+            // The retargeted file is a sibling of the original target and must
+            // contain the exact original data.
+            var retargeted = Directory.GetFiles(this.RESTOREFOLDER)
+                .Where(p => !string.Equals(p, restoredFilePath, StringComparison.Ordinal))
+                .Where(p => new FileInfo(p).Length == data.Length)
+                .FirstOrDefault(p => File.ReadAllBytes(p).SequenceEqual(data));
+            Assert.IsNotNull(retargeted, "Expected a retargeted copy containing the original file content");
+        }
+
+        [Test]
+        [Category("RestoreHandler")]
         public async Task RestoreEmptyFileAsync()
         {
             var folderPath = Path.Combine(this.DATAFOLDER, "folder");


### PR DESCRIPTION
### Summary

Fixes a wrong byte-offset calculation in `CopyOldTargetBlocksToNewTargetAsync` (new restore flow) that can make a restore fail for any file whose last block is partial — which is the common case, since most files are not an exact multiple of the block size.

### Root cause

`BlockRequest.BlockOffset` is the block **index** in the file (documented in `Interfaces.cs`: *"The offset in blocks this block represents in the target file"*), while `BlockRequest.BlockSize` is the **actual byte length** of that block. The byte offset of a block is therefore `BlockOffset * <fixed block size>`.

The code instead computed `BlockOffset * BlockSize`:

```csharp
fs_old.Seek(block.BlockOffset * block.BlockSize, SeekOrigin.Begin);
fs_new.Seek(block.BlockOffset * block.BlockSize, SeekOrigin.Begin);
```

For every block except the trailing one `BlockSize` equals the fixed block size, so the result happens to be correct. But a file's last block is normally partial (`BlockSize < Blocksize`), so its seek lands at the wrong position in **both** the old and the new target file.

### Impact

This is reachable on a normal restore: an existing target file is present, `--overwrite` is off, `--use-local-blocks` is on (the default), and the trailing partial block still matches while an earlier block differs (which triggers retargeting to a new file name). The partial block is then copied to the wrong offset, the reconstructed file's hash no longer matches, and the file is reported in `BrokenLocalFiles` and fails to restore — even though all of its data was available locally.

### What changed

Seek to `block.BlockOffset * buffer.Length` for both streams. `buffer` is allocated by the caller as `new byte[options.Blocksize]`, so `buffer.Length` is the fixed block size.

### How this was verified

Static verification against the surrounding code, no behavioural guesswork:

1. The `BlockOffset` / `BlockSize` contract is documented in `Interfaces.cs`.
2. The two sibling code paths in the **same file** already use the fixed block size — `f_original.Seek(i * options.Blocksize, …)` and `f_target.Seek(blocks[j].BlockOffset * options.Blocksize, …)`. Only `CopyOldTargetBlocksToNewTargetAsync` multiplied by the per-block size.
3. Traced `VerifyTargetBlocksAsync`: it adds the trailing partial block (with `BlockSize < Blocksize`) to `verified_blocks`, confirming the buggy path is actually reachable for a partial last block.

### Testing

Added a regression test `RestoreLocalBlocksRetargetPartialTrailingBlockAsync` in `Duplicati/UnitTest/RestoreHandlerTests.cs`. It backs up a file whose last block is partial (2.5 × block size), restores it once, corrupts the first block of the on-disk target while leaving the trailing partial block intact, then restores again with `restore-with-local-blocks=true` so the retargeting copy runs — asserting that the restore completes without errors and that a retargeted copy with the original content is produced.

Verified locally on `net10.0`: the test **fails** on the pre-fix code (`File hash mismatch`) and **passes** with the fix, confirming it exercises the buggy path.
