### PR TITLE
Treat an existing folder as success when auto-creating a destination

### DIFF
--- a/Duplicati/UnitTest/FolderExistsBackend.cs
+++ b/Duplicati/UnitTest/FolderExistsBackend.cs
@@ -1,0 +1,111 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// A test backend that reports the folder as missing, and then reports that the
+    /// folder already existed when it is asked to create it. That is what a backend
+    /// does when the folder appears between the test and the create, and what the
+    /// file and Dropbox backends do whenever their existence check and their create
+    /// disagree. Used to check that creating a destination folder that is already
+    /// there is treated as the desired outcome.
+    /// </summary>
+    public class FolderExistsBackend : IBackend
+    {
+        /// <summary>
+        /// The number of times a folder creation was requested, across all instances
+        /// </summary>
+        public static int CreateFolderCalls;
+
+        /// <summary>
+        /// True once the folder has been reported as already existing
+        /// </summary>
+        private bool m_folderReported;
+
+        public FolderExistsBackend()
+        {
+        }
+
+        // ReSharper disable once UnusedMember.Global
+        public FolderExistsBackend(string url, Dictionary<string, string> options)
+        {
+        }
+
+        /// <summary>
+        /// Forgets the recorded folder creations
+        /// </summary>
+        public static void Reset()
+            => CreateFolderCalls = 0;
+
+        public Task TestAsync(bool alsoWrite, CancellationToken cancellationToken)
+        {
+            if (!m_folderReported)
+                throw new FolderMissingException();
+
+            return Task.CompletedTask;
+        }
+
+        public Task CreateFolderAsync(CancellationToken cancellationToken)
+        {
+            CreateFolderCalls++;
+            m_folderReported = true;
+            throw new FolderAreadyExistedException();
+        }
+
+        public IAsyncEnumerable<IFileEntry> ListAsync(CancellationToken cancellationToken)
+            => EmptyListAsync();
+
+        private static async IAsyncEnumerable<IFileEntry> EmptyListAsync()
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+            yield break;
+        }
+
+        public Task PutAsync(string remotename, string filename, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task GetAsync(string remotename, string filename, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken)
+            => Task.FromResult(Array.Empty<string>());
+
+        public string DisplayName => "Existing Folder Backend";
+        public string ProtocolKey => "folderexists";
+        public string Description => "A testing backend that reports the folder as already existing";
+
+        public IList<ICommandLineArgument> SupportedCommands => new List<ICommandLineArgument>();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Duplicati/UnitTest/ServerApiIntegrationTests.cs
+++ b/Duplicati/UnitTest/ServerApiIntegrationTests.cs
@@ -37,6 +37,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Common.IO;
+using Duplicati.Library.DynamicLoader;
 using Duplicati.Server;
 using Duplicati.WebserverCore.Dto.V2;
 using Duplicati.WebserverCore.Endpoints.V1.Backup;
@@ -288,6 +289,83 @@ public class ServerApiIntegrationTests : BasicSetupHelper
                 .Any(entryPath => string.Equals(entryPath, expectedRoot, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
 
             Assert.That(rootFound, Is.True, "list-folder root listing should include the original data folder");
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// A destination folder that is already there is the desired outcome of an
+    /// automatic creation, the way the backend manager treats it. These tests use a
+    /// backend that reports the folder as missing and then reports it as already
+    /// existing, which is what happens when the folder appears between the test and
+    /// the create.
+    /// </summary>
+    [Test]
+    [Category("Integration")]
+    public async Task DestinationAutoCreateAcceptsExistingFolder_Async()
+    {
+        FolderExistsBackend.Reset();
+        BackendLoader.AddBackend(new FolderExistsBackend());
+
+        await WithAuthenticatedServerAsync(async httpClient =>
+        {
+            var response = await httpClient.PostAsJsonAsync(
+                "/api/v1/remoteoperation/test?autocreate=true",
+                new { path = "folderexists://existing" },
+                JsonOptions).ConfigureAwait(false);
+
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            Assert.That(response.IsSuccessStatusCode, Is.True,
+                $"Testing a destination that is already there should succeed; got {(int)response.StatusCode}: {body}");
+            Assert.That(FolderExistsBackend.CreateFolderCalls, Is.EqualTo(1), "The folder should have been created once");
+        }).ConfigureAwait(false);
+    }
+
+    [Test]
+    [Category("Integration")]
+    public async Task DestinationAutoCreateAcceptsExistingFolderV2_Async()
+    {
+        FolderExistsBackend.Reset();
+        BackendLoader.AddBackend(new FolderExistsBackend());
+
+        await WithAuthenticatedServerAsync(async httpClient =>
+        {
+            var request = new DestinationTestRequestDto
+            {
+                DestinationUrl = "folderexists://existing",
+                Options = new Dictionary<string, string>(),
+                AutoCreate = true
+            };
+
+            var response = await httpClient.PostAsJsonAsync("/api/v2/destination/test", request, JsonOptions).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var result = await response.Content.ReadFromJsonAsync<DestinationTestResponseDto>(JsonOptions).ConfigureAwait(false)
+                         ?? throw new InvalidOperationException("destination/test response was empty");
+
+            Assert.That(result.Success, Is.True, $"Testing a destination that is already there should succeed; got {result.StatusCode}: {result.Error}");
+            Assert.That(result.StatusCode, Is.EqualTo("OK"));
+            // The client reads the folder state from the payload, so the test has to
+            // continue after the folder was reported as existing
+            Assert.That(result.Data, Is.Not.Null, "The folder state should be reported");
+            Assert.That(result.Data!.FolderExists, Is.True);
+        }).ConfigureAwait(false);
+    }
+
+    [Test]
+    [Category("Integration")]
+    public async Task DestinationTestDoesNotCreateWhenReadOnly_Async()
+    {
+        FolderExistsBackend.Reset();
+        BackendLoader.AddBackend(new FolderExistsBackend());
+
+        await WithAuthenticatedServerAsync(async httpClient =>
+        {
+            var response = await httpClient.PostAsJsonAsync(
+                "/api/v1/remoteoperation/test?autocreate=true&readOnlyTest=true",
+                new { path = "folderexists://existing" },
+                JsonOptions).ConfigureAwait(false);
+
+            Assert.That(response.IsSuccessStatusCode, Is.False, "A read-only test of a missing folder should fail");
+            Assert.That(FolderExistsBackend.CreateFolderCalls, Is.EqualTo(0), "A read-only test should not create anything");
         }).ConfigureAwait(false);
     }
 

--- a/Duplicati/WebserverCore/Endpoints/V1/RemoteOperation.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/RemoteOperation.cs
@@ -81,7 +81,15 @@ namespace Duplicati.WebserverCore.Endpoints.V1
                             if (!autoCreate || readOnlyTest)
                                 throw;
 
-                            await b.CreateFolderAsync(cancelToken).ConfigureAwait(false);
+                            try
+                            {
+                                await b.CreateFolderAsync(cancelToken).ConfigureAwait(false);
+                            }
+                            catch (FolderAreadyExistedException)
+                            {
+                                // The folder is already there, which is the desired outcome
+                            }
+
                             await b.TestAsync(!readOnlyTest, cancelToken).ConfigureAwait(false);
                         }
                     }

--- a/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/DestinationVerify.cs
@@ -83,7 +83,15 @@ public class DestinationVerify : IEndpointV2
                         if (!input.AutoCreate || input.ReadOnlyTest)
                             throw;
 
-                        await b.CreateFolderAsync(cancelToken).ConfigureAwait(false);
+                        try
+                        {
+                            await b.CreateFolderAsync(cancelToken).ConfigureAwait(false);
+                        }
+                        catch (FolderAreadyExistedException)
+                        {
+                            // The folder is already there, which is the desired outcome
+                        }
+
                         await b.TestAsync(!input.ReadOnlyTest, cancelToken).ConfigureAwait(false);
                     }
 


### PR DESCRIPTION
## What this fixes

The backend manager documents "the folder already exists" as the desired outcome of ensuring a folder — `Duplicati/Library/Main/Backend/BackendManager.CreateFolderOperation.cs:45-52`:

```csharp
catch (FolderAreadyExistedException)
{
    // The folder already exists, which is the desired outcome of "ensure".
}
```

The web API's automatic folder creation does the opposite: it lets the exception through, so a destination whose folder is already there is reported as a failed test, and the follow-up `TestAsync` right after the create never runs. No existing issue covers this, so this PR doubles as the report.

Captured from the new tests, before the change:

| endpoint | response |
|---|---|
| `POST /api/v1/remoteoperation/test?autocreate=true` | `500` `{"Error":"error-id:FolderAlreadyExists, user-information:<localized message>","Code":500}` |
| `POST /api/v2/destination/test` with `AutoCreate: true` | `200` `{"Success":false,"StatusCode":"FolderAlreadyExists","Data":null}` |

## Honest scope note

The automatic creation only runs after `TestAsync` reported `FolderMissingException`, so reaching the already-exists case needs the existence check and the create to disagree — the folder appearing in between, or a backend that is case-insensitive about names. The two backends that raise it are `FileBackend.cs:522` and `Dropbox.cs:230`. So this is a **contract inconsistency between the two halves of the codebase** rather than a frequently hit bug; I would not claim more than that.

The explicit `POST /api/v1/remoteoperation/create` is deliberately **left as is**: the file-browser's "Create folder" button posts there with a user-typed name, and reporting that the name is taken is the right answer for an explicit create.

## The fix

The `CreateFolderAsync` call in both auto-create paths gets a narrow catch, mirroring `CreateFolderOperation`:

```csharp
try
{
    await b.CreateFolderAsync(cancelToken).ConfigureAwait(false);
}
catch (FolderAreadyExistedException)
{
    // The folder is already there, which is the desired outcome
}

await b.TestAsync(!readOnlyTest, cancelToken).ConfigureAwait(false);
```

Two details worth flagging:

- **The existing `TestAsync` after the create now actually runs.** That matters for the v2 response: the web UI computes `anyFilesFound: !res.Data?.FolderIsEmpty`, so a bare `Success: true` with `Data: null` would make it warn "The remote destination is not empty". Letting the verification continue populates `Data` as usual, and one of the new tests asserts that.
- **`SharedRemoteOperation.GetInnerException<T>` is not used here.** It throws `ArgumentNullException` when there is no match and no inner exception (`SharedRemoteOperation.cs:147-161`), which only appears to work in the existing `catch … when` filters because the CLR treats an exception inside a filter as "no match". A plain `catch` is the honest mirror of `CreateFolderOperation`, and both throw sites use the parameterless constructor, so there is no inner exception to unwrap.

No client change is needed: the ngclient has no handling for this error id or message (checked both the source and the shipped bundle), so today it lands in the generic error path — a global toast plus an "Error creating folder" dialog, with the destination test left in `generic-error`, which gates Save/Continue. Once the server reports success, the existing success paths take over unchanged.

## Verification

These endpoints had no test coverage at all. The new tests go into `Duplicati/UnitTest/ServerApiIntegrationTests.cs`, reusing its existing harness (a real server started in-process on a free port, `POST /api/v1/auth/login` for the bearer token, plain `HttpClient`).

Because the disagreement between the check and the create is a race, it is made deterministic with a small test backend, `Duplicati/UnitTest/FolderExistsBackend.cs`, registered through `BackendLoader.AddBackend` the way `NonFolderBackend` and `DeterministicErrorBackend` already are: it reports the folder as missing, raises `FolderAreadyExistedException` when asked to create it, and reports the folder as present afterwards. It uses its own protocol key, so no existing backend is affected.

| Test | Before this change |
|---|---|
| `DestinationAutoCreateAcceptsExistingFolder_Async` | fails — `500 error-id:FolderAlreadyExists` |
| `DestinationAutoCreateAcceptsExistingFolderV2_Async` | fails — `Success:false`, `StatusCode:"FolderAlreadyExists"`; after the fix `StatusCode:"OK"` **and `Data.FolderExists == true`** |
| `DestinationTestDoesNotCreateWhenReadOnly_Async` | passes before and after (guard: a read-only test still creates nothing) |

Run with `--filter "FullyQualifiedName~DestinationAutoCreate|FullyQualifiedName~DestinationTestDoesNotCreate"`; they are `Category=Integration`, like the rest of that file.

## Adjacent, not touched here

- `Duplicati/CommandLine/BackendTester/Program.cs:189` does the same unguarded auto-create, so an already-existing folder there is reported as `FolderMissingException` — the same "it exists but we say it does not" shape as #7099.
- `SharedRemoteOperation.GetInnerException<T>` throwing instead of returning null (see above) is worth cleaning up on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
