### PR TITLE
Let configured defaults apply when restore options are not specified

### DIFF
--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -420,17 +420,23 @@ namespace Duplicati.Server
 
 
         public static IRunnerData CreateRestoreTask(IBackup backup, string[]? filters,
-                                                    DateTime time, string? restoreTarget, bool overwrite, bool restore_permissions,
-                                                    bool skip_metadata, string? passphrase)
+                                                    DateTime time, string? restoreTarget, bool? overwrite, bool? restore_permissions,
+                                                    bool? skip_metadata, string? passphrase)
         {
             var dict = new Dictionary<string, string?>
             {
                 ["time"] = Utility.SerializeDateTime(time.ToUniversalTime()),
-                ["overwrite"] = overwrite ? bool.TrueString : bool.FalseString,
-                ["restore-permissions"] = restore_permissions ? bool.TrueString : bool.FalseString,
-                ["skip-metadata"] = skip_metadata ? bool.TrueString : bool.FalseString,
                 ["allow-passphrase-change"] = bool.TrueString
             };
+
+            // An unset value is not written, so the backup settings and the server's
+            // default options apply; an explicit value overrides them
+            if (overwrite.HasValue)
+                dict["overwrite"] = overwrite.Value ? bool.TrueString : bool.FalseString;
+            if (restore_permissions.HasValue)
+                dict["restore-permissions"] = restore_permissions.Value ? bool.TrueString : bool.FalseString;
+            if (skip_metadata.HasValue)
+                dict["skip-metadata"] = skip_metadata.Value ? bool.TrueString : bool.FalseString;
             if (!string.IsNullOrWhiteSpace(restoreTarget))
                 dict["restore-path"] = SpecialFolders.ExpandEnvironmentVariables(restoreTarget);
             if (!(passphrase is null))

--- a/Duplicati/UnitTest/RestoreTaskOptionsTests.cs
+++ b/Duplicati/UnitTest/RestoreTaskOptionsTests.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using Duplicati.Server;
+using Duplicati.Server.Serialization.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The restore task's extra options override the backup's configured settings and
+    /// the server's default options (they are applied after <c>ApplyOptions</c>), so an
+    /// option the caller did not specify must not be written into them at all —
+    /// otherwise a configured <c>--restore-permissions=true</c> is silently clobbered
+    /// with <c>False</c> on every restore (issue #4353).
+    /// </summary>
+    [TestFixture]
+    [Category("RestoreTaskOptions")]
+    public class RestoreTaskOptionsTests
+    {
+        private static IBackup MakeBackup()
+            => new Duplicati.Server.Database.Backup { Name = "test", TargetURL = "file://test" };
+
+        [Test]
+        public void UnspecifiedRestoreOptionsAreNotWritten()
+        {
+            var task = Runner.CreateRestoreTask(MakeBackup(), [], DateTime.UtcNow, null,
+                overwrite: null, restore_permissions: null, skip_metadata: null, passphrase: null);
+
+            Assert.IsNotNull(task.ExtraOptions);
+            Assert.IsFalse(task.ExtraOptions!.ContainsKey("overwrite"),
+                "An unspecified overwrite must not be written, so configured defaults can apply");
+            Assert.IsFalse(task.ExtraOptions.ContainsKey("restore-permissions"),
+                "An unspecified restore-permissions must not be written, so configured defaults can apply (issue #4353)");
+            Assert.IsFalse(task.ExtraOptions.ContainsKey("skip-metadata"),
+                "An unspecified skip-metadata must not be written, so configured defaults can apply");
+            Assert.IsFalse(task.ExtraOptions.ContainsKey("passphrase"),
+                "An unspecified passphrase must not be written (pre-existing behavior)");
+        }
+
+        [Test]
+        public void ExplicitRestoreOptionsOverride()
+        {
+            var task = Runner.CreateRestoreTask(MakeBackup(), [], DateTime.UtcNow, null,
+                overwrite: true, restore_permissions: false, skip_metadata: true, passphrase: "secret");
+
+            Assert.AreEqual(bool.TrueString, task.ExtraOptions!["overwrite"]);
+            Assert.AreEqual(bool.FalseString, task.ExtraOptions["restore-permissions"],
+                "An explicit false is an override and must be written");
+            Assert.AreEqual(bool.TrueString, task.ExtraOptions["skip-metadata"]);
+            Assert.AreEqual("secret", task.ExtraOptions["passphrase"]);
+        }
+    }
+}

--- a/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Backup/BackupPost.cs
@@ -143,9 +143,9 @@ public class BackupPost : IEndpointV1
             input.paths ?? [],
             Library.Utility.Timeparser.ParseTimeInterval(input.time, DateTime.Now),
             restorepath,
-            input.overwrite ?? false,
-            input.permissions ?? false,
-            input.skip_metadata ?? false,
+            input.overwrite,
+            input.permissions,
+            input.skip_metadata,
             string.IsNullOrWhiteSpace(input.passphrase) ? null : input.passphrase)));
     }
 


### PR DESCRIPTION
## Summary

**Server-side fix for the mechanism behind #4353** (*restore-permissions configured as a job setting or default option is ignored*, reproduced by @warwickmm in 2020). Deliberately **not** marked `Fixes` — see the scope note at the bottom for the honest reason.

## Mechanism

Three pieces line up to clobber the configured value on every restore:

1. `RestoreInputDto` declares `overwrite`, `permissions` and `skip_metadata` as **`bool?`** — the shape for "not specified" already exists.
2. The endpoint coerces absence to `false` (`input.permissions ?? false`), and `Runner.CreateRestoreTask` **unconditionally** writes all three into the task's extra options.
3. Extra options are merged **after** `ApplyOptions` has layered in the backup's settings and the server's default options — so they always win.

Net effect: `--restore-permissions=true` configured on the job or in Settings → Default options is silently overridden with `False` on every restore that doesn't explicitly set the flag. The setting looks accepted everywhere; only the restore page's own checkbox has any effect. Exactly what #4353 reports.

The fix follows the pattern the `passphrase` parameter **in the same method** already uses: only write a value into the extra options when the request actually specifies it. Explicit values (including an explicit `false`) still override; absent values now defer to the configured settings — which answers the design question raised in the issue thread: the nullable DTO fields already encode "explicit = override, absent = defer".

## Verified end-to-end

Local server, file carrying an explicit `Guests:(R)` ACE, backup job configured with `--restore-permissions=true`, restore-to-original after deleting the source:

| run | request | restored file has the ACE |
|---|---|---|
| pre-fix, control | `permissions: true` explicit | ✅ yes (storage + apply path healthy) |
| **pre-fix, bug** | field omitted | ❌ **no — the job's `true` was clobbered** |
| **post-fix** | field omitted | ✅ **yes — the configured setting finally applies** |

(A first E2E attempt used `--skip-metadata` with mtime as the observable and produced a false "works" — because `skip-metadata` in job settings also suppresses metadata *collection at backup time*, so there was nothing to restore either way. Redesigned around the restore-only `restore-permissions` semantics; noting it so nobody repeats that dead end.)

Tests pin the new contract: unspecified → no extra-option entry (so `ApplyOptions` output survives); explicit values → written (client override intact).

## Honest scope note (why no `Fixes #4353`)

Both bundled web UIs currently **always send explicit booleans** (`ngax`: `permissions: $scope.RestorePermissions == null ? false : …`; the compiled `ngclient` bundle likewise sends `permissions`/`skip_metadata` from form controls initialized to fixed values). So with the stock UI, an unchecked box is an explicit `false` and still overrides — this PR primarily benefits **API clients and scripts** immediately.

Completing the GUI half needs a change in the [ngclient repository](https://github.com/duplicati/ngclient): either prefill the checkbox from the job's configured value, or omit the field unless the user touches it. With this PR the server contract supports both. I'll summarize this on #4353 so the remaining work is discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
