### PR TITLE
Fixed issues with MS365

### DIFF
--- a/proprietary/Office365/APIHelper.cs
+++ b/proprietary/Office365/APIHelper.cs
@@ -23,6 +23,23 @@ internal class APIHelper : IDisposable
     private static readonly string LOGTAG = Log.LogTagFromType<APIHelper>();
 
     /// <summary>
+    /// The options used when parsing Microsoft Graph responses. Graph is not consistent with
+    /// property casing across endpoints (the site collection hostname is documented as
+    /// <c>hostname</c> for <c>/sites</c> but as <c>hostName</c> for <c>getAllSites</c>), and
+    /// silently binding nothing at all is worse than being lenient, so parsing is
+    /// case-insensitive.
+    /// </summary>
+    internal static readonly JsonSerializerOptions GraphJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// The default page size for API requests that allow big pages
+    /// </summary>
+    internal const int BIG_PAGE_SIZE = 500;
+
+    /// <summary>
     /// The default page size for API requests
     /// </summary>
     internal const int GENERAL_PAGE_SIZE = 100;
@@ -225,7 +242,7 @@ internal class APIHelper : IDisposable
         var content = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return JsonSerializer.Deserialize<T>(content) ?? throw new JsonException("Deserialized object is null");
+            return JsonSerializer.Deserialize<T>(content, GraphJsonOptions) ?? throw new JsonException("Deserialized object is null");
         }
         catch (JsonException ex)
         {
@@ -426,6 +443,54 @@ internal class APIHelper : IDisposable
                 yield return item;
             next = page.NextLink;
         }
+    }
+
+    /// <summary>
+    /// Re-orders a site feed alphabetically by name.
+    /// </summary>
+    /// <remarks>
+    /// Microsoft Graph cannot sort sites: neither the tenant-wide <c>getAllSites</c> endpoint
+    /// nor the subsites collection documents support for <c>$orderby</c>, and the site resource
+    /// has no sortable key. The ordering therefore has to be applied on the client, which means
+    /// the full feed must be buffered before the first item can be emitted. That is acceptable
+    /// here because the site collection is orders of magnitude smaller than the user collection,
+    /// and buffering has the added benefit of making the offset-based paging in the listing API
+    /// deterministic across requests.
+    /// </remarks>
+    /// <param name="sites">The unordered site feed</param>
+    /// <param name="ct">The cancellation token</param>
+    /// <returns>An asynchronous enumerable of sites, ordered by name</returns>
+    internal static async IAsyncEnumerable<GraphSite> OrderSitesByNameAsync(IAsyncEnumerable<GraphSite> sites, [EnumeratorCancellation] CancellationToken ct)
+    {
+        var buffer = new List<GraphSite>();
+        await foreach (var site in sites.ConfigureAwait(false))
+            buffer.Add(site);
+
+        // The id is the tie-breaker: display names are neither unique nor immutable,
+        // so the name alone is not a deterministic sort key.
+        foreach (var site in buffer
+            .OrderBy(GetSiteSortName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(x => x.Id, StringComparer.Ordinal))
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return site;
+        }
+    }
+
+    /// <summary>
+    /// Gets the name to sort a site by. Sites returned from <c>getAllSites</c> frequently
+    /// carry only <c>name</c> and no <c>displayName</c>, so both are considered.
+    /// </summary>
+    /// <param name="site">The site to get the sort name for</param>
+    /// <returns>The name to sort by</returns>
+    private static string GetSiteSortName(GraphSite site)
+    {
+        if (!string.IsNullOrWhiteSpace(site.DisplayName))
+            return site.DisplayName;
+        if (!string.IsNullOrWhiteSpace(site.Name))
+            return site.Name;
+
+        return site.WebUrl ?? site.Id;
     }
 
     /// <summary>

--- a/proprietary/Office365/DTOs.cs
+++ b/proprietary/Office365/DTOs.cs
@@ -61,6 +61,13 @@ internal sealed class GraphSite
     [JsonPropertyName("name")]
     public string? Name { get; set; }
 
+    /// <summary>
+    /// Whether the site is a personal (OneDrive) site. This is a top-level property on the
+    /// Graph site resource; the siteCollection facet has no equivalent property.
+    /// </summary>
+    [JsonPropertyName("isPersonalSite")]
+    public bool? IsPersonalSite { get; set; }
+
     [JsonPropertyName("webUrl")]
     public string? WebUrl { get; set; }
 
@@ -80,13 +87,14 @@ internal sealed class GraphSite
     public GraphSiteRoot? Root { get; set; }
 }
 
+/// <summary>
+/// The siteCollection facet of a site. Only populated on the root site of a site collection,
+/// so it must not be relied on for classifying arbitrary sites.
+/// </summary>
 internal sealed class GraphSiteCollection
 {
     [JsonPropertyName("hostname")]
     public string? Hostname { get; set; }
-
-    [JsonPropertyName("personalSite")]
-    public bool? PersonalSite { get; set; }
 }
 
 internal sealed class GraphSiteRoot

--- a/proprietary/Office365/SourceItems/MetaRootSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/MetaRootSourceEntry.cs
@@ -52,29 +52,50 @@ internal class MetaRootSourceEntry(SourceProvider provider, string mountPoint, O
         switch (type)
         {
             case Office365MetaType.Users:
+                // Microsoft Graph paging over users is not guaranteed to be stable, so the
+                // same user can be returned on more than one page. De-duplicate by user id
+                // to avoid emitting duplicate paths for the same user.
+                var seenUserIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
                 await foreach (var user in provider.RootApi.ListAllUsersAsync(cancellationToken).ConfigureAwait(false))
                 {
                     if (cancellationToken.IsCancellationRequested)
                         yield break;
 
-                    // Skip users whose classification is excluded by the include filter.
-                    // This uses the cached classification, so no extra Graph call is made
-                    // beyond the one already performed for seat counting.
+                    if (string.IsNullOrEmpty(user.Id) || !seenUserIds.Add(user.Id))
+                        continue;
+
+                    // Skip users whose classification is excluded by the include filter. When
+                    // every classification is included, which is the default, this does not
+                    // classify the user and so makes no Graph call.
                     if (!await provider.IsUserClassificationIncludedAsync(user, cancellationToken).ConfigureAwait(false))
                         continue;
 
-                    // Shared mailboxes without additional storage do not consume a seat.
-                    var countsAsSeat = await provider.UserCountsAsSeatAsync(user, cancellationToken).ConfigureAwait(false);
+                    // Shared mailboxes without additional storage do not consume a seat, but
+                    // determining that costs a Graph call per user and the gate below only
+                    // needs the answer once the seat limit has been reached. Until then, assume
+                    // the user consumes a seat: the gate approves either way, and nothing is
+                    // counted here because this check does not increment.
+                    var countsAsSeat = !provider.SeatLimitReached(type)
+                        || await provider.UserCountsAsSeatAsync(user, cancellationToken).ConfigureAwait(false);
 
                     if (provider.LicenseApprovedForEntry(Path, type, user.Id, false, countsAsSeat))
                         yield return new UserSourceEntry(provider, Path, user);
                 }
                 break;
             case Office365MetaType.Groups:
+                // Microsoft Graph paging over groups is not guaranteed to be stable, so the
+                // same group can be returned on more than one page. De-duplicate by group id
+                // to avoid emitting duplicate paths for the same group.
+                var seenGroupIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
                 await foreach (var group in provider.RootApi.ListAllGroupsAsync(cancellationToken).ConfigureAwait(false))
                 {
                     if (cancellationToken.IsCancellationRequested)
                         yield break;
+
+                    if (string.IsNullOrEmpty(group.Id) || !seenGroupIds.Add(group.Id))
+                        continue;
 
                     // Skip groups whose classification is excluded by the include filter.
                     if (!provider.IsGroupClassificationIncluded(group))
@@ -89,10 +110,18 @@ internal class MetaRootSourceEntry(SourceProvider provider, string mountPoint, O
                 }
                 break;
             case Office365MetaType.Sites:
+                // Microsoft Graph paging over sites is not guaranteed to be stable, so the
+                // same site can be returned on more than one page. De-duplicate by site id
+                // to avoid emitting duplicate paths for the same site.
+                var seenSiteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
                 await foreach (var site in provider.RootApi.ListAllSitesAsync(cancellationToken).ConfigureAwait(false))
                 {
                     if (cancellationToken.IsCancellationRequested)
                         yield break;
+
+                    if (string.IsNullOrEmpty(site.Id) || !seenSiteIds.Add(site.Id))
+                        continue;
 
                     // Skip sites whose classification is excluded by the include filter.
                     if (!provider.IsSiteClassificationIncluded(site))

--- a/proprietary/Office365/SourceItems/SiteSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/SiteSourceEntry.cs
@@ -15,11 +15,11 @@ internal class SiteSourceEntry(SourceProvider provider, string parentPath, Graph
             { "o365:v", "1" },
             { "o365:Id", site.Id },
             { "o365:Type", SourceItemType.Site.ToString() },
-            { "o365:Name", $"{site.DisplayName}{(site.SiteCollection?.PersonalSite == true ? " (Personal)" : "" )}" },
+            { "o365:Name", $"{site.DisplayName}{(site.IsPersonalSite == true ? " (Personal)" : "" )}" },
             { "o365:DisplayName", site.DisplayName },
             { "o365:WebUrl", site.WebUrl },
             { "o365:Hostname", site.SiteCollection?.Hostname },
-            { "o365:PersonalSite", site.SiteCollection?.PersonalSite?.ToString() },
+            { "o365:PersonalSite", site.IsPersonalSite?.ToString() },
             { "o365:Classification", SourceProvider.ClassifySite(site).ToString() }
         }
         .Where(kv => !string.IsNullOrEmpty(kv.Value))

--- a/proprietary/Office365/SourceItems/UserSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/UserSourceEntry.cs
@@ -3,6 +3,7 @@
 using System.Runtime.CompilerServices;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Logging;
 
 namespace Duplicati.Proprietary.Office365.SourceItems;
 
@@ -22,6 +23,8 @@ internal enum Office365UserType
 internal class UserSourceEntry(SourceProvider provider, string parentPath, GraphUser user)
     : MetaEntryBase(Util.AppendDirSeparator(SystemIO.IO_OS.PathCombine(parentPath, user.Id)), user.CreatedDateTime.FromGraphDateTime(), null)
 {
+    private static readonly string LOGTAG = Log.LogTagFromType<UserSourceEntry>();
+
     public override async IAsyncEnumerable<ISourceProviderEntry> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Shared mailboxes without additional storage do not consume a seat.
@@ -39,8 +42,8 @@ internal class UserSourceEntry(SourceProvider provider, string parentPath, Graph
         }
     }
 
-    public override Task<Dictionary<string, string?>> GetMinorMetadata(CancellationToken cancellationToken)
-        => Task.FromResult(new Dictionary<string, string?>
+    public override async Task<Dictionary<string, string?>> GetMinorMetadata(CancellationToken cancellationToken)
+        => new Dictionary<string, string?>
             {
                 { "o365:v", "1" },
                 { "o365:Id", user.Id },
@@ -49,20 +52,39 @@ internal class UserSourceEntry(SourceProvider provider, string parentPath, Graph
                 { "o365:DisplayName", user.DisplayName ?? "" },
                 { "o365:UserPrincipalName", user.UserPrincipalName ?? "" },
                 { "o365:AccountEnabled", user.AccountEnabled?.ToString() ?? "" },
-                { "o365:Classification", GetUserClassification() },
+                { "o365:Classification", await GetUserClassificationAsync(cancellationToken).ConfigureAwait(false) },
             }
             .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
-            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
     /// <summary>
-    /// Gets the classification string for treeview display, preferring the already-resolved
-    /// seat classification (which includes the shared-mailbox distinction) and never
-    /// triggering an extra API call.
+    /// Gets the classification string for treeview display, using the seat classification
+    /// (which includes the shared-mailbox distinction) and falling back to the directory-only
+    /// classification if it cannot be resolved.
     /// </summary>
-    private string GetUserClassification()
+    /// <remarks>
+    /// The seat classification requires a Graph lookup, cached per user. It is resolved here
+    /// rather than while enumerating so that the cost is proportional to the entries actually
+    /// displayed instead of every entry walked past. Enumerating a folder is not billed for
+    /// metadata it never emits.
+    /// </remarks>
+    private async Task<string> GetUserClassificationAsync(CancellationToken cancellationToken)
     {
         var cached = provider.TryGetCachedUserSeatCategory(user.Id);
-        return cached?.ToString() ?? SourceProvider.ClassifyUserFromDirectory(user);
+        if (cached != null)
+            return cached.Value.ToString();
+
+        try
+        {
+            var category = await provider.ClassifyUserAsync(user, cancellationToken).ConfigureAwait(false);
+            return category.ToString();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Metadata generation must not fail over a classification lookup.
+            Log.WriteVerboseMessage(LOGTAG, "UserClassificationLookupFailed", ex, $"Failed to resolve the classification for user '{user.Id}'; falling back to the directory classification.");
+            return SourceProvider.ClassifyUserFromDirectory(user);
+        }
     }
 
     public override Task<bool> FileExists(string filename, CancellationToken cancellationToken)

--- a/proprietary/Office365/SourceProvider/SourceProvider.RootItems.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.RootItems.cs
@@ -14,10 +14,16 @@ partial class SourceProvider
             var baseUrl = provider.GraphBaseUrl.TrimEnd('/');
             var select = GraphSelectBuilder.BuildSelect<GraphUser>();
 
+            // Order by displayName to give the paged user feed a stable ordering, reducing
+            // the chance that users are skipped or returned on more than one page.
+            // displayName is one of the few user properties Graph can sort on without
+            // advanced query parameters. The source entry still de-duplicates by user id
+            // as a safety net.
             var url =
                 $"{baseUrl}/v1.0/users" +
                 $"?$select={Uri.EscapeDataString(select)}" +
-                   $"&$top={APIHelper.GENERAL_PAGE_SIZE}";
+                $"&$orderby={Uri.EscapeDataString("displayName")}" +
+                $"&$top={APIHelper.BIG_PAGE_SIZE}";
 
             return provider.GetAllGraphItemsAsync<GraphUser>(url, ct);
         }
@@ -26,10 +32,17 @@ partial class SourceProvider
         {
             var baseUrl = provider.GraphBaseUrl.TrimEnd('/');
             var select = GraphSelectBuilder.BuildSelect<GraphGroup>();
+
+            // Order by displayName to give the paged group feed a stable ordering, reducing
+            // the chance that groups are skipped or returned on more than one page.
+            // displayName is the only group property Graph can sort on without advanced
+            // query parameters. The source entry still de-duplicates by group id as a
+            // safety net.
             var url =
                 $"{baseUrl}/v1.0/groups" +
                 $"?$select={Uri.EscapeDataString(select)}" +
-                $"&$top={APIHelper.GENERAL_PAGE_SIZE}";
+                $"&$orderby={Uri.EscapeDataString("displayName")}" +
+                $"&$top={APIHelper.BIG_PAGE_SIZE}";
 
             return provider.GetAllGraphItemsAsync<GraphGroup>(url, ct);
         }
@@ -44,7 +57,7 @@ partial class SourceProvider
                 $"{baseUrl}/v1.0/groups" +
                 $"?$filter={Uri.EscapeDataString(filter)}" +
                 $"&$select={Uri.EscapeDataString(select)}" +
-                $"&$top={APIHelper.GENERAL_PAGE_SIZE}";
+                $"&$top={APIHelper.BIG_PAGE_SIZE}";
 
             return provider.GetAllGraphItemsAsync<GraphGroup>(url, ct);
         }
@@ -58,9 +71,11 @@ partial class SourceProvider
             var url =
                 $"{baseUrl}/v1.0/sites/getAllSites" +
                 $"?$select={Uri.EscapeDataString(select)}" +
-                $"&$top={APIHelper.GENERAL_PAGE_SIZE}";
+                $"&$top={APIHelper.BIG_PAGE_SIZE}";
 
-            return provider.GetAllGraphItemsAsync<GraphSite>(url, ct);
+            // getAllSites does not support $orderby, so the alphabetical ordering that is
+            // presented to the user has to be applied on the client.
+            return APIHelper.OrderSitesByNameAsync(provider.GetAllGraphItemsAsync<GraphSite>(url, ct), ct);
         }
     }
 }

--- a/proprietary/Office365/SourceProvider/SourceProvider.Site.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.Site.cs
@@ -54,7 +54,18 @@ partial class SourceProvider
             return drive;
         }
 
+        /// <summary>
+        /// Lists the immediate subsites of a site, ordered alphabetically by name.
+        /// </summary>
+        /// <remarks>
+        /// The subsites collection does not support <c>$orderby</c> either, so the ordering is
+        /// applied on the client. Only the source provider orders the feed; the restore provider
+        /// scans it for a name match and does not need the buffering.
+        /// </remarks>
+        /// <param name="siteId">The parent site ID</param>
+        /// <param name="ct">The cancellation token</param>
+        /// <returns>An asynchronous enumerable of subsites, ordered by name</returns>
         internal IAsyncEnumerable<GraphSite> ListSubsitesAsync(string siteId, CancellationToken ct)
-            => provider.ListSubsitesAsync(siteId, ct);
+            => APIHelper.OrderSitesByNameAsync(provider.ListSubsitesAsync(siteId, ct), ct);
     }
 }

--- a/proprietary/Office365/SourceProvider/SourceProvider.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.cs
@@ -390,15 +390,32 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
         };
 
     /// <summary>
+    /// Whether the user-classification include filter covers every classification. When it
+    /// does, the filter can never exclude a user, so the classification does not need to be
+    /// resolved in order to apply it.
+    /// </summary>
+    private bool AllUserClassificationsIncluded
+        => _includedUserClassifications.HasFlag(OptionsHelper.ALL_USER_CLASSIFICATIONS);
+
+    /// <summary>
     /// Determines whether a user should be included based on its classification and the
-    /// configured user-classification include filter. Uses the cached classification, so no
-    /// extra Graph API call is made beyond the one already performed for seat counting.
+    /// configured user-classification include filter.
     /// </summary>
     /// <param name="user">The user to test.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><c>true</c> if the user should be included; otherwise <c>false</c>.</returns>
+    /// <remarks>
+    /// Classifying a user costs one Graph request (the <c>mailboxSettings/userPurpose</c>
+    /// lookup), so when the include filter covers every classification the test is a
+    /// tautology and is answered without classifying at all. That is the default
+    /// configuration, and it is what keeps a tenant-wide user listing from issuing one
+    /// request per user.
+    /// </remarks>
     internal async Task<bool> IsUserClassificationIncludedAsync(GraphUser user, CancellationToken cancellationToken)
     {
+        if (AllUserClassificationsIncluded)
+            return true;
+
         var category = await ClassifyUserAsync(user, cancellationToken).ConfigureAwait(false);
         return _includedUserClassifications.HasFlag(ToClassificationFlag(category));
     }
@@ -443,7 +460,17 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     /// shared between seat counting, the count operation and item metadata.
     /// </remarks>
     internal Task<UserSeatCategory> ClassifyUserAsync(GraphUser user, CancellationToken cancellationToken)
-        => _userSeatCache.GetOrAdd(user.Id, _ => ResolveUserSeatCategoryAsync(user, cancellationToken));
+    {
+        var task = _userSeatCache.GetOrAdd(user.Id, _ => ResolveUserSeatCategoryAsync(user, cancellationToken));
+
+        // The cached task captured the cancellation token of whichever caller asked first, so a
+        // cancelled lookup would otherwise stay cached and keep failing for the lifetime of the
+        // provider. Evict it so the next caller retries with its own token.
+        if (task.IsCanceled || task.IsFaulted)
+            _userSeatCache.TryRemove(new KeyValuePair<string, Task<UserSeatCategory>>(user.Id, task));
+
+        return task;
+    }
 
     /// <summary>
     /// Resolves the seat classification for a user. See <see cref="ClassifyUserAsync"/>.
@@ -487,10 +514,12 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     /// <returns>The site category.</returns>
     internal static SiteCategory ClassifySite(GraphSite site)
     {
-        if (site.SiteCollection?.PersonalSite == true)
+        if (site.IsPersonalSite == true)
             return SiteCategory.Personal;
 
-        // OneDrive personal sites are hosted on the "-my" SharePoint host.
+        // OneDrive personal sites are hosted on the "-my" SharePoint host. Note that the
+        // siteCollection facet is only populated on the root site of a site collection, so
+        // this is a fallback for the root sites only.
         var host = site.SiteCollection?.Hostname;
         if (!string.IsNullOrWhiteSpace(host) && host.Contains("-my.", StringComparison.OrdinalIgnoreCase))
             return SiteCategory.Personal;
@@ -524,6 +553,35 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     /// <returns>The classification string suitable for item metadata.</returns>
     internal static string ClassifyGroupFromDirectory(GraphGroup group)
         => GroupCountsAsSeat(group) ? "Unified" : "NotUnified";
+
+    /// <summary>
+    /// Determines whether the seat limit for the given entry type has already been reached.
+    /// </summary>
+    /// <param name="type">The entry type to check.</param>
+    /// <returns><c>true</c> if the seat limit has been reached; otherwise <c>false</c>.</returns>
+    /// <remarks>
+    /// While seats remain, <see cref="LicenseApprovedForEntry"/> approves the entry whether or
+    /// not it consumes one. Callers that only need the approval answer, and that do not
+    /// increment the counters, can therefore skip resolving <c>countsAsSeat</c> until this
+    /// returns <c>true</c>. That matters for users, where resolving it costs a Graph request
+    /// per user.
+    /// </remarks>
+    internal bool SeatLimitReached(Office365MetaType type)
+    {
+        // Restores are unlimited, so the limit is never reached.
+        if (UsedForRestoreOperation)
+            return false;
+
+        if (type.HasFlag(Office365MetaType.Users))
+            return _userCount >= LicenseChecker.LicenseHelper.AvailableOffice365UserSeats;
+        if (type.HasFlag(Office365MetaType.Groups))
+            return _groupCount >= LicenseChecker.LicenseHelper.AvailableOffice365GroupSeats;
+        if (type.HasFlag(Office365MetaType.Sites))
+            return _siteCount >= LicenseChecker.LicenseHelper.AvailableOffice365SiteSeats;
+
+        // Unknown types are not limited.
+        return false;
+    }
 
     /// <summary>
     /// Determines whether the license is approved for the given entry.


### PR DESCRIPTION
This PR fixes a parsing bug for personalSites/hostname causing off classifications.

Additionally, the users/sites/groups are now returned as alphabetically sorted.

When no classification filters are applied, we save one additional API call per user.