### PR TITLE
Reject an unusable update check interval instead of ignoring it

### DIFF
--- a/Duplicati/Library/RestAPI/Database/ServerSettings.cs
+++ b/Duplicati/Library/RestAPI/Database/ServerSettings.cs
@@ -180,6 +180,12 @@ namespace Duplicati.Server.Database
             if (newsettings == null)
                 throw new ArgumentNullException(nameof(newsettings));
 
+            // Only check a value that is actually changing, so an installation that
+            // already holds an unusable value can still change other settings
+            if (newsettings.TryGetValue(CONST.UPDATE_CHECK_INTERVAL, out var newInterval)
+                && newInterval != settings[CONST.UPDATE_CHECK_INTERVAL])
+                ValidateUpdateCheckInterval(newInterval);
+
             lock (databaseConnection.m_lock)
             {
                 latestUpdate = null;
@@ -499,6 +505,56 @@ namespace Duplicati.Server.Database
             }
         }
 
+        /// <summary>
+        /// The default interval to use when the configured one cannot be used
+        /// </summary>
+        private const int UPDATE_CHECK_FALLBACK_DAYS = 7;
+
+        /// <summary>
+        /// The last update check interval that could not be used; used to only report it
+        /// once per value, as the poll thread reads the interval on every pass
+        /// </summary>
+        private static string? lastUnusableUpdateCheckInterval;
+
+        /// <summary>
+        /// Checks that the value can be used as an update check interval
+        /// </summary>
+        /// <param name="value">The value to check</param>
+        private static void ValidateUpdateCheckInterval(string? value)
+        {
+            // An empty value means the default interval is used
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+
+            try
+            {
+                Timeparser.ParseTimeSpan(value);
+            }
+            catch (Exception ex)
+            {
+                throw new Library.Interface.UserInformationException(Strings.Program.InvalidUpdateCheckInterval(value), "InvalidUpdateCheckInterval", ex);
+            }
+        }
+
+        /// <summary>
+        /// Reports an update check interval that cannot be used, once per value
+        /// </summary>
+        /// <param name="value">The value that cannot be used</param>
+        internal static void ReportUnusableUpdateCheckInterval(string value)
+        {
+            // The fallback changes how often updates are found, so it must not be silent;
+            // stored values from before the interval was validated can end up here
+            if (lastUnusableUpdateCheckInterval == value)
+                return;
+
+            lastUnusableUpdateCheckInterval = value;
+            Library.Logging.Log.WriteWarningMessage(
+                "ServerSettings",
+                "InvalidUpdateCheckInterval",
+                null,
+                $"The configured update check interval \"{value}\" cannot be used; checking every {UPDATE_CHECK_FALLBACK_DAYS} days instead.");
+        }
+
         public string UpdateCheckInterval
         {
             get
@@ -511,6 +567,7 @@ namespace Duplicati.Server.Database
             }
             set
             {
+                ValidateUpdateCheckInterval(value);
                 lock (databaseConnection.m_lock)
                     settings[CONST.UPDATE_CHECK_INTERVAL] = value;
                 SaveSettings();
@@ -528,7 +585,8 @@ namespace Duplicati.Server.Database
                 }
                 catch
                 {
-                    return LastUpdateCheck.AddDays(7);
+                    ReportUnusableUpdateCheckInterval(UpdateCheckInterval);
+                    return LastUpdateCheck.AddDays(UPDATE_CHECK_FALLBACK_DAYS);
                 }
             }
         }

--- a/Duplicati/Library/RestAPI/Strings.cs
+++ b/Duplicati/Library/RestAPI/Strings.cs
@@ -107,6 +107,7 @@ Error message: {0}", error); }
         public static string NoEncryptionKeySpecified(string envkey, string disableoptionname) { return LC.L(@"No database encryption key was found. The database will be stored unencrypted. Supply an encryption key via the environment variable {0} or disable database encryption with the option --{1}", envkey, disableoptionname); }
         public static string EncryptionKeyMissing(string envkey) { return LC.L(@"The database appears to be encrypted, but no key was specified. Opening the database will likely fail. Use the environment variable {0} to specify the key.", envkey); }
         public static string InvalidTimezone(string timezone) { return LC.L(@"The timezone {0} is not valid", timezone); }
+        public static string InvalidUpdateCheckInterval(string interval) { return LC.L(@"The update check interval {0} is not valid", interval); }
         public static string SettingsencryptionkeyShort { get { return LC.L(@"Set the encryption key for the settings database"); } }
         public static string SettingsencryptionkeyLong(string envname) { return LC.L(@"Use this option to set the encryption key for the settings database. This option can also be set with the environment variable {0}.", envname); }
         public static string InvalidPauseResumeState(LiveControls.LiveControlState state) { return LC.L(@"Invalid pause/resume state: {0}", state); }

--- a/Duplicati/Library/RestAPI/UpdatePollThread.cs
+++ b/Duplicati/Library/RestAPI/UpdatePollThread.cs
@@ -109,6 +109,7 @@ namespace Duplicati.Server
                 }
                 catch
                 {
+                    Database.ServerSettings.ReportUnusableUpdateCheckInterval(connection.ApplicationSettings.UpdateCheckInterval);
                 }
 
                 // If we have some weirdness, just check now

--- a/Duplicati/UnitTest/UpdateCheckIntervalSettingTests.cs
+++ b/Duplicati/UnitTest/UpdateCheckIntervalSettingTests.cs
@@ -1,0 +1,180 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.AutoUpdater;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Logging;
+using Duplicati.Library.SQLiteHelper;
+using Duplicati.Server.Database;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// An update check interval that cannot be parsed is stored without complaint and
+    /// then silently replaced with a week, so the configured interval never takes
+    /// effect and the user has no way of finding out why.
+    /// </summary>
+    [TestFixture]
+    [Category("UpdateCheckIntervalSetting")]
+    public class UpdateCheckIntervalSettingTests
+    {
+        private const string SettingName = "update-check-interval";
+        private const string InvalidInterval = "1 Week";
+
+        private string _tempDataFolder = null!;
+        private string _databasePath = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDataFolder = Path.Combine(Path.GetTempPath(), $"duplicati-interval-test-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_tempDataFolder);
+            _databasePath = Path.Combine(_tempDataFolder, DataFolderManager.SERVER_DATABASE_FILENAME);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                if (Directory.Exists(_tempDataFolder))
+                    Directory.Delete(_tempDataFolder, true);
+            }
+            catch
+            {
+            }
+        }
+
+        private async Task<Connection> MakeConnectionAsync()
+        {
+            var dbConnection = await SQLiteLoader.LoadConnectionAsync(_databasePath);
+            DatabaseUpgrader.UpgradeDatabase(dbConnection, _databasePath, typeof(Library.RestAPI.Database.DatabaseSchemaMarker));
+            return new Connection(dbConnection, true, null, _tempDataFolder, () => { });
+        }
+
+        /// <summary>
+        /// Stores a value the way a previous version would have, bypassing any validation.
+        /// The settings are cached per connection, so this runs between connections.
+        /// </summary>
+        private async Task StoreRawSettingAsync(string value)
+        {
+            // Create the schema, and let the connection go again, as the settings are
+            // cached per connection
+            using (await MakeConnectionAsync()) { }
+
+            await using var db = await SQLiteLoader.LoadConnectionAsync(_databasePath);
+            await using var cmd = db.CreateCommand();
+            cmd.CommandText = @$"INSERT OR REPLACE INTO ""Option"" (""BackupID"", ""Filter"", ""Name"", ""Value"") VALUES (-2, '', '{SettingName}', '{value}')";
+            Assert.AreEqual(1, await cmd.ExecuteNonQueryAsync(), "The setting should be stored");
+        }
+
+        [Test]
+        public async Task UnusableStoredIntervalWarnsOnceAndFallsBack()
+        {
+            await StoreRawSettingAsync(InvalidInterval);
+
+            using var connection = await MakeConnectionAsync();
+            var lastCheck = connection.ApplicationSettings.LastUpdateCheck;
+
+            var captured = new List<LogEntry>();
+            DateTime first, second;
+            using (Log.StartScope(e => captured.Add(e)))
+            {
+                first = connection.ApplicationSettings.NextUpdateCheck;
+                second = connection.ApplicationSettings.NextUpdateCheck;
+            }
+
+            Assert.AreEqual(lastCheck.AddDays(7), first,
+                "An unusable interval falls back to a week (pre-existing behavior)");
+            Assert.AreEqual(first, second);
+
+            var warnings = captured.Where(x => x.Level == LogMessageType.Warning && x.Id == "InvalidUpdateCheckInterval").ToList();
+            Assert.AreEqual(1, warnings.Count,
+                $"The fallback must be logged exactly once per value (got {warnings.Count}); the poll thread reads this on every pass");
+            Assert.IsTrue(warnings[0].FormattedMessage.Contains(InvalidInterval),
+                $"The warning should name the unusable value; got: {warnings[0].FormattedMessage}");
+        }
+
+        [Test]
+        public async Task UnusableIntervalIsRejectedWhenStored()
+        {
+            using var connection = await MakeConnectionAsync();
+
+            var ex = Assert.Throws<UserInformationException>(() =>
+                connection.ApplicationSettings.UpdateSettings(new Dictionary<string, string?>
+                {
+                    [SettingName] = InvalidInterval
+                }, false));
+
+            Assert.AreEqual("InvalidUpdateCheckInterval", ex!.HelpID);
+            Assert.IsTrue(ex.Message.Contains(InvalidInterval),
+                $"The error should name the rejected value; got: {ex.Message}");
+        }
+
+        [Test]
+        public async Task UsableIntervalIsAccepted()
+        {
+            using var connection = await MakeConnectionAsync();
+
+            var captured = new List<LogEntry>();
+            DateTime next;
+            using (Log.StartScope(e => captured.Add(e)))
+            {
+                connection.ApplicationSettings.UpdateSettings(new Dictionary<string, string?>
+                {
+                    [SettingName] = "2W"
+                }, false);
+
+                next = connection.ApplicationSettings.NextUpdateCheck;
+            }
+
+            Assert.AreEqual(connection.ApplicationSettings.LastUpdateCheck.AddDays(14), next);
+            Assert.IsFalse(captured.Any(x => x.Id == "InvalidUpdateCheckInterval"),
+                "A usable interval should not be reported");
+        }
+
+        [Test]
+        public async Task StoredUnusableIntervalDoesNotBlockOtherSettings()
+        {
+            // An installation that already holds an unusable value must still be able
+            // to change unrelated settings
+            await StoreRawSettingAsync(InvalidInterval);
+
+            using var connection = await MakeConnectionAsync();
+
+            Assert.DoesNotThrow(() =>
+                connection.ApplicationSettings.UpdateSettings(new Dictionary<string, string?>
+                {
+                    ["some-unrelated-setting"] = "value",
+                    [SettingName] = InvalidInterval
+                }, false));
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

An `update-check-interval` the parser cannot read is accepted without complaint and then silently replaced with a week, so the configured interval never takes effect and there is nothing to tell the user why. No issue tracks it, so this PR doubles as the report.

Three steps, none of which say anything:

1. **Nothing validates the value on the way in.** The REST write path is `PATCH /api/v1/serversettings` → `SettingsService.PatchSettingsMasked` → `ServerSettings.UpdateSettings(dict, false)`, which writes straight into the settings dictionary.
2. **`NextUpdateCheck` swallows the parse error** — `ServerSettings.cs:521-533`: `try { Timeparser.ParseTimeInterval(...) } catch { return LastUpdateCheck.AddDays(7); }`
3. **`UpdatePollThread` swallows it again** — `UpdatePollThread.cs:105-112`: `try { maxcheck = Timeparser.ParseTimeSpan(...) } catch { }`

So `1 Week`, `7 days` or `weekly` are stored happily, updates keep being checked weekly, and the log stays quiet.

This is the same shape as #7094 (an unresolvable timezone was silently reset), which you merged — an invalid setting plus a silent fallback.

## The change

**Reject the value when it is stored.** A small `ValidateUpdateCheckInterval` is called from `UpdateSettings` and from the property setter, raising `UserInformationException`, which the web server turns into **HTTP 400 with the message** (a plain exception would become a 500 with "An error occurred" and the reason would be lost).

Two details worth flagging:

- **The check belongs in `UpdateSettings`, not only in the setter.** The setter is not on the REST path at all: the only caller of `ServerSettings.UpdateCheckInterval`'s setter is the read-only DTO in `WebserverCore/Abstractions/ServerSettings.cs`, so a validation placed only there would never run for an API write. `UpdateSettings` already carries a key-specific guard (the "prevent user from logging themselves out" block), so this fits where it is.
- **It validates with `ParseTimeSpan`, not `ParseTimeInterval`.** The two disagree: `ParseTimeInterval("2030-01-01", …)` happily returns that date, which as a *check interval* means updates are never looked for again. The setting is a duration, so it is checked as one.

**Only a value that changes is validated**, so an installation that already holds an unusable value can still change unrelated settings — otherwise this change would lock those users out of the settings page. There is a test for that.

**Make the fallback visible.** Both `catch` blocks now report the unusable value, once per value (the poll thread reads it on every pass, so warning every time would flood the log). The parsing itself and the one-week fallback are unchanged — this only stops it being silent.

New string `Strings.Program.InvalidUpdateCheckInterval`, right next to `InvalidTimezone` from #7094.

## Verification

**Unit tests** — new `Duplicati/UnitTest/UpdateCheckIntervalSettingTests.cs`, reusing the harness from `TimeZoneSettingTests` (build a real server database, write the unusable value with raw SQL between connections since settings are cached per connection, capture the log with `Log.StartScope`).

| test | before this change |
|---|---|
| `UnusableStoredIntervalWarnsOnceAndFallsBack` | fails — `Expected: 1 But was: 0` warnings; the one-week fallback itself already asserted as unchanged |
| `UnusableIntervalIsRejectedWhenStored` | fails — `Expected: <UserInformationException> But was: null` |
| `UsableIntervalIsAccepted` | passes before and after (guard: `2W` gives `LastUpdateCheck + 14 days`, no warning) |
| `StoredUnusableIntervalDoesNotBlockOtherSettings` | passes before and after (guard: a pre-existing bad value does not break other updates) |

Green together with the `TimeZoneSetting` tests from #7094.

**End to end** against a real server (`--webservice-port=18211`, own data folder):

```
PATCH /api/v1/serversettings {"update-check-interval": "1 Week"}
  -> 400 {"Error":"The update check interval 1 Week is not valid","Code":400,"HelpId":"InvalidUpdateCheckInterval"}
PATCH /api/v1/serversettings {"update-check-interval": "2W"}
  -> 200, stored value reads back as "2W"
```

That is the after state; the before state is covered by the unit tests above (today nothing rejects the value).

## Noticed while here, not fixed

Because the REST path bypasses the property setter, `UpdatePollThread.Reschedule()` is never called when the interval is changed through the API — a new interval only takes effect on the poll loop's own schedule. That is a separate change and I have left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
