### PR TITLE
Check the response status when deleting a Tahoe-LAFS file

### DIFF
--- a/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
+++ b/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
@@ -28,6 +28,8 @@ using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using Newtonsoft.Json;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend;
 
 public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
@@ -74,6 +76,17 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
         _url = Util.AppendDirSeparator(_url, "/");
         _timeouts = TimeoutOptionsHelper.Parse(options);
     }
+
+    /// <summary>
+    /// Builds the backend on a caller supplied handler, so the request handling
+    /// can be exercised without a Tahoe-LAFS instance
+    /// </summary>
+    /// <param name="url">The connection url</param>
+    /// <param name="options">The options to use</param>
+    /// <param name="handler">The message handler to send requests through</param>
+    internal TahoeBackend(string url, Dictionary<string, string?> options, HttpMessageHandler handler)
+        : this(url, options)
+        => _httpClient = new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
 
     /// <inheritdoc />
     public Task TestAsync(bool alsoWrite, CancellationToken cancelToken)
@@ -175,14 +188,15 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
     {
         try
         {
-            using (await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
-                       innerCancelToken =>
-                       {
-                           using var request = CreateRequest(remotename, string.Empty, HttpMethod.Delete);
-                           return GetHttpClient().SendAsync(request,
-                               innerCancelToken);
-                       }).ConfigureAwait(false))
-            { }
+            using var resp = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
+                innerCancelToken =>
+                {
+                    using var request = CreateRequest(remotename, string.Empty, HttpMethod.Delete);
+                    return GetHttpClient().SendAsync(request,
+                        innerCancelToken);
+                }).ConfigureAwait(false);
+
+            resp.EnsureSuccessStatusCode();
         }
         catch (HttpRequestException wex)
             when (wex.StatusCode is HttpStatusCode.Conflict or HttpStatusCode.NotFound)

--- a/Duplicati/UnitTest/TahoeDeleteStatusTests.cs
+++ b/Duplicati/UnitTest/TahoeDeleteStatusTests.cs
@@ -1,0 +1,114 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Deleting a file from Tahoe-LAFS sends the request and throws the response
+/// away. Listing does the same thing but checks the status first, and the two
+/// carry the same catch clause, so a delete that the server refused looks
+/// exactly like one that worked.
+/// </summary>
+[TestFixture]
+public class TahoeDeleteStatusTests
+{
+    /// <summary>
+    /// The constructor insists on a dircap in the path
+    /// </summary>
+    private const string Url = "tahoe://example.invalid/uri/URI:DIR2:aaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbb/";
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public StubHandler(HttpStatusCode status)
+            => _status = status;
+
+        public int Calls { get; private set; }
+        public HttpMethod? LastMethod { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            LastMethod = request.Method;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(string.Empty, Encoding.UTF8, "text/plain")
+            });
+        }
+    }
+
+    private static TahoeBackend CreateBackend(StubHandler handler)
+        => new(Url, new Dictionary<string, string?>(), handler);
+
+    [Test]
+    [Category("Backend")]
+    public void FailedDeleteIsNotReportedAsSuccess()
+    {
+        var handler = new StubHandler(HttpStatusCode.InternalServerError);
+        using var backend = CreateBackend(handler);
+
+        var ex = Assert.CatchAsync<HttpRequestException>(async () =>
+            await backend.DeleteAsync("duplicati-b0123456789.dblock.zip.aes", CancellationToken.None));
+
+        Assert.AreEqual(HttpStatusCode.InternalServerError, ex!.StatusCode);
+        Assert.AreEqual(1, handler.Calls);
+        Assert.AreEqual(HttpMethod.Delete, handler.LastMethod);
+    }
+
+    [Test]
+    [Category("Backend")]
+    public void MissingFileIsReportedAsFolderMissing()
+    {
+        // The catch clause for this was already written, it just could not be
+        // reached without a status check
+        var handler = new StubHandler(HttpStatusCode.NotFound);
+        using var backend = CreateBackend(handler);
+
+        Assert.CatchAsync<FolderMissingException>(async () =>
+            await backend.DeleteAsync("duplicati-b0123456789.dblock.zip.aes", CancellationToken.None));
+    }
+
+    [Test]
+    [Category("Backend")]
+    public async Task SuccessfulDeleteStillSucceeds()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK);
+        using var backend = CreateBackend(handler);
+
+        await backend.DeleteAsync("duplicati-b0123456789.dblock.zip.aes", CancellationToken.None);
+
+        Assert.AreEqual(1, handler.Calls);
+    }
+}


### PR DESCRIPTION
A delete that the Tahoe-LAFS server refused is reported as a successful delete.

### Why

`DeleteAsync` sends the request and throws the response away without looking at it:

```csharp
try
{
    using (await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
               innerCancelToken =>
               {
                   using var request = CreateRequest(remotename, string.Empty, HttpMethod.Delete);
                   return GetHttpClient().SendAsync(request, innerCancelToken);
               }).ConfigureAwait(false))
    { }
}
catch (HttpRequestException wex)
    when (wex.StatusCode is HttpStatusCode.Conflict or HttpStatusCode.NotFound)
{
    throw new FolderMissingException(Strings.TahoeBackend.MissingFolderError(_url, wex.Message), wex);
}
```

`HttpClient.SendAsync` does not throw on a non-2xx, so the method returns normally whatever the server said. The file is still there; nothing reports it.

**The catch clause is the giveaway.** It is character for character the one in `ListAsync`, and it filters on `HttpRequestException.StatusCode` — which is only populated when `EnsureSuccessStatusCode` is what threw. `ListAsync` calls that before parsing; `DeleteAsync` never does. So the clause could not run: the 404 and 409 it was written to translate into `FolderMissingException` were being swallowed instead.

This is the only one of the five requests in the backend whose status is not checked. `CreateFolderAsync`, `ListAsync`, `GetAsync` and `RenameAsync` all call `EnsureSuccessStatusCode()` right after sending.

### The change

```csharp
using var resp = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
    innerCancelToken =>
    {
        using var request = CreateRequest(remotename, string.Empty, HttpMethod.Delete);
        return GetHttpClient().SendAsync(request, innerCancelToken);
    }).ConfigureAwait(false);

resp.EnsureSuccessStatusCode();
```

Same shape as the other four. The existing catch clause now does what it was written to do.

### Tests

`Duplicati/UnitTest/TahoeDeleteStatusTests.cs` drives the backend through a stubbed `HttpMessageHandler`, so no Tahoe-LAFS instance is involved.

| Test | Response | Before | After |
| --- | --- | --- | --- |
| `FailedDeleteIsNotReportedAsSuccess` | 500 | **returns normally** | `HttpRequestException`, status 500 |
| `MissingFileIsReportedAsFolderMissing` | 404 | **returns normally** | `FolderMissingException` |
| `SuccessfulDeleteStillSucceeds` | 200 | passes | passes |

The second one is the catch clause finally being reachable.

### The test seam

`TahoeBackend` builds its `HttpClient` lazily in `GetHttpClient()`, which returns `_httpClient` when it is already set. That makes the seam purely additive — a separate `internal` constructor beside the existing one, which is otherwise untouched:

```csharp
internal TahoeBackend(string url, Dictionary<string, string?> options, HttpMessageHandler handler)
    : this(url, options)
    => _httpClient = new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
```

The parameterless and two argument constructors are unchanged, so `BackendLoader`'s `Activator.CreateInstance(type, url, options)` binds exactly as before — this is a different arity, not an optional parameter.

`InternalsVisibleTo("Duplicati.UnitTest")` follows what `Duplicati.Library.Utility`, `Duplicati.Library.Main` and the backend tester already do.

### How this was verified

- The table above is what the tests actually reported against unmodified code
- `dotnet build Duplicati.slnx -c Debug` — clean
- `Category=Backend` — green

**I do not have a Tahoe-LAFS instance, so none of this was exercised against a running grid.** The verification is entirely offline; it covers the mapping from an HTTP status to an exception, and nothing about how Tahoe-LAFS behaves in practice.

Last of four from a sweep for unchecked `SendAsync` results across the backends, after #7114 (Filen), #7115 (Filejump) and #7117 (pCloud). Drime and OneDrive were checked and are fine; they route everything through a helper that gets this right.
