### PR TITLE
Accept a missing probe file when testing a destination

### DIFF
--- a/Duplicati/Library/Utility/BackendExtensions.cs
+++ b/Duplicati/Library/Utility/BackendExtensions.cs
@@ -27,6 +27,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Localization.Short;
 
 namespace Duplicati.Library.Utility;
 
@@ -35,6 +36,11 @@ namespace Duplicati.Library.Utility;
 /// </summary>
 public static class BackendExtensions
 {
+    /// <summary>
+    /// The log tag for messages from this class
+    /// </summary>
+    private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(BackendExtensions));
+
     /// <summary>
     /// The test file name used to test access permissions
     /// </summary>
@@ -78,7 +84,16 @@ public static class BackendExtensions
                     continue;
 
                 connected = true;
-                await backend.DeleteAsync(TEST_FILE_NAME, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await backend.DeleteAsync(TEST_FILE_NAME, cancellationToken).ConfigureAwait(false);
+                }
+                catch (FileMissingException)
+                {
+                    // A listing can report a file that is already deleted, and this
+                    // step only needs the file to be gone
+                    Logging.Log.WriteInformationMessage(LOGTAG, "TestFileAlreadyGone", LC.L($"The listed file {TEST_FILE_NAME} was already gone"));
+                }
                 break;
             }
         }
@@ -148,6 +163,12 @@ public static class BackendExtensions
         try
         {
             await backend.DeleteAsync(TEST_FILE_NAME, cancellationToken).ConfigureAwait(false);
+        }
+        catch (FileMissingException)
+        {
+            // A file that was just written is not always addressable right away, and
+            // the file being gone is what the cleanup is for
+            Logging.Log.WriteInformationMessage(LOGTAG, "TestFileAlreadyGone", LC.L($"The file {TEST_FILE_NAME} was already gone when cleaning up"));
         }
         catch (Exception e)
         {

--- a/Duplicati/UnitTest/BackendTestPermissionsTests.cs
+++ b/Duplicati/UnitTest/BackendTestPermissionsTests.cs
@@ -1,0 +1,184 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Common.IO;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Testing a destination writes a probe file, reads it back and removes it again.
+    /// A listing can report a file that is already deleted, and a file that was just
+    /// written is not always immediately addressable, so either delete of the probe
+    /// file can report the file as missing. That used to fail the whole test, which
+    /// is what the user sees when testing a destination.
+    /// </summary>
+    [TestFixture]
+    public class BackendTestPermissionsTests
+    {
+        /// <summary>
+        /// A backend that keeps the written files in memory, with replaceable listing
+        /// and delete behavior
+        /// </summary>
+        private sealed class ProbeFileBackend : IBackend
+        {
+            private readonly Dictionary<string, string> _stored = new();
+
+            /// <summary>
+            /// The names to report from the listing
+            /// </summary>
+            public List<string> Listing { get; set; } = new();
+
+            /// <summary>
+            /// The error to raise for the given delete attempt number, if any
+            /// </summary>
+            public Func<int, Exception?> OnDelete { get; set; } = _ => null;
+
+            /// <summary>
+            /// The error to raise when listing, if any
+            /// </summary>
+            public Func<Exception?> OnList { get; set; } = () => null;
+
+            public int Deletes { get; private set; }
+
+            public async IAsyncEnumerable<IFileEntry> ListAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                var error = OnList();
+                if (error != null)
+                    throw error;
+
+                await Task.CompletedTask.ConfigureAwait(false);
+                foreach (var name in Listing)
+                    yield return new FileEntry(name);
+            }
+
+            public Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+            {
+                Deletes++;
+                var error = OnDelete(Deletes);
+                if (error != null)
+                    throw error;
+
+                _stored.Remove(remotename);
+                return Task.CompletedTask;
+            }
+
+            public Task PutAsync(string remotename, string filename, CancellationToken cancellationToken)
+            {
+                _stored[remotename] = File.ReadAllText(filename);
+                return Task.CompletedTask;
+            }
+
+            public Task GetAsync(string remotename, string filename, CancellationToken cancellationToken)
+            {
+                if (!_stored.TryGetValue(remotename, out var content))
+                    throw new FileMissingException();
+
+                File.WriteAllText(filename, content);
+                return Task.CompletedTask;
+            }
+
+            public Task TestAsync(bool alsoWrite, CancellationToken cancellationToken)
+                => this.TestBackendAsync(alsoWrite, cancellationToken);
+
+            public Task CreateFolderAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult(Array.Empty<string>());
+
+            public string DisplayName => "Probe File Backend";
+            public string ProtocolKey => "probefile";
+            public string Description => "A testing backend that keeps files in memory";
+            public IList<ICommandLineArgument> SupportedCommands => new List<ICommandLineArgument>();
+
+            public void Dispose()
+            {
+            }
+        }
+
+        [Test]
+        [Category("Backend")]
+        public async Task StaleListingEntryDoesNotFailTheTest_Async()
+        {
+            // The listing still reports the probe file from an earlier test, but it is
+            // already gone by the time it is removed
+            using var backend = new ProbeFileBackend
+            {
+                Listing = { BackendExtensions.TEST_FILE_NAME },
+                OnDelete = attempt => attempt == 1 ? new FileMissingException() : null
+            };
+
+            await backend.TestReadWritePermissionsAsync(CancellationToken.None);
+
+            Assert.AreEqual(2, backend.Deletes, "Both the initial removal and the cleanup should be attempted");
+        }
+
+        [Test]
+        [Category("Backend")]
+        public async Task MissingProbeFileOnCleanupDoesNotFailTheTest_Async()
+        {
+            // The probe file was written and read back, but is no longer addressable
+            // when it is removed again
+            using var backend = new ProbeFileBackend
+            {
+                OnDelete = _ => new FileMissingException()
+            };
+
+            await backend.TestReadWritePermissionsAsync(CancellationToken.None);
+
+            Assert.AreEqual(1, backend.Deletes, "Only the cleanup should be attempted when the listing is empty");
+        }
+
+        [Test]
+        [Category("Backend")]
+        public void MissingFolderIsStillReported_Async()
+        {
+            // The auto-create flow keys on this exception, so it has to pass through
+            using var backend = new ProbeFileBackend
+            {
+                OnList = () => new FolderMissingException()
+            };
+
+            Assert.ThrowsAsync<FolderMissingException>(() => backend.TestReadWritePermissionsAsync(CancellationToken.None));
+        }
+
+        [Test]
+        [Category("Backend")]
+        public void FailingCleanupIsStillReported_Async()
+        {
+            // A delete that fails for any other reason is a real problem
+            using var backend = new ProbeFileBackend
+            {
+                OnDelete = _ => new IOException("connection reset")
+            };
+
+            Assert.ThrowsAsync<TestAfterConnectException>(() => backend.TestReadWritePermissionsAsync(CancellationToken.None));
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

Testing a destination writes a probe file (`duplicati-access-privileges-test.tmp`), reads it back and removes it again. Both of the deletes fail the whole test if the backend answers that the file is not there — which happens when a listing still reports a file that was already deleted, or when a file that was just written is not addressable yet. No issue tracks this, so this PR doubles as the report.

`BackendExtensions.TestReadWritePermissionsAsync` has two delete calls, and neither tolerates it:

| where | today | what the user gets |
|---|---|---|
| `BackendExtensions.cs:72-83`, removing a probe file that the listing reported | the outer filter deliberately passes `FileMissingException` to the caller (`cs:86-88`, *"so we can pass those through to the caller"*) | `FileMissingException` reaches the caller. It derives from `UserInformationException` with the message **"The requested file does not exist"** — for a *connection test*, which is baffling |
| `BackendExtensions.cs:148-155`, the cleanup at the end | `catch (Exception)` → `TestAfterConnectException("TestCleanupError")` | the test fails **after the write and the read already succeeded** |

This is reachable through `TestAsync(alsoWrite: true)`, which is what the web UI's destination test, `POST /api/v1/remoteoperation/test`, `POST /api/v2/destination/test` and the backend tester all call. I ran into it from the other side in #7108: on pCloud, `DeleteAsync` → `GetFileId` raises `FileMissingException` for a file the listing had just reported.

## Why "already gone" is a success here

This is already the rule elsewhere in the codebase. `BackendManager.DeleteOperation.cs:163-190` catches a failed delete, checks whether the error means the file is missing, confirms with a listing and then logs

```
"Listing indicates file {RemoteFilename} was deleted correctly"
```

and treats the delete as **successful**. The two probe-file deletes are the only places that do the opposite.

## The change

- The delete in the "remove the file if it exists" step gets its own `try`/`catch (FileMissingException)`. **The outer filter is untouched**, so `FolderMissingException` — which the auto-create flow keys on — and everything else keep behaving exactly as before.
- The cleanup gets a `catch (FileMissingException)` ahead of its `catch (Exception)`, so a real delete failure is still reported as `TestAfterConnectException`.
- Both log at information level rather than swallowing silently, matching what `DeleteOperation` does.

One deliberate difference from that precedent: it confirms with a listing before accepting the delete, and this does not. Here the listing is the unreliable party — a stale entry is exactly what got us into this — so re-reading it would mostly produce the wrong answer. The probe file only has to be gone, and the backend just said it is.

`TestReadPermissionsAsync` only lists and is left alone.

## Verification

New tests in `Duplicati/UnitTest/BackendTestPermissionsTests.cs` (`[Category("Backend")]`); `BackendExtensions` had no test coverage. A fake `IBackend` keeps the written files in memory and lets each test decide what the listing reports and what each delete attempt raises, so this is deterministic and offline.

| test | before this change |
|---|---|
| `StaleListingEntryDoesNotFailTheTest_Async` | fails — the `FileMissingException` from the first delete propagates |
| `MissingProbeFileOnCleanupDoesNotFailTheTest_Async` | fails — `TestAfterConnectException`, after write and read succeeded |
| `MissingFolderIsStillReported_Async` | passes before and after (guard: `FolderMissingException` still reaches the caller) |
| `FailingCleanupIsStillReported_Async` | passes before and after (guard: an `IOException` is still `TestAfterConnectException`) |

`Category=Backend` is green locally on Windows/net10.0, including the Box, S3 and backend-tester tests. I have no pCloud account, so the live jobs are the only end-to-end check; the evidence here is the CI log in #7108 plus this red→green.

Related: #7108 fixes the same stale-listing problem in the backend tester's own clean-up step. This one is the product path behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
