### PR TITLE
Fix logout not awaiting invalidation and not clearing the refresh cookie

### DIFF
--- a/Duplicati/WebserverCore/Endpoints/V1/Auth.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Auth.cs
@@ -184,14 +184,18 @@ public partial class Auth : IEndpointV1
             Domain = context.Request.Host.Host
         });
 
-    private static object PerformLogout(ILoginProvider loginProvider, IHttpContextAccessor httpContextAccessor, Dto.RefreshTokenInputDto? input)
+    private static async Task<object> PerformLogout(ILoginProvider loginProvider, IHttpContextAccessor httpContextAccessor, Dto.RefreshTokenInputDto? input)
     {
+        var context = httpContextAccessor.HttpContext!;
         var cookieName = GetCookieName(httpContextAccessor);
-        if (httpContextAccessor.HttpContext!.Request.Cookies.TryGetValue(cookieName, out var refreshTokenString))
+        if (context.Request.Cookies.TryGetValue(cookieName, out var refreshTokenString))
         {
             try
             {
-                loginProvider.PerformLogoutWithRefreshTokenAsync(refreshTokenString, input?.Nonce, CancellationToken.None);
+                // Must be awaited, otherwise exceptions from the async call are
+                // never observed by the catch below and the intended
+                // "ignore invalid refresh tokens" handling does not run.
+                await loginProvider.PerformLogoutWithRefreshTokenAsync(refreshTokenString, input?.Nonce, CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {
@@ -199,8 +203,15 @@ public partial class Auth : IEndpointV1
             }
         }
 
-        // Also remove the cookie, in case we failed to delete it
-        httpContextAccessor.HttpContext!.Response.Cookies.Delete(cookieName);
+        // Also remove the cookie, in case we failed to delete it.
+        // The Path and Domain must match the values used when the cookie was
+        // created (see AddCookie), otherwise the browser will not match and
+        // remove the stored cookie.
+        context.Response.Cookies.Delete(cookieName, new CookieOptions
+        {
+            Path = "/api/v1/auth/refresh",
+            Domain = context.Request.Host.Host
+        });
         return new { success = true };
     }
 


### PR DESCRIPTION
### Summary

Fixes two related defects in the `auth/refresh/logout` endpoint: the server-side refresh-token invalidation was never awaited, and the refresh-token cookie was never actually removed from the browser.

### Defect 1 — invalidation is fire-and-forget

`PerformLogoutWithRefreshTokenAsync` is an `async Task` method, but it was called without `await`:

```csharp
loginProvider.PerformLogoutWithRefreshTokenAsync(refreshTokenString, input?.Nonce, CancellationToken.None);
```

The returned `Task` is discarded, so:

- Any exception it raises surfaces on a faulted, unobserved `Task` (`TaskScheduler.UnobservedTaskException`) instead of being caught by the surrounding `try/catch`. The `// Ignore invalid refresh tokens` handler is effectively dead code.
- The invalidation runs as a fire-and-forget task that can continue touching request-scoped services (DB connection / token store) **after** the request scope has been disposed.

### Defect 2 — logout does not delete the cookie

The cookie is created (see `AddCookie`) with `Path = "/api/v1/auth/refresh"` and an explicit `Domain`, but was deleted with:

```csharp
httpContextAccessor.HttpContext!.Response.Cookies.Delete(cookieName);
```

`Delete(name)` uses the default options (`Path = "/"`, no domain). Browsers match cookies by **name + domain + path**, so the emitted `Set-Cookie` does not match the stored cookie and it is left in the browser until it expires — contradicting the code's own comment *"Also remove the cookie, in case we failed to delete it."*

### What changed

- `PerformLogout` is now `async Task<object>` and `await`s the invalidation, so the `catch` works and the request scope stays alive for the call.
- `Cookies.Delete` is passed the same `Path` and `Domain` used in `AddCookie`.

### How this was verified

- Confirmed `PerformLogoutWithRefreshTokenAsync` returns `Task` and is `async` in both `ILoginProvider` and its `LoginProvider` implementation, so the un-awaited call is a genuine fire-and-forget.
- Confirmed the cookie's creation attributes in `AddCookie` and cross-checked the cookie-matching rule (name/domain/path) that makes the default `Delete` a no-op here.
