### PR TITLE
Use the requested path when looking up a Box entry

### DIFF
--- a/Duplicati/Library/Backend/Box/BoxBackend.cs
+++ b/Duplicati/Library/Backend/Box/BoxBackend.cs
@@ -30,6 +30,8 @@ using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using Newtonsoft.Json;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend.Box
 {
     public class BoxBackend : IStreamingBackend, IRenameEnabledBackend, IFolderEnabledBackend
@@ -53,8 +55,8 @@ namespace Duplicati.Library.Backend.Box
         private class BoxHelper : OAuthHelperHttpClient
         {
             private readonly TimeoutOptionsHelper.Timeouts _timeouts;
-            public BoxHelper(AuthIdOptionsHelper.AuthIdOptions authId, TimeoutOptionsHelper.Timeouts timeouts)
-                : base(authId.AuthId, "box.com", authId.OAuthUrl)
+            public BoxHelper(AuthIdOptionsHelper.AuthIdOptions authId, TimeoutOptionsHelper.Timeouts timeouts, HttpClient? httpClient = null)
+                : base(authId.AuthId, "box.com", authId.OAuthUrl, httpClient)
             {
                 AutoAuthHeader = true;
                 _timeouts = timeouts;
@@ -105,6 +107,18 @@ namespace Duplicati.Library.Backend.Box
         }
 
         public BoxBackend(string url, Dictionary<string, string?> options)
+            : this(url, options, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a backend that uses the supplied <see cref="HttpClient"/>,
+        /// so the Box API responses can be stubbed in tests
+        /// </summary>
+        /// <param name="url">The backend url</param>
+        /// <param name="options">The options to use</param>
+        /// <param name="httpClient">The client to use, or null to create one</param>
+        internal BoxBackend(string url, Dictionary<string, string?> options, HttpClient? httpClient)
         {
             var uri = new RelaxedUri(url);
 
@@ -116,7 +130,7 @@ namespace Duplicati.Library.Backend.Box
             _deleteFromTrash = Utility.Utility.ParseBoolOption(options, REALLY_DELETE_OPTION);
             _timeouts = TimeoutOptionsHelper.Parse(options);
 
-            _oAuthHelper = new BoxHelper(authid, _timeouts);
+            _oAuthHelper = new BoxHelper(authid, _timeouts, httpClient);
 
         }
 
@@ -224,7 +238,7 @@ namespace Duplicati.Library.Backend.Box
 
         public async Task<IFileEntry?> GetEntryAsync(string path, CancellationToken cancellationToken)
         {
-            var parts = GetAbsolutePath(_path).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var parts = GetAbsolutePath(path).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length == 0)
                 return new FileEntry(string.Empty) { IsFolder = true };
 

--- a/Duplicati/UnitTest/BoxEntryLookupTests.cs
+++ b/Duplicati/UnitTest/BoxEntryLookupTests.cs
@@ -1,0 +1,178 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.Box;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Looking up a single entry is how a remote source or destination is browsed.
+/// The Box lookup passed its own configured path to the path builder instead of
+/// the requested one, so it either found nothing or answered with the root.
+/// These tests drive the backend against stubbed Box API responses, so no
+/// network or credentials are needed.
+/// </summary>
+[TestFixture]
+public class BoxEntryLookupTests
+{
+    /// <summary>
+    /// A host that cannot be resolved, so a request that is not stubbed fails
+    /// instead of reaching the real OAuth service
+    /// </summary>
+    private const string OAuthUrl = "http://oauth.invalid/token";
+    private const string ItemsUrlPrefix = "https://api.box.com/2.0/folders/";
+
+    /// <summary>
+    /// Answers folder listings from a fixed layout of folder id to items
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string[]> _folders;
+
+        public StubHandler(Dictionary<string, string[]> folders)
+            => _folders = folders;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+
+            if (url.StartsWith(OAuthUrl, StringComparison.Ordinal))
+                return Task.FromResult(Json("{\"access_token\":\"test-token\",\"expires\":3600}"));
+
+            if (url.StartsWith(ItemsUrlPrefix, StringComparison.Ordinal))
+            {
+                var id = url[ItemsUrlPrefix.Length..].Split('/')[0];
+                var entries = _folders.TryGetValue(id, out var e) ? e : [];
+                return Task.FromResult(Json($"{{\"total_count\":{entries.Length},\"entries\":[{string.Join(",", entries)}]}}"));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage Json(string body)
+            => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static string Folder(string id, string name)
+        => $"{{\"type\":\"folder\",\"id\":\"{id}\",\"name\":\"{name}\"}}";
+
+    private static string File(string id, string name, long size)
+        => $"{{\"type\":\"file\",\"id\":\"{id}\",\"name\":\"{name}\",\"size\":{size}}}";
+
+    private static BoxBackend CreateBackend(Dictionary<string, string[]> folders, string url)
+        => new BoxBackend(url, new Dictionary<string, string?>
+        {
+            ["authid"] = "test-authid",
+            ["oauth-url"] = OAuthUrl
+        }, new HttpClient(new StubHandler(folders)));
+
+    /// <summary>
+    /// The backend is configured for "target", which holds a folder and a file
+    /// </summary>
+    private static BoxBackend CreateBackendWithTargetFolder()
+        => CreateBackend(new Dictionary<string, string[]>
+        {
+            ["0"] = [Folder("100", "target")],
+            ["100"] = [Folder("200", "child"), File("300", "note.txt", 7)],
+            ["200"] = []
+        }, "box://target");
+
+    [Test]
+    [Category("Backend")]
+    public async Task RequestedFolderIsReturned()
+    {
+        using var backend = CreateBackendWithTargetFolder();
+
+        var entry = await backend.GetEntryAsync("child", CancellationToken.None);
+
+        Assert.IsNotNull(entry, "The requested folder should be found");
+        Assert.IsTrue(entry!.IsFolder);
+        Assert.AreEqual("child/", entry.Name, "A folder name ends with a separator");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task RequestedFileIsReturned()
+    {
+        using var backend = CreateBackendWithTargetFolder();
+
+        var entry = await backend.GetEntryAsync("note.txt", CancellationToken.None);
+
+        Assert.IsNotNull(entry, "The requested file should be found");
+        Assert.IsFalse(entry!.IsFolder);
+        Assert.AreEqual("note.txt", entry.Name);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task ConfiguredFolderIsReturnedForAnEmptyPath()
+    {
+        // An empty path means the folder the backend is configured for, which is
+        // what the browsing endpoint asks for first
+        using var backend = CreateBackendWithTargetFolder();
+
+        var entry = await backend.GetEntryAsync("", CancellationToken.None);
+
+        Assert.IsNotNull(entry, "The configured folder should be found");
+        Assert.IsTrue(entry!.IsFolder);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task MissingEntryIsReportedAsMissing()
+    {
+        using var backend = CreateBackendWithTargetFolder();
+
+        var entry = await backend.GetEntryAsync("nope", CancellationToken.None);
+
+        Assert.IsNull(entry, "An entry that does not exist should be reported as missing, not as an error");
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task RequestedFolderIsReturnedForABackendAtTheRoot()
+    {
+        // Without a folder in the url the requested path was dropped entirely
+        // and the root was answered for every request
+        using var backend = CreateBackend(new Dictionary<string, string[]>
+        {
+            ["0"] = [Folder("200", "child")],
+            ["200"] = []
+        }, "box://");
+
+        var entry = await backend.GetEntryAsync("child", CancellationToken.None);
+
+        Assert.IsNotNull(entry, "The requested folder should be found");
+        Assert.AreEqual("child/", entry!.Name, "The requested folder should be answered, not the root");
+    }
+}


### PR DESCRIPTION
## What this fixes

`BoxBackend.GetEntryAsync` builds its lookup from the backend's own configured path instead of the path it was asked for:

```csharp
public async Task<IFileEntry?> GetEntryAsync(string path, CancellationToken cancellationToken)
{
    var parts = GetAbsolutePath(_path).Split(...);   // the argument is never used
```

`GetAbsolutePath` returns `_path` for an empty argument and otherwise appends to `_path`. Since `_path` is set as `Util.AppendDirSeparator(uri.HostAndPath, "/")` it always ends in `/` and is never empty, so feeding it back through the helper **doubles the last segment**. There is no existing issue for this (searched open+closed for `GetEntryAsync`, Box folder browsing, `destination/list`), so this PR doubles as the report.

Two distinct broken behaviors, depending on the url:

| Box url | `_path` | built lookup path | result |
|---|---|---|---|
| `box://folder/sub` | `folder/sub/` | `folder/sub/folder/sub` | always **null** — every entry reports as missing |
| `box://` | `/` | `/` → no segments | **the root entry is returned for every requested path** — no error, wrong contents |

## Where it shows up

`GetEntryAsync` is the single-entry lookup behind remote-source and destination browsing. Backup and restore to a Box *destination* are unaffected — `BackendManager.ListOperation` only uses `ListAsync`.

- `WebserverCore/Endpoints/V2/DestinationList.cs:65` — `POST /destination/list` treats null as `"Folder does not exist"`, and otherwise enumerates the returned entry's children. So browsing into a Box folder either fails, or silently lists the **root's** contents while the user believes they are inside the folder they clicked.
- `Library/Main/Operation/Sync/SyncHandler.cs:174` — a source root that reports as missing is logged as `SourceRootMissing` and skipped.
- `Library/SourceProvider/Builtin/BackendSourceFileEntry.cs:187` — `FileExists` is `entry != null && !entry.IsFolder`, so it is always false and exclusion-marker files on a remote source are never found.

## History — a refactoring slip, not a decision

- Added in [8a08b35546bd](https://github.com/duplicati/duplicati/commit/8a08b35546bd) (2026-01-28, PR #6732), where the argument **was** honoured, combined inline:
  ```csharp
  var fullPath = _path; if (!string.IsNullOrEmpty(path)) { var p = path.TrimStart('/'); … }
  ```
- Broken in [bb78aa57ae15](https://github.com/duplicati/duplicati/commit/bb78aa57ae15) (2026-01-29, commit 6 of the same PR, "More work on Box paths"), which replaced that block with the new `GetAbsolutePath` helper and substituted `_path` for `path`.

So the argument has never been honoured in any merged state, and `sl blame` attributes only that one line to the later commit.

## The fix

```csharp
var parts = GetAbsolutePath(path).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
```

The rest of the method already assumes this: `parts.Length == 0` then means "the root was requested", `parentPath`/`name` split the requested path, `FolderMissingException` and a missing child both yield `null`, and `ParseEntry` already sets `IsFolder` and the trailing separator the interface asks for. It also makes the method symmetric with its sibling `ListAsync(string? path, …)`, which already does `GetAbsolutePath(path)`.

For reference, Box was the only one of the nine `IFolderEnabledBackend.GetEntryAsync` implementations that ignored the argument — `GoogleDrive.cs:204` has the identical helper and the identical structure and does `var fullPath = GetAbsolutePath(path);`.

## Verification

New offline tests in `Duplicati/UnitTest/BoxEntryLookupTests.cs` driving the backend against a stubbed `HttpMessageHandler` (the OAuth endpoint is stubbed too and points at an unresolvable host, so no request can escape).

| Test | Before this change |
|---|---|
| `RequestedFolderIsReturned` | fails — `null` |
| `RequestedFileIsReturned` | fails — `null` |
| `ConfiguredFolderIsReturnedForAnEmptyPath` | fails — `null`, which is what makes browsing report "Folder does not exist" |
| `RequestedFolderIsReturnedForABackendAtTheRoot` | fails — returns the root entry: `Expected: "child/" But was: <string.Empty>` |
| `MissingEntryIsReportedAsMissing` | passes before and after (guard: missing stays `null`, not an error) |

`Category=Backend` is green locally on Windows/net10.0. I have no Box account, so the live `Box.com Tests` job is the only end-to-end check; the evidence here is the layer-level red→green plus the paths above.

**Overlap with #7099**: this PR contains the same test seam as [#7099](https://github.com/duplicati/duplicati/pull/7099) — an `internal` `BoxBackend` constructor taking an `HttpClient` (the base `OAuthHelperHttpClient` already accepts one), the `BoxHelper` parameter, and `InternalsVisibleTo`. The edits are byte-identical in both branches so they merge as the same change, the test files have different names, and the one-word fix here is in a different part of the file from #7099's changes. If #7099 lands first, this PR reduces to that one word plus the tests. The public two-argument and parameterless constructors are untouched, since `BackendLoader` creates backends via `Activator.CreateInstance(type, url, options)`.

## Out of scope

`Idrivee2Backend.cs:280` and `SSHv2Backend.cs:649` implement `GetEntryAsync` as `Task.FromResult<IFileEntry?>(null)`, so browsing a remote source on those backends always reports the entry as missing. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
