### PR TITLE
Handle console reconnect issues

### DIFF
--- a/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
+++ b/Duplicati/Library/Backend/S3/Duplicati.Library.Backend.S3.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.2.6" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.4" />
     <PackageReference Include="Minio" Version="6.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/RemoteControl/Duplicati.Library.RemoteControl.csproj
+++ b/Duplicati/Library/RemoteControl/Duplicati.Library.RemoteControl.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="jose-jwt" Version="5.2.0" />
-    <PackageReference Include="Websocket.Client" Version="5.2.0" />
+    <PackageReference Include="jose-jwt" Version="5.3.0" />
+    <PackageReference Include="Websocket.Client" Version="5.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
+++ b/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
@@ -22,6 +22,8 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Security.Cryptography;
 using System.Text.Json;
 using CoCoL;
@@ -59,7 +61,7 @@ public class KeepRemoteConnection : IDisposable
     /// <summary>
     /// The time between reconnect attempts if no response is received
     /// </summary>
-    private static readonly TimeSpan NoResponseTimeout = HeartbeatInterval * 2;
+    private static readonly TimeSpan NoResponseTimeout = HeartbeatInterval * 5;
 
     /// <summary>
     /// The minimum time between certificate refreshes
@@ -271,7 +273,7 @@ public class KeepRemoteConnection : IDisposable
                     reconnectHelper.Signal();
                 }
                 // If we do not get any response from the server, we should reconnect
-                else if ((_state == ConnectionState.Authenticated || _state == ConnectionState.WelcomeReceived) && _lastMessageReceived.Add(NoResponseTimeout) < DateTimeOffset.Now)
+                else if ((_state == ConnectionState.Authenticated || _state == ConnectionState.WelcomeReceived) && _lastMessageReceived.Add(NoResponseTimeout) < DateTimeOffset.UtcNow)
                 {
                     SetState(ConnectionState.Error);
                     Log.WriteMessage(LogMessageType.Warning, LogTag, "WebsocketDisconnect", "No response from server");
@@ -298,7 +300,7 @@ public class KeepRemoteConnection : IDisposable
             RefreshCertificatesAsync,
             _cancellationTokenSource.Token);
 
-        _client.DisconnectionHappened.Subscribe(info =>
+        using var h1 = _client.DisconnectionHappened.Subscribe(info =>
         {
             SetState(ConnectionState.NotConnected);
             _serverCertificate = null;
@@ -306,7 +308,7 @@ public class KeepRemoteConnection : IDisposable
             if (!IsAutoReconnectDisabled())
             {
                 reconnectHelper.Signal();
-                Log.WriteMessage(LogMessageType.Warning, LogTag, "WebsocketDisconnect", "Disconnected from the server");
+                Log.WriteMessage(LogMessageType.Warning, LogTag, "WebsocketDisconnect", $"Disconnected from server. Type: {info.Type}, Status: {info.CloseStatus}, Description: {info.CloseStatusDescription}");
             }
             else
             {
@@ -314,7 +316,26 @@ public class KeepRemoteConnection : IDisposable
             }
         });
 
-        _client.MessageReceived.Subscribe(msg => OnMessageAsync(msg, certificateRefreshHelper, reconnectHelper).Await());
+        using var h2 = _client.MessageReceived
+            // Use specific pool to avoid deep-sleep pausing the receive
+            .ObserveOn(TaskPoolScheduler.Default)
+            // The remote UI may send multiple concurrent requests,
+            // and the SelectMany allows us to handle multiple messages concurrently.
+            // Only the initial handshake requires strict ordering, but here the
+            // server will only send a single message anyway.
+            .SelectMany(async msg =>
+            {
+                try
+                {
+                    await OnMessageAsync(msg, certificateRefreshHelper, reconnectHelper);
+                }
+                catch (Exception ex)
+                {
+                    Log.WriteMessage(LogMessageType.Warning, LogTag, "MessageProcessingError", ex, "Failed to process message: {0}", msg);
+                }
+                return System.Reactive.Unit.Default;
+            })
+            .Subscribe();
 
         // Start the connection
         if (forceConnect || !IsAutoReconnectDisabled())
@@ -338,7 +359,7 @@ public class KeepRemoteConnection : IDisposable
         if (_state == ConnectionState.Error)
             return;
 
-        _lastMessageReceived = DateTimeOffset.Now;
+        _lastMessageReceived = DateTimeOffset.UtcNow;
         if (_state == ConnectionState.NotConnected)
             Log.WriteMessage(LogMessageType.Verbose, LogTag, "WebsocketMessage", "Received message from server: {0}", msg);
         else // Encrypted messages are not logged, as the content has no meaning before being decrypted
@@ -364,7 +385,7 @@ public class KeepRemoteConnection : IDisposable
 
                 if (string.IsNullOrWhiteSpace(welcomeMessage.PublicKeyHash))
                     throw new ProtocolViolationException("No public key hash in welcome message");
-                _serverCertificate = _serverKeys.FirstOrDefault(x => x.PublicKeyHash == welcomeMessage.PublicKeyHash && x.Expiry > DateTimeOffset.Now);
+                _serverCertificate = _serverKeys.FirstOrDefault(x => x.PublicKeyHash == welcomeMessage.PublicKeyHash && x.Expiry.ToUniversalTime() > DateTimeOffset.UtcNow);
 
                 if (_serverCertificate == null)
                 {

--- a/Duplicati/PackageRef/Duplicati.PackageRef.csproj
+++ b/Duplicati/PackageRef/Duplicati.PackageRef.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="8.14.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
   </ItemGroup>

--- a/proprietary/Office365/Duplicati.Proprietary.Office365.csproj
+++ b/proprietary/Office365/Duplicati.Proprietary.Office365.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="../../Duplicati/Library/Utility/Duplicati.Library.Utility.csproj" />
     <ProjectReference Include="../LicenseChecker/Duplicati.Proprietary.LicenseChecker.csproj" />
     <PackageReference Include="MimeKit" Version="4.16.0" />
-    <PackageReference Include="jose-jwt" Version="5.2.0" />
+    <PackageReference Include="jose-jwt" Version="5.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates the reconnect and message handling logic for the console connection.

The alive-check timers were a bit too close causing them to step on each other in some cases. Now the self-managed timer is 2 minutes and the socket managed timer is 5 minutes.

To ensure messages are processed even if the process is in a low-power state, an explicit scheduling pool is selected.

Further, to allow processing multiple messages concurrently, the message handler was updated. This should give better performance on remote management and prevent cases where the remote UI appears to hang for a longer period.

An issue with missing dispose calls was also adressed.