### PR TITLE
Stop the Filejump error handler from calling itself forever

### DIFF
--- a/Duplicati/Library/Backend/Filejump/Filejump.cs
+++ b/Duplicati/Library/Backend/Filejump/Filejump.cs
@@ -27,6 +27,8 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend
 {
     /// <summary>
@@ -202,12 +204,22 @@ namespace Duplicati.Library.Backend
             var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
             using var request = new HttpRequestMessage(HttpMethod.Post, "auth/login") { Content = content };
             request.Headers.Add("Accept", "application/json");
-            var response = await Utility.Utility.WithTimeout(m_timeoutOptions.ShortTimeout, cancelToken, ct => client.SendAsync(request, ct));
+            using var response = await Utility.Utility.WithTimeout(m_timeoutOptions.ShortTimeout, cancelToken, ct => client.SendAsync(request, ct));
 
             var body = await response.Content.ReadAsStringAsync(cancelToken);
-            var result = JsonSerializer.Deserialize<AuthResponseOuter>(body, m_jsonOptions);
+
+            // A failing gateway answers with html, which is not the shape expected here
+            AuthResponseOuter? result = null;
+            try
+            {
+                result = JsonSerializer.Deserialize<AuthResponseOuter>(body, m_jsonOptions);
+            }
+            catch (JsonException)
+            {
+            }
+
             if (result == null || !string.Equals(result.Status, "success", StringComparison.OrdinalIgnoreCase))
-                throw new UserInformationException($"Failed to authenticate: {result?.Message}", "LoginFailed");
+                throw new UserInformationException($"Failed to authenticate: {result?.Message ?? $"the server returned {(int)response.StatusCode} {response.StatusCode}"}", "LoginFailed");
             if (!string.IsNullOrWhiteSpace(result?.User?.Banned_At))
                 throw new UserInformationException($"User is banned: {result.User.Banned_At}", "UserBanned");
             response.EnsureSuccessStatusCode();
@@ -250,7 +262,9 @@ namespace Duplicati.Library.Backend
             using var request = new HttpRequestMessage(HttpMethod.Post, "uploads") { Content = content };
             request.Headers.Add("Accept", "application/json");
 
-            var response = await client.SendAsync(request, token);
+            using var response = await client.SendAsync(request, token);
+            await EnsureSuccessStatusCode(response);
+
             var body = await response.Content.ReadAsStringAsync(token);
             var result = JsonSerializer.Deserialize<FileEntryOuter>(body, m_jsonOptions);
             if (result == null || !string.Equals(result.Status, "success", StringComparison.OrdinalIgnoreCase))
@@ -258,7 +272,6 @@ namespace Duplicati.Library.Backend
 
             if (string.IsNullOrWhiteSpace(result?.FileEntry?.Id.ToString()))
                 throw new InvalidOperationException($"Failed to upload file: {result?.Message}");
-            await EnsureSuccessStatusCode(response);
 
             cache[result.FileEntry.Name] = new(result.FileEntry.Id, result.FileEntry.Url);
         }
@@ -553,17 +566,29 @@ namespace Duplicati.Library.Backend
         /// </summary>
         /// <param name="response">The HTTP response to check</param>
         /// <returns>An awaitable task</returns>
-        private static async Task EnsureSuccessStatusCode(HttpResponseMessage response)
+        internal static async Task EnsureSuccessStatusCode(HttpResponseMessage response)
         {
             if (response.IsSuccessStatusCode)
                 return;
 
             var body = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<ResponseEnvelope>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            if (result == null || !string.IsNullOrWhiteSpace(result.Message))
-                throw new InvalidOperationException($"Request failed: {result?.Message}");
 
-            await EnsureSuccessStatusCode(response);
+            // The body is not always the shape this backend expects; a gateway in
+            // front of the API answers with html, and some errors carry no message
+            string? message = null;
+            try
+            {
+                message = JsonSerializer.Deserialize<ResponseEnvelope>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })?.Message;
+            }
+            catch (JsonException)
+            {
+            }
+
+            if (!string.IsNullOrWhiteSpace(message))
+                throw new InvalidOperationException($"Request failed: {message}");
+
+            // Nothing to report beyond the status, so let the framework say it
+            response.EnsureSuccessStatusCode();
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/FilejumpErrorReportingTests.cs
+++ b/Duplicati/UnitTest/FilejumpErrorReportingTests.cs
@@ -1,0 +1,103 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using StringAssert = NUnit.Framework.Legacy.StringAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Every listing, delete and folder lookup in the Filejump backend hands its
+/// response to the same error handler, so what that handler does with a failed
+/// request is what the user ends up seeing.
+/// </summary>
+[TestFixture]
+public class FilejumpErrorReportingTests
+{
+    private static HttpResponseMessage Respond(HttpStatusCode status, string body, string mediaType = "application/json")
+        => new(status) { Content = new StringContent(body, Encoding.UTF8, mediaType) };
+
+    [Test]
+    [Category("Backend")]
+    public void ErrorBodyWithoutMessageIsReportedAsHttpFailure()
+    {
+        // Nothing in the body to report, so the status is all there is to go on
+        using var response = Respond(HttpStatusCode.InternalServerError, "{}");
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () => await Filejump.EnsureSuccessStatusCode(response));
+
+        Assert.AreEqual(HttpStatusCode.InternalServerError, ex!.StatusCode);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void ErrorBodyWithOnlyAStatusFieldIsReportedAsHttpFailure()
+    {
+        using var response = Respond(HttpStatusCode.ServiceUnavailable, "{\"status\":\"error\"}");
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () => await Filejump.EnsureSuccessStatusCode(response));
+
+        Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex!.StatusCode);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void NonJsonErrorBodyIsReportedAsHttpFailure()
+    {
+        // A gateway in front of the API answers with html, not with the shape
+        // the backend expects
+        using var response = Respond(HttpStatusCode.BadGateway,
+            "<html><head><title>502 Bad Gateway</title></head><body>502 Bad Gateway</body></html>", "text/html");
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () => await Filejump.EnsureSuccessStatusCode(response));
+
+        Assert.AreEqual(HttpStatusCode.BadGateway, ex!.StatusCode);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void ErrorMessageFromTheServerIsReported()
+    {
+        using var response = Respond((HttpStatusCode)422, "{\"message\":\"Storage quota exceeded\"}");
+
+        var ex = Assert.CatchAsync<InvalidOperationException>(async () => await Filejump.EnsureSuccessStatusCode(response));
+
+        StringAssert.Contains("Storage quota exceeded", ex!.Message);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task SuccessfulResponseIsAccepted()
+    {
+        using var response = Respond(HttpStatusCode.OK, "{\"status\":\"success\"}");
+
+        await Filejump.EnsureSuccessStatusCode(response);
+    }
+}


### PR DESCRIPTION
The Filejump error handler calls itself with the same response, so certain server errors take the process down with a stack overflow.

### The recursion

```csharp
private static async Task EnsureSuccessStatusCode(HttpResponseMessage response)
{
    if (response.IsSuccessStatusCode)
        return;

    var body = await response.Content.ReadAsStringAsync();
    var result = JsonSerializer.Deserialize<ResponseEnvelope>(body, ...);
    if (result == null || !string.IsNullOrWhiteSpace(result.Message))
        throw new InvalidOperationException($"Request failed: {result?.Message}");

    await EnsureSuccessStatusCode(response);   // <-- the local method, not the one on the response
}
```

The last line looks like it was meant to be `response.EnsureSuccessStatusCode()` — the framework method that throws with the status code. The names are identical, so it bound to the enclosing method instead.

It is reached when `result` parsed but `Message` is empty, and nothing about the response changes in between, so the next call takes the same branch. `StringContent` reads complete synchronously, so the continuations stay on the stack rather than moving to the heap, and it ends in a `StackOverflowException` — which .NET does not let you catch.

Trigger: a non-2xx response whose body is a JSON object without a `message`. `{}` and `{"status":"error"}` both qualify.

This is not an obscure path. `ListAsync`, `DeleteAsync`, `GetFolderIdAsync` and `CreateFolderAsync` all hand their response to this handler immediately after sending, so any listing or delete against a backend having a bad moment can hit it.

### Two smaller problems in the same handler

- A body that is not JSON at all (an html error page from a gateway) came back as `JsonException: '<' is an invalid start of a value`, never mentioning the status
- `result == null` produced `Request failed: ` with nothing after it

Both now fall through to the status.

### The status was also checked too late in two places

`GetClient` (login) and `PutAsync` (upload) checked the status only after the body had been deserialized and inspected. A 502 serving html failed in the parser first, so the check was unreachable exactly when it was needed.

Upload now checks first. Login is handled differently on purpose: running it through the generic handler would turn a wrong password — the most common failure there — from a `UserInformationException` with help id `LoginFailed` into an `InvalidOperationException`, which Duplicati no longer presents as something the user can fix. Instead the parse tolerates a non-JSON body and the status is named in the message, matching what the Drime backend already does.

### Tests

`Duplicati/UnitTest/FilejumpErrorReportingTests.cs` calls the handler with a constructed `HttpResponseMessage`, so there is no HTTP and no account involved. The handler was made `internal` for this; `InternalsVisibleTo("Duplicati.UnitTest")` is already used in `Duplicati.Library.Utility`, `Duplicati.Library.Main` and the backend tester.

| Test | Response | Before | After |
| --- | --- | --- | --- |
| `ErrorBodyWithoutMessageIsReportedAsHttpFailure` | 500 + `{}` | **test host crash** | `HttpRequestException`, status 500 |
| `ErrorBodyWithOnlyAStatusFieldIsReportedAsHttpFailure` | 503 + `{"status":"error"}` | **test host crash** | `HttpRequestException`, status 503 |
| `NonJsonErrorBodyIsReportedAsHttpFailure` | 502 + html | `JsonException` | `HttpRequestException`, status 502 |
| `ErrorMessageFromTheServerIsReported` | 422 + `{"message":"..."}` | passes | passes |
| `SuccessfulResponseIsAccepted` | 200 | passes | passes |

The first two were run on their own against unmodified code, because a stack overflow takes the runner with it. That run ended:

```
The active test run was aborted. Reason: Test host process crashed : Stack overflow.
   at System.Text.Json.JsonSerializer.Deserialize[...](System.String, System.Text.Json.JsonSerializerOptions)
   at Duplicati.Library.Backend.Filejump+<EnsureSuccessStatusCode>d__49.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[...](System.__Canon ByRef)
   at Duplicati.Library.Backend.Filejump.EnsureSuccessStatusCode(System.Net.Http.HttpResponseMessage)
   at Duplicati.Library.Backend.Filejump+<EnsureSuccessStatusCode>d__49.MoveNext()
   ... repeating to the end of the stack
```

### How this was verified

- The exceptions in the table are what the tests actually reported against unmodified code, including the crash above
- `dotnet build Duplicati.slnx -c Debug` — clean
- `Category=Backend` — green

**I do not have a Filejump account, so nothing here was exercised against the live service.**

**The login and upload ordering change is not covered by a test.** The backend builds its `HttpClient` internally in both the constructor and `GetClient`, so reaching those paths offline would mean adding a test-only seam to the production code. I left that out rather than widen the change; that part rests on reading the code.

This came out of a sweep for unchecked `SendAsync` results across the backends, following #7114. Two more are still to come — the pCloud upload path and `TahoeLAFS.DeleteAsync` — each as its own PR. Drime and OneDrive were checked and are fine; they route everything through a helper that gets this right.
