### PR TITLE
Accept an already deleted file when cleaning the remote folder

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -206,7 +206,7 @@ namespace Duplicati.CommandLine.BackendTester
                             if (Library.Utility.Utility.ParseBoolOption(options, "force"))
                             {
                                 Console.WriteLine($"{LogTimeStamp}Auto clean, removing file: {fe.Name}");
-                                Retry(() => backend.DeleteAsync(fe.Name, CancellationToken.None), retries).Await();
+                                DeleteListedFileAsync(backend, fe.Name, retries).Await();
                                 continue;
                             }
                             else
@@ -649,6 +649,28 @@ namespace Duplicati.CommandLine.BackendTester
 
             return filename;
         }
+
+        /// <summary>
+        /// Deletes a file that was reported by the listing, accepting that it may already be gone
+        /// </summary>
+        /// <param name="backend">The backend to delete from</param>
+        /// <param name="remotename">The name of the file to delete</param>
+        /// <param name="retries">The number of attempts to make</param>
+        /// <returns>An awaitable task</returns>
+        internal static Task DeleteListedFileAsync(IBackend backend, string remotename, int retries)
+            => Retry(async () =>
+            {
+                try
+                {
+                    await backend.DeleteAsync(remotename, CancellationToken.None);
+                }
+                catch (FileMissingException)
+                {
+                    // A listing can report a file that was just deleted, and removing
+                    // it is what this was for, so the file being gone is the result
+                    Console.WriteLine($"{LogTimeStamp}File was already gone: {remotename}");
+                }
+            }, retries);
 
         private static async Task<T> Retry<T>(Func<Task<T>> action, int retries)
         {

--- a/Duplicati/UnitTest/BackendTesterCleanupTests.cs
+++ b/Duplicati/UnitTest/BackendTesterCleanupTests.cs
@@ -1,0 +1,119 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.CommandLine.BackendTester;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Before testing, the backend tester removes the files that the remote folder
+    /// already holds. A listing can still report a file that was just deleted, and
+    /// deleting it again then reports it as missing, which used to abort the whole
+    /// test run.
+    /// </summary>
+    [TestFixture]
+    [Category("BackendTesterVerification")]
+    public class BackendTesterCleanupTests
+    {
+        /// <summary>
+        /// A backend that only supports deleting, with a replaceable outcome
+        /// </summary>
+        private sealed class DeletingBackend : IBackend
+        {
+            private readonly Func<string, Exception?> _onDelete;
+
+            public List<string> Deletes { get; } = new();
+
+            public DeletingBackend(Func<string, Exception?> onDelete)
+                => _onDelete = onDelete;
+
+            public Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+            {
+                Deletes.Add(remotename);
+                var error = _onDelete(remotename);
+                if (error != null)
+                    throw error;
+
+                return Task.CompletedTask;
+            }
+
+            public IAsyncEnumerable<IFileEntry> ListAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task PutAsync(string remotename, string filename, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task GetAsync(string remotename, string filename, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task TestAsync(bool alsoWrite, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task CreateFolderAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult(Array.Empty<string>());
+
+            public string DisplayName => "Deleting Backend";
+            public string ProtocolKey => "deleting";
+            public string Description => "A testing backend that only supports deleting";
+            public IList<ICommandLineArgument> SupportedCommands => new List<ICommandLineArgument>();
+
+            public void Dispose()
+            {
+            }
+        }
+
+        [Test]
+        public async Task ListedFileThatIsAlreadyGoneIsAccepted_Async()
+        {
+            // The file is gone, which is what removing it was supposed to achieve
+            using var backend = new DeletingBackend(_ => new FileMissingException());
+
+            await Program.DeleteListedFileAsync(backend, "already-gone.tmp", 3);
+
+            Assert.AreEqual(1, backend.Deletes.Count,
+                "A file that is already gone should not be attempted again");
+        }
+
+        [Test]
+        public void FailingDeleteIsStillReported_Async()
+        {
+            // Anything other than the file being gone is a real failure
+            using var backend = new DeletingBackend(_ => new IOException("connection reset"));
+
+            Assert.ThrowsAsync<IOException>(() => Program.DeleteListedFileAsync(backend, "locked.tmp", 2));
+
+            Assert.AreEqual(2, backend.Deletes.Count, "A failing delete should be retried");
+        }
+
+        [Test]
+        public async Task DeleteIsPerformedOnce_Async()
+        {
+            using var backend = new DeletingBackend(_ => null);
+
+            await Program.DeleteListedFileAsync(backend, "present.tmp", 3);
+
+            Assert.AreEqual(1, backend.Deletes.Count);
+            Assert.AreEqual("present.tmp", backend.Deletes[0]);
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

The backend tester aborts the whole run when the remote folder lists a file that has already been deleted. This is red right now on unrelated pull requests — for example on #7106, which changes only `help.txt`, where `pCloud Tests (macos-latest)` failed like this:

```
[08:53:39 617] Starting run no 0
[08:53:45 154] Auto clean, removing file: duplicati-access-privileges-test.tmp
[08:53:46 076] Operation failed with exception, 2 retries left, delaying retry for 1000 ms
[08:53:50 486] Unittest failed: Duplicati.Library.Interface.FileMissingException: duplicati-access-privileges-test.tmp
   at Duplicati.Library.Backend.pCloudBackend.GetFileId(…)   pCloudBackend.cs:507
   at Duplicati.Library.Backend.pCloudBackend.DeleteAsync(…) pCloudBackend.cs:393
   at Duplicati.CommandLine.BackendTester.Program.Retry(…)   Program.cs:678
   at Duplicati.CommandLine.BackendTester.Program.Run(…)     Program.cs:209
```

There is no issue tracking it, so this PR doubles as the report.

The file it fails on is the tester's own: `duplicati-access-privileges-test.tmp` is `BackendExtensions.TEST_FILE_NAME`, the probe file that `TestReadWritePermissionsAsync` writes, reads back and deletes. The tester runs that test first, so the sequence is:

1. `TestAsync(alsoWrite: true)` writes the probe file and deletes it again
2. seconds later, the listing that `--auto-clean` works from **still reports it**
3. auto-clean asks the backend to delete it, and the backend correctly answers that there is no such file
4. `Retry` tries three times, the file stays gone, and the exception leaves `Run()` and `Main` — so the whole tester exits on a file it had just deleted itself

## The change

The delete in the auto-clean path goes through a small helper that accepts the file already being gone:

```csharp
internal static Task DeleteListedFileAsync(IBackend backend, string remotename, int retries)
    => Retry(async () =>
    {
        try
        {
            await backend.DeleteAsync(remotename, CancellationToken.None);
        }
        catch (FileMissingException)
        {
            // A listing can report a file that was just deleted, and removing
            // it is what this was for, so the file being gone is the result
            Console.WriteLine($"{LogTimeStamp}File was already gone: {remotename}");
        }
    }, retries);
```

Catching inside the retried delegate also removes the pointless retry delays: the failing run above spent three attempts and 3 s on a file that was never coming back.

Only the auto-clean delete is changed. The other two places that remove files are already right, and deliberately so:

| place | today | why it stays |
|---|---|---|
| `Program.cs:209` auto-clean | unguarded — the exception ends the run | **fixed here.** These files were not uploaded by this run; the point is for them to be gone |
| `Program.cs:453` the delete loop | `catch (Exception)` → `failAfterFinished = true` + `*** Failed to delete file …` | these files *were* uploaded by this run, so a missing file is a real problem and has to stay reported |
| `Program.cs:467-485` the leftover check after deleting | re-reads the listing with backoff before reporting | already tolerates a listing that lags |

That split is the whole point: a file that this run did not create is *expected* to end up gone, while a file it did create going missing is a finding about the backend.

This is not a consequence of #7072 — the failing path is the unguarded delete, not the `failAfterFinished` reporting that PR added, and it has behaved this way for as long as auto-clean has existed.

## Verification

New tests in `Duplicati/UnitTest/BackendTesterCleanupTests.cs`, using the `InternalsVisibleTo` seam and the `[Category("BackendTesterVerification")]` category that the existing `BackendTesterVerificationTests` already use. A minimal `IBackend` records the delete attempts and decides what each one raises, so this is deterministic and needs no network.

| test | before this change |
|---|---|
| `ListedFileThatIsAlreadyGoneIsAccepted_Async` | fails — the `FileMissingException` is raised after three attempts and 3 s |
| `FailingDeleteIsStillReported_Async` | passes before and after (guard: an `IOException` is retried and then reported) |
| `DeleteIsPerformedOnce_Async` | passes before and after (guard: a normal delete is a single call) |

`Category=BackendTesterVerification` is green locally, including the existing verification tests. I have no pCloud account, so the live `pCloud Tests` job is the only end-to-end check; the evidence here is the CI log above plus the offline red→green.

## Related, not touched here

`BackendExtensions.TestReadWritePermissionsAsync` starts by listing the folder and deleting the probe file if it is there, and it deliberately lets `FileMissingException` through (`BackendExtensions.cs:86-88`, "Don't catch FolderMissingException or FileMissingException so we can pass those through to the caller"). The same stale listing can therefore fail a plain connection test, which is a product path rather than the test harness — worth a look on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
