### PR TITLE
Report the server error when a multipart upload fails

### DIFF
--- a/Duplicati/Library/Backend/OAuthHelper/JSONWebHelperHttpClient.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/JSONWebHelperHttpClient.cs
@@ -99,7 +99,9 @@ public class JsonWebHelperHttpClient(HttpClient httpClient)
     {
         using var req = await CreateRequestAsync(url, HttpMethod.Post, cancellationToken).ConfigureAwait(false);
         req.Content = parts;
-        return await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
+        // Reading the content here keeps the response body available to the error
+        // handler, and matches the completion option used for the other requests
+        return await GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Duplicati/UnitTest/JsonWebHelperMultipartTests.cs
+++ b/Duplicati/UnitTest/JsonWebHelperMultipartTests.cs
@@ -1,0 +1,182 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using StringAssert = NUnit.Framework.Legacy.StringAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A multipart post is the upload path for Box.com. The response status was not
+/// checked, so a failed upload was handed to the JSON parser and reported as a
+/// missing file id instead of the error the server sent.
+/// </summary>
+[TestFixture]
+public class JsonWebHelperMultipartTests
+{
+    private const string UploadUrl = "https://upload.example.com/files/content";
+
+    /// <summary>
+    /// The shape of an upload response, mirroring the way Box.com reports the
+    /// uploaded file. An error body deserializes into this without failing.
+    /// </summary>
+    private sealed class UploadResponse
+    {
+        public UploadEntry[]? Entries { get; set; }
+    }
+
+    private sealed class UploadEntry
+    {
+        public string? Id { get; set; }
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+
+        public StubHandler(HttpStatusCode status, string body)
+        {
+            _status = status;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json")
+            });
+    }
+
+    /// <summary>
+    /// Stands in for a backend, recording what the error handler is given
+    /// </summary>
+    private sealed class TestClient : JsonWebHelperHttpClient, IDisposable
+    {
+        private readonly HttpClient _client;
+
+        public TestClient(HttpClient httpClient) : base(httpClient)
+            => _client = httpClient;
+
+        public void Dispose()
+            => _client.Dispose();
+
+        /// <summary>
+        /// Set to false to act like a backend that does not recognize the error
+        /// </summary>
+        public bool ReportError { get; set; } = true;
+
+        public int HandlerCalls { get; private set; }
+        public HttpStatusCode? HandledStatus { get; private set; }
+        public string? HandledBody { get; private set; }
+
+        public override async Task AttemptParseAndThrowExceptionAsync(Exception ex, HttpResponseMessage? responseContext, CancellationToken cancellationToken)
+        {
+            HandlerCalls++;
+            HandledStatus = responseContext?.StatusCode;
+            if (responseContext != null)
+                HandledBody = await responseContext.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            if (ReportError)
+                throw new UserInformationException("The server reported an error", "test");
+        }
+
+        public Task<UploadResponse> UploadAsync(CancellationToken cancellationToken)
+        {
+            var parts = new MultipartFormDataContent
+            {
+                { new StringContent("{\"name\":\"file.txt\"}", Encoding.UTF8, "application/json"), "attributes" },
+                { new ByteArrayContent([1, 2, 3]), "file", "file.txt" }
+            };
+
+            return PostMultipartAndGetJsonDataAsync<UploadResponse>(UploadUrl, cancellationToken, parts);
+        }
+    }
+
+    private static TestClient CreateClient(HttpStatusCode status, string body)
+        => new TestClient(new HttpClient(new StubHandler(status, body)));
+
+    private const string ErrorBody = "{\"type\":\"error\",\"status\":409,\"code\":\"item_name_in_use\",\"message\":\"Item with the same name already exists\"}";
+
+    [Test]
+    [Category("Backend")]
+    public void FailedUploadIsReportedByTheBackend()
+    {
+        // The error body parses into the expected response type without any
+        // entries, so the failure has to be caught from the status
+        using var client = CreateClient(HttpStatusCode.Conflict, ErrorBody);
+
+        var ex = Assert.CatchAsync<UserInformationException>(async () => await client.UploadAsync(CancellationToken.None));
+
+        StringAssert.Contains("The server reported an error", ex!.Message);
+        Assert.AreEqual(1, client.HandlerCalls, "The error should be handed to the backend exactly once");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void FailedUploadPassesTheResponseToTheBackend()
+    {
+        // The backend reads the error body to build its message, so the response
+        // must still be readable when it is called
+        using var client = CreateClient(HttpStatusCode.Conflict, ErrorBody);
+
+        Assert.CatchAsync<UserInformationException>(async () => await client.UploadAsync(CancellationToken.None));
+
+        Assert.AreEqual(HttpStatusCode.Conflict, client.HandledStatus);
+        StringAssert.Contains("item_name_in_use", client.HandledBody ?? "");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void FailedUploadReportsTheHttpErrorWhenTheBackendDoesNot()
+    {
+        // A backend that does not recognize the error leaves the request error in place
+        using var client = CreateClient(HttpStatusCode.InternalServerError, "not json");
+        client.ReportError = false;
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () => await client.UploadAsync(CancellationToken.None));
+
+        Assert.AreEqual(HttpStatusCode.InternalServerError, ex!.StatusCode);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task SuccessfulUploadIsReturned()
+    {
+        using var client = CreateClient(HttpStatusCode.OK, "{\"entries\":[{\"id\":\"1234\"}]}");
+
+        var result = await client.UploadAsync(CancellationToken.None);
+
+        Assert.AreEqual("1234", result.Entries?[0].Id);
+        Assert.AreEqual(0, client.HandlerCalls, "A successful upload should not invoke the error handler");
+    }
+}


### PR DESCRIPTION
## What this fixes

`JsonWebHelperHttpClient.PostMultipartAsync` never checks whether the request succeeded:

```csharp
using var req = await CreateRequestAsync(url, HttpMethod.Post, cancellationToken).ConfigureAwait(false);
req.Content = parts;
return await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
```

Every other request in the same class goes through `GetResponseAsync`, which calls `EnsureSuccessStatusCode()` and hands failures to the virtual `AttemptParseAndThrowExceptionAsync` hook so the backend can turn the API's error body into a meaningful exception. The multipart post is the one path that skips it. Found while working on #7099; no existing issue, so this PR doubles as the report.

## What that costs today

The call chain has a single consumer, so the effect is narrow but certain:

`PostMultipartAsync` ← `PostMultipartAndGetJsonDataAsync` ← `BoxBackend.PutAsync` (the Box upload)

1. The error response is returned unchecked.
2. `ReadJsonResponseAsync<FileList>` **successfully** deserializes Box's error body into `FileList` — that model only has `total_count`/`entries`/`offset`/`limit`, so `{"type":"error","status":409,"code":"item_name_in_use",…}` becomes a non-null object with `Entries == null`.
3. `BoxBackend` then throws `InvalidDataException("No file ID returned after upload")`.

So **any** failed Box upload — 401, 409, 500 — is reported as a missing file id, with the status code, the Box error code and the message all discarded. `BoxHelper.AttemptParseAndThrowExceptionAsync`, which exists to produce `Box.com ErrorResponse: {status} - {code}: {message}`, is never reached on this path. When the failure body is not JSON at all (a proxy's HTML 502), the user gets `IOException: Invalid JSON data: "<!DOCTYPE html…"` instead.

The new tests show the layer behavior directly: before this change, a 409 with an error body produced **no exception at all** from `PostMultipartAndGetJsonDataAsync`.

## The fix

Route the multipart post through the checked helper that already exists in the same class, instead of duplicating the try/catch:

```csharp
return await GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
```

- `ResponseContentRead` is what the previous two-argument `SendAsync(req, ct)` used, so the success path is unchanged — and the body stays buffered, which is what lets the error handler read it after `using var req` disposes the request and its content.
- Ownership of the response is unchanged: `GetResponseAsync` disposes it **only** on the failure path (its `finally` sits inside the `catch`), so on success the caller's `using var response` in `PostMultipartAndGetJsonDataAsync` remains the sole owner — no double dispose.
- A backend whose handler does not recognize the error still gets the original `HttpRequestException`, per `GetResponseAsync`'s existing contract.

`GetResponseUncheckedAsync` is deliberately left alone — not checking is its purpose.

## Verification

New tests in `Duplicati/UnitTest/JsonWebHelperMultipartTests.cs`. `JsonWebHelperHttpClient` is public, its primary constructor takes the `HttpClient`, `PostMultipartAsync` is `protected virtual` and the error hook is `public virtual`, so a test subclass with a stubbed `HttpMessageHandler` covers this offline — no production test seam was needed, and `Duplicati.UnitTest` already references the OAuthHelper project.

| Test | Before this change |
|---|---|
| `FailedUploadIsReportedByTheBackend` | fails — **no exception**, the 409 body parses into the response type with no entries |
| `FailedUploadPassesTheResponseToTheBackend` | fails — the handler is never called, so it never sees the 409 or the body |
| `FailedUploadReportsTheHttpErrorWhenTheBackendDoesNot` | fails — `IOException: Invalid JSON data: "not json"` instead of the 500 |
| `SuccessfulUploadIsReturned` | passes before and after (guard: the success path and the untouched handler) |

`Category=Backend` is green locally on Windows/net10.0. I have no Box account, so the live `Box.com Tests` job is the only end-to-end check for the consumer side; the evidence here is the layer-level red→green plus the code path above.

Note on scope: Box's handler also has a 429 → `TooManyRequestException(Retry-After)` branch that this path skipped. I am not claiming a retry-behavior change from that — `TooManyRequestException` is currently only acted on by the Backblaze backend — the gain here is that the error is reported instead of being replaced.

## Adjacent, not touched here

Other upload paths that read a response without checking the status, if you want them handled the same way:

- `Duplicati/Library/Backend/Filen/FilenClient.cs:646` — chunk download fed straight into decryption, so an HTTP error surfaces as a decryption failure.
- `Duplicati/Library/Backend/pCloud/pCloudBackend.cs:280` — upload relies only on the JSON `result` code.
- `Duplicati/Library/Backend/Filejump/Filejump.cs:253` — `EnsureSuccessStatusCode` is called *after* the throws above it, so an HTTP error is reported as `"Failed to upload file: "`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
