### PR TITLE
Wait for a written secret to become readable in the AWS secret provider test

### DIFF
--- a/Duplicati/UnitTest/SecretProviderSetSecretTests.cs
+++ b/Duplicati/UnitTest/SecretProviderSetSecretTests.cs
@@ -105,7 +105,11 @@ public class SecretProviderSetSecretTests
         var secretName = queryParams["secrets"];
 
         AmazonSecretsManagerClient? cleanupClient = null;
-        string createdSecretId = string.Empty;
+        // The keys written through the provider are stored inside the configured
+        // secret, while the direct lookup test creates a secret of its own, so both
+        // have to be cleaned up separately
+        var createdSecretIds = new List<string>();
+        string? containerKey = null;
 
         try
         {
@@ -115,13 +119,13 @@ public class SecretProviderSetSecretTests
             await provider.InitializeAsync(uri, CancellationToken.None);
 
             var key = $"duplicati-aws-{Guid.NewGuid():N}";
-            createdSecretId = key;
+            containerKey = key;
 
             await provider.SetSecretAsync(key, "value1", overwrite: false, CancellationToken.None);
-            var secrets = await provider.ResolveSecretsAsync(new[] { key }, CancellationToken.None);
+            var secrets = await ResolveSecretWithRetryAsync(provider, key, "value1");
             Assert.AreEqual("value1", secrets[key]);
 
-            NUnit.Framework.Assert.ThrowsAsync<UserInformationException>(() => provider.SetSecretAsync(key, "value2", overwrite: false, CancellationToken.None));
+            await AssertSetSecretRejectsExistingKeyAsync(provider, key, "value2");
 
             await provider.SetSecretAsync(key, "value3", overwrite: true, CancellationToken.None);
             var updated = await ResolveSecretWithRetryAsync(provider, key, "value3");
@@ -129,7 +133,7 @@ public class SecretProviderSetSecretTests
 
             // Verify direct-secret lookup path and missing-key behavior in AWSSecretProvider.ResolveSecretsAsync.
             var directSecretId = $"duplicati-aws-direct-{Guid.NewGuid():N}";
-            createdSecretId = directSecretId;
+            createdSecretIds.Add(directSecretId);
 
             await cleanupClient.CreateSecretAsync(new Amazon.SecretsManager.Model.CreateSecretRequest
             {
@@ -137,7 +141,7 @@ public class SecretProviderSetSecretTests
                 SecretString = "direct-value"
             }).ConfigureAwait(false);
 
-            var directSecrets = await provider.ResolveSecretsAsync(new[] { directSecretId }, CancellationToken.None);
+            var directSecrets = await ResolveSecretWithRetryAsync(provider, directSecretId, "direct-value");
             Assert.AreEqual("direct-value", directSecrets[directSecretId]);
 
             NUnit.Framework.Assert.ThrowsAsync<KeyNotFoundException>(() =>
@@ -147,13 +151,13 @@ public class SecretProviderSetSecretTests
         {
             if (cleanupClient != null)
             {
-                if (!string.IsNullOrEmpty(createdSecretId))
+                foreach (var secretId in createdSecretIds)
                 {
                     try
                     {
                         await cleanupClient.DeleteSecretAsync(new Amazon.SecretsManager.Model.DeleteSecretRequest
                         {
-                            SecretId = createdSecretId,
+                            SecretId = secretId,
                             ForceDeleteWithoutRecovery = true
                         }).ConfigureAwait(false);
                     }
@@ -162,8 +166,47 @@ public class SecretProviderSetSecretTests
                     }
                 }
 
+                if (containerKey != null)
+                    await RemoveKeyFromContainerSecretAsync(cleanupClient, secretName, containerKey).ConfigureAwait(false);
+
                 cleanupClient.Dispose();
             }
+        }
+    }
+
+    /// <summary>
+    /// Removes a single key from the secret that the provider stores its keys in, so
+    /// the test keys do not pile up in it
+    /// </summary>
+    /// <param name="client">The client to use</param>
+    /// <param name="secrets">The configured secrets, of which the first one is used as the store</param>
+    /// <param name="key">The key to remove</param>
+    private static async Task RemoveKeyFromContainerSecretAsync(AmazonSecretsManagerClient client, string secrets, string key)
+    {
+        var containerSecretId = secrets.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(containerSecretId))
+            return;
+
+        try
+        {
+            var current = await client.GetSecretValueAsync(new GetSecretValueRequest { SecretId = containerSecretId }).ConfigureAwait(false);
+            var values = string.IsNullOrWhiteSpace(current.SecretString)
+                ? null
+                : JsonSerializer.Deserialize<Dictionary<string, string>>(current.SecretString);
+
+            if (values == null || !values.Remove(key))
+                return;
+
+            await client.PutSecretValueAsync(new PutSecretValueRequest
+            {
+                SecretId = containerSecretId,
+                SecretString = JsonSerializer.Serialize(values)
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Cleaning up must not turn a passing test into a failing one
+            Console.WriteLine($"Failed to remove the test key from the secret store: {ex.Message}");
         }
     }
 
@@ -338,24 +381,166 @@ public class SecretProviderSetSecretTests
         }
     }
 
-    private static async Task<IDictionary<string, string>> ResolveSecretWithRetryAsync(ISecretProvider provider, string key, string expected)
+    /// <summary>
+    /// A provider that reports a written secret as missing for the first reads, the
+    /// way a service that is not immediately consistent behaves
+    /// </summary>
+    private sealed class DelayedVisibilitySecretProvider : ISecretProvider
     {
-        var delays = new[]
+        /// <summary>
+        /// The number of attempts that report a stored secret as still missing
+        /// </summary>
+        private readonly int _staleAttempts;
+        private readonly Dictionary<string, string> _stored = new();
+        private int _staleReads;
+        private int _staleChecks;
+
+        public DelayedVisibilitySecretProvider(int staleAttempts)
+            => _staleAttempts = staleAttempts;
+
+        public Task<Dictionary<string, string>> ResolveSecretsAsync(IEnumerable<string> keys, CancellationToken cancellationToken)
         {
-            TimeSpan.Zero,
-            TimeSpan.FromSeconds(1),
-            TimeSpan.FromSeconds(5),
-            TimeSpan.FromSeconds(10)
-        };
+            var result = new Dictionary<string, string>();
+            var missing = new List<string>();
 
-        IDictionary<string, string>? secrets = null;
+            foreach (var key in keys)
+            {
+                if (_stored.TryGetValue(key, out var value) && _staleReads++ >= _staleAttempts)
+                    result[key] = value;
+                else
+                    missing.Add(key);
+            }
 
-        foreach (var delay in delays)
+            if (missing.Count > 0)
+                throw new KeyNotFoundException("The following keys were not found: " + string.Join(", ", missing));
+
+            return Task.FromResult(result);
+        }
+
+        public Task SetSecretAsync(string key, string value, bool overwrite, CancellationToken cancellationToken)
+        {
+            // The existence check reads the stored values, so it can miss a secret
+            // that was just written, the same way the read does
+            if (!overwrite && _stored.ContainsKey(key) && _staleChecks++ >= _staleAttempts)
+                throw new UserInformationException($"The key '{key}' already exists", "KeyAlreadyExists");
+
+            _stored[key] = value;
+            return Task.CompletedTask;
+        }
+
+        public Task InitializeAsync(Uri config, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<bool> IsSupported(CancellationToken cancellationToken) => Task.FromResult(true);
+        public bool IsSetSupported => true;
+        public string Key => "delayed";
+        public string DisplayName => "Delayed visibility provider";
+        public string Description => "A provider that becomes readable only after a number of reads";
+        public IList<ICommandLineArgument> SupportedCommands => new List<ICommandLineArgument>();
+    }
+
+    [Test]
+    public async Task ResolveSecretWithRetry_WaitsForADelayedSecret_Async()
+    {
+        // A write is not guaranteed to be visible to the next read, and the read
+        // reports a missing key by throwing
+        var provider = new DelayedVisibilitySecretProvider(staleAttempts: 1);
+        await provider.SetSecretAsync("alpha", "bravo", overwrite: false, CancellationToken.None);
+
+        var secrets = await ResolveSecretWithRetryAsync(provider, "alpha", "bravo");
+
+        Assert.AreEqual("bravo", secrets["alpha"]);
+    }
+
+    [Test]
+    public async Task ResolveSecretWithRetry_ReportsASecretThatNeverAppears_Async()
+    {
+        // A key that is genuinely absent must still fail, not be reported as empty
+        var provider = new DelayedVisibilitySecretProvider(staleAttempts: int.MaxValue);
+        var noDelays = new[] { TimeSpan.Zero, TimeSpan.Zero };
+
+        Assert.ThrowsAsync<KeyNotFoundException>(() => ResolveSecretWithRetryAsync(provider, "alpha", "bravo", noDelays));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task SetSecretRejectsExistingKey_WaitsForTheWriteToBeVisible_Async()
+    {
+        // The duplicate check reads the stored values, so it can miss a key that
+        // was just written
+        var provider = new DelayedVisibilitySecretProvider(staleAttempts: 1);
+        await provider.SetSecretAsync("alpha", "bravo", overwrite: false, CancellationToken.None);
+
+        await AssertSetSecretRejectsExistingKeyAsync(provider, "alpha", "charlie");
+    }
+
+    /// <summary>
+    /// The delays to use while waiting for a written secret to become readable
+    /// </summary>
+    private static readonly TimeSpan[] ConsistencyDelays =
+    [
+        TimeSpan.Zero,
+        TimeSpan.FromSeconds(1),
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(10)
+    ];
+
+    /// <summary>
+    /// Checks that writing to an existing key is rejected. The existence check reads
+    /// the stored secrets, so it can miss a key that was just written; a write that
+    /// slips through is harmless here, as the callers overwrite the value afterwards.
+    /// </summary>
+    /// <param name="provider">The provider to write to</param>
+    /// <param name="key">The key that already exists</param>
+    /// <param name="value">The value to attempt to write</param>
+    /// <param name="delays">The delays to use, or null to use the defaults</param>
+    private static async Task AssertSetSecretRejectsExistingKeyAsync(ISecretProvider provider, string key, string value, TimeSpan[]? delays = null)
+    {
+        foreach (var delay in delays ?? ConsistencyDelays)
         {
             if (delay > TimeSpan.Zero)
                 await Task.Delay(delay).ConfigureAwait(false);
 
-            secrets = await provider.ResolveSecretsAsync(new[] { key }, CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                await provider.SetSecretAsync(key, value, overwrite: false, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (UserInformationException)
+            {
+                return;
+            }
+        }
+
+        NUnit.Framework.Assert.Fail($"Writing to the existing key '{key}' should have been rejected");
+    }
+
+    /// <summary>
+    /// Reads a secret, waiting for it to become readable, as a write is not
+    /// guaranteed to be visible to the next read
+    /// </summary>
+    /// <param name="provider">The provider to read from</param>
+    /// <param name="key">The key to read</param>
+    /// <param name="expected">The value to wait for</param>
+    /// <param name="delays">The delays to use, or null to use the defaults</param>
+    /// <returns>The resolved secrets</returns>
+    private static async Task<IDictionary<string, string>> ResolveSecretWithRetryAsync(ISecretProvider provider, string key, string expected, TimeSpan[]? delays = null)
+    {
+        var schedule = delays ?? ConsistencyDelays;
+        IDictionary<string, string>? secrets = null;
+
+        for (var i = 0; i < schedule.Length; i++)
+        {
+            if (schedule[i] > TimeSpan.Zero)
+                await Task.Delay(schedule[i]).ConfigureAwait(false);
+
+            try
+            {
+                secrets = await provider.ResolveSecretsAsync(new[] { key }, CancellationToken.None).ConfigureAwait(false);
+            }
+            // A key that is not readable yet is reported as missing; on the last
+            // attempt the error is passed on, so a key that is really absent fails
+            catch (KeyNotFoundException) when (i < schedule.Length - 1)
+            {
+                continue;
+            }
 
             if (secrets.TryGetValue(key, out var actual) && actual == expected)
                 break;


### PR DESCRIPTION
## What this fixes

`AwsProvider_SetSecret_Works_Async` fails intermittently, and it is currently red on unrelated pull requests — for example on #7106, which changes only `help.txt`. There is no issue tracking it, so this PR doubles as the report.

The three failures I could look at came from two runs of the Secret Provider workflow, and they hit a **different OS each time**, which rules out anything OS-specific:

| run | OS | failure |
|---|---|---|
| 30430277329 | macos | `KeyNotFoundException : The following keys were not found: duplicati-aws-ef49da…` |
| 30430616772 | ubuntu | `KeyNotFoundException : The following keys were not found: duplicati-aws-7be60…` |
| 30430616772 | windows | `Assert.That(caughtException, expression) Expected: <UserInformationException>` |

## Why

`AWSSecretProvider.SetSecretAsync` keeps all keys inside one configured secret and updates it read-modify-write (`GetSecretValue` → edit the JSON → `PutSecretValue`), and the duplicate check at `AWSSecretProvider.cs:362` (`if (!overwrite && values.ContainsKey(key))`) is based on that same read. AWS Secrets Manager does not guarantee that a write is visible to the next read, so when the read returns the previous version:

- the read path finds the key neither in the store nor as a secret of its own → `KeyNotFoundException` (the two `KeyNotFoundException` failures, at the read right after the write)
- the write path concludes the key does not exist yet and stores it instead of rejecting it → the expected `UserInformationException` never arrives (the windows failure)

**The provider itself is fine.** `SetSecretAsync` just calls `PutSecretValueAsync`/`CreateSecretAsync` with no version-stage handling, so nothing is written to the wrong place — the test simply assumes a read-your-writes guarantee that the service does not give.

Parallelism is not involved: the matrix uses `max-parallel: 1` and the workflow holds `concurrency: duplicati-ci-secretprovidertests` with `cancel-in-progress: false`, so the jobs and the runs are serialized. No lost update is possible.

Worth noting that the test file already contains the countermeasure — `ResolveSecretWithRetryAsync`, with delays of 0/1/5/10 s — but it is used at only **one** of the read points in each of the four remote-provider tests (the `value3` read). The two points that failed use the plain calls. And the helper as written could not have saved them anyway: `ResolveSecretsAsync` reports a missing key by *throwing*, which escaped the loop on the first attempt instead of retrying.

## The change

Test-only; no production code is touched.

- `ResolveSecretWithRetryAsync` now treats `KeyNotFoundException` as "not readable yet" and retries, while letting the error through on the final attempt so a key that is genuinely absent still fails. The delay schedule is now shared and can be overridden, which keeps the new offline tests fast.
- The read right after the write, and the read after the raw `CreateSecretAsync` in the direct-lookup part, go through that helper.
- The duplicate check is wrapped in `AssertSetSecretRejectsExistingKeyAsync`, which retries until the write becomes visible to the existence check. If a write slips through in the meantime that is harmless, because the following step overwrites the value anyway.
- Cleanup: `createdSecretId` was reassigned before the second secret was created, so only one of the two was ever deleted, and the key written through the provider was never removed from the store — every run left one behind. The two are now tracked separately, and the test key is removed from the store it was written to (only that key; failures there are logged, never fail the test). This also puts the `secretName` variable, parsed but unused until now, to use.

Only the AWS test is changed. The other three remote-provider tests have the same unprotected shape, but they create one secret per key instead of updating a shared one, so they are far less exposed — and the one GCS failure in these runs was `RpcException Status(Unavailable, "502:Bad Gateway")`, a transient service error that this change would not address. Extending the same treatment there is easy if they turn out to flake.

## Verification

The provider tests need `DUPLICATI_TEST_AWSSM_URL` and are skipped without it, so **the AWS path itself can only be exercised in CI** — I have no AWS account for it. What I could verify locally is the retry logic, with a fake `ISecretProvider` that reports a stored secret as missing for the first attempts, the way a service that is not immediately consistent behaves:

| test | before this change |
|---|---|
| `ResolveSecretWithRetry_WaitsForADelayedSecret_Async` | fails — the first `KeyNotFoundException` escapes the retry loop |
| `SetSecretRejectsExistingKey_WaitsForTheWriteToBeVisible_Async` | fails — `Expected: <UserInformationException> But was: null` |
| `ResolveSecretWithRetry_ReportsASecretThatNeverAppears_Async` | passes before and after (guard: a key that never appears still throws) |
| `FileProvider_SetSecret_WritesToFile_Async` | passes before and after (existing test, no credentials needed) |

Run with `--filter "FullyQualifiedName~SecretProviderSetSecret"`; the five credential-dependent tests report as skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
