### PR TITLE
Observe read timeout on chunked uploads to Google and Dropbox

### DIFF
--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -125,7 +125,9 @@ namespace Duplicati.Library.Backend
         {
             using var req = await reqTask.ConfigureAwait(false);
             using var ls = new ReadLimitLengthStream(stream, offset, Math.Min(chunksize, stream.Length - offset));
-            using var ts = ls.ObserveWriteTimeout(m_timeouts.ReadWriteTimeout);
+            // The chunk stream is used as the request body and is only read by the
+            // HTTP stack, so the read timeout must be observed here.
+            using var ts = ls.ObserveReadTimeout(m_timeouts.ReadWriteTimeout);
 
             req.Content = new StreamContent(ts);
             req.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCommon.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCommon.cs
@@ -164,7 +164,9 @@ namespace Duplicati.Library.Backend.GoogleServices
 
                     var chunkSize = Math.Min(UPLOAD_CHUNK_SIZE, stream.Length - offset);
                     using var ls = new ReadLimitLengthStream(stream, offset, chunkSize);
-                    using var ts = ls.ObserveWriteTimeout(readWriteTimeout);
+                    // The chunk stream is used as the request body and is only read
+                    // by the HTTP stack, so the read timeout must be observed here.
+                    using var ts = ls.ObserveReadTimeout(readWriteTimeout);
                     req.Content = new StreamContent(ts);
                     req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                     req.Content.Headers.Add("Content-Range", $"bytes {offset}-{offset + chunkSize - 1}/{stream.Length}");

--- a/Duplicati/Library/Utility/ReadLimitLengthStream.cs
+++ b/Duplicati/Library/Utility/ReadLimitLengthStream.cs
@@ -158,8 +158,8 @@ namespace Duplicati.Library.Utility
 
         public override int WriteTimeout
         {
-            get => m_innerStream.ReadTimeout;
-            set => m_innerStream.ReadTimeout = value;
+            get => m_innerStream.WriteTimeout;
+            set => m_innerStream.WriteTimeout = value;
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)


### PR DESCRIPTION
### Summary

Chunked uploads to Google Drive / Google Cloud Storage and Dropbox never enforce `read-write-timeout`, so a stalled upload to these backends can hang indefinitely. The upload stream is guarded with the wrong timeout direction.

### Root cause

Both backends wrap the upload chunk with `ObserveWriteTimeout` and then hand it to `StreamContent` as the request body:

```csharp
using var ls = new ReadLimitLengthStream(stream, offset, chunkSize);
using var ts = ls.ObserveWriteTimeout(readWriteTimeout);   // <-- wrong direction
req.Content = new StreamContent(ts);
```

The HTTP stack only ever **reads** a request-body stream, so only a *read* timeout can fire. `ObserveWriteTimeout` sets `WriteTimeout` on the wrapper, which is never consulted; the chunk stream is a read-only `ReadLimitLengthStream` whose write path throws. Net effect: `read-write-timeout` is silently ignored on these upload paths and a stalled connection never times out.

### What changed

- `GoogleCommon.cs` and `DropboxHelper.cs`: `ObserveWriteTimeout` → `ObserveReadTimeout` on the upload chunk stream.
- `ReadLimitLengthStream.cs`: fix a copy-paste bug in the `WriteTimeout` property, whose getter/setter proxied the inner stream's `ReadTimeout` instead of its `WriteTimeout`.

### How this was verified

This is confirmed by the established convention across the codebase, not by guessing:

- Every other backend that uses a stream as an **upload source** (read by the HTTP stack) uses `ObserveReadTimeout` — e.g. FTP, Backblaze B2, S3, Azure Blob, OpenStack, Jottacloud, Tahoe-LAFS. `ObserveWriteTimeout` is only used for **download targets** (streams being written to), e.g. Azure/pCloud/SSHv2 download paths.
- Google Drive's own *download* path already uses `ObserveReadTimeout`; only the shared chunked-*upload* helper used the write variant.
- The two `Observe*Timeout` helpers in `Utility.cs` differ only in whether they set `ReadTimeout` or `WriteTimeout`, and `ReadLimitLengthStream.CanWrite` is `false`, so the write side is provably inert here.
