### PR TITLE
Check the response status before treating a pCloud upload as done

### DIFF
--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -29,6 +29,8 @@ using Uri = System.Uri;
 using System.Runtime.CompilerServices;
 using Duplicati.Library.Utility.Options;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend;
 
 /// <summary>
@@ -86,7 +88,7 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
     /// <summary>
     /// HttpClient to be used for requests
     /// </summary>
-    private readonly HttpClient _HttpClient;
+    private HttpClient _HttpClient;
 
     /// <summary>
     /// Variable being used to cache the folder ID, as it is required to upload files
@@ -159,6 +161,21 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
         // Set the timeout to infinite, all methods are called with cancelationTokens.
         _HttpClient.Timeout = Timeout.InfiniteTimeSpan;
 
+    }
+
+    /// <summary>
+    /// Builds the backend on a caller supplied handler, so the request handling
+    /// can be exercised without a pCloud account
+    /// </summary>
+    /// <param name="url">URL in Duplicati Uri format</param>
+    /// <param name="options">options to be used in the backend</param>
+    /// <param name="handler">The message handler to send requests through</param>
+    internal pCloudBackend(string url, Dictionary<string, string?> options, HttpMessageHandler handler)
+        : this(url, options)
+    {
+        _HttpClient.Dispose();
+        _HttpClient = new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
+        _HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _Token);
     }
 
     /// <summary>
@@ -278,6 +295,8 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
             new MediaTypeHeaderValue("application/octet-stream");
 
         using var response = await _HttpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
 
         var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         var uploadResponse = JsonSerializer.Deserialize<pCloudUploadResponse>(content)

--- a/Duplicati/UnitTest/PCloudUploadStatusTests.cs
+++ b/Duplicati/UnitTest/PCloudUploadStatusTests.cs
@@ -1,0 +1,127 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// An upload to pCloud is judged by the result code in the body. That code is an
+/// int defaulting to zero, which is what pCloud uses for success, so a body that
+/// does not carry one at all reads as a completed upload.
+/// </summary>
+[TestFixture]
+public class PCloudUploadStatusTests
+{
+    /// <summary>
+    /// No path in the url, so the folder id is resolved without a request and the
+    /// upload is the only call the stub has to answer
+    /// </summary>
+    private const string Url = "pcloud://api.pcloud.com/";
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+        private readonly string _mediaType;
+
+        public StubHandler(HttpStatusCode status, string body, string mediaType = "application/json")
+        {
+            _status = status;
+            _body = body;
+            _mediaType = mediaType;
+        }
+
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, _mediaType)
+            });
+        }
+    }
+
+    private static pCloudBackend CreateBackend(StubHandler handler)
+        => new(Url, new Dictionary<string, string?> { ["authid"] = "test-auth-id" }, handler);
+
+    private static Stream Volume()
+        => new MemoryStream(Encoding.UTF8.GetBytes("the contents of a backup volume"));
+
+    [Test]
+    [Category("Backend")]
+    public async Task FailedUploadIsNotReportedAsSuccess()
+    {
+        // The body is json, so it deserializes without complaint, and the result
+        // code it does not contain reads as zero
+        var handler = new StubHandler(HttpStatusCode.InternalServerError, "{\"error\":\"upstream failure\"}");
+        using var backend = CreateBackend(handler);
+        await using var volume = Volume();
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () =>
+            await backend.PutAsync("duplicati-b0123456789.dblock.zip.aes", volume, CancellationToken.None));
+
+        Assert.AreEqual(HttpStatusCode.InternalServerError, ex!.StatusCode);
+        Assert.AreEqual(1, handler.Calls);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task NonJsonErrorBodyIsReportedAsHttpFailure()
+    {
+        var handler = new StubHandler(HttpStatusCode.BadGateway,
+            "<html><head><title>502 Bad Gateway</title></head><body>502 Bad Gateway</body></html>", "text/html");
+        using var backend = CreateBackend(handler);
+        await using var volume = Volume();
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () =>
+            await backend.PutAsync("duplicati-b0123456789.dblock.zip.aes", volume, CancellationToken.None));
+
+        Assert.AreEqual(HttpStatusCode.BadGateway, ex!.StatusCode);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task SuccessfulUploadStillSucceeds()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, "{\"result\":0,\"fileids\":[1234]}");
+        using var backend = CreateBackend(handler);
+        await using var volume = Volume();
+
+        await backend.PutAsync("duplicati-b0123456789.dblock.zip.aes", volume, CancellationToken.None);
+
+        Assert.AreEqual(1, handler.Calls);
+    }
+}


### PR DESCRIPTION
A pCloud upload that fails with a server error is recorded as a completed upload.

### Why

`PutAsync` never looks at the response status. It judges the upload solely by the result code in the body:

```csharp
using var response = await _HttpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);

var content = await response.Content.ReadAsStringAsync(cancellationToken);
var uploadResponse = JsonSerializer.Deserialize<pCloudUploadResponse>(content)
    ?? throw new Exception("Failed to deserialize upload response");

if (pCloudErrorList.ErrorMessages.TryGetValue(uploadResponse.result, out var message))
    throw new Exception(message);

if (uploadResponse.result != 0)
    throw new Exception(...);
```

`pCloudUploadResponse.result` is an `int`, and pCloud uses **0 for success**. A body that does not contain `result` at all deserializes to an object whose `result` is the default — zero. So a 500 carrying something like `{"error":"upstream failure"}` walks straight through both checks and `PutAsync` returns normally.

The volume was never stored, but as far as the backup is concerned it was. That is worse than a confusing error message: nothing is retried and nothing is reported until a later verify or restore runs into the missing file.

If the body is not json — an html error page from a gateway — the failure does surface, but as `JsonException: '<' is an invalid start of a value`, which never mentions the status either.

### The change

```csharp
using var response = await _HttpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);

response.EnsureSuccessStatusCode();

var content = await response.Content.ReadAsStringAsync(cancellationToken);
```

This is the only one of the six requests in the backend whose status is not checked. `ListWithMetadata` already shows the intended shape — status, then parse, then result code — and the upload now matches it.

### Tests

`Duplicati/UnitTest/PCloudUploadStatusTests.cs` drives the backend through a stubbed `HttpMessageHandler`, so no account is involved. The url carries no path, so the folder id resolves without a request and the upload is the only call the stub has to answer.

| Test | Response | Before | After |
| --- | --- | --- | --- |
| `FailedUploadIsNotReportedAsSuccess` | 500 + `{"error":"upstream failure"}` | **returns normally** | `HttpRequestException`, status 500 |
| `NonJsonErrorBodyIsReportedAsHttpFailure` | 502 + html | `JsonException` | `HttpRequestException`, status 502 |
| `SuccessfulUploadStillSucceeds` | 200 + `{"result":0,...}` | passes | passes |

The first one is the point of the change. Against unmodified code it reported:

```
Expected: instance of <System.Net.Http.HttpRequestException>
But was:  null
```

`null` meaning no exception was thrown at all — the failed upload completed successfully.

### The test seam

`pCloudBackend` builds its own `HttpClient`, so reaching `PutAsync` offline needs a way in. Rather than touch the existing constructor, this adds a separate `internal` one beside it that delegates to the public one and then swaps the client:

```csharp
internal pCloudBackend(string url, Dictionary<string, string?> options, HttpMessageHandler handler)
    : this(url, options)
{
    _HttpClient.Dispose();
    _HttpClient = new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
    _HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _Token);
}
```

`_HttpClient` loses its `readonly` for this. The parameterless and two argument constructors are untouched, so `BackendLoader`'s `Activator.CreateInstance(type, url, options)` binds exactly as before — this is a different arity, not an optional parameter.

`InternalsVisibleTo("Duplicati.UnitTest")` follows what `Duplicati.Library.Utility`, `Duplicati.Library.Main` and the backend tester already do.

### How this was verified

- The table above is what the tests actually reported against unmodified code, including the `But was: null`
- `dotnet build Duplicati.slnx -c Debug` — clean
- `Category=Backend` — green

**I do not have a pCloud account, so none of this was exercised against the live service.** The verification is entirely offline; it covers the mapping from an HTTP status to an exception, and nothing about how pCloud behaves in practice.

Third of four from a sweep for unchecked `SendAsync` results across the backends, after #7114 (Filen) and #7115 (Filejump). `TahoeLAFS.DeleteAsync` is the last one and follows separately. Drime and OneDrive were checked and are fine.
