### PR TITLE
Check the response status before decrypting a Filen download

### DIFF
--- a/Duplicati/Library/Backend/Filen/FilenClient.cs
+++ b/Duplicati/Library/Backend/Filen/FilenClient.cs
@@ -643,7 +643,8 @@ public class FilenClient : IDisposable
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _authResult.ApiKey);
 
-            var response = await _httpClient.SendAsync(request, cancellationToken);
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
             var encrypted = await response.Content.ReadAsByteArrayAsync(cancellationToken);
 
             var decrypted = fileKey.DecryptData(file.Version, encrypted);

--- a/Duplicati/UnitTest/FilenDownloadStatusTests.cs
+++ b/Duplicati/UnitTest/FilenDownloadStatusTests.cs
@@ -1,0 +1,170 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.Filen;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A download from Filen is decrypted as it arrives. The response status was not
+/// checked, so whatever the server sent on an error was handed to the decrypter
+/// and reported as a cryptographic failure instead of the error itself.
+/// </summary>
+[TestFixture]
+public class FilenDownloadStatusTests
+{
+    /// <summary>
+    /// The file key doubles as the AES key, so it has to be 32 characters
+    /// </summary>
+    private const string FileKey = "0123456789abcdef0123456789abcdef";
+    private const string Region = "de-1";
+    private const string Bucket = "filen-1";
+    private const string FileUuid = "11111111-2222-3333-4444-555555555555";
+
+    /// <summary>
+    /// What a gateway or CDN sends when it is not able to serve the request. The
+    /// body is longer than an IV plus a GCM tag, so it reaches the tag check.
+    /// </summary>
+    private const string ServerErrorBody =
+        "<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n" +
+        "<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>";
+
+    /// <summary>
+    /// Answers the two calls the login makes, and hands the download whatever the
+    /// test asked for. The gateway and egest hosts are picked at random from eight
+    /// candidates each, so the requests are told apart by path.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _downloadStatus;
+        private readonly HttpContent _downloadContent;
+
+        public StubHandler(HttpStatusCode downloadStatus, HttpContent downloadContent)
+        {
+            _downloadStatus = downloadStatus;
+            _downloadContent = downloadContent;
+        }
+
+        public int DownloadCalls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path.EndsWith("/v3/auth/info", StringComparison.Ordinal))
+                return Task.FromResult(Json("{\"status\":true,\"data\":{\"authVersion\":2,\"salt\":\"736f6d6573616c74\"}}"));
+
+            if (path.EndsWith("/v3/user/masterKeys", StringComparison.Ordinal))
+                return Task.FromResult(Json("{\"status\":true,\"data\":{\"masterKeys\":\"\"}}"));
+
+            if (path.EndsWith($"/{Region}/{Bucket}/{FileUuid}/0", StringComparison.Ordinal))
+            {
+                DownloadCalls++;
+                return Task.FromResult(new HttpResponseMessage(_downloadStatus) { Content = _downloadContent });
+            }
+
+            throw new InvalidOperationException($"Unexpected request to {request.RequestUri}");
+        }
+
+        private static HttpResponseMessage Json(string body)
+            => new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static Task<FilenClient> CreateClientAsync(StubHandler handler)
+        => FilenClient.CreateClientAsync(new HttpClient(handler), "user@example.com", "password", null, "test-api-key", CancellationToken.None);
+
+    private static FilenFileEntry CreateEntry(long size)
+        => new()
+        {
+            Uuid = FileUuid,
+            Name = "duplicati-b0123456789.dblock.zip.aes",
+            IsFolder = false,
+            Size = size,
+            LastModified = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CreatedTimestamp = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Region = Region,
+            Bucket = Bucket,
+            Chunks = 1,
+            FileKey = FileKey,
+            Version = 2,
+            MimeType = "application/octet-stream"
+        };
+
+    [Test]
+    [Category("Backend")]
+    public async Task ServerErrorIsReportedAsHttpFailure()
+    {
+        // An error page is not ciphertext, so decrypting it fails the tag check
+        // and the status the server actually sent is lost
+        var handler = new StubHandler(HttpStatusCode.ServiceUnavailable, new StringContent(ServerErrorBody, Encoding.UTF8, "text/html"));
+        using var client = await CreateClientAsync(handler);
+        using var target = new MemoryStream();
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () =>
+            await client.DownloadAndDecryptToStreamAsync(CreateEntry(1024), target, CancellationToken.None));
+
+        Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex!.StatusCode);
+        Assert.AreEqual(1, handler.DownloadCalls);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task ShortErrorBodyIsReportedAsHttpFailure()
+    {
+        // A body shorter than the IV never reaches the tag check, it fails while
+        // being sliced apart, which says even less about what went wrong
+        var handler = new StubHandler(HttpStatusCode.BadGateway, new StringContent("bad gateway", Encoding.UTF8, "text/plain"));
+        using var client = await CreateClientAsync(handler);
+        using var target = new MemoryStream();
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () =>
+            await client.DownloadAndDecryptToStreamAsync(CreateEntry(1024), target, CancellationToken.None));
+
+        Assert.AreEqual(HttpStatusCode.BadGateway, ex!.StatusCode);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task SuccessfulDownloadIsStillDecrypted()
+    {
+        var payload = Encoding.UTF8.GetBytes("the contents of a backup volume");
+        var encrypted = FilenCrypto.EncryptData(payload, DerivedKey.Create(FileKey));
+
+        var handler = new StubHandler(HttpStatusCode.OK, new ByteArrayContent(encrypted));
+        using var client = await CreateClientAsync(handler);
+        using var target = new MemoryStream();
+
+        await client.DownloadAndDecryptToStreamAsync(CreateEntry(payload.Length), target, CancellationToken.None);
+
+        Assert.AreEqual(payload, target.ToArray());
+    }
+}


### PR DESCRIPTION
A failed download from Filen is reported as a cryptographic error, so a temporary server problem looks like a damaged backup.

### What happens

`DownloadAndDecryptToStreamAsync` decrypts each chunk as it arrives, but never looks at the status of the response:

```csharp
var response = await _httpClient.SendAsync(request, cancellationToken);
var encrypted = await response.Content.ReadAsByteArrayAsync(cancellationToken);

var decrypted = fileKey.DecryptData(file.Version, encrypted);
```

When the egest server answers with an error, that error page is what gets decrypted. Depending on how long the body is, the user gets one of:

- `AuthenticationTagMismatchException: The computed authentication tag did not match the input authentication tag.` — the body is long enough to reach the GCM tag check
- `ArgumentOutOfRangeException` — the body is shorter than the 12 byte IV, so `FilenCrypto.DecryptData` fails while slicing it apart

Neither one mentions the server. Someone whose restore fails this way has every reason to conclude their backup is corrupt or their password is wrong, when a retry would have worked.

### Why this looks like an oversight rather than a decision

There are eleven `SendAsync` calls in `FilenClient`, and this is the only one whose status is not checked. The other ten all go through `ExtractDataFromResponse`, which begins with `EnsureSuccessStatusCode()`, and the master key request calls it explicitly as well.

### Where it turned up

The `Filen.io Tests (windows-latest)` job failed this way on #7111 ([run 30696129846](https://github.com/duplicati/duplicati/actions/runs/30696129846)). Files 0 through 17 downloaded and hashed fine; 18 and 19 failed with the tag mismatch above.

**That failure is not caused by #7111** — its change to the Filen backend is the `Uri` to `RelaxedUri` rename and nothing else, and it does not touch this file. `Drime Tests (windows-latest)` failed in the same run with `Request failed: 500 Internal Server Error`, which is what a backend looks like when it does check the status.

I want to be precise about what that run does and does not prove: because the status is discarded, there is no record of what the server actually sent, so I cannot demonstrate that those two files came back as non-200. That is the point of this change. Right now a server error and a genuinely corrupt chunk are indistinguishable in the logs.

### The change

```csharp
using var response = await _httpClient.SendAsync(request, cancellationToken);
response.EnsureSuccessStatusCode();
var encrypted = await response.Content.ReadAsByteArrayAsync(cancellationToken);
```

`EnsureSuccessStatusCode()` to match how the rest of the file treats a response, and `using` because this response was the one that was not being disposed.

A 404 is deliberately **not** mapped to `FileMissingException`. Whether a file exists is already settled by `GetFileEntryAsync` returning null before the download starts, and turning a transient 404 from a CDN into "the file is gone" would make a retryable situation worse rather than better.

### Tests

`Duplicati/UnitTest/FilenDownloadStatusTests.cs` drives `FilenClient` against a stubbed `HttpMessageHandler`, so no account is needed. The gateway and egest hosts are chosen at random from eight candidates each, so the stub matches on path.

| Test | Before | After |
| --- | --- | --- |
| `ServerErrorIsReportedAsHttpFailure` (503 + error page) | `AuthenticationTagMismatchException` | `HttpRequestException`, status 503 |
| `ShortErrorBodyIsReportedAsHttpFailure` (502 + short body) | `ArgumentOutOfRangeException` at `FilenCrypto.cs:282` | `HttpRequestException`, status 502 |
| `SuccessfulDownloadIsStillDecrypted` (200 + real ciphertext) | passes | passes |

The first case reproduces the CI exception exactly. The third one was green before the change as well; it is there so the fix cannot quietly break the path that works.

### How this was verified

- The two failing tests were run against unmodified code first, and the exceptions in the table above are what they actually reported, not what I expected them to report
- `dotnet build Duplicati.slnx -c Debug` — clean
- `Category=Backend` — green

**I do not have a Filen account, so none of this was exercised against the live service.** The verification is entirely offline against a stubbed handler. What that covers is the mapping from an HTTP status to an exception; it does not cover anything about how Filen behaves in practice.

Related: #7100 fixed the same class of defect in the Box upload path, where an unchecked status turned a failed upload into a missing file id.
