### PR TITLE
Resolve the Box folder when the name is already in use instead of reporting it missing

### DIFF
--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -30,6 +30,8 @@ using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using Newtonsoft.Json;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend.Box
 {
     public class BoxBackend : IStreamingBackend, IRenameEnabledBackend, IFolderEnabledBackend
@@ -42,6 +44,19 @@ namespace Duplicati.Library.Backend.Box
 
         private const int PAGE_SIZE = 200;
 
+        /// <summary>
+        /// The Box.com error code reported when the name is already used by an item
+        /// </summary>
+        private const string NAME_IN_USE_CODE = "item_name_in_use";
+        /// <summary>
+        /// The number of times to look for a folder that Box reports as existing
+        /// </summary>
+        private const int CONFLICT_LOOKUP_ATTEMPTS = 3;
+        /// <summary>
+        /// The delay to use between the lookups for a folder that Box reports as existing
+        /// </summary>
+        private static readonly TimeSpan CONFLICT_LOOKUP_DELAY = TimeSpan.FromSeconds(1);
+
         private readonly BoxHelper _oAuthHelper;
         private readonly string _path;
         private readonly bool _deleteFromTrash;
@@ -53,8 +68,8 @@ namespace Duplicati.Library.Backend.Box
         private class BoxHelper : OAuthHelperHttpClient
         {
             private readonly TimeoutOptionsHelper.Timeouts _timeouts;
-            public BoxHelper(AuthIdOptionsHelper.AuthIdOptions authId, TimeoutOptionsHelper.Timeouts timeouts)
-                : base(authId.AuthId, "box.com", authId.OAuthUrl)
+            public BoxHelper(AuthIdOptionsHelper.AuthIdOptions authId, TimeoutOptionsHelper.Timeouts timeouts, HttpClient? httpClient = null)
+                : base(authId.AuthId, "box.com", authId.OAuthUrl, httpClient)
             {
                 AutoAuthHeader = true;
                 _timeouts = timeouts;
@@ -76,7 +91,7 @@ namespace Duplicati.Library.Backend.Box
                 catch { }
 
                 errorResponse ??= new ErrorResponse { Status = (int)responseContext.StatusCode, Code = "Unknown", Message = rawData };
-                throw new UserInformationException($"Box.com ErrorResponse: {errorResponse.Status} - {errorResponse.Code}: {errorResponse.Message}", "box.com");
+                throw new BoxException(errorResponse, ex);
             }
 
             public async Task<T> PutAndGetJsonDataAsync<T>(string url, object item, CancellationToken cancellationToken)
@@ -105,6 +120,18 @@ namespace Duplicati.Library.Backend.Box
         }
 
         public BoxBackend(string url, Dictionary<string, string?> options)
+            : this(url, options, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a backend that uses the supplied <see cref="HttpClient"/>,
+        /// so the Box API responses can be stubbed in tests
+        /// </summary>
+        /// <param name="url">The backend url</param>
+        /// <param name="options">The options to use</param>
+        /// <param name="httpClient">The client to use, or null to create one</param>
+        internal BoxBackend(string url, Dictionary<string, string?> options, HttpClient? httpClient)
         {
             var uri = new RelaxedUri(url);
 
@@ -116,7 +143,7 @@ namespace Duplicati.Library.Backend.Box
             _deleteFromTrash = Utility.Utility.ParseBoolOption(options, REALLY_DELETE_OPTION);
             _timeouts = TimeoutOptionsHelper.Parse(options);
 
-            _oAuthHelper = new BoxHelper(authid, _timeouts);
+            _oAuthHelper = new BoxHelper(authid, _timeouts, httpClient);
 
         }
 
@@ -140,21 +167,32 @@ namespace Duplicati.Library.Backend.Box
 
             foreach (var p in path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
             {
-                var el = (MiniFolder?)await PagedFileListResponse(parentid, true, cancelToken).FirstOrDefaultAsync(x => x.Name == p, cancellationToken: cancelToken).ConfigureAwait(false);
+                var el = await FindFolderAsync(parentid, p, cancelToken).ConfigureAwait(false);
                 if (el == null)
                 {
                     if (!create)
                         throw new FolderMissingException();
 
-                    el = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, ct => _oAuthHelper.PostAndGetJsonDataAsync<ListFolderResponse>(
-                        $"{BOX_API_URL}/folders",
-                        new CreateItemRequest
-                        {
-                            Name = p,
-                            Parent = new IDReference { ID = parentid }
-                        },
-                        ct
-                    )).ConfigureAwait(false);
+                    try
+                    {
+                        el = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, ct => _oAuthHelper.PostAndGetJsonDataAsync<ListFolderResponse>(
+                            $"{BOX_API_URL}/folders",
+                            new CreateItemRequest
+                            {
+                                Name = p,
+                                Parent = new IDReference { ID = parentid }
+                            },
+                            ct
+                        )).ConfigureAwait(false);
+                    }
+                    catch (BoxException bex) when (bex.Error.Status == (int)HttpStatusCode.Conflict && bex.Error.Code == NAME_IN_USE_CODE)
+                    {
+                        // The name is taken, so the folder is there even though the
+                        // listing did not report it
+                        el = await ResolveExistingFolderAsync(parentid, p, bex, cancelToken).ConfigureAwait(false);
+                        if (el == null)
+                            throw;
+                    }
                 }
 
                 parentid = el.ID;
@@ -163,6 +201,61 @@ namespace Duplicati.Library.Backend.Box
             }
 
             return parentid;
+        }
+
+        /// <summary>
+        /// Finds a folder by name in the given folder
+        /// </summary>
+        /// <param name="parentid">The id of the folder to look in</param>
+        /// <param name="name">The name of the folder to find</param>
+        /// <param name="cancelToken">The cancellation token to use</param>
+        /// <returns>The folder, or null if there is no such folder</returns>
+        private async Task<MiniFolder?> FindFolderAsync(string parentid, string name, CancellationToken cancelToken)
+            // Box.com does not allow two items in a folder to have names that differ
+            // only in casing, and reports the name as used when they do, so the names
+            // are compared the same way here
+            => (MiniFolder?)await PagedFileListResponse(parentid, true, cancelToken)
+                .FirstOrDefaultAsync(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase), cancellationToken: cancelToken)
+                .ConfigureAwait(false);
+
+        /// <summary>
+        /// Finds a folder that Box reports as already using the requested name,
+        /// either from the conflicting items in the error or by listing the parent again
+        /// </summary>
+        /// <param name="parentid">The id of the folder to look in</param>
+        /// <param name="name">The name of the folder to find</param>
+        /// <param name="error">The error reporting the name as taken</param>
+        /// <param name="cancelToken">The cancellation token to use</param>
+        /// <returns>The folder, or null if it could not be found</returns>
+        private async Task<MiniFolder?> ResolveExistingFolderAsync(string parentid, string name, BoxException error, CancellationToken cancelToken)
+        {
+            // Box reports the canonical name, which can differ in case from the requested one
+            var conflicts = error.Error.GetConflictingItems()
+                .Where(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var conflictingFolder = conflicts.FirstOrDefault(x => x.Type == "folder" && !string.IsNullOrWhiteSpace(x.ID));
+            if (conflictingFolder != null)
+                return conflictingFolder;
+
+            // Something that is not a folder uses the name, so no folder can have
+            // it and listing again will not produce one
+            if (conflicts.Count > 0)
+                return null;
+
+            // Only the name was reported as taken, so look for the folder again,
+            // allowing for the listing to catch up
+            for (var attempt = 1; attempt <= CONFLICT_LOOKUP_ATTEMPTS; attempt++)
+            {
+                if (attempt > 1)
+                    await Task.Delay(Utility.Utility.GetRetryDelay(CONFLICT_LOOKUP_DELAY, attempt - 1, true), cancelToken).ConfigureAwait(false);
+
+                var el = await FindFolderAsync(parentid, name, cancelToken).ConfigureAwait(false);
+                if (el != null)
+                    return el;
+            }
+
+            return null;
         }
 
         private IFileEntry ParseEntry(FileEntity n)
@@ -291,12 +384,11 @@ namespace Duplicati.Library.Backend.Box
         private async IAsyncEnumerable<FileEntity> PagedFileListResponse(string parentid, bool onlyfolders, [EnumeratorCancellation] CancellationToken cancelToken)
         {
             var offset = 0;
-            var done = false;
 
             if (!onlyfolders)
                 _fileCache.Clear();
 
-            do
+            while (true)
             {
                 var resp = await Utility.Utility.WithTimeout(_timeouts.ListTimeout, cancelToken, ct => _oAuthHelper.GetJsonDataAsync<ShortListResponse>($"{BOX_API_URL}/folders/{parentid}/items?limit={PAGE_SIZE}&offset={offset}&fields=name,size,modified_at", ct)).ConfigureAwait(false);
 
@@ -308,11 +400,10 @@ namespace Duplicati.Library.Backend.Box
                     if (string.IsNullOrWhiteSpace(f.Name) || string.IsNullOrWhiteSpace(f.ID))
                         continue;
 
+                    // No sort order is requested, so a non-folder entry does not
+                    // mean the remaining entries are non-folders as well
                     if (onlyfolders && f.Type != "folder")
-                    {
-                        done = true;
-                        break;
-                    }
+                        continue;
 
                     if (!onlyfolders && f.Type == "file")
                         _fileCache[f.Name] = f.ID;
@@ -320,12 +411,13 @@ namespace Duplicati.Library.Backend.Box
                     yield return f;
                 }
 
-                offset = offset + PAGE_SIZE;
+                // Fewer entries than requested may be returned while more remain,
+                // so continue after the entries that were actually received
+                offset += resp.Entries.Length;
 
                 if (offset >= resp.TotalCount)
                     break;
-
-            } while (!done);
+            }
         }
 
         public async Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken)

--- a/Duplicati/Library/Backend/Box/Model/BoxException.cs
+++ b/Duplicati/Library/Backend/Box/Model/BoxException.cs
@@ -1,0 +1,26 @@
+using Duplicati.Library.Interface;
+
+namespace Duplicati.Library.Backend.Box;
+
+/// <summary>
+/// An error reported by the Box.com API, carrying the parsed error response so
+/// callers can react to a specific error without matching on the message
+/// </summary>
+public sealed class BoxException : UserInformationException
+{
+    /// <summary>
+    /// The error reported by Box.com
+    /// </summary>
+    public ErrorResponse Error { get; }
+
+    /// <summary>
+    /// Creates a new exception for a Box.com error
+    /// </summary>
+    /// <param name="error">The parsed error response</param>
+    /// <param name="innerException">The exception that reported the failed request</param>
+    public BoxException(ErrorResponse error, Exception innerException)
+        : base($"Box.com ErrorResponse: {error.Status} - {error.Code}: {error.Message}", "box.com", innerException)
+    {
+        Error = error;
+    }
+}

--- a/Duplicati/Library/Backend/Box/Model/ErrorResponse.cs
+++ b/Duplicati/Library/Backend/Box/Model/ErrorResponse.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Duplicati.Library.Backend.Box;
 
@@ -10,4 +11,44 @@ public class ErrorResponse
     [JsonProperty("help_url")] public string? HelpUrl { get; set; }
     [JsonProperty("message")] public string? Message { get; set; }
     [JsonProperty("request_id")] public string? RequestId { get; set; }
+    [JsonProperty("context_info")] public ErrorContextInfo? ContextInfo { get; set; }
+
+    /// <summary>
+    /// Gets the items that already use the requested name, if the error reports any
+    /// </summary>
+    /// <returns>The conflicting items</returns>
+    public IEnumerable<MiniFolder> GetConflictingItems()
+    {
+        var conflicts = ContextInfo?.Conflicts;
+        if (conflicts == null)
+            return [];
+
+        var result = new List<MiniFolder>();
+        foreach (var item in conflicts is JArray array ? array : [conflicts])
+        {
+            try
+            {
+                var parsed = item.ToObject<MiniFolder>();
+                if (parsed != null)
+                    result.Add(parsed);
+            }
+            catch (JsonException)
+            {
+                // Not an item description, so there is nothing to use here
+            }
+        }
+
+        return result;
+    }
+}
+
+public class ErrorContextInfo
+{
+    /// <summary>
+    /// The items that already use the requested name.
+    /// Box reports a list when creating a folder and a single item for file
+    /// operations, so this is kept untyped and read through
+    /// <see cref="ErrorResponse.GetConflictingItems"/>.
+    /// </summary>
+    [JsonProperty("conflicts")] public JToken? Conflicts { get; set; }
 }

--- a/Duplicati/UnitTest/BoxFolderResolutionTests.cs
+++ b/Duplicati/UnitTest/BoxFolderResolutionTests.cs
@@ -1,0 +1,310 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.Box;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using StringAssert = NUnit.Framework.Legacy.StringAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// The Box folder lookup lists the parent folder and creates the folder when it
+/// is not in the listing. When the listing does not show a folder that exists,
+/// Box answers the create with "409 item_name_in_use" and the backend reported
+/// the folder as missing. These tests drive the backend against stubbed Box API
+/// responses, so no network or credentials are needed.
+/// </summary>
+[TestFixture]
+public class BoxFolderResolutionTests
+{
+    /// <summary>
+    /// A host that cannot be resolved, so a request that is not stubbed fails
+    /// instead of reaching the real OAuth service
+    /// </summary>
+    private const string OAuthUrl = "http://oauth.invalid/token";
+    private const string ItemsUrlPrefix = "https://api.box.com/2.0/folders/";
+    private const string CreateFolderUrl = "https://api.box.com/2.0/folders";
+
+    /// <summary>
+    /// Serves canned responses and records the requests that were made
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public List<string> Requests { get; } = new();
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+            Requests.Add($"{request.Method} {url}");
+
+            if (url.StartsWith(OAuthUrl, StringComparison.Ordinal))
+                return Task.FromResult(Json(HttpStatusCode.OK, "{\"access_token\":\"test-token\",\"expires\":3600}"));
+
+            return Task.FromResult(_responder(request));
+        }
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode code, string body)
+        => new HttpResponseMessage(code) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    /// <summary>
+    /// Builds a folder item listing, as returned by GET /folders/{id}/items
+    /// </summary>
+    private static string Listing(long totalCount, params string[] entries)
+        => $"{{\"total_count\":{totalCount},\"entries\":[{string.Join(",", entries)}]}}";
+
+    private static string Item(string type, string id, string name)
+        => $"{{\"type\":\"{type}\",\"id\":\"{id}\",\"name\":\"{name}\"}}";
+
+    /// <summary>
+    /// Builds a Box error body for a name that is already in use
+    /// </summary>
+    /// <param name="conflicts">The raw json for context_info.conflicts, or null to omit it</param>
+    private static string NameInUseError(string? conflicts)
+    {
+        var context = conflicts == null ? "" : $",\"context_info\":{{\"conflicts\":{conflicts}}}";
+        return $"{{\"type\":\"error\",\"status\":409,\"code\":\"item_name_in_use\",\"message\":\"Item with the same name already exists\"{context}}}";
+    }
+
+    private static BoxBackend CreateBackend(StubHandler handler, string url = "box://target")
+        => new BoxBackend(url, new Dictionary<string, string?>
+        {
+            ["authid"] = "test-authid",
+            ["oauth-url"] = OAuthUrl
+        }, new HttpClient(handler));
+
+    /// <summary>
+    /// Enumerates the backend listing, which resolves the folder id first
+    /// </summary>
+    private static async Task<List<IFileEntry>> ListAsync(BoxBackend backend)
+    {
+        var result = new List<IFileEntry>();
+        await foreach (var entry in backend.ListAsync(CancellationToken.None).ConfigureAwait(false))
+            result.Add(entry);
+        return result;
+    }
+
+    private static bool RequestedItemsOf(StubHandler handler, string folderId)
+        => handler.Requests.Any(x => x.StartsWith($"GET {ItemsUrlPrefix}{folderId}/items", StringComparison.Ordinal));
+
+    [Test]
+    [Category("Backend")]
+    public async Task FolderIsFoundWhenTheListingStartsWithAFile()
+    {
+        // Box is not asked for a specific sort order, so a file can precede the
+        // folder; that must not end the folder scan
+        var handler = new StubHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.StartsWith($"{ItemsUrlPrefix}0/items", StringComparison.Ordinal))
+                return Json(HttpStatusCode.OK, Listing(2, Item("file", "f1", "aaa.txt"), Item("folder", "100", "target")));
+
+            return Json(HttpStatusCode.OK, Listing(0));
+        });
+
+        using var backend = CreateBackend(handler);
+        var entries = await ListAsync(backend);
+
+        Assert.AreEqual(0, entries.Count);
+        Assert.IsTrue(RequestedItemsOf(handler, "100"),
+            "The folder that is present in the listing should be used");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task FolderIsFoundWhenTheNameDiffersInCasing()
+    {
+        // Box.com does not allow sibling names that differ only in casing, and
+        // reports the name as used when creating one, so a folder that differs
+        // only in casing is the folder that was asked for
+        var handler = new StubHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.StartsWith($"{ItemsUrlPrefix}0/items", StringComparison.Ordinal))
+                return Json(HttpStatusCode.OK, Listing(1, Item("folder", "500", "Target")));
+
+            return Json(HttpStatusCode.OK, Listing(0));
+        });
+
+        using var backend = CreateBackend(handler, "box://target");
+        await ListAsync(backend);
+
+        Assert.IsTrue(RequestedItemsOf(handler, "500"),
+            "A folder that differs only in casing should be used instead of being created");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task FolderIsFoundWhenAPageReturnsFewerEntriesThanRequested()
+    {
+        // Box may return fewer entries than the requested limit while more
+        // remain, so the next offset must follow the entries actually received
+        const int firstPageSize = 150;
+        const int totalCount = 201;
+        const int targetIndex = 175;
+
+        var all = Enumerable.Range(0, totalCount)
+            .Select(i => Item("folder", $"{1000 + i}", i == targetIndex ? "target" : $"other-{i}"))
+            .ToArray();
+
+        var handler = new StubHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (url.StartsWith($"{ItemsUrlPrefix}0/items", StringComparison.Ordinal))
+            {
+                var offset = int.Parse(System.Web.HttpUtility.ParseQueryString(request.RequestUri!.Query)["offset"] ?? "0");
+                var page = all.Skip(offset).Take(offset == 0 ? firstPageSize : totalCount).ToArray();
+                return Json(HttpStatusCode.OK, Listing(totalCount, page));
+            }
+
+            return Json(HttpStatusCode.OK, Listing(0));
+        });
+
+        using var backend = CreateBackend(handler);
+        await ListAsync(backend);
+
+        Assert.IsTrue(RequestedItemsOf(handler, $"{1000 + targetIndex}"),
+            "A short first page must not cause the remaining entries to be skipped");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task NameInUseResolvesTheConflictingFolder()
+    {
+        // The listing does not show the folder, but Box reports the name as
+        // taken and names the conflicting item
+        var handler = new StubHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (request.Method == HttpMethod.Post && url == CreateFolderUrl)
+                return Json(HttpStatusCode.Conflict, NameInUseError($"[{Item("folder", "200", "Target")}]"));
+
+            return Json(HttpStatusCode.OK, Listing(0));
+        });
+
+        using var backend = CreateBackend(handler);
+        await backend.CreateFolderAsync(CancellationToken.None);
+        await ListAsync(backend);
+
+        Assert.IsTrue(RequestedItemsOf(handler, "200"),
+            "The folder id reported by Box should be used");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task NameInUseResolvesByListingAgainWhenNoConflictIsReported()
+    {
+        // Without the conflicting item in the error, the folder has to be
+        // looked up again; it is now visible
+        var listCalls = 0;
+        var handler = new StubHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (request.Method == HttpMethod.Post && url == CreateFolderUrl)
+                return Json(HttpStatusCode.Conflict, NameInUseError(null));
+
+            if (url.StartsWith($"{ItemsUrlPrefix}0/items", StringComparison.Ordinal))
+                return Json(HttpStatusCode.OK, ++listCalls == 1
+                    ? Listing(0)
+                    : Listing(1, Item("folder", "300", "target")));
+
+            return Json(HttpStatusCode.OK, Listing(0));
+        });
+
+        using var backend = CreateBackend(handler);
+        await backend.CreateFolderAsync(CancellationToken.None);
+        await ListAsync(backend);
+
+        Assert.IsTrue(RequestedItemsOf(handler, "300"),
+            "The folder should be resolved by listing the parent again");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void NameInUseByAFileIsStillReported()
+    {
+        // A file with the same name means the folder really cannot be created,
+        // so the file id must not be mistaken for the folder
+        var handler = new StubHandler(request =>
+        {
+            var url = request.RequestUri!.ToString();
+            if (request.Method == HttpMethod.Post && url == CreateFolderUrl)
+                return Json(HttpStatusCode.Conflict, NameInUseError($"[{Item("file", "400", "target")}]"));
+
+            return Json(HttpStatusCode.OK, Listing(0));
+        });
+
+        using var backend = CreateBackend(handler);
+        var ex = Assert.CatchAsync<UserInformationException>(async () => await backend.CreateFolderAsync(CancellationToken.None));
+
+        StringAssert.Contains("item_name_in_use", ex!.Message);
+        Assert.IsFalse(RequestedItemsOf(handler, "400"),
+            "A conflicting file must not be used as the folder");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void BackendIsCreatedThroughTheLoader()
+    {
+        // The loader creates the backend with two arguments through reflection,
+        // which only finds a constructor with a matching number of parameters
+        using var backend = Library.DynamicLoader.BackendLoader.GetBackend("box://target",
+            new Dictionary<string, string> { ["authid"] = "test-authid" });
+
+        Assert.IsNotNull(backend, "The Box backend should be creatable through the loader");
+    }
+
+    [TestCase(HttpStatusCode.Forbidden, "{\"type\":\"error\",\"status\":403,\"code\":\"access_denied\",\"message\":\"Access denied\"}",
+        "Box.com ErrorResponse: 403 - access_denied: Access denied")]
+    [TestCase(HttpStatusCode.Conflict, "{\"type\":\"error\",\"status\":409,\"code\":\"item_name_in_use\",\"message\":\"Item with the same name already exists\",\"context_info\":{\"conflicts\":{\"type\":\"file\",\"id\":\"1\",\"name\":\"x\"}}}",
+        "Box.com ErrorResponse: 409 - item_name_in_use: Item with the same name already exists")]
+    [Category("Backend")]
+    public void ErrorMessagesAreUnchanged(HttpStatusCode status, string body, string expected)
+    {
+        // The reported errors must keep their wording, including when Box sends
+        // a single conflicting item instead of a list. Catching
+        // UserInformationException also covers the existing handlers, as the
+        // Box errors are reported through a subclass of it.
+        var handler = new StubHandler(_ => Json(status, body));
+
+        using var backend = CreateBackend(handler);
+        var ex = Assert.CatchAsync<UserInformationException>(async () => await ListAsync(backend));
+
+        Assert.AreEqual(expected, ex!.Message);
+    }
+}


### PR DESCRIPTION
## What this fixes

The Box folder lookup can fail to find a folder that exists, and then reports it as missing — while Box itself says the opposite. From CI run [30099854089](https://github.com/duplicati/duplicati/actions/runs/30099854089) (all three OS jobs):

```
Autocreate folder failed with message: Box.com ErrorResponse: 409 - item_name_in_use: Item with the same name already exists
Unittest failed: Duplicati.Library.Interface.FolderMissingException: The requested folder does not exist
```

Box answers the create with "the name is already in use", which means the folder *is* there, and we still report it missing. There is no existing issue for this (searched open+closed for `item_name_in_use`, Box folder/create failures), so this PR doubles as the report.

This is not a transient race: that job runs with `max-parallel: 1`, and the live tests pass `--failure-retries=3`, so `CreateFolderAsync` was retried and the listing missed the same folder on every attempt, seconds apart.

## The three defects behind it

All in `GetFolderIdAsync` / `PagedFileListResponse`, all covered by the new tests:

1. **The folder scan stops at the first non-folder entry.** `if (onlyfolders && f.Type != "folder") { done = true; break; }` assumes Box returns every folder before any file. The request does not ask for a sort order, and the response's `order` field is parsed into `ShortListResponse.Order` but never read — so this is an unchecked assumption, and when it does not hold the scan ends before reaching the folder.
2. **Pagination advances by the requested page size, not by what was returned.** `offset += PAGE_SIZE` while the response may contain fewer entries than `limit` — those entries are then skipped for good.
3. **Folder names are compared with `==` (ordinal).** Box does not allow two items in a folder whose names differ only in casing — which is exactly why it answers `item_name_in_use`. An ordinal comparison therefore cannot find a folder whose stored casing differs from the requested one, and it never will, no matter how often it retries.

Once the folder is missed, the create is attempted and the 409 is surfaced as a failure instead of being read for what it is.

## The fix

- The scan skips non-folder entries instead of ending, and continues after the entries actually received.
- Folder names are matched case-insensitively, matching Box's own uniqueness rule.
- A `409 item_name_in_use` on create is now resolved rather than reported: the conflicting folder from `context_info.conflicts` is used when Box names it (only entries of type `folder` — a conflicting *file* means no folder can have that name, and that error is still reported), otherwise the parent is listed again, three attempts with `Utility.GetRetryDelay` backoff, and the original error is rethrown unchanged if it stays unresolved.
- To detect that error without matching on message text, the Box errors are now raised as `BoxException : UserInformationException`, carrying the parsed `ErrorResponse` and the original `HttpRequestException` as inner. **The message text is unchanged**, and `context_info.conflicts` is typed as `JToken` because Box sends a list for folder creates and a single object for file operations — a typed array would break parsing of the latter and change its message. Both shapes are covered by a test.

No `FolderAreadyExistedException` is thrown: the resolved id is needed to continue for multi-segment paths, and the auto-create paths in the web server do not catch it today.

## Verification

New offline tests in `Duplicati/UnitTest/BoxFolderResolutionTests.cs`, driving the backend against a stubbed `HttpMessageHandler` (the OAuth endpoint is stubbed too and points at an unresolvable host, so no request can escape). This required threading the `HttpClient` that `OAuthHelperHttpClient` already accepts through `BoxHelper`, plus an `internal` constructor — the public two-argument and parameterless constructors are untouched, because `BackendLoader` creates backends through `Activator.CreateInstance(type, url, options)` and `DynamicLoader` requires the parameterless one. A test creates the backend through `BackendLoader` to guard exactly that.

| Test | Before |
|---|---|
| `FolderIsFoundWhenTheListingStartsWithAFile` | fails — `FolderMissingException` |
| `FolderIsFoundWhenTheNameDiffersInCasing` | fails — `FolderMissingException` |
| `FolderIsFoundWhenAPageReturnsFewerEntriesThanRequested` | fails — entry 175 skipped when the first page returns 150 of 201 |
| `NameInUseResolvesTheConflictingFolder` | fails — 409 reported |
| `NameInUseResolvesByListingAgainWhenNoConflictIsReported` | fails — 409 reported |
| `NameInUseByAFileIsStillReported` | passes before and after (guard) |
| `ErrorMessagesAreUnchanged` (403, and 409 with a single conflicting item) | passes before and after (message compatibility) |
| `BackendIsCreatedThroughTheLoader` | passes before and after (reflection guard) |

`Category=Backend` is green (20/20, includes the existing S3 tests) on Windows/net10.0. I have no Box account, so the live `Box.com Tests` job is the only end-to-end check — the evidence above is the CI log plus the unit tests.

## Note on what triggered the CI failure

The Box job passes on other branches (9/9 across three runs of `feature/handle-remote-reconnect-issues`, one of them after the failure) and fails only on `feature/deprecate-relaxed-uri`, i.e. #7097. That branch switches Box to `CompatUri`, which takes `Host` from `System.Uri` — and `System.Uri` lowercases the host, so the first path segment reaching `GetFolderIdAsync` changes casing. Combined with defect 3 that produces exactly the observed signature: the listing never matches, the create collides, and Box reports the name as in use.

So the trigger looks like #7097, but the defects are pre-existing and independent of it — and with this PR, that failure mode resolves instead of failing. Worth a look either way when landing #7097.

## Out of scope, spotted while here

- `BoxBackend.GetEntryAsync(string path, …)` ignores its `path` argument and always inspects the backend root.
- `JSONWebHelperHttpClient.PostMultipartAsync` never calls `EnsureSuccessStatusCode`, so a failed Box upload surfaces as `InvalidDataException("No file ID returned after upload")` instead of the API error.
- The web server auto-create paths (`RemoteOperation`, `DestinationVerify`) do not catch `FolderAreadyExistedException`, so backends that throw it report a failure.
- Box recommends marker-based pagination over offset for large folders; this PR keeps offset paging.

Happy to split the 409 handling out if you prefer — the scan and comparison fixes stand on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
