### PR TITLE
Prevent credentials from leaking through GetUrlWithoutCredentials on malformed URLs

### DIFF
--- a/Duplicati/Library/Utility/Uri.cs
+++ b/Duplicati/Library/Utility/Uri.cs
@@ -209,7 +209,7 @@ namespace Duplicati.Library.Utility
                     catch
                     {
                     }
-                throw new ArgumentException(Strings.Uri.UriParseError(url), nameof(url));
+                throw new ArgumentException(Strings.Uri.UriParseError(Utility.StripUrlUserInfo(url)), nameof(url));
             }
 
             this.Scheme = m.Groups["scheme"].Value;
@@ -224,7 +224,7 @@ namespace Duplicati.Library.Utility
             {
                 p = h + p;
                 if (p.IndexOfAny(System.IO.Path.GetInvalidPathChars()) >= 0)
-                    throw new ArgumentException(Strings.Uri.UriParseError(url), nameof(url));
+                    throw new ArgumentException(Strings.Uri.UriParseError(Utility.StripUrlUserInfo(url)), nameof(url));
                 p = System.IO.Path.GetFullPath(p);
                 h = null;
             }
@@ -283,7 +283,7 @@ namespace Duplicati.Library.Utility
         public void RequireHost()
         {
             if (string.IsNullOrEmpty(Host))
-                throw new ArgumentException(Strings.Uri.NoHostname(OriginalUri));
+                throw new ArgumentException(Strings.Uri.NoHostname(Utility.StripUrlUserInfo(OriginalUri)));
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1851,6 +1851,22 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// Matches a leading userinfo segment (user:password@, up to the last @ before
+        /// the first path separator), optionally preceded by a scheme. The scheme needs
+        /// at least two characters so a drive letter is not mistaken for one.
+        /// </summary>
+        private static readonly Regex URL_USERINFO_MATCHER = new Regex(@"^(?<scheme>[a-zA-Z][a-zA-Z0-9+._\-]+:/{0,2})??[^/\\]*@", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Removes a leading userinfo (user:password@) segment from a url-like string,
+        /// keeping any scheme prefix
+        /// </summary>
+        /// <param name="url">The url-like string to strip</param>
+        /// <returns>The string without the userinfo segment</returns>
+        internal static string StripUrlUserInfo(string url)
+            => URL_USERINFO_MATCHER.Replace(url, "${scheme}", 1);
+
+        /// <summary>
         /// Returns a url that is safe to display, by removing any credentials
         /// </summary>
         /// <param name="url">The url to sanitize</param>
@@ -1862,25 +1878,26 @@ namespace Duplicati.Library.Utility
             if (string.IsNullOrWhiteSpace(url))
                 return url;
 
-            // Use a reportable url without credentials
-            var pipeIndex = url.IndexOf('|');
-            var sepIndex = pipeIndex >= 0 ? pipeIndex + 1 : 0;
-            var length = url.Length - sepIndex;
-            var shown = Math.Min(length, maxShown);
-            var hidden = length - shown;
-            var sanitizedUrl = $"{url[sepIndex..(sepIndex + shown)]}{new string('*', hidden)}";
+            // Remove any userinfo before parsing, so a url the parser misreads
+            // (or rejects) cannot carry credentials into the displayed result
+            var target = StripUrlUserInfo(url[(url.IndexOf('|') + 1)..]);
 
             // If we can parse it, this result is better
             try
             {
-                var uri = new Uri(url[sepIndex..]);
-                sanitizedUrl = new Uri($"{uri.Scheme}://{uri.Host}").SetPath(uri.Path).ToString();
+                var uri = new Uri(target);
+                return new Uri($"{uri.Scheme}://{uri.Host}").SetPath(uri.Path).ToString();
             }
             catch
             {
             }
 
-            return sanitizedUrl;
+            // Not parseable even as a path; show a truncated prefix, without any query
+            var queryIndex = target.IndexOf('?');
+            if (queryIndex >= 0)
+                target = target[..queryIndex];
+            var shown = Math.Min(target.Length, maxShown);
+            return $"{target[..shown]}{new string('*', target.Length - shown)}";
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -592,6 +592,74 @@ namespace Duplicati.UnitTest
             for (int i = 0; i < testValues.Length; i++)
                 Assert.AreEqual(TimeSpan.FromSeconds(expect[i]), Utility.GetRetryDelay(baseDelay, testValues[i], true));
         }
+
+        [Test]
+        [Category("Utility")]
+        public static void GetUrlWithoutCredentialsRemovesCredentialsFromMalformedUrls()
+        {
+            // An unencoded '@' in the password makes the relaxed parser read
+            // "ssw0rd@example.com" as the host
+            var result = Utility.GetUrlWithoutCredentials("ftp://user:p@ssw0rd@example.com/path");
+            StringAssert.DoesNotContain("ssw0rd", result);
+
+            // A single-slash typo does not match the url parser, so the whole
+            // url is reinterpreted as a local file path and shown in full
+            result = Utility.GetUrlWithoutCredentials("ftps:/user:hunter2@example.com/path");
+            StringAssert.DoesNotContain("hunter2", result);
+
+            // Same reinterpretation when the scheme is missing entirely
+            result = Utility.GetUrlWithoutCredentials("user:hunter2@example.com/path");
+            StringAssert.DoesNotContain("hunter2", result);
+
+            // '\0' is an invalid path character on all platforms, so this is
+            // neither a url nor a path and hits the truncating fallback
+            result = Utility.GetUrlWithoutCredentials("user:hunter2@ex\0ample/x");
+            StringAssert.DoesNotContain("hunter2", result);
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void GetUrlWithoutCredentialsKeepsSafeUrlsReadable()
+        {
+            // Well-formed urls keep the exact pre-existing output
+            Assert.AreEqual("ftp://example.com/path", Utility.GetUrlWithoutCredentials("ftp://user:pass@example.com/path"));
+            Assert.AreEqual("ftp://example.com/path", Utility.GetUrlWithoutCredentials("ftp://example.com/path"));
+
+            // The part before a '|' separator stays hidden
+            Assert.AreEqual("ftp://host/x", Utility.GetUrlWithoutCredentials("mount|ftp://user:pass@host/x"));
+
+            // An '@' after the first path separator is not userinfo and must survive
+            var decoded = Library.Utility.Uri.UrlDecode(Utility.GetUrlWithoutCredentials("ftp://host/dir@name/x"));
+            StringAssert.Contains("dir@name", decoded);
+
+            decoded = Library.Utility.Uri.UrlDecode(Utility.GetUrlWithoutCredentials("/mnt/data@x/y"));
+            StringAssert.Contains("data@x", decoded);
+
+            // A drive letter is not a scheme, so '@' in a Windows path is kept
+            decoded = Library.Utility.Uri.UrlDecode(Utility.GetUrlWithoutCredentials(@"C:\backup@daily\x"));
+            StringAssert.Contains("backup@daily", decoded);
+
+            decoded = Library.Utility.Uri.UrlDecode(Utility.GetUrlWithoutCredentials(@"file://C:\backup@daily\x"));
+            StringAssert.Contains("backup@daily", decoded);
+
+            // Null and blank inputs pass through
+            Assert.IsNull(Utility.GetUrlWithoutCredentials(null));
+            Assert.AreEqual("", Utility.GetUrlWithoutCredentials(""));
+            Assert.AreEqual("   ", Utility.GetUrlWithoutCredentials("   "));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void UriExceptionsDoNotEchoCredentials()
+        {
+            // The parse error for an invalid url is shown to the user, so it
+            // must not echo an embedded password
+            var parseEx = Assert.Throws<ArgumentException>(() => new Library.Utility.Uri("user:hunter2@ex\0ample/x"));
+            StringAssert.DoesNotContain("hunter2", parseEx.Message);
+
+            var hostEx = Assert.Throws<ArgumentException>(() => new Library.Utility.Uri("ftp://user:hunter2@/path").RequireHost());
+            StringAssert.DoesNotContain("hunter2", hostEx.Message);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## What this fixes

`Utility.GetUrlWithoutCredentials` exists for exactly one purpose: producing a URL that is safe to display. On malformed URLs it does the opposite and leaks the embedded `user:password@` into warnings, exception texts, and result DTOs. There is no existing issue for this (searched open+closed for credential/password/log leak variants), so this PR doubles as the report. Found during a mechanical audit of error-handling paths, verified on latest master.

All 5 call sites are display paths: `SourceProviderFactory` (exception texts + warning), `RemoteSynchronizationConfig.ToString()`, `RemoteSynchronizationHandler` (results DTO `Destination`), `SyncHandler` (exception + warning).

## The leak paths (all reproduced)

An important subtlety for review: the unqualified `Uri` inside `Utility.cs` is **Duplicati's own relaxed parser** (`Duplicati.Library.Utility.Uri`, same namespace), not `System.Uri`. That parser falls back to interpreting unparseable input as a local file path, which is what makes these leaks reachable:

1. **Unencoded `@` in the password** — the relaxed regex misreads the host:
   ```
   GetUrlWithoutCredentials("ftp://user:p@ssw0rd@example.com/path")
   → "ftp://ssw0rd:@example.com/path"        (actual output, captured by the new unit test pre-fix)
   ```
2. **Malformed URL reinterpreted as a file path** (single-slash typo, missing scheme): the regex rejects it, `Path.GetFullPath` accepts it (modern .NET validates almost nothing), and the *whole URL including credentials* is displayed as a "path" — not even truncated. Captured in a real backup run with a malformed `--remote-sync-json-config` destination (pre-fix):
   ```
   Error during operation: List => The folder C:\...\ftps:\user:hunter2@example.com\path does not exist
   Remote synchronization to ... Dst: user2:hunter3@ex<NUL>ample/x ... failed: Invalid URI: user2:hunter3@ex<NUL>ample/x
   ```
   The `Dst:` value is this function's output (raw 25-char fallback).
3. **The truncating fallback** shows the first 25 raw characters, which is where userinfo lives.
4. **Adjacent, same class**: the relaxed `Uri`'s own error messages (`UriParseError`, `NoHostname`) echo the raw URL, so `catch (ex) → log ex.Message` call sites leaked the credentials a second way (visible in the same log line above).

## The fix

Strip the userinfo *before* parsing, so no downstream branch (parse success, file-path reinterpretation, or truncating fallback) can ever see credentials:

```csharp
private static readonly Regex URL_USERINFO_MATCHER =
    new Regex(@"^(?<scheme>[a-zA-Z][a-zA-Z0-9+._\-]+:/{0,2})??[^/\\]*@", RegexOptions.Compiled);

internal static string StripUrlUserInfo(string url)
    => URL_USERINFO_MATCHER.Replace(url, "${scheme}", 1);
```

Design notes (18 edge cases verified against the same .NET regex engine before implementing):
- the scheme prefix requires **2+ characters**, so a drive letter is never mistaken for a scheme — `C:\backup@daily\x`, `C:/backup@daily/x`, `file://C:\backup@daily\x` keep their `@`;
- the lazy `??` prefers the schemeless interpretation, so `user:pass@host/x` (missing scheme) is stripped fully;
- `[^/\\]*@` is greedy up to the **last** `@` before the first path separator, so `user:p@ssw0rd@` is removed as a whole;
- `@` after the first `/` is never touched (`ftp://host/dir@name/x`, `/mnt/data@x/y`);
- the well-formed case produces byte-identical output to before (`ftp://user:pass@example.com/path` → `ftp://example.com/path`).

The same helper is applied to the three `Uri` exception messages (`UriParseError` ×2, `NoHostname`), closing vector 4. The truncating fallback now also cuts at the first `?` so query-string secrets (e.g. `authid`) can't ride along in the shown prefix.

**Known limitation** (unchanged behavior, documented in the relaxed parser itself — "the password may not contain a @/:"): an unencoded `/` inside a password (`ftp://u:pa/ss@h/x`) is ambiguous to the relaxed grammar and partially survives in the path portion, exactly as before this PR.

## Verification

**Unit tests** (new, `UtilityTests.cs`): red→green for every vector.
- `GetUrlWithoutCredentialsRemovesCredentialsFromMalformedUrls` — the 4 leak inputs above; fails pre-fix (first failure message: `Expected: not String containing "ssw0rd" But was: "ftp://ssw0rd:@example.com/path"`).
- `GetUrlWithoutCredentialsKeepsSafeUrlsReadable` — well-formed equality, `|`-prefix, `@`-in-path preservation (URL-decode-robust asserts), null/blank passthrough. This method passes both pre- and post-fix, proving no behavior change for safe inputs.
- `UriExceptionsDoNotEchoCredentials` — parse error and `RequireHost` messages; red pre-fix.

Full categories after the fix: `Category=Utility` **108/108**, `Category=UriUtility` **78/78** (Windows, net10.0). The platform-dependent path-fallback assertions were additionally executed on Linux in a `mcr.microsoft.com/dotnet/sdk:10.0` container against this exact commit: all pass.

**E2E** (real CLI backups, `--remote-sync-json-config` with hostile destination URLs; the file backend target backup itself succeeds, then the sync stage displays the destination):

| destination URL | before | after |
|---|---|---|
| `user2:hunter3@example/x` | `Dst: user2:hunter3@ex·ample/x` + raw URL echoed twice in the exception | `Dst: ex·ample/x`, exception says `Invalid URI: ex·ample/x` |
| `ftp://user:p@ssw0rd@no-such-host…invalid/path` | (unit-test evidence: `ftp://ssw0rd:@…`) | `Dst: ftp://no-such-host-duplicati-e2e.invalid/path` |
| `nosuchbackend://user:secretpw@example.com/x` (regression) | `Dst: nosuchbackend://example.com/x` | identical — readable display preserved |

Grepping all post-fix logs for any of the three planted passwords: **zero occurrences**.

## History / context

The function was introduced in [b3fe276a137cba8dd7a033da046222484e1cc7bf](https://github.com/duplicati/duplicati/commit/b3fe276a137cba8dd7a033da046222484e1cc7bf) (merged via #6492) and the `|`-prefix handling was adjusted in [682ee1ae7ce8be5f82cd6c3979b9865a6e26aa4b](https://github.com/duplicati/duplicati/commit/682ee1ae7ce8be5f82cd6c3979b9865a6e26aa4b).

On disclosure: the exposure is credentials appearing in the user's own local logs, job results, and error dialogs (a place users routinely copy-paste from when asking for help), not something remotely triggerable — which is why this is a public PR. If you'd rather handle display-of-credentials issues through the security advisory process, happy to close and refile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
