### PR TITLE
Fail on an invalid webservice timezone instead of silently resetting it

### DIFF
--- a/Duplicati/Library/RestAPI/Database/ServerSettings.cs
+++ b/Duplicati/Library/RestAPI/Database/ServerSettings.cs
@@ -802,6 +802,12 @@ namespace Duplicati.Server.Database
             set => SetAndSaveSetting(CONST.PRELOAD_SETTINGS_HASH, value);
         }
 
+        /// <summary>
+        /// The last timezone id that failed to resolve; used to only warn once per id,
+        /// as the timezone is read repeatedly by the scheduler
+        /// </summary>
+        private static string? lastUnresolvableTimezoneId;
+
         public TimeZoneInfo Timezone
         {
             get
@@ -812,15 +818,22 @@ namespace Duplicati.Server.Database
                 if (string.IsNullOrEmpty(id))
                     return TimeZoneInfo.Utc;
 
-                try
+                var tzi = TimeZoneHelper.GetTimeZoneById(id);
+                if (tzi != null)
+                    return tzi;
+
+                // The fallback changes when scheduled backups run, so it must not be silent;
+                // this can happen when the database is moved between operating systems
+                if (lastUnresolvableTimezoneId != id)
                 {
-                    if (!string.IsNullOrEmpty(id))
-                        return TimeZoneHelper.GetTimeZoneById(id)
-                            ?? TimeZoneInfo.Local;
+                    lastUnresolvableTimezoneId = id;
+                    Library.Logging.Log.WriteWarningMessage(
+                        "ServerSettings",
+                        "UnresolvableTimezone",
+                        null,
+                        $"The configured timezone \"{id}\" cannot be resolved on this system; using the local timezone \"{TimeZoneInfo.Local.Id}\" instead.");
                 }
-                catch
-                {
-                }
+
                 return TimeZoneInfo.Local;
             }
             set

--- a/Duplicati/Library/Utility/TimeZoneHelper.cs
+++ b/Duplicati/Library/Utility/TimeZoneHelper.cs
@@ -68,7 +68,10 @@ public static class TimeZoneHelper
         {
             return TimeZoneInfo.FindSystemTimeZoneById(id);
         }
-        catch
+        catch (TimeZoneNotFoundException)
+        {
+        }
+        catch (InvalidTimeZoneException)
         {
         }
         return null;

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -693,14 +693,14 @@ namespace Duplicati.Server
                 connection.ApplicationSettings.SetAllowedHostnames(commandlineOptions[WebServerLoader.OPTION_WEBSERVICE_ALLOWEDHOSTNAMES_ALT]);
 
             if (commandlineOptions.ContainsKey(WebServerLoader.OPTION_WEBSERVICE_TIMEZONE) && !string.IsNullOrEmpty(commandlineOptions[WebServerLoader.OPTION_WEBSERVICE_TIMEZONE]))
-                try
-                {
-                    connection.ApplicationSettings.Timezone = TimeZoneHelper.FindTimeZone(commandlineOptions[WebServerLoader.OPTION_WEBSERVICE_TIMEZONE]);
-                }
-                catch (Exception ex)
-                {
-                    throw new UserInformationException(Strings.Program.InvalidTimezone(commandlineOptions[WebServerLoader.OPTION_WEBSERVICE_TIMEZONE]), "InvalidTimeZone", ex);
-                }
+            {
+                // FindTimeZone reports an unknown timezone by returning null, not by
+                // throwing; assigning the null would silently clear the stored setting
+                var timezone = TimeZoneHelper.FindTimeZone(commandlineOptions[WebServerLoader.OPTION_WEBSERVICE_TIMEZONE]);
+                if (timezone == null)
+                    throw new UserInformationException(Strings.Program.InvalidTimezone(commandlineOptions[WebServerLoader.OPTION_WEBSERVICE_TIMEZONE]), "InvalidTimeZone");
+                connection.ApplicationSettings.Timezone = timezone;
+            }
 
             // The database has recorded a new version
             if (connection.ApplicationSettings.UpdatedVersion != null)

--- a/Duplicati/UnitTest/TimeZoneSettingTests.cs
+++ b/Duplicati/UnitTest/TimeZoneSettingTests.cs
@@ -1,0 +1,125 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.AutoUpdater;
+using Duplicati.Library.Logging;
+using Duplicati.Library.SQLiteHelper;
+using Duplicati.Library.Utility;
+using Duplicati.Server.Database;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// A stored timezone id that no longer resolves (e.g. after moving the server
+    /// database between Windows and Linux) makes the scheduler silently compute all
+    /// next-run times in the server's local timezone. The fallback must be visible
+    /// in the log, so the user can find out why their schedule shifted.
+    /// </summary>
+    [TestFixture]
+    [Category("TimeZoneSetting")]
+    public class TimeZoneSettingTests
+    {
+        private string _tempDataFolder = null!;
+        private string _databasePath = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDataFolder = Path.Combine(Path.GetTempPath(), $"duplicati-tz-test-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_tempDataFolder);
+            _databasePath = Path.Combine(_tempDataFolder, DataFolderManager.SERVER_DATABASE_FILENAME);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                if (Directory.Exists(_tempDataFolder))
+                    Directory.Delete(_tempDataFolder, true);
+            }
+            catch
+            {
+            }
+        }
+
+        private async Task<Connection> MakeConnectionAsync()
+        {
+            var dbConnection = await SQLiteLoader.LoadConnectionAsync(_databasePath);
+            DatabaseUpgrader.UpgradeDatabase(dbConnection, _databasePath, typeof(Library.RestAPI.Database.DatabaseSchemaMarker));
+            return new Connection(dbConnection, true, null, _tempDataFolder, () => { });
+        }
+
+        [Test]
+        public async Task UnresolvableStoredTimezoneWarnsOnceAndFallsBack()
+        {
+            // Store a valid timezone through the normal path, so the settings row exists
+            using (var setup = await MakeConnectionAsync())
+                setup.ApplicationSettings.Timezone = TimeZoneInfo.Utc;
+
+            // Corrupt the stored id the way a cross-platform database move would:
+            // write an id this system cannot resolve (settings are cached per
+            // connection, so this happens between connections)
+            await using (var db = await SQLiteLoader.LoadConnectionAsync(_databasePath))
+            await using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = @"UPDATE ""Option"" SET ""Value"" = 'No/Such_Zone' WHERE ""Name"" = 'server-timezone' AND ""BackupID"" = -2";
+                Assert.AreEqual(1, await cmd.ExecuteNonQueryAsync(), "The timezone settings row should exist");
+            }
+
+            using var connection = await MakeConnectionAsync();
+            var captured = new List<LogEntry>();
+            TimeZoneInfo first, second;
+            using (Log.StartScope(e => captured.Add(e)))
+            {
+                first = connection.ApplicationSettings.Timezone;
+                second = connection.ApplicationSettings.Timezone;
+            }
+
+            Assert.AreEqual(TimeZoneInfo.Local.Id, first.Id,
+                "An unresolvable stored timezone falls back to the local timezone (pre-existing behavior)");
+            Assert.AreEqual(TimeZoneInfo.Local.Id, second.Id);
+
+            var warnings = captured.Where(x => x.Level == LogMessageType.Warning && x.Id == "UnresolvableTimezone").ToList();
+            Assert.AreEqual(1, warnings.Count,
+                $"The fallback must be logged exactly once per id (got {warnings.Count}); the scheduler reads this property on every pass");
+            Assert.IsTrue(warnings[0].FormattedMessage.Contains("No/Such_Zone"),
+                $"The warning should name the unresolvable id; got: {warnings[0].FormattedMessage}");
+        }
+
+        [Test]
+        public void FindTimeZoneReturnsNullForUnknownId()
+        {
+            Assert.IsNull(TimeZoneHelper.FindTimeZone("No/Such_Zone"),
+                "An unknown timezone must yield null so callers can report it");
+            Assert.IsNotNull(TimeZoneHelper.FindTimeZone(TimeZoneInfo.Local.Id));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**This PR doubles as the bug report — there is no existing issue for it** (searched open issues for timezone/schedule symptoms; only unrelated hits). Found while auditing every silent `catch { }` in the repository.

Two failure paths around the server timezone setting are completely silent, and one of them turns a typo into **destruction of the stored setting**.

### 1. `--webservice-timezone` with a typo silently *clears* the configured timezone — and the error prepared for this case is dead code

Startup does:

```csharp
try {
    connection.ApplicationSettings.Timezone = TimeZoneHelper.FindTimeZone(...);
} catch (Exception ex) {
    throw new UserInformationException(Strings.Program.InvalidTimezone(...), "InvalidTimeZone", ex);
}
```

But `FindTimeZone` **cannot throw**: `GetTimeZoneById` swallows the lookup exception and returns null, and the fuzzy search ends in `FirstOrDefault`. So the catch is unreachable and the `InvalidTimezone` message has never fired. Worse, the null flows into the `Timezone` setter, which stores `value?.Id` — **a typo erases whatever timezone was previously configured** and the server reverts to UTC. It starts cleanly; the only symptom is every schedule shifting, with nothing in any log.

The fix checks the null and throws the **already-existing** error — the message that was prepared for exactly this case is finally used.

### 2. An unresolvable *stored* timezone id silently swaps the scheduler to local time

When the stored id can't be resolved — typically after moving the server database between operating systems (Windows and Linux timezone ids differ), or on containers with trimmed tzdata — the getter silently falls back to `TimeZoneInfo.Local`, and the scheduler computes every next run in the wrong timezone. The fallback behavior is kept, but it now logs a warning naming the unresolvable id, **once per id** (the scheduler reads this property on every pass).

Also narrowed `GetTimeZoneById`'s `catch { }` to the two documented lookup exceptions; its null-on-failure contract is unchanged (both callers rely on it, and the pre-existing `TimeZoneHelperTests` still pass).

One observation left as-is to avoid a behavior change: the fallbacks are asymmetric (no configured id → UTC, unresolvable id → Local). Happy to align them if you prefer.

## Verified end-to-end on a local server

**Before** — `--webservice-timezone=Invalid/Zone`:
```
HTTP 200                                  ← starts cleanly
stored server-timezone setting: ''        ← previously configured value erased
```

**After** — same command line:
```
UserInformationException: The timezone Invalid/Zone is not valid
   at Duplicati.Server.Program.AdjustApplicationSettings(...)
```

**After** — `--webservice-timezone=Tokyo Standard Time`: starts normally, setting stored correctly (no regression).

## Tests

- The warn-once fallback of the settings getter: writes an unresolvable id directly into the server database (the way a cross-platform move would), asserts the getter falls back to Local **and** logs exactly one `UnresolvableTimezone` warning across two reads. **Fails before this change (0 warnings), passes after.**
- `FindTimeZone` null contract pinned for unknown ids.
- The 5 pre-existing `TimeZoneHelperTests` (abbreviation/display-name search) still pass, confirming the narrowed catch changes nothing for valid lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
