### PR TITLE
Fix incorrect Array.Copy when merging a hash fragment

### DIFF
--- a/Duplicati/Library/Utility/HashCalculatingStream.cs
+++ b/Duplicati/Library/Utility/HashCalculatingStream.cs
@@ -90,7 +90,10 @@ namespace Duplicati.Library.Utility
             if (m_hashbufferLength > 0 && count + m_hashbufferLength > m_hashbuffer.Length)
             {
                 int bytesToUse = m_hashbuffer.Length - m_hashbufferLength;
-                Array.Copy(buffer, m_hashbuffer, bytesToUse);
+                // Append the new bytes (starting at offset) after the existing
+                // fragment in m_hashbuffer, rather than overwriting the fragment
+                // from the start of both buffers.
+                Array.Copy(buffer, offset, m_hashbuffer, m_hashbufferLength, bytesToUse);
                 m_hash.TransformBlock(m_hashbuffer, 0, m_hashbuffer.Length, m_hashbuffer, 0);
                 count -= bytesToUse;
                 offset += bytesToUse;


### PR DESCRIPTION
### Summary

Fixes an incorrect `Array.Copy` in `HashCalculatingStream.UpdateHash` that would corrupt the computed hash when merging a carried-over fragment. The buggy branch is currently **dormant** (not reachable with today's hashers), so this is a correctness-hardening fix rather than an active user-facing bug.

### Root cause

When a partial input block is carried over between calls, the fragment-merge branch tops it up from the next buffer:

```csharp
int bytesToUse = m_hashbuffer.Length - m_hashbufferLength;
Array.Copy(buffer, m_hashbuffer, bytesToUse);   // <-- wrong
```

`Array.Copy(buffer, m_hashbuffer, bytesToUse)` copies from `buffer[0]` into `m_hashbuffer[0]`. That ignores the source `offset` and overwrites the existing fragment instead of appending after it, so the wrong bytes are fed to `TransformBlock` and the resulting hash is incorrect.

### Why it is not currently triggered

The branch only runs when `m_hashbufferLength > 0`, which only happens when the hash algorithm's `InputBlockSize > 1` (`m_hashbuffer` is sized to `InputBlockSize`). Every hasher created via `HashFactory` today (`System.Security.Cryptography` MD5/SHA-1/SHA-256/384/512) reports `InputBlockSize == 1`, so `m_hashbufferLength` is always `0` and the branch never executes. The fix guards against any future hasher with a larger input block size.

### What changed

```csharp
Array.Copy(buffer, offset, m_hashbuffer, m_hashbufferLength, bytesToUse);
```

Copies from the correct source `offset` and appends after the existing fragment at `m_hashbufferLength`, matching the intent of the surrounding code (the "keep trailing bytes" branch already writes into `m_hashbuffer` using `offset`/`count` correctly).

### How this was verified

Static analysis of `UpdateHash`: compared the buggy call with the sibling "keep trailing bytes" copy in the same method, and confirmed reachability by tracing `m_hashbuffer = new byte[m_hash.InputBlockSize]` against the `InputBlockSize == 1` behaviour of the hashers `HashFactory` produces. Hence the honest framing above: real defect, currently unreachable.
