### PR TITLE
Remove relaxed url parsing

### DIFF
--- a/Duplicati/CommandLine/BackendTool/Program.cs
+++ b/Duplicati/CommandLine/BackendTool/Program.cs
@@ -104,7 +104,7 @@ namespace Duplicati.CommandLine.BackendTool
                                where n is Library.Interface.IConnectionModule
                                select n).ToArray();
 
-                var uri = new Library.Utility.Uri(args[1]);
+                var uri = new Library.Utility.CompatUri(args[1]);
                 var qp = uri.QueryParameters;
 
                 var backendOpts = new Dictionary<string, string>();

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -337,12 +337,12 @@ namespace Duplicati.Library.AutoUpdater
             // we look for packages there as well
             if (AutoUpdateSettings.UsesAlternateURLs)
             {
-                var packagepath = new Library.Utility.Uri(updates[0]).Path;
+                var packagepath = new Library.Utility.CompatUri(updates[0]).Path;
                 var packagename = packagepath.Split('/').Last();
 
                 foreach (var alt_url in AutoUpdateSettings.URLs.Reverse())
                 {
-                    var alt_uri = new Library.Utility.Uri(alt_url);
+                    var alt_uri = new Library.Utility.CompatUri(alt_url);
                     var path_components = alt_uri.Path.Split('/');
                     var path = string.Join("/", path_components.Take(path_components.Count() - 1).Union(new string[] { packagename }));
 

--- a/Duplicati/Library/Backend/AliyunOSS/AliyunOSSBackend.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/AliyunOSSBackend.cs
@@ -56,7 +56,7 @@ namespace Duplicati.Library.Backend.AliyunOSS
         {
             _timeouts = TimeoutOptionsHelper.Parse(options);
 
-            var uri = new Utility.Uri(url?.Trim() ?? "");
+            var uri = new Utility.CompatUri(url?.Trim() ?? "");
             var prefix = uri.HostAndPath?.TrimPath();
 
             var auth = AuthOptionsHelper.ParseWithAlias(options, uri, OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET)

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -108,7 +108,7 @@ namespace Duplicati.Library.Backend.AzureBlob
         // This constructor is needed by the BackendLoader.
         public AzureBlobBackend(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
             uri.RequireHost();
 
             var containerName = (uri.Host ?? "").ToLowerInvariant();

--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -194,7 +194,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
     /// <param name="options">options to be used in the backend</param>
     public B2(string url, Dictionary<string, string?> options)
     {
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
 
         _bucketName = uri.Host ?? "";
         _prefix = Util.AppendDirSeparator("/" + uri.Path, "/");
@@ -202,7 +202,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
         // For B2 we do not use a leading slash
         _prefix = _prefix.TrimStart('/');
 
-        _urlencodedPrefix = string.Join("/", _prefix.Split(new[] { '/' }).Select(x => Utility.Uri.UrlPathEncode(x)));
+        _urlencodedPrefix = string.Join("/", _prefix.Split(new[] { '/' }).Select(x => Utility.CompatUri.UrlPathEncode(x)));
 
         _bucketType = DEFAULT_BUCKET_TYPE;
         if (options.TryGetValue(B2_CREATE_BUCKET_TYPE_OPTION, out var option1))
@@ -352,7 +352,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
 
             request.Headers.TryAddWithoutValidation("Authorization", uploadUrlData.AuthorizationToken);
             request.Headers.Add("X-Bz-Content-Sha1", sha1);
-            request.Headers.Add("X-Bz-File-Name", _urlencodedPrefix + Utility.Uri.UrlPathEncode(remotename));
+            request.Headers.Add("X-Bz-File-Name", _urlencodedPrefix + Utility.CompatUri.UrlPathEncode(remotename));
             request.Content = new StreamContent(timeoutStream);
 
             request.Content.Headers.Add("Content-Type", "application/octet-stream");
@@ -414,9 +414,9 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
 
         using var request = _filecache != null && _filecache.ContainsKey(remotename)
             ? await _b2AuthHelper.CreateRequestAsync(
-                $"{config.DownloadUrl}/b2api/v1/b2_download_file_by_id?fileId={Utility.Uri.UrlEncode(await GetFileId(remotename, cancellationToken))}", HttpMethod.Get, cancellationToken).ConfigureAwait(false)
+                $"{config.DownloadUrl}/b2api/v1/b2_download_file_by_id?fileId={Utility.CompatUri.UrlEncode(await GetFileId(remotename, cancellationToken))}", HttpMethod.Get, cancellationToken).ConfigureAwait(false)
             : await _b2AuthHelper.CreateRequestAsync(
-                $"{config.DownloadUrl}/{_urlencodedPrefix}{Utility.Uri.UrlPathEncode(remotename)}", HttpMethod.Get, cancellationToken).ConfigureAwait(false);
+                $"{config.DownloadUrl}/{_urlencodedPrefix}{Utility.CompatUri.UrlPathEncode(remotename)}", HttpMethod.Get, cancellationToken).ConfigureAwait(false);
 
         HttpResponseMessage? response = null;
         try
@@ -712,7 +712,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
         await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancellationToken, async ct =>
             await _b2AuthHelper.PostAndGetJsonDataAsync<FileEntity>(
                 $"{config.APIUrl}/b2api/v1/b2_copy_file",
-                new CopyFileRequest(sourceFileId, _urlencodedPrefix + Utility.Uri.UrlPathEncode(newname)),
+                new CopyFileRequest(sourceFileId, _urlencodedPrefix + Utility.CompatUri.UrlPathEncode(newname)),
                 ct).ConfigureAwait(false)
         ).ConfigureAwait(false);
 

--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -29,7 +29,6 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using Newtonsoft.Json;
-using Uri = Duplicati.Library.Utility.Uri;
 
 namespace Duplicati.Library.Backend.Box
 {
@@ -107,7 +106,7 @@ namespace Duplicati.Library.Backend.Box
 
         public BoxBackend(string url, Dictionary<string, string?> options)
         {
-            var uri = new Uri(url);
+            var uri = new CompatUri(url);
 
             _path = Util.AppendDirSeparator(uri.HostAndPath, "/");
 

--- a/Duplicati/Library/Backend/DrimeCloud/DrimeBackend.cs
+++ b/Duplicati/Library/Backend/DrimeCloud/DrimeBackend.cs
@@ -24,15 +24,12 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json;
 using Duplicati.Library.Backend.DrimeCloud.Model;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
-using Duplicati.StreamUtil;
 using FileEntry = Duplicati.Library.Common.IO.FileEntry;
-using UtilityUri = Duplicati.Library.Utility.Uri;
 
 namespace Duplicati.Library.Backend.DrimeCloud;
 
@@ -187,7 +184,7 @@ public class DrimeBackend : IBackend, IStreamingBackend //, IRenameEnabledBacken
     /// <param name="options">Options dictionary</param>
     public DrimeBackend(string url, Dictionary<string, string?> options)
     {
-        var uri = new UtilityUri(url);
+        var uri = new CompatUri(url);
         _path = uri.HostAndPath?.Trim('/') ?? "";
 
         if (string.IsNullOrWhiteSpace(_path))

--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -46,9 +46,9 @@ namespace Duplicati.Library.Backend
         // This constructor is needed by the BackendLoader.
         public Dropbox(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
 
-            m_path = Utility.Uri.UrlDecode(uri.HostAndPath);
+            m_path = Utility.CompatUri.UrlDecode(uri.HostAndPath);
             if (m_path.Length != 0 && !m_path.StartsWith("/", StringComparison.Ordinal))
                 m_path = "/" + m_path;
 

--- a/Duplicati/Library/Backend/Dropbox/WebApi.cs
+++ b/Duplicati/Library/Backend/Dropbox/WebApi.cs
@@ -24,34 +24,34 @@ namespace Duplicati.Library.Backend.WebApi
     public static class Dropbox
     {
         public static string CreateFolderUrl()
-            => Utility.Uri.UriBuilder(Url.API, Path.CreateFolder);
+            => Utility.CompatUri.UriBuilder(Url.API, Path.CreateFolder);
 
         public static string ListFilesUrl()
-            => Utility.Uri.UriBuilder(Url.API, Path.ListFolder);
+            => Utility.CompatUri.UriBuilder(Url.API, Path.ListFolder);
 
         public static string ListFilesContinueUrl()
-            => Utility.Uri.UriBuilder(Url.API, Path.ListFolderContinue);
+            => Utility.CompatUri.UriBuilder(Url.API, Path.ListFolderContinue);
 
         public static string GetMetadataUrl()
-            => Utility.Uri.UriBuilder(Url.API, Path.GetMetadata);
+            => Utility.CompatUri.UriBuilder(Url.API, Path.GetMetadata);
 
         public static string DeleteUrl()
-            => Utility.Uri.UriBuilder(Url.API, Path.DeleteFolder);
+            => Utility.CompatUri.UriBuilder(Url.API, Path.DeleteFolder);
 
         public static string MoveUrl()
-            => Utility.Uri.UriBuilder(Url.API, Path.Move);
+            => Utility.CompatUri.UriBuilder(Url.API, Path.Move);
 
         public static string UploadSessionStartUrl()
-            => Utility.Uri.UriBuilder(Url.CONTENT_API_URL, Path.UploadSessionStart);
+            => Utility.CompatUri.UriBuilder(Url.CONTENT_API_URL, Path.UploadSessionStart);
 
         public static string UploadSessionAppendUrl()
-            => Utility.Uri.UriBuilder(Url.CONTENT_API_URL, Path.UploadSessionAppend);
+            => Utility.CompatUri.UriBuilder(Url.CONTENT_API_URL, Path.UploadSessionAppend);
 
         public static string UploadSessionFinishUrl()
-            => Utility.Uri.UriBuilder(Url.CONTENT_API_URL, Path.UploadSessionFinish);
+            => Utility.CompatUri.UriBuilder(Url.CONTENT_API_URL, Path.UploadSessionFinish);
 
         public static string DownloadFilesUrl()
-            => Utility.Uri.UriBuilder(Url.CONTENT_API_URL, Path.DownloadFiles);
+            => Utility.CompatUri.UriBuilder(Url.CONTENT_API_URL, Path.DownloadFiles);
 
         public static string[] Hosts()
             => [new Uri(Url.API).Host, new Uri(Url.CONTENT_API_URL).Host];

--- a/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
+++ b/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
@@ -135,15 +135,15 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     /// <param name="options">The backend options</param>
     public DuplicatiBackend(string url, Dictionary<string, string?> options)
     {
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
         if (string.IsNullOrWhiteSpace(uri.HostAndPath))
-            uri = new Utility.Uri(DEFAULT_ENDPOINT);
+            uri = new Utility.CompatUri(DEFAULT_ENDPOINT);
         else
             uri = uri.SetScheme("https").SetQuery(null);
 
         var endpoint = options.GetValueOrDefault(ENDPOINT_OPTION);
         if (!string.IsNullOrWhiteSpace(endpoint))
-            uri = new Utility.Uri(endpoint);
+            uri = new Utility.CompatUri(endpoint);
 
         _client = new HttpClient
         {
@@ -157,7 +157,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
         _backup_id = options.GetValueOrDefault(BACKUP_ID_OPTION) ?? string.Empty;
         if (string.IsNullOrEmpty(_backup_id))
             throw new ArgumentException(Strings.DuplicatiBackend.ErrorMissingBackupId, BACKUP_ID_OPTION);
-        _auth = AuthOptionsHelper.ParseWithAlias(options, new Utility.Uri(url), AUTH_API_ID_OPTION, AUTH_API_KEY_OPTION)
+        _auth = AuthOptionsHelper.ParseWithAlias(options, new Utility.CompatUri(url), AUTH_API_ID_OPTION, AUTH_API_KEY_OPTION)
             .RequireCredentials();
 
         _authTimeout = Utility.Utility.ParseTimespanOption(options, AUTH_TIMEOUT_OPTION, DEFAULT_AUTH_TIMEOUT);
@@ -180,7 +180,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     /// <returns>The merged URL</returns>
     public static string MergeArgsIntoUrl(string url, string? apiId, string? apiKey, string? endpoint)
     {
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
         var opts = new Dictionary<string, string?>
         {
             [AUTH_API_ID_OPTION] = apiId,
@@ -190,12 +190,12 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
         var qp = uri.QueryParameters;
         foreach (var kvp in opts)
             if (!string.IsNullOrWhiteSpace(kvp.Value) && string.IsNullOrWhiteSpace(qp.Get(kvp.Key)))
-                qp[kvp.Key] = Utility.Uri.UrlEncode(kvp.Value);
+                qp[kvp.Key] = Utility.CompatUri.UrlEncode(kvp.Value);
 
-        var query = Utility.Uri.BuildUriQuery(qp);
+        var query = Utility.CompatUri.BuildUriQuery(qp);
 
         if (string.IsNullOrWhiteSpace(uri.HostAndPath) && !string.IsNullOrWhiteSpace(endpoint))
-            uri = new Utility.Uri(endpoint).SetScheme(uri.Scheme).SetQuery(null);
+            uri = new Utility.CompatUri(endpoint).SetScheme(uri.Scheme).SetQuery(null);
 
         return uri.SetQuery(query).ToString();
     }

--- a/Duplicati/Library/Backend/Duplicati/ListBackupsModule.cs
+++ b/Duplicati/Library/Backend/Duplicati/ListBackupsModule.cs
@@ -60,7 +60,7 @@ public class ListBackupsModule : IWebModule
         var url = opts.GetValueOrDefault("url");
         if (string.IsNullOrEmpty(url))
             throw new UserInformationException("The 'url' option must be specified", "UrlOptionMissing");
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         foreach (var key in uri.QueryParameters.AllKeys)
             if (key != null)
                 opts[key] = uri.QueryParameters[key];

--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -269,7 +269,7 @@ namespace Duplicati.Library.Backend
             _sslOptions = SslOptionsHelper.Parse(options);
             _sslValidator = new SslCertificateValidator(_sslOptions.AcceptAllCertificates, _sslOptions.AcceptSpecificCertificateHashes, _sslOptions.IgnoreRevocationFailure);
 
-            var u = new Utility.Uri(url);
+            var u = new Utility.CompatUri(url);
             u.RequireHost();
 
             var auth = AuthOptionsHelper.Parse(options, u);

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.Backend
         /// <param name="options">The options for the file backend</param>
         public File(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
             var path = uri.HostAndPath;
             var auth = AuthOptionsHelper.Parse(options, uri);
             m_timeouts = TimeoutOptionsHelper.Parse(options);

--- a/Duplicati/Library/Backend/Filejump/Filejump.cs
+++ b/Duplicati/Library/Backend/Filejump/Filejump.cs
@@ -129,7 +129,7 @@ namespace Duplicati.Library.Backend
 
         public Filejump(string url, Dictionary<string, string?> options)
         {
-            var u = new Utility.Uri(url);
+            var u = new Utility.CompatUri(url);
             m_path = u.HostAndPath.Trim('/');
             if (string.IsNullOrWhiteSpace(m_path))
                 m_path = "/";

--- a/Duplicati/Library/Backend/Filen/FilenBackend.cs
+++ b/Duplicati/Library/Backend/Filen/FilenBackend.cs
@@ -93,7 +93,7 @@ public class FilenBackend : IStreamingBackend, IRenameEnabledBackend
     /// <param name="options">The options to use</param>
     public FilenBackend(string url, Dictionary<string, string?> options)
     {
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
         _path = uri.HostAndPath;
 
         _auth = AuthOptionsHelper.Parse(options, uri)

--- a/Duplicati/Library/Backend/Filen/GetApiKeyModule.cs
+++ b/Duplicati/Library/Backend/Filen/GetApiKeyModule.cs
@@ -63,7 +63,7 @@ public class GetApiKeyModule : IWebModule
         if (string.IsNullOrEmpty(url))
             throw new UserInformationException("URL is required", "UrlOptionMissing");
 
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
 
         var newOpts = new Dictionary<string, string?>(options);
         foreach (var key in uri.QueryParameters.AllKeys)

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -87,7 +87,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public GoogleCloudStorage(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
 
             m_bucket = uri.Host ?? "";
             m_prefix = Util.AppendDirSeparator("/" + uri.Path, "/");
@@ -184,7 +184,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         /// <inheritdoc />
         public async IAsyncEnumerable<IFileEntry> ListAsync([EnumeratorCancellation] CancellationToken cancelToken)
         {
-            var url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.Uri.UrlEncode(m_prefix));
+            var url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.CompatUri.UrlEncode(m_prefix));
             while (true)
             {
                 var resp = await HandleListExceptions(() =>
@@ -215,7 +215,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
                 var token = resp.nextPageToken;
                 if (string.IsNullOrWhiteSpace(token))
                     break;
-                url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.Uri.UrlEncode(m_prefix), token);
+                url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.CompatUri.UrlEncode(m_prefix), token);
             }
         }
 
@@ -232,7 +232,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         }
         public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
         {
-            using var req = await m_oauth.CreateRequestAsync(WebApi.GoogleCloudStorage.DeleteUrl(m_bucket, Library.Utility.Uri.UrlPathEncode(m_prefix + remotename)), HttpMethod.Delete, cancelToken);
+            using var req = await m_oauth.CreateRequestAsync(WebApi.GoogleCloudStorage.DeleteUrl(m_bucket, Library.Utility.CompatUri.UrlPathEncode(m_prefix + remotename)), HttpMethod.Delete, cancelToken);
 
             await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, async ct
                 =>
@@ -243,7 +243,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task<DateTime?> GetObjectLockUntilAsync(string remotename, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.Uri.UrlPathEncode(m_prefix + remotename));
+            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.CompatUri.UrlPathEncode(m_prefix + remotename));
 
             try
             {
@@ -265,7 +265,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task SetObjectLockUntilAsync(string remotename, DateTime lockUntilUtc, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.Uri.UrlPathEncode(m_prefix + remotename));
+            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.CompatUri.UrlPathEncode(m_prefix + remotename));
 
             var metadata = new ObjectMetadata
             {
@@ -382,7 +382,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         {
             try
             {
-                var url = WebApi.GoogleCloudStorage.GetUrl(m_bucket, Utility.Uri.UrlPathEncode(m_prefix + remotename));
+                var url = WebApi.GoogleCloudStorage.GetUrl(m_bucket, Utility.CompatUri.UrlPathEncode(m_prefix + remotename));
                 using var req = await m_oauth.CreateRequestAsync(url, HttpMethod.Get, cancelToken);
                 using var resp = await Library.Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, ct => m_oauth.GetResponseAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)).ConfigureAwait(false);
                 using var source = await Library.Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, ct => resp.Content.ReadAsStreamAsync(cancelToken)).ConfigureAwait(false);
@@ -400,7 +400,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task RenameAsync(string oldname, string newname, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.RewriteUrl(m_bucket, Utility.Uri.UrlPathEncode(m_prefix + oldname), m_bucket, Utility.Uri.UrlPathEncode(m_prefix + newname));
+            var url = WebApi.GoogleCloudStorage.RewriteUrl(m_bucket, Utility.CompatUri.UrlPathEncode(m_prefix + oldname), m_bucket, Utility.CompatUri.UrlPathEncode(m_prefix + newname));
 
             // Perform rewrite (copy)
             await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancellationToken, async ct =>

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -57,7 +57,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
 
         public GoogleDrive(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
 
             m_path = Util.AppendDirSeparator(uri.HostAndPath, "/");
 
@@ -413,7 +413,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
 
                 foreach (var fileid in entries.Select(x => x.id).WhereNotNullOrWhiteSpace())
                 {
-                    var url = WebApi.GoogleDrive.DeleteUrl(Library.Utility.Uri.UrlPathEncode(fileid), m_teamDriveID);
+                    var url = WebApi.GoogleDrive.DeleteUrl(Library.Utility.CompatUri.UrlPathEncode(fileid), m_teamDriveID);
                     await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken,
                         async ct =>
                         {
@@ -566,7 +566,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
                 "trashed=false"
             };
 
-            var encodedFileQuery = Utility.Uri.UrlEncode(string.Join(" and ", fileQuery.Where(x => x != null)));
+            var encodedFileQuery = Utility.CompatUri.UrlEncode(string.Join(" and ", fileQuery.Where(x => x != null)));
             var url = WebApi.GoogleDrive.ListUrl(encodedFileQuery, m_teamDriveID);
 
             while (true)

--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -61,7 +61,7 @@ namespace Duplicati.Library.Backend.WebApi
         {
             var path = BucketObjectPath(bucketId, objectId);
 
-            return Utility.Uri.UriBuilder(Url.API, path);
+            return Utility.CompatUri.UriBuilder(Url.API, path);
         }
 
         public static string CreateFolderUrl(string projectId)
@@ -71,17 +71,17 @@ namespace Duplicati.Library.Backend.WebApi
                 { QueryParam.Project, projectId }
             };
 
-            return Utility.Uri.UriBuilder(Url.API, Path.Bucket, queryParams);
+            return Utility.CompatUri.UriBuilder(Url.API, Path.Bucket, queryParams);
         }
 
         public static string RenameUrl(string bucketId, string objectId)
-            => Utility.Uri.UriBuilder(Url.API, BucketObjectPath(bucketId, objectId));
+            => Utility.CompatUri.UriBuilder(Url.API, BucketObjectPath(bucketId, objectId));
 
         public static string RewriteUrl(string sourceBucket, string sourceObject, string destBucket, string destObject)
         {
             var path = UrlPath.Create(Path.Bucket).Append(sourceBucket).Append(Path.Object).Append(sourceObject)
                 .Append("rewriteTo").Append(Path.Bucket).Append(destBucket).Append(Path.Object).Append(destObject).ToString();
-            return Utility.Uri.UriBuilder(Url.API, path);
+            return Utility.CompatUri.UriBuilder(Url.API, path);
         }
 
         public static string ListUrl(string bucketId, string prefix)
@@ -98,7 +98,7 @@ namespace Duplicati.Library.Backend.WebApi
                 queryParams.Set(QueryParam.PageToken, token);
             }
 
-            return Utility.Uri.UriBuilder(Url.API, BucketObjectPath(bucketId), queryParams);
+            return Utility.CompatUri.UriBuilder(Url.API, BucketObjectPath(bucketId), queryParams);
         }
 
         public static string PutUrl(string bucketId)
@@ -108,7 +108,7 @@ namespace Duplicati.Library.Backend.WebApi
                 { QueryParam.UploadType, QueryValue.Resumable }
             };
             var path = UrlPath.Create(Path.Bucket).Append(bucketId).Append(Path.Object).ToString();
-            return Utility.Uri.UriBuilder(Url.UPLOAD, path, queryParams);
+            return Utility.CompatUri.UriBuilder(Url.UPLOAD, path, queryParams);
         }
 
         public static string GetUrl(string bucketId, string objectId)
@@ -120,13 +120,13 @@ namespace Duplicati.Library.Backend.WebApi
                 };
             var path = BucketObjectPath(bucketId, objectId);
 
-            return Utility.Uri.UriBuilder(Url.API, path, queryParams);
+            return Utility.CompatUri.UriBuilder(Url.API, path, queryParams);
         }
 
         public static string MetadataUrl(string bucketId, string objectId)
         {
             var path = BucketObjectPath(bucketId, objectId);
-            return Utility.Uri.UriBuilder(Url.API, path);
+            return Utility.CompatUri.UriBuilder(Url.API, path);
         }
 
         private static class Url
@@ -174,7 +174,7 @@ namespace Duplicati.Library.Backend.WebApi
             });
 
         public static string DeleteUrl(string fileId, string? teamDriveId)
-            => FileQueryUrl(Utility.Uri.UrlPathEncode(fileId), AddTeamDriveParam(teamDriveId));
+            => FileQueryUrl(Utility.CompatUri.UrlPathEncode(fileId), AddTeamDriveParam(teamDriveId));
 
         public static string PutUrl(string? fileId, bool useTeamDrive)
         {
@@ -188,7 +188,7 @@ namespace Duplicati.Library.Backend.WebApi
             }
 
             return !string.IsNullOrWhiteSpace(fileId) ?
-                FileUploadUrl(Utility.Uri.UrlPathEncode(fileId), queryParams) :
+                FileUploadUrl(Utility.CompatUri.UrlPathEncode(fileId), queryParams) :
                       FileUploadUrl(queryParams);
         }
 
@@ -217,7 +217,7 @@ namespace Duplicati.Library.Backend.WebApi
             => FileQueryUrl(AddTeamDriveParam(teamDriveId));
 
         public static string AboutInfoUrl()
-            => Utility.Uri.UriBuilder(Url.DRIVE, Path.About);
+            => Utility.CompatUri.UriBuilder(Url.DRIVE, Path.About);
 
         private static class Url
         {
@@ -252,16 +252,16 @@ namespace Duplicati.Library.Backend.WebApi
         }
 
         private static string FileQueryUrl(NameValueCollection values)
-            => Utility.Uri.UriBuilder(Url.DRIVE, Path.File, values);
+            => Utility.CompatUri.UriBuilder(Url.DRIVE, Path.File, values);
 
         private static string FileQueryUrl(string fileId, NameValueCollection? values = null)
-            => Utility.Uri.UriBuilder(Url.DRIVE, UrlPath.Create(Path.File).Append(fileId).ToString(), values);
+            => Utility.CompatUri.UriBuilder(Url.DRIVE, UrlPath.Create(Path.File).Append(fileId).ToString(), values);
 
         private static string FileUploadUrl(string fileId, NameValueCollection? values)
-            => Utility.Uri.UriBuilder(Url.UPLOAD, UrlPath.Create(Path.File).Append(fileId).ToString(), values);
+            => Utility.CompatUri.UriBuilder(Url.UPLOAD, UrlPath.Create(Path.File).Append(fileId).ToString(), values);
 
         private static string FileUploadUrl(NameValueCollection values)
-            => Utility.Uri.UriBuilder(Url.UPLOAD, Path.File, values);
+            => Utility.CompatUri.UriBuilder(Url.UPLOAD, Path.File, values);
 
         private static NameValueCollection AddTeamDriveParam(string? teamDriveId)
         {

--- a/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
@@ -90,7 +90,7 @@ namespace Duplicati.Library.Backend
         /// <inheritdoc />
         public Idrivee2Backend(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
             _bucket = uri.Host ?? "";
             _prefix = uri.Path;
             _prefix = _prefix.Trim();

--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -135,7 +135,7 @@ public class Jottacloud : IStreamingBackend, IRenameEnabledBackend
             .RequireCredentials(TOKEN_URL);
 
         // Build URL
-        var u = new Utility.Uri(url);
+        var u = new Utility.CompatUri(url);
         m_path = u.HostAndPath; // Host and path of "jottacloud://folder/subfolder" is "folder/subfolder", so the actual folder path within the mount point.
         if (string.IsNullOrEmpty(m_path)) // Require a folder. Actually it is possible to store files directly on the root level of the mount point, but that does not seem to be a good option.
             throw new UserInformationException(Strings.Jottacloud.NoPathError, "JottaNoPath");
@@ -421,7 +421,7 @@ public class Jottacloud : IStreamingBackend, IRenameEnabledBackend
     private async Task<HttpRequestMessage> CreateRequest(HttpMethod method, string remotename, string queryparams, bool upload, CancellationToken cancelToken)
     {
         (var _, var urls) = await GetClient(cancelToken).ConfigureAwait(false);
-        return await CreateRequest((upload ? urls.UploadUrl : urls.Url) + Utility.Uri.UrlEncode(remotename).Replace("+", "%20"), queryparams, method, cancelToken).ConfigureAwait(false);
+        return await CreateRequest((upload ? urls.UploadUrl : urls.Url) + Utility.CompatUri.UrlEncode(remotename).Replace("+", "%20"), queryparams, method, cancelToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -649,7 +649,7 @@ public class Jottacloud : IStreamingBackend, IRenameEnabledBackend
     {
         (var client, var _) = await GetClient(cancellationToken).ConfigureAwait(false);
         var destPath = "/" + m_path + newname;
-        using var req = await CreateRequest(HttpMethod.Post, oldname, "mv=" + Utility.Uri.UrlEncode(destPath), false, cancellationToken).ConfigureAwait(false);
+        using var req = await CreateRequest(HttpMethod.Post, oldname, "mv=" + Utility.CompatUri.UrlEncode(destPath), false, cancellationToken).ConfigureAwait(false);
         using var response = await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancellationToken,
             innerCancellationToken => client.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, innerCancellationToken)).ConfigureAwait(false);
 

--- a/Duplicati/Library/Backend/Mega/MegaBackend.cs
+++ b/Duplicati/Library/Backend/Mega/MegaBackend.cs
@@ -73,7 +73,7 @@ namespace Duplicati.Library.Backend.Mega
 
         public MegaBackend(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
 
             var auth = AuthOptionsHelper.Parse(options, uri);
             if (options.ContainsKey("auth-two-factor-key"))

--- a/Duplicati/Library/Backend/MovistarCloud/MovistarCloudBackend.cs
+++ b/Duplicati/Library/Backend/MovistarCloud/MovistarCloudBackend.cs
@@ -269,7 +269,7 @@ public sealed class MovistarCloudBackend : IBackend
         _password = RequireOption(options, PasswordOption);
         _deviceId = RequireOption(options, DeviceIdOption);
 
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
         _rootFolderPathOpt = uri.HostAndPath;
 
         _listLimit = Library.Utility.Utility.ParseIntOption(options, ListLimitOption, DefaultListLimit);

--- a/Duplicati/Library/Backend/OAuthHelper/MultipartItem.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/MultipartItem.cs
@@ -101,7 +101,7 @@ namespace Duplicati.Library
                 if (string.IsNullOrWhiteSpace(value))
                     Headers.Remove("Content-Disposition");
                 else
-                    Headers["Content-Disposition"] = string.Format("form-data; name=\"{0}\"", Library.Utility.Uri.UrlEncode(value)); 
+                    Headers["Content-Disposition"] = string.Format("form-data; name=\"{0}\"", Library.Utility.CompatUri.UrlEncode(value)); 
             }
         }
 
@@ -132,7 +132,7 @@ namespace Duplicati.Library
         }
         public MultipartItem SetHeader(string key, string value)
         {
-            return SetHeaderRaw(key, Library.Utility.Uri.UrlEncode(value));
+            return SetHeaderRaw(key, Library.Utility.CompatUri.UrlEncode(value));
         }
         public MultipartItem SetContentDisposition(string name, string filename = null)
         {
@@ -142,7 +142,7 @@ namespace Duplicati.Library
                 return this;
             }
                 
-            return SetHeaderRaw("Content-Disposition", string.Format("form-data; name=\"{0}\"; filename=\"{1}\"", Library.Utility.Uri.UrlEncode(name), Library.Utility.Uri.UrlEncode(filename)));
+            return SetHeaderRaw("Content-Disposition", string.Format("form-data; name=\"{0}\"; filename=\"{1}\"", Library.Utility.CompatUri.UrlEncode(name), Library.Utility.CompatUri.UrlEncode(filename)));
         }
 
     }}

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -678,9 +678,9 @@ namespace Duplicati.Library.Backend
         protected virtual Task<string> GetRootPathFromUrlAsync(string url, CancellationToken cancelToken)
         {
             // Extract out the path to the backup root folder from the given URI
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
 
-            return Task.FromResult(Utility.Uri.UrlDecode(uri.HostAndPath));
+            return Task.FromResult(Utility.CompatUri.UrlDecode(uri.HostAndPath));
         }
 
         protected Task<T> GetAsync<T>(string url, CancellationToken cancelToken)

--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -30,7 +30,6 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using Exception = System.Exception;
-using Uri = Duplicati.Library.Utility.Uri;
 
 namespace Duplicati.Library.Backend.OpenStack;
 
@@ -108,7 +107,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
 
     public OpenStackStorage(string url, Dictionary<string, string?> options)
     {
-        var uri = new Uri(url);
+        var uri = new CompatUri(url);
 
         m_container = uri.Host ?? "";
         m_prefix = Util.AppendDirSeparator("/" + uri.Path, "/");
@@ -330,7 +329,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     /// <inheritdoc />
     public async Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, Uri.UrlPathEncode(m_prefix + remotename));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, CompatUri.UrlPathEncode(m_prefix + remotename));
         using var req = m_helper.CreateRequest(url, "PUT");
         await using var ts = stream.ObserveReadTimeout(_timeouts.ReadWriteTimeout, false);
 
@@ -344,7 +343,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     /// <inheritdoc />
     public async Task GetAsync(string remotename, Stream stream, CancellationToken cancelToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, Uri.UrlPathEncode(m_prefix + remotename));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, CompatUri.UrlPathEncode(m_prefix + remotename));
 
         try
         {
@@ -387,7 +386,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     {
         var plainurl = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container) + string.Format("?format=json&delimiter=/&limit={0}", PAGE_LIMIT);
         if (!string.IsNullOrEmpty(m_prefix))
-            plainurl += "&prefix=" + Uri.UrlEncode(m_prefix);
+            plainurl += "&prefix=" + CompatUri.UrlEncode(m_prefix);
 
         var url = plainurl;
 
@@ -418,7 +417,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
                 yield break;
 
             // Prepare next listing entry
-            url = plainurl + $"&marker={Uri.UrlEncode(items.Last().name ?? "")}";
+            url = plainurl + $"&marker={CompatUri.UrlEncode(items.Last().name ?? "")}";
         }
     }
 
@@ -439,7 +438,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     /// <inheritdoc />
     public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, Uri.UrlPathEncode(m_prefix + remotename));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, CompatUri.UrlPathEncode(m_prefix + remotename));
         using var req = m_helper.CreateRequest(url, "DELETE");
         using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, ct => m_helper.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, ct)).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
@@ -508,9 +507,9 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
 
     public async Task RenameAsync(string oldname, string newname, CancellationToken cancellationToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancellationToken).ConfigureAwait(false), m_container, Uri.UrlPathEncode(m_prefix + oldname));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancellationToken).ConfigureAwait(false), m_container, CompatUri.UrlPathEncode(m_prefix + oldname));
         using var req = m_helper.CreateRequest(url, "COPY");
-        req.Headers.Add("Destination", "/" + m_container + "/" + Uri.UrlPathEncode(m_prefix + newname));
+        req.Headers.Add("Destination", "/" + m_container + "/" + CompatUri.UrlPathEncode(m_prefix + newname));
 
         using var response = await m_httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();

--- a/Duplicati/Library/Backend/Rclone/Rclone.cs
+++ b/Duplicati/Library/Backend/Rclone/Rclone.cs
@@ -62,7 +62,7 @@ namespace Duplicati.Library.Backend
 
         public Rclone(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
             /*should check here if program is installed */
 
             local_repo = options.GetValueOrDefault(OPTION_LOCAL_REPO) ?? "";

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -240,7 +240,7 @@ namespace Duplicati.Library.Backend
 
         public S3(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
             uri.RequireHost();
 
             m_bucket = uri.Host ?? "";

--- a/Duplicati/Library/Backend/SMB/SMBBackend.cs
+++ b/Duplicati/Library/Backend/SMB/SMBBackend.cs
@@ -129,7 +129,7 @@ public class SMBBackend : IStreamingBackend, IFolderEnabledBackend, IRenameEnabl
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
         uri.RequireHost();
         _DnsName = uri.Host ?? "";
 

--- a/Duplicati/Library/Backend/SSHv2/KeyGenerator.cs
+++ b/Duplicati/Library/Backend/SSHv2/KeyGenerator.cs
@@ -132,7 +132,7 @@ namespace Duplicati.Library.Backend
 
             var b64 = sb.ToString().Trim();
             var pem = string.Format(pem_template, b64);
-            var uri = SSHv2.KEYFILE_URI + Duplicati.Library.Utility.Uri.UrlEncode(pem);
+            var uri = SSHv2.KEYFILE_URI + Duplicati.Library.Utility.CompatUri.UrlEncode(pem);
             var pub = key_name + " " + Convert.ToBase64String(public_key) + " " + username;
 
             res["privkey"] = b64_raw;

--- a/Duplicati/Library/Backend/SSHv2/KeyUploader.cs
+++ b/Duplicati/Library/Backend/SSHv2/KeyUploader.cs
@@ -51,7 +51,7 @@ namespace Duplicati.Library.Backend
             if (string.IsNullOrWhiteSpace(pubkey_s))
                 throw new ArgumentException(OPTION_KEY);
 
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
             foreach (var key in uri.QueryParameters.AllKeys)
                 if (!string.IsNullOrWhiteSpace(key))
                     options[key] = uri.QueryParameters[key] ?? "";

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -82,7 +82,7 @@ namespace Duplicati.Library.Backend
         public SSHv2(string url, Dictionary<string, string?> options)
         {
             m_options = options;
-            var uri = new Utility.Uri(url);
+            var uri = new Utility.CompatUri(url);
             uri.RequireHost();
 
             var auth = AuthOptionsHelper.Parse(options, uri);
@@ -596,7 +596,7 @@ namespace Duplicati.Library.Backend
                 using (var ms = new MemoryStream())
                 using (var sr = new StreamWriter(ms))
                 {
-                    sr.Write(Utility.Uri.UrlDecode(inline));
+                    sr.Write(Utility.CompatUri.UrlDecode(inline));
                     sr.Flush();
 
                     ms.Position = 0;

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -53,7 +53,7 @@ namespace Duplicati.Library.Backend
         #region [Variables and constants declarations]
 
         /// <summary> Auth-stripped HTTPS-URI as passed to constructor. </summary>
-        private readonly Utility.Uri m_orgUrl;
+        private readonly Utility.CompatUri m_orgUrl;
         /// <summary> Server relative path to backup folder. </summary>
         private readonly string m_serverRelPath;
         /// <summary> User's credentials to create client context </summary>
@@ -106,7 +106,7 @@ namespace Duplicati.Library.Backend
 
         public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult(new string?[] {
             m_orgUrl.Host,
-            string.IsNullOrWhiteSpace(m_spWebUrl) ? null : new Utility.Uri(m_spWebUrl).Host
+            string.IsNullOrWhiteSpace(m_spWebUrl) ? null : new Utility.CompatUri(m_spWebUrl).Host
         }.WhereNotNullOrWhiteSpace().ToArray());
 
         #endregion
@@ -149,11 +149,11 @@ namespace Duplicati.Library.Backend
             catch { }
 
 
-            var u = new Utility.Uri(url);
+            var u = new Utility.CompatUri(url);
             u.RequireHost();
 
             // Create sanitized plain https-URI (note: still has double slashes for processing web)
-            m_orgUrl = new Utility.Uri("https", u.Host, u.Path, null, null, null, u.Port);
+            m_orgUrl = new Utility.CompatUri("https", u.Host, u.Path, null, null, null, u.Port);
 
             // Actual path to Web will be searched for on first use. Ctor should not throw.
             m_spWebUrl = null;
@@ -273,7 +273,7 @@ namespace Duplicati.Library.Backend
         /// If that won't help, we will try all possible paths from longest
         /// to shortest...
         /// </summary>
-        private static async Task<(string? testUrl, ClientContext? retCtx)> FindCorrectWebPathAsync(Utility.Uri orgUrl, System.Net.ICredentials userInfo, TimeSpan timeout, CancellationToken cancelToken)
+        private static async Task<(string? testUrl, ClientContext? retCtx)> FindCorrectWebPathAsync(Utility.CompatUri orgUrl, System.Net.ICredentials userInfo, TimeSpan timeout, CancellationToken cancelToken)
         {
             ClientContext? retCtx = null;
             int status;
@@ -284,7 +284,7 @@ namespace Duplicati.Library.Backend
             // if a hint is supplied, we will of course use this first.
             if (webIndicatorPos >= 0)
             {
-                var testUrl = new Utility.Uri(orgUrl.Scheme, orgUrl.Host, path.Substring(0, webIndicatorPos), null, null, null, orgUrl.Port).ToString();
+                var testUrl = new Utility.CompatUri(orgUrl.Scheme, orgUrl.Host, path.Substring(0, webIndicatorPos), null, null, null, orgUrl.Port).ToString();
                 (status, retCtx) = await TestUrlForWebAsync(testUrl, userInfo, false, timeout, cancelToken).ConfigureAwait(false);
                 if (status >= 0)
                     return (testUrl, retCtx);
@@ -296,7 +296,7 @@ namespace Duplicati.Library.Backend
             var docLibrary = Array.FindIndex(pathParts, p => StringComparer.OrdinalIgnoreCase.Equals(p, "documents"));
             if (docLibrary >= 0)
             {
-                var testUrl = new Utility.Uri(orgUrl.Scheme, orgUrl.Host,
+                var testUrl = new Utility.CompatUri(orgUrl.Scheme, orgUrl.Host,
                     string.Join("/", pathParts, 0, docLibrary),
                     null, null, null, orgUrl.Port).ToString();
                 (status, retCtx) = await TestUrlForWebAsync(testUrl, userInfo, false, timeout, cancelToken).ConfigureAwait(false);
@@ -309,7 +309,7 @@ namespace Duplicati.Library.Backend
             {
                 if (pi == docLibrary) continue; // already tested
 
-                var testUrl = new Utility.Uri(orgUrl.Scheme, orgUrl.Host,
+                var testUrl = new Utility.CompatUri(orgUrl.Scheme, orgUrl.Host,
                     string.Join("/", pathParts, 0, pi),
                     null, null, null, orgUrl.Port).ToString();
                 (status, retCtx) = await TestUrlForWebAsync(testUrl, userInfo, false, timeout, cancelToken).ConfigureAwait(false);
@@ -664,7 +664,7 @@ namespace Duplicati.Library.Backend
             {
                 if (string.IsNullOrWhiteSpace(m_spWebUrl))
                     throw new HttpRequestException(Strings.SharePoint.NoSharePointWebFoundError(m_orgUrl.ToString()));
-                var pathLengthToWeb = new Utility.Uri(m_spWebUrl).Path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).Length;
+                var pathLengthToWeb = new Utility.CompatUri(m_spWebUrl).Path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).Length;
 
                 var folderNames = m_serverRelPath.Substring(0, m_serverRelPath.Length - 1).Split('/');
                 folderNames = Array.ConvertAll(folderNames, fold => System.Net.WebUtility.UrlDecode(fold));

--- a/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
+++ b/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
@@ -27,7 +27,6 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using Newtonsoft.Json;
-using Uri = Duplicati.Library.Utility.Uri;
 
 namespace Duplicati.Library.Backend;
 
@@ -63,7 +62,7 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
     public TahoeBackend(string url, Dictionary<string, string?> options)
     {
         //Validate URL
-        var u = new Uri(url);
+        var u = new CompatUri(url);
         u.RequireHost();
 
         if (!u.Path.StartsWith("uri/URI:DIR2:", StringComparison.Ordinal) && !u.Path.StartsWith("uri/URI%3ADIR2%3A", StringComparison.Ordinal))
@@ -261,7 +260,7 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
     /// <returns></returns>
     private HttpRequestMessage CreateRequest(string remotename, string queryparams, HttpMethod? method = null)
     {
-        var request = new HttpRequestMessage(method == null ? HttpMethod.Get : method, $"{_url}{Uri.UrlEncode(remotename).Replace("+", "%20")}{(string.IsNullOrEmpty(queryparams) || queryparams.Trim().Length == 0 ? String.Empty : "?" + queryparams)}");
+        var request = new HttpRequestMessage(method == null ? HttpMethod.Get : method, $"{_url}{CompatUri.UrlEncode(remotename).Replace("+", "%20")}{(string.IsNullOrEmpty(queryparams) || queryparams.Trim().Length == 0 ? String.Empty : "?" + queryparams)}");
         request.Headers.UserAgent.ParseAdd($"Duplicati Tahoe-LAFS Client {Assembly.GetExecutingAssembly().GetName().Version?.ToString()}");
         return request;
     }
@@ -284,7 +283,7 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
         using var resp = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancellationToken,
             innerCancelToken =>
             {
-                using var request = CreateRequest(string.Empty, $"t=rename&from_name={Uri.UrlEncode(oldname)}&to_name={Uri.UrlEncode(newname)}", HttpMethod.Post);
+                using var request = CreateRequest(string.Empty, $"t=rename&from_name={CompatUri.UrlEncode(oldname)}&to_name={CompatUri.UrlEncode(newname)}", HttpMethod.Post);
                 return GetHttpClient().SendAsync(request, innerCancelToken);
             }).ConfigureAwait(false);
 

--- a/Duplicati/Library/Backend/TencentCOS/COSBackend.cs
+++ b/Duplicati/Library/Backend/TencentCOS/COSBackend.cs
@@ -123,7 +123,7 @@ namespace Duplicati.Library.Backend.TencentCOS
 
         public COS(string url, Dictionary<string, string?> options)
         {
-            var uri = new Utility.Uri(url?.Trim() ?? "");
+            var uri = new Utility.CompatUri(url?.Trim() ?? "");
             var prefix = uri.HostAndPath?.Trim()?.Trim('/')?.Trim('\\');
             var auth = AuthOptionsHelper.ParseWithAlias(options, uri, COS_SECRET_ID, COS_SECRET_KEY)
                 .RequireCredentials();

--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -159,7 +159,7 @@ namespace Duplicati.Library.Backend
 
         public WEBDAV(string url, Dictionary<string, string?> options)
         {
-            var u = new Utility.Uri(url);
+            var u = new Utility.CompatUri(url);
             u.RequireHost();
             m_dnsName = u.Host ?? "";
             var auth = AuthOptionsHelper.Parse(options, u);
@@ -190,16 +190,16 @@ namespace Duplicati.Library.Backend
                 m_path = "/" + m_path;
             m_path = Util.AppendDirSeparator(m_path, "/");
 
-            m_path = Utility.Uri.UrlDecode(m_path);
-            m_rawurl = new Utility.Uri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path).ToString();
+            m_path = Utility.CompatUri.UrlDecode(m_path);
+            m_rawurl = new Utility.CompatUri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path).ToString();
 
             int port = u.Port;
             if (port <= 0)
                 port = m_certificateOptions.UseSSL ? 443 : 80;
 
-            m_rawurlPort = new Utility.Uri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path, null, null, null, port).ToString();
-            m_sanitizedUrl = new Utility.Uri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path).ToString();
-            m_reverseProtocolUrl = new Utility.Uri(m_certificateOptions.UseSSL ? "http" : "https", u.Host, m_path).ToString();
+            m_rawurlPort = new Utility.CompatUri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path, null, null, null, port).ToString();
+            m_sanitizedUrl = new Utility.CompatUri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path).ToString();
+            m_reverseProtocolUrl = new Utility.CompatUri(m_certificateOptions.UseSSL ? "http" : "https", u.Host, m_path).ToString();
             m_timeouts = TimeoutOptionsHelper.Parse(options);
 
             m_baseUri = new System.Uri(m_url, System.UriKind.Absolute);
@@ -238,7 +238,7 @@ namespace Duplicati.Library.Backend
             if (path == null)
                 return;
 
-            var normalized = Utility.Uri.UrlDecode(path.Replace("+", "%2B"));
+            var normalized = Utility.CompatUri.UrlDecode(path.Replace("+", "%2B"));
 
             if (!normalized.StartsWith("/", StringComparison.Ordinal))
                 normalized = "/" + normalized;
@@ -264,17 +264,17 @@ namespace Duplicati.Library.Backend
                 }
                 else
                 {
-                    var decodedValue = Utility.Uri.UrlDecode(trimmed.Replace("+", "%2B"));
+                    var decodedValue = Utility.CompatUri.UrlDecode(trimmed.Replace("+", "%2B"));
                     return ExtractRelativeFromDecodedPath(decodedValue);
                 }
             }
 
-            var decodedPath = Utility.Uri.UrlDecode(hrefUri.AbsolutePath.Replace("+", "%2B"));
+            var decodedPath = Utility.CompatUri.UrlDecode(hrefUri.AbsolutePath.Replace("+", "%2B"));
             var name = ExtractRelativeFromDecodedPath(decodedPath);
             if (!string.IsNullOrEmpty(name))
                 return name;
 
-            var decodedHref = Utility.Uri.UrlDecode(trimmed.Replace("+", "%2B"));
+            var decodedHref = Utility.CompatUri.UrlDecode(trimmed.Replace("+", "%2B"));
             return ExtractRelativeFromDecodedPath(decodedHref);
         }
 
@@ -329,7 +329,7 @@ namespace Duplicati.Library.Backend
             if (string.IsNullOrWhiteSpace(hrefValue))
                 return null;
 
-            string name = Utility.Uri.UrlDecode(hrefValue.Replace("+", "%2B"));
+            string name = Utility.CompatUri.UrlDecode(hrefValue.Replace("+", "%2B"));
 
             string cmp_path;
 
@@ -611,7 +611,7 @@ namespace Duplicati.Library.Backend
 
         private HttpRequestMessage CreateRequest(string remotename, HttpMethod? method = null)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{m_url}{Utility.Uri.UrlEncode(remotename).Replace("+", "%20")}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{m_url}{Utility.CompatUri.UrlEncode(remotename).Replace("+", "%20")}");
             request.Headers.Add(HttpRequestHeader.UserAgent.ToString(), "Duplicati WEBDAV Client v" + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
 
             request.Headers.ConnectionClose = !m_useIntegratedAuthentication; // ConnectionClose is incompatible with integrated authentication
@@ -686,7 +686,7 @@ namespace Duplicati.Library.Backend
             try
             {
                 using var request = CreateRequest(oldname, new HttpMethod("MOVE"));
-                request.Headers.Add("Destination", $"{m_url}{Utility.Uri.UrlEncode(newname).Replace("+", "%20")}");
+                request.Headers.Add("Destination", $"{m_url}{Utility.CompatUri.UrlEncode(newname).Replace("+", "%20")}");
                 request.Headers.Add("Overwrite", "T");
 
                 using var response = await GetHttpClient().SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -129,7 +129,7 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
     /// <param name="options">options to be used in the backend</param>
     public pCloudBackend(string url, Dictionary<string, string?> options)
     {
-        var uri = new Utility.Uri(url);
+        var uri = new Utility.CompatUri(url);
         uri.RequireHost();
         _DnsName = uri.Host ?? "";
 

--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -66,7 +66,7 @@ namespace Duplicati.Library.DynamicLoader
             /// <returns>The instanciated backend or null if the url is not supported</returns>
             public IBackend GetBackend(string url, Dictionary<string, string> options)
             {
-                var uri = new Utility.Uri(url);
+                var uri = new Utility.CompatUri(url);
 
                 LoadInterfaces();
 
@@ -120,7 +120,7 @@ namespace Duplicati.Library.DynamicLoader
             /// <returns>The supported commands or null if the url scheme was not supported</returns>
             public IReadOnlyList<ICommandLineArgument> GetSupportedCommands(string url)
             {
-                var uri = new Utility.Uri(url);
+                var uri = new Utility.CompatUri(url);
 
                 LoadInterfaces();
 

--- a/Duplicati/Library/DynamicLoader/RestoreDestinationProviderLoader.cs
+++ b/Duplicati/Library/DynamicLoader/RestoreDestinationProviderLoader.cs
@@ -69,7 +69,7 @@ namespace Duplicati.Library.DynamicLoader
             /// <returns>The instanciated SourceProvider or null if the url is not supported</returns>
             public IRestoreDestinationProvider GetRestoreDestinationProvider(string url, Dictionary<string, string> options)
             {
-                var uri = new Utility.Uri(url);
+                var uri = new Utility.CompatUri(url);
 
                 LoadInterfaces();
 
@@ -107,7 +107,7 @@ namespace Duplicati.Library.DynamicLoader
             /// <returns>The supported commands or null if the url scheme was not supported</returns>
             public IReadOnlyList<ICommandLineArgument> GetSupportedCommands(string url)
             {
-                var uri = new Utility.Uri(url);
+                var uri = new Utility.CompatUri(url);
 
                 LoadInterfaces();
 

--- a/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
+++ b/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
@@ -69,7 +69,7 @@ namespace Duplicati.Library.DynamicLoader
             /// <returns>The instanciated SourceProvider or null if the url is not supported</returns>
             public ISourceProviderModule GetSourceProvider(string url, string mountPoint, Dictionary<string, string> options)
             {
-                var uri = new Utility.Uri(url);
+                var uri = new Utility.CompatUri(url);
 
                 LoadInterfaces();
 
@@ -107,7 +107,7 @@ namespace Duplicati.Library.DynamicLoader
             /// <returns>The supported commands or null if the url scheme was not supported</returns>
             public IReadOnlyList<ICommandLineArgument> GetSupportedCommands(string url)
             {
-                var uri = new Utility.Uri(url);
+                var uri = new Utility.CompatUri(url);
 
                 LoadInterfaces();
 

--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -195,7 +195,7 @@ internal partial class BackendManager : IBackendManager
         if (string.IsNullOrWhiteSpace(subPath))
             return backendUrl;
 
-        var uri = new Library.Utility.Uri(backendUrl);
+        var uri = new Library.Utility.CompatUri(backendUrl);
         // Trim trailing path separators from the existing path AND the sub-path before
         // joining with a single '/'. The URL path can end with a backslash on Windows
         // (e.g. a file:// URL built from a TempFolder path, which always carries a

--- a/Duplicati/Library/Main/CLIDatabaseLocator.cs
+++ b/Duplicati/Library/Main/CLIDatabaseLocator.cs
@@ -133,7 +133,7 @@ namespace Duplicati.Library.Main
                 configs = Newtonsoft.Json.JsonConvert.DeserializeObject<List<BackendEntry>>(System.IO.File.ReadAllText(file, System.Text.Encoding.UTF8))
                     ?? new List<BackendEntry>();
 
-            var uri = new Library.Utility.Uri(backend);
+            var uri = new Library.Utility.CompatUri(backend);
             var server = uri.Host ?? "";
             var path = uri.Path;
             var type = uri.Scheme;

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -125,7 +125,7 @@ namespace Duplicati.Library.Main
         /// <inheritdoc />
         public async Task<IBackupResults> BackupAsync(string[] inputsources, IFilter inputFilter = null)
         {
-            UsageReporter.Reporter.Report("USE_BACKEND", new Library.Utility.Uri(m_backendUrl).Scheme);
+            UsageReporter.Reporter.Report("USE_BACKEND", new Library.Utility.CompatUri(m_backendUrl).Scheme);
             UsageReporter.Reporter.Report("USE_COMPRESSION", m_options.CompressionModule);
             UsageReporter.Reporter.Report("USE_ENCRYPTION", m_options.EncryptionModule);
 
@@ -827,7 +827,7 @@ namespace Duplicati.Library.Main
 
             // Store the URL connection options separately, as these should only be visible to modules implementing IConnectionModule
             var conopts = new Dictionary<string, string>(m_options.RawOptions);
-            var qp = new Library.Utility.Uri(m_backendUrl).QueryParameters;
+            var qp = new Library.Utility.CompatUri(m_backendUrl).QueryParameters;
             foreach (var k in qp.Keys)
                 conopts[(string)k] = qp[(string)k];
 
@@ -937,7 +937,7 @@ namespace Duplicati.Library.Main
 
         private async Task ApplySecretProviderAsync(CancellationToken cancellationToken)
         {
-            var args = new[] { new Library.Utility.Uri(m_backendUrl) };
+            var args = new[] { new Library.Utility.CompatUri(m_backendUrl) };
             await SecretProviderHelper.ApplySecretProviderAsync([], args, m_options.RawOptions, TempFolder.SystemTempPath, SecretProvider, cancellationToken).ConfigureAwait(false);
             // Write back the backend argument, if it was modified by the secret provider
             m_backendUrl = args[0].ToString();
@@ -1032,7 +1032,7 @@ namespace Duplicati.Library.Main
 
             // Throw url-encoded options into the mix
             //TODO: This can hide values if both commandline and url-parameters supply the same key
-            var ext = new Library.Utility.Uri(m_backendUrl).QueryParameters;
+            var ext = new Library.Utility.CompatUri(m_backendUrl).QueryParameters;
             foreach (var k in ext.AllKeys)
                 ropts[k] = ext[k];
 

--- a/Duplicati/Library/Main/SecretProviderHelper.cs
+++ b/Duplicati/Library/Main/SecretProviderHelper.cs
@@ -120,13 +120,13 @@ public static class SecretProviderHelper
     /// Note that this method modifes the arguments and options in place.
     /// </summary>
     /// <param name="realUriArguments">The arguments to modify, of type <see cref="System.Uri"/></param>
-    /// <param name="internalUriArguments">The arguments to modify, of type <see cref="Library.Utility.Uri"/></param>
+    /// <param name="internalUriArguments">The arguments to modify, of type <see cref="Library.Utility.CompatUri"/></param>
     /// <param name="options">The options to modify</param>
     /// <param name="persistedFolder">The persisted secret cache folder</param>
     /// <param name="fallbackProvider">The fallback provider to use if no provider is specified</param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>The secret provider</returns>
-    public static async Task<ISecretProvider?> ApplySecretProviderAsync(System.Uri?[] realUriArguments, Library.Utility.Uri[] internalUriArguments, Dictionary<string, string?> options, string persistedFolder, ISecretProvider? fallbackProvider, CancellationToken cancellationToken)
+    public static async Task<ISecretProvider?> ApplySecretProviderAsync(System.Uri?[] realUriArguments, Library.Utility.CompatUri[] internalUriArguments, Dictionary<string, string?> options, string persistedFolder, ISecretProvider? fallbackProvider, CancellationToken cancellationToken)
     {
         var provider = options.GetValueOrDefault("secret-provider");
         if (string.IsNullOrWhiteSpace(provider) && fallbackProvider == null)
@@ -170,12 +170,12 @@ public static class SecretProviderHelper
     /// </summary>
     /// <param name="provider">The secret provider to use</param>
     /// <param name="realUriArguments">The arguments to modify, of type <see cref="System.Uri"/></param>
-    /// <param name="internalUriArguments">The arguments to modify, of type <see cref="Library.Utility.Uri"/></param>
+    /// <param name="internalUriArguments">The arguments to modify, of type <see cref="Library.Utility.CompatUri"/></param>
     /// <param name="options">Any options to update</param>
     /// <param name="matchpattern">The prefix to look for</param>
     /// <param name="cancelToken">The cancellation token</param>
     /// <returns>An awaitable task</returns>
-    public static async Task ReplaceSecretsAsync(ISecretProvider provider, System.Uri?[] realUriArguments, Library.Utility.Uri[] internalUriArguments, Dictionary<string, string?> options, string matchpattern, CancellationToken cancelToken)
+    public static async Task ReplaceSecretsAsync(ISecretProvider provider, System.Uri?[] realUriArguments, Library.Utility.CompatUri[] internalUriArguments, Dictionary<string, string?> options, string matchpattern, CancellationToken cancelToken)
     {
         // Unwrap ${} to support ${name is long}
         var suffix = string.Empty;
@@ -267,8 +267,8 @@ public static class SecretProviderHelper
             {
                 var uri = internalUriArguments[s];
                 var kp = uri.QueryParameters;
-                kp[k] = Library.Utility.Uri.UrlEncode(translated[v.Key]);
-                uri = uri.SetQuery(Library.Utility.Uri.BuildUriQuery(kp));
+                kp[k] = Library.Utility.CompatUri.UrlEncode(translated[v.Key]);
+                uri = uri.SetQuery(Library.Utility.CompatUri.BuildUriQuery(kp));
                 internalUriArguments[s] = uri;
             }
 

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -249,7 +249,7 @@ namespace Duplicati.Library.Modules.Builtin
                 }
                 else
                 {
-                    var values = Utility.Uri.ParseQueryString(extraData);
+                    var values = Utility.CompatUri.ParseQueryString(extraData);
                     m_extraValues = values.AllKeys
                         .Where(x => !string.IsNullOrWhiteSpace(x))
                         .ToDictionary(key => key, key => values[key]);

--- a/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
@@ -197,7 +197,7 @@ namespace Duplicati.Library.Modules.Builtin
 
         protected override void SendMessage(string subject, string body)
         {
-            var uri = new Utility.Uri(m_username.Contains("://") ? m_username : "http://" + m_username);
+            var uri = new Utility.CompatUri(m_username.Contains("://") ? m_username : "http://" + m_username);
             var resource = uri.Path ?? "";
             if (resource.StartsWith("/", StringComparison.Ordinal))
                 resource = resource.Substring(1);

--- a/Duplicati/Library/RestAPI/Database/Backup.cs
+++ b/Duplicati/Library/RestAPI/Database/Backup.cs
@@ -132,18 +132,18 @@ namespace Duplicati.Server.Database
         /// </summary>
         private void SanitizeTargetUrl()
         {
-            var url = new Duplicati.Library.Utility.Uri(this.TargetURL);
+            var url = new Duplicati.Library.Utility.CompatUri(this.TargetURL);
             NameValueCollection filteredParameters = new NameValueCollection();
             if (url.Query != null)
             {
                 // We cannot use url.QueryParameters since it contains decoded parameter values, which
                 // breaks assumptions made by the decode_uri function in AppUtils.js. Since we are simply
                 // removing password parameters, we will leave the parameters as they are in the target URL.
-                filteredParameters = Library.Utility.Uri.ParseQueryString(url.Query, false);
+                filteredParameters = Library.Utility.CompatUri.ParseQueryString(url.Query, false);
                 foreach (var field in Connection.PasswordFieldNames)
                     filteredParameters.Remove(field);
             }
-            url = url.SetQuery(Duplicati.Library.Utility.Uri.BuildUriQuery(filteredParameters));
+            url = url.SetQuery(Duplicati.Library.Utility.CompatUri.BuildUriQuery(filteredParameters));
             this.TargetURL = url.ToString();
         }
 
@@ -168,15 +168,15 @@ namespace Duplicati.Server.Database
                 if (SourceMasking.IsSpecialSource(this.Sources[i]))
                 {
                     var urlString = SourceMasking.ExtractUrl(this.Sources[i]);
-                    var url = new Library.Utility.Uri(urlString);
+                    var url = new Library.Utility.CompatUri(urlString);
 
                     if (url.Query != null)
                     {
-                        var filteredParameters = Library.Utility.Uri.ParseQueryString(url.Query, false);
+                        var filteredParameters = Library.Utility.CompatUri.ParseQueryString(url.Query, false);
                         foreach (var field in Connection.PasswordFieldNames)
                             filteredParameters.Remove(field);
 
-                        url = url.SetQuery(Library.Utility.Uri.BuildUriQuery(filteredParameters));
+                        url = url.SetQuery(Library.Utility.CompatUri.BuildUriQuery(filteredParameters));
                         this.Sources[i] = SourceMasking.ReplaceUrl(this.Sources[i], url.ToString());
                     }
                 }
@@ -205,11 +205,11 @@ namespace Duplicati.Server.Database
                 if (target == null || string.IsNullOrEmpty(target.TargetUrl))
                     continue;
 
-                var url = new Duplicati.Library.Utility.Uri(target.TargetUrl);
+                var url = new Duplicati.Library.Utility.CompatUri(target.TargetUrl);
                 var filteredParameters = url.QueryParameters;
                 foreach (var field in Connection.PasswordFieldNames)
                     filteredParameters.Remove(field);
-                url = url.SetQuery(Duplicati.Library.Utility.Uri.BuildUriQuery(filteredParameters));
+                url = url.SetQuery(Duplicati.Library.Utility.CompatUri.BuildUriQuery(filteredParameters));
                 target.TargetUrl = url.ToString();
             }
         }

--- a/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
+++ b/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
@@ -45,12 +45,12 @@ public static class QuerystringMasking
         if (string.IsNullOrEmpty(urlstring))
             return urlstring;
 
-        var url = new Library.Utility.Uri(urlstring);
+        var url = new Library.Utility.CompatUri(urlstring);
         if (string.IsNullOrWhiteSpace(url.Query))
             return urlstring;
 
         var modified = false;
-        var query = Library.Utility.Uri.ParseQueryString(url.Query, false);
+        var query = Library.Utility.CompatUri.ParseQueryString(url.Query, false);
         foreach (var k in query.AllKeys)
         {
             if (k is null) continue;
@@ -63,7 +63,7 @@ public static class QuerystringMasking
 
         if (!modified) return urlstring;
 
-        url = url.SetQuery(Library.Utility.Uri.BuildUriQuery(query));
+        url = url.SetQuery(Library.Utility.CompatUri.BuildUriQuery(query));
         return url.ToString();
     }
 
@@ -88,11 +88,11 @@ public static class QuerystringMasking
         if (string.IsNullOrEmpty(newUrl))
             throw new ArgumentException("newUrl is null or empty");
 
-        var newUb = new Library.Utility.Uri(newUrl);
+        var newUb = new Library.Utility.CompatUri(newUrl);
         if (string.IsNullOrWhiteSpace(newUb.Query))
             return newUrl;
 
-        var newQuery = Library.Utility.Uri.ParseQueryString(newUb.Query, false);
+        var newQuery = Library.Utility.CompatUri.ParseQueryString(newUb.Query, false);
 
         var modified = false;
         foreach (var key in newQuery.AllKeys)
@@ -116,8 +116,8 @@ public static class QuerystringMasking
                         if (string.IsNullOrEmpty(previousUrl))
                             continue;
 
-                        var prevUb = new Library.Utility.Uri(previousUrl);
-                        var prevQuery = Library.Utility.Uri.ParseQueryString(prevUb.Query ?? "", false);
+                        var prevUb = new Library.Utility.CompatUri(previousUrl);
+                        var prevQuery = Library.Utility.CompatUri.ParseQueryString(prevUb.Query ?? "", false);
                         prevValues = GetValuesCaseInsensitive(prevQuery, key);
                         if (prevValues != null && prevValues.Any(x => !Connection.IsPasswordPlaceholder(x)))
                             break;
@@ -139,7 +139,7 @@ public static class QuerystringMasking
         if (!modified)
             return newUrl;
 
-        newUb = newUb.SetQuery(Library.Utility.Uri.BuildUriQuery(newQuery));
+        newUb = newUb.SetQuery(Library.Utility.CompatUri.BuildUriQuery(newQuery));
 
         return newUb.ToString();
 

--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -1545,7 +1545,7 @@ namespace Duplicati.Server
                 );
             }
 
-            var uri = new Library.Utility.Uri(backup.TargetURL);
+            var uri = new Library.Utility.CompatUri(backup.TargetURL);
             if (uri.Scheme.Equals(Library.Backend.Duplicati.DuplicatiBackend.PROTOCOL, StringComparison.OrdinalIgnoreCase))
                 url = Library.Backend.Duplicati.DuplicatiBackend.MergeArgsIntoUrl(
                     url,

--- a/Duplicati/Library/Utility/CompatUri.cs
+++ b/Duplicati/Library/Utility/CompatUri.cs
@@ -1,0 +1,500 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Specialized;
+
+#nullable enable
+
+namespace Duplicati.Library.Utility
+{
+    /// <summary>
+    /// A compatibility wrapper that exposes the same surface as <see cref="LegacyUri"/> but
+    /// chooses the parsing implementation at runtime.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// By default, URLs are parsed strictly with <see cref="System.Uri"/>. This rejects the
+    /// ambiguous or malformed URLs that the legacy relaxed parser accepted, which avoids
+    /// subtle bugs (for example an <c>@</c> in a local path being read as userinfo).
+    /// </para>
+    /// <para>
+    /// Existing installations that rely on the old, relaxed parsing can opt back in by either
+    /// setting the <c>DUPLICATI_LEGACY_URL_PARSING</c> environment variable to a truthy value,
+    /// or by placing a file named <c>legacy-url-parsing.txt</c> in the binary folder (the same
+    /// location as <c>insecure-permissions.txt</c>). When legacy parsing is enabled, parsing
+    /// and round-tripping are delegated to <see cref="LegacyUri"/>, preserving the previous
+    /// behavior exactly.
+    /// </para>
+    /// <para>
+    /// The static helper methods (<see cref="UrlEncode"/>, <see cref="UrlDecode"/>,
+    /// <see cref="ParseQueryString"/>, <see cref="BuildUriQuery"/>, <see cref="UriBuilder"/>
+    /// and <see cref="ExtractPath"/>) always delegate to <see cref="LegacyUri"/> regardless of
+    /// the parsing mode, since those are pure encoding/string utilities and do not depend on
+    /// the URL parsing strategy.
+    /// </para>
+    /// </remarks>
+    public readonly struct CompatUri
+    {
+        /// <summary>
+        /// The environment variable that, when set to a truthy value, enables the legacy
+        /// relaxed URL parser. Values <c>false</c>, <c>0</c>, <c>no</c> and <c>off</c> disable it;
+        /// any other non-empty value (or an empty value, indicating the variable was set) enables it.
+        /// </summary>
+        public const string LegacyUrlParsingEnvVar = "DUPLICATI_LEGACY_URL_PARSING";
+
+        /// <summary>
+        /// The marker file that, when present in the binary folder, enables the legacy relaxed
+        /// URL parser. Mirrors the <c>insecure-permissions.txt</c> opt-in mechanism.
+        /// </summary>
+        public const string LegacyUrlParsingMarkerFile = "legacy-url-parsing.txt";
+
+        /// <summary>
+        /// Cached result of the legacy-parsing opt-in check. The check only touches the
+        /// environment and the filesystem once and is safe to cache for the process lifetime.
+        /// </summary>
+        private static readonly bool s_useLegacyParsing = DetectLegacyParsing();
+
+        /// <summary>
+        /// Gets a value indicating whether legacy URL parsing is enabled.
+        /// </summary>
+        public static bool UseLegacyParsing => s_useLegacyParsing;
+
+        /// <summary>
+        /// Detects whether the user has opted in to legacy URL parsing, either via the
+        /// <see cref="LegacyUrlParsingEnvVar"/> environment variable or the
+        /// <see cref="LegacyUrlParsingMarkerFile"/> marker file in the binary folder.
+        /// </summary>
+        /// <returns><c>true</c> if legacy parsing is enabled; otherwise <c>false</c>.</returns>
+        private static bool DetectLegacyParsing()
+        {
+            var envValue = Environment.GetEnvironmentVariable(LegacyUrlParsingEnvVar);
+            if (envValue != null)
+                return ParseBool(envValue);
+
+            var installfolder = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            if (!string.IsNullOrWhiteSpace(installfolder))
+            {
+                var path = System.IO.Path.Combine(installfolder, LegacyUrlParsingMarkerFile);
+                if (System.IO.File.Exists(path))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Parses a truthy string value. An empty or whitespace value is treated as enabled
+        /// (the option was present); <c>false</c>, <c>0</c>, <c>no</c> and <c>off</c> disable it.
+        /// </summary>
+        /// <param name="value">The value to parse.</param>
+        /// <returns><c>true</c> if the value is truthy; otherwise <c>false</c>.</returns>
+        private static bool ParseBool(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return true;
+
+            return !value.Equals("false", StringComparison.OrdinalIgnoreCase)
+                   && !value.Equals("0", StringComparison.OrdinalIgnoreCase)
+                   && !value.Equals("no", StringComparison.OrdinalIgnoreCase)
+                   && !value.Equals("off", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// The backing <see cref="LegacyUri"/> when legacy parsing is enabled, or the parsed
+        /// components when using <see cref="System.Uri"/>.
+        /// </summary>
+        private readonly LegacyUri m_legacy;
+
+        /// <summary>
+        /// The URL scheme, e.g. http
+        /// </summary>
+        public readonly string Scheme;
+        /// <summary>
+        /// The server name, e.g. www.example.com
+        /// </summary>
+        public readonly string? Host;
+        /// <summary>
+        /// The server path, e.g. index.html.
+        /// Note that the path does NOT have a leading /.
+        /// </summary>
+        public readonly string Path;
+        /// <summary>
+        /// The server port, e.g. 80, is -1 if using the default port
+        /// </summary>
+        public readonly int Port;
+        /// <summary>
+        /// The querystring, e.g. ?id=1
+        /// </summary>
+        public readonly string? Query;
+        /// <summary>
+        /// The username, if any
+        /// </summary>
+        public readonly string? Username;
+        /// <summary>
+        /// The password, if any
+        /// </summary>
+        public readonly string? Password;
+
+        /// <summary>
+        /// The original URI.
+        /// </summary>
+        public readonly string OriginalUri;
+
+        /// <summary>
+        /// Cache for the query parameters.
+        /// </summary>
+        private readonly NameValueCollection? m_queryParams;
+
+        /// <summary>
+        /// Gets the parameters in the query string
+        /// </summary>
+        /// <value>The query parameters.</value>
+        public NameValueCollection QueryParameters
+        {
+            get
+            {
+                if (m_queryParams != null)
+                    return m_queryParams;
+
+                if (s_useLegacyParsing)
+                    return m_legacy.QueryParameters;
+
+                if (Query == null)
+                    return new NameValueCollection();
+                return ParseQueryString(Query);
+            }
+        }
+
+        /// <summary>
+        /// Gets the host and path.
+        /// </summary>
+        /// <value>The host and path.</value>
+        public string HostAndPath
+        {
+            get
+            {
+                if (s_useLegacyParsing)
+                    return m_legacy.HostAndPath;
+
+                if (string.IsNullOrEmpty(Path))
+                    return Host ?? "";
+                if (string.IsNullOrEmpty(Host))
+                    return Path;
+                return Host + "/" + Path;
+            }
+        }
+
+        /// <summary>
+        /// Gets the path and query.
+        /// </summary>
+        /// <value>The path and query.</value>
+        public string PathAndQuery
+        {
+            get
+            {
+                if (s_useLegacyParsing)
+                    return m_legacy.PathAndQuery;
+
+                return (Path ?? "") + (Query == null ? "" : "?" + Query);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompatUri"/> struct by parsing the
+        /// given URL with the active parsing strategy.
+        /// </summary>
+        /// <param name="url">The URL to parse</param>
+        public CompatUri(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+                throw new ArgumentNullException(nameof(url));
+
+            if (s_useLegacyParsing)
+            {
+                m_legacy = new LegacyUri(url);
+                Scheme = m_legacy.Scheme;
+                Host = m_legacy.Host;
+                Path = m_legacy.Path;
+                Port = m_legacy.Port;
+                Query = m_legacy.Query;
+                Username = m_legacy.Username;
+                Password = m_legacy.Password;
+                OriginalUri = m_legacy.OriginalUri;
+                m_queryParams = null;
+            }
+            else
+            {
+                m_legacy = default;
+                m_queryParams = null;
+                OriginalUri = url;
+
+                // Parse strictly with System.Uri. An invalid/malformed URL throws, which is
+                // the intended behavior in non-legacy mode: it surfaces ambiguous URLs early
+                // rather than silently guessing at their structure.
+                if (!System.Uri.TryCreate(url, UriKind.Absolute, out var systemUri) || systemUri == null)
+                    throw new ArgumentException(Strings.Uri.UriParseError(url), nameof(url));
+
+                Scheme = systemUri.Scheme;
+                Host = systemUri.Host.Length == 0 ? null : systemUri.Host;
+
+                // Mirror the LegacyUri convention: strip the leading '/' only when a host is
+                // present. For host-less URIs (e.g. file:///path), the leading '/' is part of
+                // the absolute path and must be preserved so that round-tripping through
+                // BuildUriString yields file:///path rather than file://path.
+                var absolutePath = systemUri.IsAbsoluteUri ? systemUri.AbsolutePath : systemUri.OriginalString;
+                Path = !string.IsNullOrEmpty(Host) && absolutePath.Length > 0 && absolutePath[0] == '/'
+                    ? absolutePath.Substring(1)
+                    : absolutePath;
+
+                Port = systemUri.IsDefaultPort ? -1 : systemUri.Port;
+
+                // System.Uri leaves the '?' out of Query, matching the LegacyUri convention
+                Query = string.IsNullOrEmpty(systemUri.Query) ? null : systemUri.Query.TrimStart('?');
+
+                var userInfo = systemUri.UserInfo;
+                if (!string.IsNullOrEmpty(userInfo))
+                {
+                    var colon = userInfo.IndexOf(':');
+                    if (colon >= 0)
+                    {
+                        Username = userInfo.Substring(0, colon);
+                        Password = userInfo.Substring(colon + 1);
+                    }
+                    else
+                    {
+                        Username = userInfo;
+                        Password = null;
+                    }
+                }
+                else
+                {
+                    Username = null;
+                    Password = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Constructs a free-form URI from components.
+        /// </summary>
+        /// <param name="scheme">The url scheme, e.g. http</param>
+        /// <param name="host">The hostname, e.g. www.example.com</param>
+        /// <param name="path">The path, e.g. index.html</param>
+        /// <param name="query">The query string, e.g. id=1</param>
+        /// <param name="username">The username</param>
+        /// <param name="password">The password</param>
+        /// <param name="port">The port</param>
+        public CompatUri(string scheme, string? host, string? path = null, string? query = null, string? username = null, string? password = null, int port = -1)
+        {
+            m_legacy = default;
+            m_queryParams = null;
+            Scheme = scheme;
+            Host = host;
+            Path = path ?? "";
+            Query = query;
+            Username = username;
+            Password = password;
+            Port = port;
+            OriginalUri = AsString(scheme, host, path, query, username, password, port);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents the current <see cref="CompatUri"/>.
+        /// </summary>
+        /// <returns>A <see cref="System.String"/> that represents the current <see cref="CompatUri"/>.</returns>
+        public override string ToString()
+        {
+            if (s_useLegacyParsing)
+                return m_legacy.ToString();
+
+            return AsString(Scheme, Host, Path, Query, Username, Password, Port);
+        }
+
+        /// <summary>
+        /// Throws an exception if the host name is missing.
+        /// </summary>
+        public void RequireHost()
+        {
+            if (string.IsNullOrEmpty(Host))
+                throw new ArgumentException(Strings.Uri.NoHostname(OriginalUri));
+        }
+
+        /// <summary>
+        /// Constructs an url-like string from components. This mirrors <see cref="LegacyUri"/>'s
+        /// <c>AsString</c> so that round-tripping is consistent across parsing modes.
+        /// </summary>
+        /// <returns>An url-like string</returns>
+        /// <param name="scheme">The url scheme, e.g. http</param>
+        /// <param name="host">The hostname, e.g. www.example.com</param>
+        /// <param name="path">The path, e.g. index.html</param>
+        /// <param name="query">The query string, e.g. id=1</param>
+        /// <param name="username">The username</param>
+        /// <param name="password">The password</param>
+        /// <param name="port">The port</param>
+        private static string AsString(string scheme, string? host, string? path, string? query, string? username, string? password, int port)
+            => LegacyUri.BuildUriString(scheme, host, path, query, username, password, port);
+
+        /// <summary>
+        /// Creates a new instance with another scheme
+        /// </summary>
+        /// <returns>A new instance</returns>
+        /// <param name="scheme">The new scheme to use</param>
+        public CompatUri SetScheme(string scheme)
+            => new CompatUri(scheme, Host, Path, Query, Username, Password, Port);
+
+        /// <summary>
+        /// Creates a new instance with another host
+        /// </summary>
+        /// <returns>A new instance</returns>
+        /// <param name="host">The new hostname to use</param>
+        public CompatUri SetHost(string host)
+            => new CompatUri(Scheme, host, Path, Query, Username, Password, Port);
+
+        /// <summary>
+        /// Creates a new instance with another path
+        /// </summary>
+        /// <returns>A new instance</returns>
+        /// <param name="path">The new path to use</param>
+        public CompatUri SetPath(string? path)
+            => new CompatUri(Scheme, Host, path, Query, Username, Password, Port);
+
+        /// <summary>
+        /// Creates a new instance with another query
+        /// </summary>
+        /// <returns>A new instance</returns>
+        /// <param name="query">The new query to use</param>
+        public CompatUri SetQuery(string? query)
+            => new CompatUri(Scheme, Host, Path, query, Username, Password, Port);
+
+        /// <summary>
+        /// Creates a new instance with other credentials
+        /// </summary>
+        /// <returns>A new instance</returns>
+        /// <param name="username">The new username to use</param>
+        /// <param name="password">The new password to use</param>
+        public CompatUri SetCredentials(string? username, string? password)
+            => new CompatUri(Scheme, Host, Path, Query, username, password, Port);
+
+        /// <summary>
+        /// Creates a new instance with another port
+        /// </summary>
+        /// <returns>A new instance</returns>
+        /// <param name="port">The new port to use</param>
+        public CompatUri SetPort(int port)
+            => new CompatUri(Scheme, Host, Path, Query, Username, Password, port);
+
+        // The static encoding/query helpers always delegate to LegacyUri. These are pure
+        // string utilities whose behavior must not change with the parsing mode.
+
+        /// <summary>
+        /// Encodes a URL path segment, like System.Web.HttpUtility.UrlPathEncode
+        /// </summary>
+        /// <returns>The encoded URL</returns>
+        /// <param name="value">The URL fragment to encode</param>
+        /// <param name="encoding">The encoding to use</param>
+        public static string UrlPathEncode(string value, System.Text.Encoding? encoding = null)
+            => LegacyUri.UrlPathEncode(value, encoding);
+
+        /// <summary>
+        /// Encodes a URL, like System.Web.HttpUtility.UrlEncode
+        /// </summary>
+        /// <returns>The encoded URL</returns>
+        /// <param name="value">The URL fragment to encode</param>
+        /// <param name="encoding">The encoding to use</param>
+        public static string UrlEncode(string value, System.Text.Encoding? encoding = null, string spacevalue = "+")
+            => LegacyUri.UrlEncode(value, encoding, spacevalue);
+
+        /// <summary>
+        /// Decodes a URL, like System.Web.HttpUtility.UrlDecode
+        /// </summary>
+        /// <returns>The decoded URL</returns>
+        /// <param name="value">The URL fragment to decode</param>
+        /// <param name="encoding">The encoding to use</param>
+        public static string UrlDecode(string value, System.Text.Encoding? encoding = null)
+            => LegacyUri.UrlDecode(value, encoding);
+
+        /// <summary>
+        /// Parses the query string.
+        /// This is a local implementation of System.Web.HttpUtility.ParseQueryString, kept for consistent behavior.
+        /// </summary>
+        /// <returns>The parsed query string</returns>
+        /// <param name="query">The query to parse</param>
+        public static NameValueCollection ParseQueryString(string query)
+            => LegacyUri.ParseQueryString(query);
+
+        /// <summary>
+        /// Parses the query string.
+        /// This is a local implementation of System.Web.HttpUtility.ParseQueryString, kept for consistent behavior.
+        /// </summary>
+        /// <returns>The parsed query string</returns>
+        /// <param name="query">The query to parse</param>
+        /// <param name="decodeValues">Whether to the parameter values should be decoded or not.</param>
+        public static NameValueCollection ParseQueryString(string query, bool decodeValues)
+            => LegacyUri.ParseQueryString(query, decodeValues);
+
+        /// <summary>
+        /// Build the querystring to be used in a URL
+        /// </summary>
+        /// <returns>The generated querystring</returns>
+        /// <param name="query">A collection of name value pairs to be translated into a query string</param>
+        /// <param name="delimiter">The delimiter to separate key value pairs in the query string</param>
+        public static string BuildUriQuery(NameValueCollection query, string delimiter)
+            => LegacyUri.BuildUriQuery(query, delimiter);
+
+        /// <summary>
+        /// Build the querystring to be used in a URL
+        /// </summary>
+        /// <returns>The generated querystring</returns>
+        /// <param name="query">A collection of name value pairs to be translated into a query string that is
+        /// ampersand delimited.</param>
+        public static string BuildUriQuery(NameValueCollection query)
+            => LegacyUri.BuildUriQuery(query);
+
+        /// <summary>
+        /// Builds a URL together using a base URL, a path and a query.
+        /// </summary>
+        /// <returns>The built together URL.</returns>
+        /// <param name="url">Base URL, containing schema, host, port.</param>
+        /// <param name="path">Base path.</param>
+        /// <param name="query">A collection of name value pairs to be translated into a query string.</param>
+        public static string UriBuilder(string url, string path, NameValueCollection? query)
+            => LegacyUri.UriBuilder(url, path, query);
+
+        /// <summary>
+        /// Builds a URL together using a base URL and path.
+        /// </summary>
+        /// <returns>The built together URL.</returns>
+        /// <param name="url">Base URL, containing schema, host, port.</param>
+        /// <param name="path">Base path.</param>
+        public static string UriBuilder(string url, string path)
+            => LegacyUri.UriBuilder(url, path);
+
+        /// <summary>
+        /// Grab path part of a URI.
+        /// At the moment, simple implementation does not remove fragments.
+        /// </summary>
+        /// <returns>The path.</returns>
+        /// <param name="url">URL.</param>
+        public static string? ExtractPath(string url)
+            => new CompatUri(url).Path;
+    }
+}

--- a/Duplicati/Library/Utility/CompatUri.cs
+++ b/Duplicati/Library/Utility/CompatUri.cs
@@ -119,6 +119,30 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// Determines whether the original URL string carried an explicit path component after
+        /// the "<c>scheme://</c>" authority separator. <see cref="System.Uri"/> collapses
+        /// "<c>dummy://</c>" (no path) and "<c>dummy:///</c>" (root path) to the same
+        /// <see cref="System.Uri.AbsolutePath"/> of "<c>/</c>", so the original string is
+        /// consulted to tell them apart and preserve a lossless round-trip. A query string
+        /// directly after the separator (e.g. "<c>dummy://?a=b</c>") is not a path.
+        /// </summary>
+        /// <param name="originalUri">The original, unmodified URL string.</param>
+        /// <param name="scheme">The URL scheme (e.g. "dummy").</param>
+        /// <returns>
+        /// <c>true</c> if a path (including a lone root "<c>/</c>") follows the
+        /// "<c>scheme://</c>" separator; <c>false</c> if nothing, or only a query string,
+        /// follows it.
+        /// </returns>
+        private static bool UrlHasPathAfterScheme(string originalUri, string scheme)
+        {
+            var prefix = scheme + "://";
+            var idx = originalUri.IndexOf(prefix, StringComparison.Ordinal);
+            return idx >= 0
+                && originalUri.Length > idx + prefix.Length
+                && originalUri[idx + prefix.Length] != '?';
+        }
+
+        /// <summary>
         /// The backing <see cref="LegacyUri"/> when legacy parsing is enabled, or the parsed
         /// components when using <see cref="System.Uri"/>.
         /// </summary>
@@ -269,6 +293,18 @@ namespace Duplicati.Library.Utility
                 // with a space. Decode to match the legacy contract.
                 var absolutePath = systemUri.IsAbsoluteUri ? systemUri.AbsolutePath : systemUri.OriginalString;
                 absolutePath = LegacyUri.UrlDecode(absolutePath);
+
+                // System.Uri reports AbsolutePath="/" for both "dummy://" (no path) and
+                // "dummy:///" (root path), but LegacyUri parses "dummy://" with an empty
+                // path. A host-less URL that the user wrote with no path after "://" (no
+                // third slash, e.g. "dummy://", "file://", "dummy://?a=b") must round-trip
+                // losslessly; a synthetic root path would turn "dummy://" into "dummy:///"
+                // and break the exact-match backend guard in ValidateOptions (#4812).
+                // Treat a lone root path as empty unless the original URL actually carried
+                // a path after "://".
+                if (string.IsNullOrEmpty(Host) && absolutePath == "/" && !UrlHasPathAfterScheme(systemUri.OriginalString, systemUri.Scheme))
+                    absolutePath = "";
+
                 Path = !string.IsNullOrEmpty(Host) && absolutePath.Length > 0 && absolutePath[0] == '/'
                     ? absolutePath.Substring(1)
                     : absolutePath;

--- a/Duplicati/Library/Utility/CompatUri.cs
+++ b/Duplicati/Library/Utility/CompatUri.cs
@@ -260,7 +260,15 @@ namespace Duplicati.Library.Utility
                 // present. For host-less URIs (e.g. file:///path), the leading '/' is part of
                 // the absolute path and must be preserved so that round-tripping through
                 // BuildUriString yields file:///path rather than file://path.
+                // System.Uri.AbsolutePath returns the percent-encoded path (e.g. a space is
+                // reported as "%20"), but LegacyUri decodes the path. The two must stay
+                // symmetric: SetPath/ToString encode, and Path decodes, so that a URL built
+                // from a path containing spaces round-trips back to the same path. Backends
+                // like FileBackend use Path directly as a filesystem path, so an encoded
+                // value here would look up a folder literally named "%20" instead of the one
+                // with a space. Decode to match the legacy contract.
                 var absolutePath = systemUri.IsAbsoluteUri ? systemUri.AbsolutePath : systemUri.OriginalString;
+                absolutePath = LegacyUri.UrlDecode(absolutePath);
                 Path = !string.IsNullOrEmpty(Host) && absolutePath.Length > 0 && absolutePath[0] == '/'
                     ? absolutePath.Substring(1)
                     : absolutePath;

--- a/Duplicati/Library/Utility/LegacyUri.cs
+++ b/Duplicati/Library/Utility/LegacyUri.cs
@@ -36,6 +36,12 @@ namespace Duplicati.Library.Utility
     // but it does not make sense to support "invalid" urls as that increases the complexity
     // of the code and potentially introduces ambiguity for the user.
 
+    // This is the legacy implementation retained for backwards compatibility. New code
+    // should use <see cref="CompatUri"/>, which parses with <see cref="System.Uri"/> by
+    // default and only falls back to this implementation when the user opts in via the
+    // DUPLICATI_LEGACY_URL_PARSING environment variable or the legacy_url_parsing.txt
+    // marker file in the binary folder.
+
     /// <summary>
     /// Represents a relaxed parsing of a URL.
     /// The goal is to cover as many types of url's as possible,
@@ -43,7 +49,7 @@ namespace Duplicati.Library.Utility
     /// The major limitations is that an embedded username may not contain a :,
     /// and the password may not contain a @.
     /// </summary>
-    public struct Uri
+    public struct LegacyUri
     {
         /// <summary>
         /// A very lax version of a URL parser
@@ -145,10 +151,10 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.Uri"/> struct.
+        /// Initializes a new instance of the <see cref="Duplicati.Library.Utility.LegacyUri"/> struct.
         /// </summary>
         /// <param name="url">The URL to parse</param>
-        public Uri(string url)
+        public LegacyUri(string url)
         {
             if (string.IsNullOrEmpty(url))
                 throw new ArgumentNullException(nameof(url));
@@ -255,7 +261,7 @@ namespace Duplicati.Library.Utility
         /// <param name="username">The username</param>
         /// <param name="password">The password</param>
         /// <param name="port">The port</param>
-        public Uri(string scheme, string? host, string? path = null, string? query = null, string? username = null, string? password = null, int port = -1)
+        public LegacyUri(string scheme, string? host, string? path = null, string? query = null, string? username = null, string? password = null, int port = -1)
         {
             m_queryParams = null;
             Scheme = scheme;
@@ -265,16 +271,16 @@ namespace Duplicati.Library.Utility
             Username = username;
             Password = password;
             Port = port;
-            OriginalUri = AsString(scheme, host, path, query, username, password, port);
+            OriginalUri = BuildUriString(scheme, host, path, query, username, password, port);
         }
 
         /// <summary>
-        /// Returns a <see cref="System.String"/> that represents the current <see cref="Duplicati.Library.Utility.Uri"/>.
+        /// Returns a <see cref="System.String"/> that represents the current <see cref="Duplicati.Library.Utility.LegacyUri"/>.
         /// </summary>
-        /// <returns>A <see cref="System.String"/> that represents the current <see cref="Duplicati.Library.Utility.Uri"/>.</returns>
+        /// <returns>A <see cref="System.String"/> that represents the current <see cref="Duplicati.Library.Utility.LegacyUri"/>.</returns>
         public override string ToString()
         {
-            return AsString(Scheme, Host, Path, Query, Username, Password, Port);
+            return BuildUriString(Scheme, Host, Path, Query, Username, Password, Port);
         }
 
         /// <summary>
@@ -297,7 +303,7 @@ namespace Duplicati.Library.Utility
         /// <param name="username">The username</param>
         /// <param name="password">The password</param>
         /// <param name="port">The port</param>
-        private static string AsString(string scheme, string? host, string? path, string? query, string? username, string? password, int port)
+        internal static string BuildUriString(string scheme, string? host, string? path, string? query, string? username, string? password, int port)
         {
             var s = scheme + "://";
             if (!string.IsNullOrEmpty(username) || !string.IsNullOrEmpty(password))
@@ -335,9 +341,9 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>A new instance</returns>
         /// <param name="scheme">The new scheme to use</param>
-        public Uri SetScheme(string scheme)
+        public LegacyUri SetScheme(string scheme)
         {
-            return new Uri(scheme, Host, Path, Query, Username, Password, Port);
+            return new LegacyUri(scheme, Host, Path, Query, Username, Password, Port);
         }
 
         /// <summary>
@@ -345,9 +351,9 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>A new instance</returns>
         /// <param name="host">The new hostname to use</param>
-        public Uri SetHost(string host)
+        public LegacyUri SetHost(string host)
         {
-            return new Uri(Scheme, host, Path, Query, Username, Password, Port);
+            return new LegacyUri(Scheme, host, Path, Query, Username, Password, Port);
         }
 
         /// <summary>
@@ -355,9 +361,9 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>A new instance</returns>
         /// <param name="path">The new path to use</param>
-        public Uri SetPath(string? path)
+        public LegacyUri SetPath(string? path)
         {
-            return new Uri(Scheme, Host, path, Query, Username, Password, Port);
+            return new LegacyUri(Scheme, Host, path, Query, Username, Password, Port);
         }
 
         /// <summary>
@@ -365,9 +371,9 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>A new instance</returns>
         /// <param name="query">The new query to use</param>
-        public Uri SetQuery(string? query)
+        public LegacyUri SetQuery(string? query)
         {
-            return new Uri(Scheme, Host, Path, query, Username, Password, Port);
+            return new LegacyUri(Scheme, Host, Path, query, Username, Password, Port);
         }
 
         /// <summary>
@@ -376,9 +382,9 @@ namespace Duplicati.Library.Utility
         /// <returns>A new instance</returns>
         /// <param name="username">The new username to use</param>
         /// <param name="password">The new password to use</param>
-        public Uri SetCredentials(string? username, string? password)
+        public LegacyUri SetCredentials(string? username, string? password)
         {
-            return new Uri(Scheme, Host, Path, Query, username, password, Port);
+            return new LegacyUri(Scheme, Host, Path, Query, username, password, Port);
         }
 
         /// <summary>
@@ -386,9 +392,9 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>A new instance</returns>
         /// <param name="port">The new port to use</param>
-        public Uri SetPort(int port)
+        public LegacyUri SetPort(int port)
         {
-            return new Uri(Scheme, Host, Path, Query, Username, Password, port);
+            return new LegacyUri(Scheme, Host, Path, Query, Username, Password, port);
         }
 
         /// <summary>
@@ -601,7 +607,7 @@ namespace Duplicati.Library.Utility
         /// <param name="url">URL.</param>
         public static string? ExtractPath(string url)
         {
-            return new Uri(url).Path;
+            return new LegacyUri(url).Path;
         }
 
         /// <summary>

--- a/Duplicati/Library/Utility/Options/AuthIdOptionsHelper.cs
+++ b/Duplicati/Library/Utility/Options/AuthIdOptionsHelper.cs
@@ -75,7 +75,7 @@ public static class AuthIdOptionsHelper
     {
         if (string.IsNullOrWhiteSpace(oauthurl))
             oauthurl = DUPLICATI_OAUTH_SERVICE;
-        var u = new Uri(oauthurl);
+        var u = new CompatUri(oauthurl);
         var addr = u.SetPath("").SetQuery((u.Query ?? "") + (string.IsNullOrWhiteSpace(u.Query) ? "" : "&") + "type={0}");
         return string.Format(addr.ToString(), modulename);
     }
@@ -89,7 +89,7 @@ public static class AuthIdOptionsHelper
         if (string.IsNullOrWhiteSpace(oauthurl))
             oauthurl = DUPLICATI_OAUTH_SERVICE_NEW;
 
-        var u = new Uri(oauthurl);
+        var u = new CompatUri(oauthurl);
         var addr = u.SetPath("").SetQuery((u.Query ?? "") + (string.IsNullOrWhiteSpace(u.Query) ? "" : "&") + "type={0}");
         return string.Format(addr.ToString(), modulename);
     }

--- a/Duplicati/Library/Utility/Options/AuthOptionsHelper.cs
+++ b/Duplicati/Library/Utility/Options/AuthOptionsHelper.cs
@@ -60,7 +60,7 @@ public static class AuthOptionsHelper
     /// <param name="username">The name of the username options</param>
     /// <param name="password">The name of the password options</param>
     /// <returns>The parsed authentication options</returns>
-    public static AuthOptions ParseWithAlias(IReadOnlyDictionary<string, string?> options, Uri uri, string username, string password)
+    public static AuthOptions ParseWithAlias(IReadOnlyDictionary<string, string?> options, CompatUri uri, string username, string password)
     {
         // Prefer the primary name, if set
         var optionUsername = options.GetValueOrDefault(username);
@@ -82,7 +82,7 @@ public static class AuthOptionsHelper
     /// <param name="uri">The URI to get the default values from</param>
     /// <param name="prefix">An optional prefix for the options</param>
     /// <returns>The parsed authentication options</returns>
-    public static AuthOptions Parse(IReadOnlyDictionary<string, string?> options, Uri uri, string? prefix = null)
+    public static AuthOptions Parse(IReadOnlyDictionary<string, string?> options, CompatUri uri, string? prefix = null)
     {
         var optionUsername = options.GetValueOrDefault($"{prefix}{AuthUsernameOption}");
         var optionPassword = options.GetValueOrDefault($"{prefix}{AuthPasswordOption}");

--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1873,8 +1873,8 @@ namespace Duplicati.Library.Utility
             // If we can parse it, this result is better
             try
             {
-                var uri = new Uri(url[sepIndex..]);
-                sanitizedUrl = new Uri($"{uri.Scheme}://{uri.Host}").SetPath(uri.Path).ToString();
+                var uri = new LegacyUri(url[sepIndex..]);
+                sanitizedUrl = new LegacyUri($"{uri.Scheme}://{uri.Host}").SetPath(uri.Path).ToString();
             }
             catch
             {

--- a/Duplicati/UnitTest/DeterministicErrorBackend.cs
+++ b/Duplicati/UnitTest/DeterministicErrorBackend.cs
@@ -62,7 +62,7 @@ namespace Duplicati.UnitTest
         // ReSharper disable once UnusedMember.Global
         public DeterministicErrorBackend(string url, Dictionary<string, string> options)
         {
-            var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();
+            var u = new Library.Utility.CompatUri(url).SetScheme(WrappedBackend).ToString();
             m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(u, options);
         }
 

--- a/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
+++ b/Duplicati/UnitTest/GeneralBlackBoxTesting.cs
@@ -122,7 +122,7 @@ namespace Duplicati.UnitTest
         [Category("SVNData")]
         public async Task TestWithErrorsAsync()
         {
-            var u = new Library.Utility.Uri(TestUtils.GetDefaultTarget());
+            var u = new Library.Utility.CompatUri(TestUtils.GetDefaultTarget());
             RandomErrorBackend.WrappedBackend = u.Scheme;
             var target = u.SetScheme(new RandomErrorBackend().ProtocolKey).ToString();
             Library.DynamicLoader.BackendLoader.AddBackend(new RandomErrorBackend());
@@ -138,7 +138,7 @@ namespace Duplicati.UnitTest
         [Category("SVNData")]
         public async Task TestWithoutSizeInfoAsync()
         {
-            var u = new Library.Utility.Uri(TestUtils.GetDefaultTarget());
+            var u = new Library.Utility.CompatUri(TestUtils.GetDefaultTarget());
             SizeOmittingBackend.WrappedBackend = u.Scheme;
             var target = u.SetScheme(new SizeOmittingBackend().ProtocolKey).ToString();
             Library.DynamicLoader.BackendLoader.AddBackend(new SizeOmittingBackend());

--- a/Duplicati/UnitTest/NonFolderBackend.cs
+++ b/Duplicati/UnitTest/NonFolderBackend.cs
@@ -62,7 +62,7 @@ namespace Duplicati.UnitTest
             // into it; this wrapper does not pre-create it, mirroring how a real
             // folderless backend would behave (folders are created explicitly via
             // CreateFolderAsync, not implicitly on construction).
-            var wrappedUrl = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();
+            var wrappedUrl = new Library.Utility.CompatUri(url).SetScheme(WrappedBackend).ToString();
             m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(wrappedUrl, options);
         }
 

--- a/Duplicati/UnitTest/RandomErrorBackend.cs
+++ b/Duplicati/UnitTest/RandomErrorBackend.cs
@@ -45,7 +45,7 @@ namespace Duplicati.UnitTest
         // ReSharper disable once UnusedMember.Global
         public RandomErrorBackend(string url, Dictionary<string, string> options)
         {
-            var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();
+            var u = new Library.Utility.CompatUri(url).SetScheme(WrappedBackend).ToString();
             m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(u, options);
         }
 

--- a/Duplicati/UnitTest/SecretProviderHelperTests.cs
+++ b/Duplicati/UnitTest/SecretProviderHelperTests.cs
@@ -103,7 +103,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=$key2&user=$key1&other=123")
+            new Library.Utility.CompatUri("test://host?pass=$key2&user=$key1&other=123")
         };
 
         await SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None);
@@ -135,7 +135,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=$key/with/slash&user=$key1&other=123")
+            new Library.Utility.CompatUri("test://host?pass=$key/with/slash&user=$key1&other=123")
         };
 
         await SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None);
@@ -167,7 +167,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=$key-with-dash&user=$key1&other=123")
+            new Library.Utility.CompatUri("test://host?pass=$key-with-dash&user=$key1&other=123")
         };
 
         await SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None);
@@ -196,7 +196,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=$key1&user=user")
+            new Library.Utility.CompatUri("test://host?pass=$key1&user=user")
         };
 
         await SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None);
@@ -230,7 +230,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=${key2}&user=${key1}&other=123"),
+            new Library.Utility.CompatUri("test://host?pass=${key2}&user=${key1}&other=123"),
         };
 
         await SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None);
@@ -263,7 +263,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=:sec{key2}&user=:sec{key1}&other=123"),
+            new Library.Utility.CompatUri("test://host?pass=:sec{key2}&user=:sec{key1}&other=123"),
         };
 
         await SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None);
@@ -319,7 +319,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=$key2&user=$key1&other=123"),
+            new Library.Utility.CompatUri("test://host?pass=$key2&user=$key1&other=123"),
         };
 
         Assert.ThrowsAsync<UserInformationException>(() => SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None));
@@ -344,7 +344,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=$key2&user=$key1&other=123"),
+            new Library.Utility.CompatUri("test://host?pass=$key2&user=$key1&other=123"),
         };
 
         Assert.ThrowsAsync<InvalidOperationException>(() => SecretProviderHelper.ApplySecretProviderAsync(argsSys, argsInternal, settings, null, secretProvider, CancellationToken.None));
@@ -476,7 +476,7 @@ public class SecretProviderHelperTests : BasicSetupHelper
         };
 
         var argsInternal = new[] {
-            new Library.Utility.Uri("test://host?pass=$key2&user=$key)5&other=123"),
+            new Library.Utility.CompatUri("test://host?pass=$key2&user=$key)5&other=123"),
         };
 
         var logCapture = new LogCapture();

--- a/Duplicati/UnitTest/SizeOmittingBackend.cs
+++ b/Duplicati/UnitTest/SizeOmittingBackend.cs
@@ -43,7 +43,7 @@ namespace Duplicati.UnitTest
         // ReSharper disable once UnusedMember.Global
         public SizeOmittingBackend(string url, Dictionary<string, string> options)
         {
-            var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();
+            var u = new Library.Utility.CompatUri(url).SetScheme(WrappedBackend).ToString();
             m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(u, options);
         }
 

--- a/Duplicati/UnitTest/SoftDeleteTests.cs
+++ b/Duplicati/UnitTest/SoftDeleteTests.cs
@@ -469,7 +469,7 @@ namespace Duplicati.UnitTest
         // ReSharper disable once UnusedMember.Global
         public NoRenameBackend(string url, Dictionary<string, string> options)
         {
-            var u = new Library.Utility.Uri(url).SetScheme(WrappedBackend).ToString();
+            var u = new Library.Utility.CompatUri(url).SetScheme(WrappedBackend).ToString();
             m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(u, options);
         }
 

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -32,25 +32,25 @@ namespace Duplicati.UnitTest
         public static void TestBuildUriQuery()
         {
             var query = new NameValueCollection { { "a", "b" } };
-            var queryUrl = Library.Utility.Uri.BuildUriQuery(query);
+            var queryUrl = Library.Utility.CompatUri.BuildUriQuery(query);
             Assert.AreEqual("a=b", queryUrl);
             query.Add(new NameValueCollection { { "c", "d" } });
-            queryUrl = Library.Utility.Uri.BuildUriQuery(query);
+            queryUrl = Library.Utility.CompatUri.BuildUriQuery(query);
             Assert.AreEqual("a=b&c=d", queryUrl);
 
             // Test with space in value
             query = new NameValueCollection { { "key", "value with space" } };
-            queryUrl = Library.Utility.Uri.BuildUriQuery(query);
+            queryUrl = Library.Utility.CompatUri.BuildUriQuery(query);
             Assert.AreEqual("key=value with space", queryUrl);
 
             // Test with + in value
             query = new NameValueCollection { { "key", "value+plus" } };
-            queryUrl = Library.Utility.Uri.BuildUriQuery(query);
+            queryUrl = Library.Utility.CompatUri.BuildUriQuery(query);
             Assert.AreEqual("key=value+plus", queryUrl);
 
             // Test with % in value
             query = new NameValueCollection { { "key", "value%percent" } };
-            queryUrl = Library.Utility.Uri.BuildUriQuery(query);
+            queryUrl = Library.Utility.CompatUri.BuildUriQuery(query);
             Assert.AreEqual("key=value%percent", queryUrl);
         }
 
@@ -61,7 +61,7 @@ namespace Duplicati.UnitTest
             var baseUrl = "http://localhost";
             var path = "files";
             var query = new NameValueCollection { { "a", "b" }, { "c", "d" }, { "e", "+ %" } };
-            var url = Library.Utility.Uri.UriBuilder(baseUrl, path, query);
+            var url = Library.Utility.CompatUri.UriBuilder(baseUrl, path, query);
             Assert.AreEqual(baseUrl + "/" + path + "?a=b&c=d&e=+%20%25", url);
         }
 
@@ -70,7 +70,7 @@ namespace Duplicati.UnitTest
         public static void TestExtractPath()
         {
             var url = "http://localhost/a/b";
-            var path = Library.Utility.Uri.ExtractPath(url);
+            var path = Library.Utility.CompatUri.ExtractPath(url);
             Assert.AreEqual("a/b", path);
         }
 
@@ -97,7 +97,8 @@ namespace Duplicati.UnitTest
         {
             string uriStr = $"http://{user}{host}{port}{path}{query}";
 
-            var uri = new Library.Utility.Uri(uriStr);
+            // This exercises the legacy relaxed parser directly, locking in its contract.
+            var uri = new Library.Utility.LegacyUri(uriStr);
             Assert.AreEqual("http", uri.Scheme);
             Assert.AreEqual(host, uri.Host);
             if (port.Length != 0)
@@ -135,26 +136,26 @@ namespace Duplicati.UnitTest
         {
             if (System.OperatingSystem.IsWindows())
             {
-                var a = new Library.Utility.Uri("file://c:/a/b/");
-                var b = new Library.Utility.Uri("c:/a/b/");
+                var a = new Library.Utility.LegacyUri("file://c:/a/b/");
+                var b = new Library.Utility.LegacyUri("c:/a/b/");
 
                 Assert.AreEqual(a.ToString(), b.ToString());
                 Assert.AreEqual(a.Path, b.Path);
 
-                a = new Library.Utility.Uri("file://C:\\a\\b");
-                b = new Library.Utility.Uri("C:\\a\\b");
+                a = new Library.Utility.LegacyUri("file://C:\\a\\b");
+                b = new Library.Utility.LegacyUri("C:\\a\\b");
                 Assert.AreEqual(a.ToString(), b.ToString());
                 Assert.AreEqual(a.Path, b.Path);
             }
             else
             {
-                var a = new Library.Utility.Uri("file:///a/b");
-                var b = new Library.Utility.Uri("/a/b");
+                var a = new Library.Utility.LegacyUri("file:///a/b");
+                var b = new Library.Utility.LegacyUri("/a/b");
                 Assert.AreEqual(a.ToString(), b.ToString());
                 Assert.AreEqual(a.Path, b.Path);
 
-                a = new Library.Utility.Uri("file:///a/b/");
-                b = new Library.Utility.Uri("/a/b/");
+                a = new Library.Utility.LegacyUri("file:///a/b/");
+                b = new Library.Utility.LegacyUri("/a/b/");
                 Assert.AreEqual(a.ToString(), b.ToString());
                 Assert.AreEqual(a.Path, b.Path);
             }
@@ -169,7 +170,7 @@ namespace Duplicati.UnitTest
             if (!System.OperatingSystem.IsWindows())
                 return;
 
-            var a = new Library.Utility.Uri("file://c:\\@folder\\");
+            var a = new Library.Utility.LegacyUri("file://c:\\@folder\\");
             Assert.AreEqual("file", a.Scheme);
             Assert.IsNull(a.Host, "Host should be null for a local path");
             Assert.IsNull(a.Username, "Username should be null");
@@ -178,19 +179,110 @@ namespace Duplicati.UnitTest
             Assert.IsTrue(System.IO.Path.IsPathRooted(a.Path), "Path should be a rooted local path");
 
             // The file:// form must parse the same as the raw path form
-            var b = new Library.Utility.Uri("c:\\@folder\\");
+            var b = new Library.Utility.LegacyUri("c:\\@folder\\");
             Assert.AreEqual(b.Path, a.Path);
             Assert.AreEqual(b.ToString(), a.ToString());
 
             // Re-parsing ToString() round-trips to the same path (no corruption)
-            var roundtrip = new Library.Utility.Uri(a.ToString());
+            var roundtrip = new Library.Utility.LegacyUri(a.ToString());
             Assert.AreEqual(a.Path, roundtrip.Path);
             Assert.IsNull(roundtrip.Host);
             Assert.IsNull(roundtrip.Username);
 
             // The url-encoded form (%40) resolves to the same path
-            var encoded = new Library.Utility.Uri("file://c:\\%40folder\\");
+            var encoded = new Library.Utility.LegacyUri("file://c:\\%40folder\\");
             Assert.AreEqual(a.Path, encoded.Path);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriStrictParse()
+        {
+            // In default (strict) mode CompatUri parses with System.Uri, so the components
+            // mirror what System.Uri reports rather than the relaxed legacy interpretation.
+            var uri = new Library.Utility.CompatUri("http://user:pw@example.com:8080/path?query=1");
+            Assert.AreEqual("http", uri.Scheme);
+            Assert.AreEqual("example.com", uri.Host);
+            Assert.AreEqual(8080, uri.Port);
+            Assert.AreEqual("path", uri.Path);
+            Assert.AreEqual("query=1", uri.Query);
+            Assert.AreEqual("user", uri.Username);
+            Assert.AreEqual("pw", uri.Password);
+            Assert.AreEqual("http://user:pw@example.com:8080/path?query=1", uri.OriginalUri);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriRejectsMalformedInStrictMode()
+        {
+            // System.Uri cannot parse this, and strict mode surfaces that as an error rather
+            // than guessing at the structure. (The relaxed parser would accept it.)
+            Assert.Throws<System.ArgumentException>(() => new Library.Utility.CompatUri("://no-scheme"));
+            // null/empty input is rejected by the argument guard before parsing
+            Assert.Throws<System.ArgumentNullException>(() => new Library.Utility.CompatUri(""));
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriSetMethodsRoundTrip()
+        {
+            var uri = new Library.Utility.CompatUri("http://example.com/a?x=1");
+            Assert.AreEqual("https://example.com/a?x=1", uri.SetScheme("https").ToString());
+            Assert.AreEqual("http://other.com/a?x=1", uri.SetHost("other.com").ToString());
+            Assert.AreEqual("http://example.com/b?x=1", uri.SetPath("b").ToString());
+            Assert.AreEqual("http://example.com/a?y=2", uri.SetQuery("y=2").ToString());
+            Assert.AreEqual(9000, uri.SetPort(9000).Port);
+            var creds = uri.SetCredentials("bob", "secret");
+            Assert.AreEqual("bob", creds.Username);
+            Assert.AreEqual("secret", creds.Password);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriQueryAttributes()
+        {
+            var uri = new Library.Utility.CompatUri("http://example.com/path?a=1&b=2");
+            Assert.AreEqual("a=1&b=2", uri.Query);
+            Assert.AreEqual("1", uri.QueryParameters["a"]);
+            Assert.AreEqual("2", uri.QueryParameters["b"]);
+            Assert.AreEqual("example.com/path", uri.HostAndPath);
+            Assert.AreEqual("path?a=1&b=2", uri.PathAndQuery);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriRequireHost()
+        {
+            // A scheme-only URL with no host must trip RequireHost.
+            var uri = new Library.Utility.CompatUri("file:///path");
+            Assert.Throws<System.ArgumentException>(() => uri.RequireHost());
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriStaticHelpersDelegateToLegacy()
+        {
+            // The static encoding/query helpers must behave identically regardless of the
+            // active parsing mode, because they are pure string utilities.
+            var query = new NameValueCollection { { "a", "b" } };
+            Assert.AreEqual(Library.Utility.LegacyUri.BuildUriQuery(query), Library.Utility.CompatUri.BuildUriQuery(query));
+            Assert.AreEqual(Library.Utility.LegacyUri.UrlEncode("a b"), Library.Utility.CompatUri.UrlEncode("a b"));
+            Assert.AreEqual(Library.Utility.LegacyUri.UrlDecode("a+b"), Library.Utility.CompatUri.UrlDecode("a+b"));
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriHostLessPathKeepsLeadingSlash()
+        {
+            // A host-less file:// URI must keep its leading slash so it round-trips through
+            // ToString() back to the triple-slash form. The FileBackend relies on
+            // HostAndPath returning a rooted path here.
+            var uri = new Library.Utility.CompatUri("file:///some/path/to/destination/");
+            Assert.AreEqual("file", uri.Scheme);
+            Assert.IsNull(uri.Host);
+            Assert.AreEqual("/some/path/to/destination/", uri.Path);
+            Assert.AreEqual("/some/path/to/destination/", uri.HostAndPath);
+            Assert.AreEqual("file:///some/path/to/destination/", uri.ToString());
         }
     }
 }

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -284,5 +284,54 @@ namespace Duplicati.UnitTest
             Assert.AreEqual("/some/path/to/destination/", uri.HostAndPath);
             Assert.AreEqual("file:///some/path/to/destination/", uri.ToString());
         }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriPathIsDecodedToMatchLegacyContract()
+        {
+            // System.Uri.AbsolutePath returns the percent-encoded path (a space becomes
+            // "%20"), but LegacyUri decodes the path. CompatUri must match the legacy
+            // contract so that SetPath/ToString (which encode) and Path (which decodes)
+            // stay symmetric. Backends like FileBackend use Path directly as a filesystem
+            // path, so an encoded value would look up a folder literally named "%20".
+            // This is the contract BackendManager.MergeBackendPath relies on: it builds a
+            // sub-path URL with SetPath(...).ToString() (encoding spaces to "%20") and the
+            // backend re-parses it, expecting Path to decode back to the original.
+            var uri = new Library.Utility.CompatUri("file:///some/path/header files");
+            Assert.AreEqual("/some/path/header files", uri.Path);
+            Assert.AreEqual("/some/path/header files", uri.HostAndPath);
+
+            // The correctly-encoded form must resolve to the same decoded path.
+            var encoded = new Library.Utility.CompatUri("file:///some/path/header%20files");
+            Assert.AreEqual(uri.Path, encoded.Path);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestMergeBackendPathRoundTripsSpaces()
+        {
+            // Reproduces the BackendManager.MergeBackendPath -> FileBackend re-parse flow
+            // that broke sync tests against the DSMCBE dataset (which contains a folder
+            // named "header files"). MergeBackendPath builds a sub-path URL via
+            // SetPath(...).ToString() (encoding the space), and the FileBackend
+            // constructor re-parses that URL. The re-parsed HostAndPath must decode back
+            // to the original path with the literal space, not the encoded "%20".
+            var backendUrl = "file:///tmp/dest";
+            var subPath = "SPU/header files";
+
+            var uri = new Library.Utility.CompatUri(backendUrl);
+            var basePath = uri.Path?.TrimEnd('/', '\\') ?? "";
+            var sub = subPath.Trim('/', '\\');
+            var mergedPath = string.IsNullOrEmpty(basePath) ? sub : basePath + "/" + sub;
+            var mergedUrl = uri.SetPath(mergedPath).ToString();
+
+            // The produced URL is correctly percent-encoded.
+            Assert.AreEqual("file:///tmp/dest/SPU/header%20files", mergedUrl);
+
+            // Re-parsing (as FileBackend does) must yield the decoded path.
+            var reparsed = new Library.Utility.CompatUri(mergedUrl);
+            Assert.AreEqual("/tmp/dest/SPU/header files", reparsed.HostAndPath);
+            Assert.IsFalse(reparsed.HostAndPath.Contains("%20"));
+        }
     }
 }

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -287,6 +287,37 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("UriUtility")]
+        public static void TestCompatUriSchemeOnlyRoundTrip()
+        {
+            // A scheme-only URL with neither host nor path (e.g. the "dummy://" placeholder
+            // used by test-filters/system-info/send-mail) must round-trip through ToString()
+            // losslessly. Controller.ApplySecretProviderAsync writes m_backendUrl back from
+            // CompatUri.ToString(); a round-trip that injects a path (turning "dummy://" into
+            // "dummy:///") breaks the exact-match backend guard in ValidateOptions and makes
+            // those commands fail with BackendNotSupported (#4812 regression).
+            var uri = new Library.Utility.CompatUri("dummy://");
+            Assert.AreEqual("dummy", uri.Scheme);
+            Assert.IsNull(uri.Host);
+            Assert.AreEqual("dummy://", uri.ToString());
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestCompatUriSchemeOnlyWithQueryRoundTrip()
+        {
+            // A query string directly after "://" is not a path: LegacyUri parses
+            // "dummy://?a=b" with an empty path, so strict mode must not synthesize a root
+            // path that would round-trip to "dummy:///?a=b".
+            var uri = new Library.Utility.CompatUri("dummy://?a=b");
+            Assert.AreEqual("dummy", uri.Scheme);
+            Assert.IsNull(uri.Host);
+            Assert.AreEqual("", uri.Path);
+            Assert.AreEqual("a=b", uri.Query);
+            Assert.AreEqual("dummy://?a=b", uri.ToString());
+        }
+
+        [Test]
+        [Category("UriUtility")]
         public static void TestCompatUriPathIsDecodedToMatchLegacyContract()
         {
             // System.Uri.AbsolutePath returns the percent-encoded path (a space becomes

--- a/Duplicati/WebserverCore/Endpoints/Shared/SharedRemoteOperation.cs
+++ b/Duplicati/WebserverCore/Endpoints/Shared/SharedRemoteOperation.cs
@@ -43,7 +43,7 @@ public record RestoreDestinationProviderTupleDisposeWrapper(IRestoreDestinationP
 
 public class SharedRemoteOperation
 {
-    public static Dictionary<string, string?> ParseUrlOptions(Connection connection, Library.Utility.Uri uri)
+    public static Dictionary<string, string?> ParseUrlOptions(Connection connection, Library.Utility.CompatUri uri)
     {
         var qp = uri.QueryParameters;
 
@@ -81,7 +81,7 @@ public class SharedRemoteOperation
     public static async Task<(string Url, Dictionary<string, string?> Options)> ExpandUrlAsync(Connection connection, IApplicationSettings applicationSettings, string url, string? backupId, long connectionStringId, string? sourcePrefix, CancellationToken cancelToken)
     {
         url = UnmaskUrl(connection, url, backupId, connectionStringId, sourcePrefix);
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         var opts = ParseUrlOptions(connection, uri);
 
         var tmp = new[] { uri };
@@ -111,7 +111,7 @@ public class SharedRemoteOperation
         if (string.IsNullOrEmpty(url))
             return url;
 
-        var source = new Library.Utility.Uri(url);
+        var source = new Library.Utility.CompatUri(url);
         var path = (source.Path ?? "").TrimEnd('/') + "/" + additionalPath.TrimStart('/');
         return new UriBuilder(url) { Path = path }.Uri.AbsoluteUri;
     }

--- a/Duplicati/WebserverCore/Endpoints/V2/ConnectionStrings.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/ConnectionStrings.cs
@@ -132,8 +132,8 @@ namespace Duplicati.WebserverCore.Endpoints.V2
 
         private static string MergeConnectionStrings(string connectionStringUrl, string backupUrl)
         {
-            var csUri = new Duplicati.Library.Utility.Uri(connectionStringUrl);
-            var backupUri = new Duplicati.Library.Utility.Uri(backupUrl);
+            var csUri = new Duplicati.Library.Utility.CompatUri(connectionStringUrl);
+            var backupUri = new Duplicati.Library.Utility.CompatUri(backupUrl);
 
             // Start with backup URI to keep Scheme, Host, Port, Path
             var resultUri = backupUri;
@@ -147,8 +147,8 @@ namespace Duplicati.WebserverCore.Endpoints.V2
 
             // Merge Query Parameters
             // Use decodeValues=false to preserve encoding
-            var csQuery = Duplicati.Library.Utility.Uri.ParseQueryString(csUri.Query ?? "", false);
-            var backupQuery = Duplicati.Library.Utility.Uri.ParseQueryString(backupUri.Query ?? "", false);
+            var csQuery = Duplicati.Library.Utility.CompatUri.ParseQueryString(csUri.Query ?? "", false);
+            var backupQuery = Duplicati.Library.Utility.CompatUri.ParseQueryString(backupUri.Query ?? "", false);
 
             var mergedQuery = new System.Collections.Specialized.NameValueCollection(backupQuery);
 
@@ -158,7 +158,7 @@ namespace Duplicati.WebserverCore.Endpoints.V2
                     mergedQuery[key] = csQuery[key];
             }
 
-            resultUri = resultUri.SetQuery(Duplicati.Library.Utility.Uri.BuildUriQuery(mergedQuery));
+            resultUri = resultUri.SetQuery(Duplicati.Library.Utility.CompatUri.BuildUriQuery(mergedQuery));
 
             return resultUri.ToString();
         }

--- a/proprietary/DiskImage/RestoreProvider.cs
+++ b/proprietary/DiskImage/RestoreProvider.cs
@@ -111,7 +111,7 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     /// <param name="options">The options for the restore operation</param>
     public RestoreProvider(string url, Dictionary<string, string?> options)
     {
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         _restorePath = uri.HostAndPath;
         _devicePath = uri.HostAndPath;
 

--- a/proprietary/DiskImage/SourceProvider.cs
+++ b/proprietary/DiskImage/SourceProvider.cs
@@ -76,7 +76,7 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
     {
         _mountPoint = mountPoint;
 
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         _devicePath = uri.HostAndPath;
 
         _treatFilesystemAsUnknown = !Library.Utility.Utility.ParseBoolOption(options, OptionsHelper.DISK_IMAGE_FILESYSTEM_PARSED_OPTION);

--- a/proprietary/GoogleWorkspace/RestoreProvider/RestoreProvider.cs
+++ b/proprietary/GoogleWorkspace/RestoreProvider/RestoreProvider.cs
@@ -103,7 +103,7 @@ public partial class RestoreProvider : IRestoreDestinationProviderModule
     /// <param name="options">The options for the restore operation</param>
     public RestoreProvider(string url, Dictionary<string, string?> options)
     {
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         _restorePath = uri.HostAndPath;
 
         var parsedOptions = OptionsHelper.ParseOptions(options);

--- a/proprietary/GoogleWorkspace/WebModule/WebModule.cs
+++ b/proprietary/GoogleWorkspace/WebModule/WebModule.cs
@@ -90,7 +90,7 @@ public class WebModule : IWebModule
             { "store-metadata-content-in-database", "true" }
         };
 
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         foreach (var key in uri.QueryParameters.AllKeys)
             forwardoptions[key!] = uri.QueryParameters[key];
 

--- a/proprietary/Office365/OptionsHelper.cs
+++ b/proprietary/Office365/OptionsHelper.cs
@@ -101,7 +101,7 @@ internal static class OptionsHelper
 
     internal static ParsedOptions ParseAndValidateOptions(string url, Dictionary<string, string?> options)
     {
-        var _authOptions = AuthOptionsHelper.ParseWithAlias(options, new Library.Utility.Uri(url), OFFICE_CLIENT_OPTION, OFFICE_SECRET_OPTION)
+        var _authOptions = AuthOptionsHelper.ParseWithAlias(options, new Library.Utility.CompatUri(url), OFFICE_CLIENT_OPTION, OFFICE_SECRET_OPTION)
             .RequireCredentials();
         var _tenantId = options.GetValueOrDefault(OFFICE_TENANT_OPTION)!;
         if (string.IsNullOrWhiteSpace(_tenantId))

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.cs
@@ -147,7 +147,7 @@ public partial class RestoreProvider : IRestoreDestinationProviderModule
     /// <param name="options">The options for the restore operation</param>
     public RestoreProvider(string url, Dictionary<string, string?> options)
     {
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         _restorePath = uri.HostAndPath;
 
         var parsedOptions = OptionsHelper.ParseAndValidateOptions(url, options);

--- a/proprietary/Office365/WebModule/WebModule.cs
+++ b/proprietary/Office365/WebModule/WebModule.cs
@@ -86,7 +86,7 @@ public class WebModule : IWebModule
             { "store-metadata-content-in-database", "true" }
         };
 
-        var uri = new Library.Utility.Uri(url);
+        var uri = new Library.Utility.CompatUri(url);
         foreach (var key in uri.QueryParameters.AllKeys)
             forwardoptions[key!] = uri.QueryParameters[key];
 


### PR DESCRIPTION
This update removes the support for parsing relaxed urls.

The relaxed url parsing was introduced to allow simpler remote destinations when using the commandline, where escaping things like passwords or folder names could be difficult to do correctly.

Additionally, since there were issues with the `System.Uri` class under Mono, a replacement `Utility.Uri` class was introduced that doubled both as a relaxed url parser and a replacement.

Today we have no issues with Mono, relatively few direct CLI users, and are routinely discovering edge cases where the relaxed parsing is causing issues.

To be more standardized in the future, this PR renames the  `Utility.Uri` class to `Utility.LegacyUri` and defaults to not using it. An intermediate `Utility.CompatUri` is introduced that works by choosing which underlying `Uri` class to use.

By default it will use the .NET default `System.Uri` class, which requires strict url encoding.

For most users, the new UI will already have encoded urls correctly, so the change should have limited impact.

But, since there may be users that rely on the relaxed parsing, and essentially every backend is affected, this change has an escape hatch. A user may either set the `DUPLICATI_LEGACY_URL_PARSING-true` environment variable or place a `legacy-url-parsing.txt` file in the install folder to toggle the use of the `LegacyUri` class.