### PR TITLE
Move the URL encoding helpers out of the relaxed URL parser

### DIFF
--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -202,7 +202,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
         // For B2 we do not use a leading slash
         _prefix = _prefix.TrimStart('/');
 
-        _urlencodedPrefix = string.Join("/", _prefix.Split(new[] { '/' }).Select(x => Utility.RelaxedUri.UrlPathEncode(x)));
+        _urlencodedPrefix = string.Join("/", _prefix.Split(new[] { '/' }).Select(x => Utility.UrlEncoding.UrlPathEncode(x)));
 
         _bucketType = DEFAULT_BUCKET_TYPE;
         if (options.TryGetValue(B2_CREATE_BUCKET_TYPE_OPTION, out var option1))
@@ -352,7 +352,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
 
             request.Headers.TryAddWithoutValidation("Authorization", uploadUrlData.AuthorizationToken);
             request.Headers.Add("X-Bz-Content-Sha1", sha1);
-            request.Headers.Add("X-Bz-File-Name", _urlencodedPrefix + Utility.RelaxedUri.UrlPathEncode(remotename));
+            request.Headers.Add("X-Bz-File-Name", _urlencodedPrefix + Utility.UrlEncoding.UrlPathEncode(remotename));
             request.Content = new StreamContent(timeoutStream);
 
             request.Content.Headers.Add("Content-Type", "application/octet-stream");
@@ -414,9 +414,9 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
 
         using var request = _filecache != null && _filecache.ContainsKey(remotename)
             ? await _b2AuthHelper.CreateRequestAsync(
-                $"{config.DownloadUrl}/b2api/v1/b2_download_file_by_id?fileId={Utility.RelaxedUri.UrlEncode(await GetFileId(remotename, cancellationToken))}", HttpMethod.Get, cancellationToken).ConfigureAwait(false)
+                $"{config.DownloadUrl}/b2api/v1/b2_download_file_by_id?fileId={Utility.UrlEncoding.UrlEncode(await GetFileId(remotename, cancellationToken))}", HttpMethod.Get, cancellationToken).ConfigureAwait(false)
             : await _b2AuthHelper.CreateRequestAsync(
-                $"{config.DownloadUrl}/{_urlencodedPrefix}{Utility.RelaxedUri.UrlPathEncode(remotename)}", HttpMethod.Get, cancellationToken).ConfigureAwait(false);
+                $"{config.DownloadUrl}/{_urlencodedPrefix}{Utility.UrlEncoding.UrlPathEncode(remotename)}", HttpMethod.Get, cancellationToken).ConfigureAwait(false);
 
         HttpResponseMessage? response = null;
         try
@@ -712,7 +712,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
         await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancellationToken, async ct =>
             await _b2AuthHelper.PostAndGetJsonDataAsync<FileEntity>(
                 $"{config.APIUrl}/b2api/v1/b2_copy_file",
-                new CopyFileRequest(sourceFileId, _urlencodedPrefix + Utility.RelaxedUri.UrlPathEncode(newname)),
+                new CopyFileRequest(sourceFileId, _urlencodedPrefix + Utility.UrlEncoding.UrlPathEncode(newname)),
                 ct).ConfigureAwait(false)
         ).ConfigureAwait(false);
 

--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -48,7 +48,7 @@ namespace Duplicati.Library.Backend
         {
             var uri = new Utility.RelaxedUri(url);
 
-            m_path = Utility.RelaxedUri.UrlDecode(uri.HostAndPath);
+            m_path = Utility.UrlEncoding.UrlDecode(uri.HostAndPath);
             if (m_path.Length != 0 && !m_path.StartsWith("/", StringComparison.Ordinal))
                 m_path = "/" + m_path;
 

--- a/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
+++ b/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
@@ -190,9 +190,9 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
         var qp = uri.QueryParameters;
         foreach (var kvp in opts)
             if (!string.IsNullOrWhiteSpace(kvp.Value) && string.IsNullOrWhiteSpace(qp.Get(kvp.Key)))
-                qp[kvp.Key] = Utility.RelaxedUri.UrlEncode(kvp.Value);
+                qp[kvp.Key] = Utility.UrlEncoding.UrlEncode(kvp.Value);
 
-        var query = Utility.RelaxedUri.BuildUriQuery(qp);
+        var query = Utility.UrlEncoding.BuildUriQuery(qp);
 
         if (string.IsNullOrWhiteSpace(uri.HostAndPath) && !string.IsNullOrWhiteSpace(endpoint))
             uri = new Utility.RelaxedUri(endpoint).SetScheme(uri.Scheme).SetQuery(null);

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -184,7 +184,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         /// <inheritdoc />
         public async IAsyncEnumerable<IFileEntry> ListAsync([EnumeratorCancellation] CancellationToken cancelToken)
         {
-            var url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.RelaxedUri.UrlEncode(m_prefix));
+            var url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.UrlEncoding.UrlEncode(m_prefix));
             while (true)
             {
                 var resp = await HandleListExceptions(() =>
@@ -215,7 +215,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
                 var token = resp.nextPageToken;
                 if (string.IsNullOrWhiteSpace(token))
                     break;
-                url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.RelaxedUri.UrlEncode(m_prefix), token);
+                url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.UrlEncoding.UrlEncode(m_prefix), token);
             }
         }
 
@@ -232,7 +232,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         }
         public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
         {
-            using var req = await m_oauth.CreateRequestAsync(WebApi.GoogleCloudStorage.DeleteUrl(m_bucket, Library.Utility.RelaxedUri.UrlPathEncode(m_prefix + remotename)), HttpMethod.Delete, cancelToken);
+            using var req = await m_oauth.CreateRequestAsync(WebApi.GoogleCloudStorage.DeleteUrl(m_bucket, Library.Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename)), HttpMethod.Delete, cancelToken);
 
             await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, async ct
                 =>
@@ -243,7 +243,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task<DateTime?> GetObjectLockUntilAsync(string remotename, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.RelaxedUri.UrlPathEncode(m_prefix + remotename));
+            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename));
 
             try
             {
@@ -265,7 +265,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task SetObjectLockUntilAsync(string remotename, DateTime lockUntilUtc, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.RelaxedUri.UrlPathEncode(m_prefix + remotename));
+            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename));
 
             var metadata = new ObjectMetadata
             {
@@ -382,7 +382,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         {
             try
             {
-                var url = WebApi.GoogleCloudStorage.GetUrl(m_bucket, Utility.RelaxedUri.UrlPathEncode(m_prefix + remotename));
+                var url = WebApi.GoogleCloudStorage.GetUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename));
                 using var req = await m_oauth.CreateRequestAsync(url, HttpMethod.Get, cancelToken);
                 using var resp = await Library.Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, ct => m_oauth.GetResponseAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)).ConfigureAwait(false);
                 using var source = await Library.Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, ct => resp.Content.ReadAsStreamAsync(cancelToken)).ConfigureAwait(false);
@@ -400,7 +400,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task RenameAsync(string oldname, string newname, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.RewriteUrl(m_bucket, Utility.RelaxedUri.UrlPathEncode(m_prefix + oldname), m_bucket, Utility.RelaxedUri.UrlPathEncode(m_prefix + newname));
+            var url = WebApi.GoogleCloudStorage.RewriteUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + oldname), m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + newname));
 
             // Perform rewrite (copy)
             await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancellationToken, async ct =>

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -413,7 +413,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
 
                 foreach (var fileid in entries.Select(x => x.id).WhereNotNullOrWhiteSpace())
                 {
-                    var url = WebApi.GoogleDrive.DeleteUrl(Library.Utility.RelaxedUri.UrlPathEncode(fileid), m_teamDriveID);
+                    var url = WebApi.GoogleDrive.DeleteUrl(Library.Utility.UrlEncoding.UrlPathEncode(fileid), m_teamDriveID);
                     await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken,
                         async ct =>
                         {
@@ -566,7 +566,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
                 "trashed=false"
             };
 
-            var encodedFileQuery = Utility.RelaxedUri.UrlEncode(string.Join(" and ", fileQuery.Where(x => x != null)));
+            var encodedFileQuery = Utility.UrlEncoding.UrlEncode(string.Join(" and ", fileQuery.Where(x => x != null)));
             var url = WebApi.GoogleDrive.ListUrl(encodedFileQuery, m_teamDriveID);
 
             while (true)

--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -174,7 +174,7 @@ namespace Duplicati.Library.Backend.WebApi
             });
 
         public static string DeleteUrl(string fileId, string? teamDriveId)
-            => FileQueryUrl(Utility.RelaxedUri.UrlPathEncode(fileId), AddTeamDriveParam(teamDriveId));
+            => FileQueryUrl(Utility.UrlEncoding.UrlPathEncode(fileId), AddTeamDriveParam(teamDriveId));
 
         public static string PutUrl(string? fileId, bool useTeamDrive)
         {
@@ -188,7 +188,7 @@ namespace Duplicati.Library.Backend.WebApi
             }
 
             return !string.IsNullOrWhiteSpace(fileId) ?
-                FileUploadUrl(Utility.RelaxedUri.UrlPathEncode(fileId), queryParams) :
+                FileUploadUrl(Utility.UrlEncoding.UrlPathEncode(fileId), queryParams) :
                       FileUploadUrl(queryParams);
         }
 

--- a/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
+++ b/Duplicati/Library/Backend/Jottacloud/Jottacloud.cs
@@ -421,7 +421,7 @@ public class Jottacloud : IStreamingBackend, IRenameEnabledBackend
     private async Task<HttpRequestMessage> CreateRequest(HttpMethod method, string remotename, string queryparams, bool upload, CancellationToken cancelToken)
     {
         (var _, var urls) = await GetClient(cancelToken).ConfigureAwait(false);
-        return await CreateRequest((upload ? urls.UploadUrl : urls.Url) + Utility.RelaxedUri.UrlEncode(remotename).Replace("+", "%20"), queryparams, method, cancelToken).ConfigureAwait(false);
+        return await CreateRequest((upload ? urls.UploadUrl : urls.Url) + Utility.UrlEncoding.UrlEncode(remotename).Replace("+", "%20"), queryparams, method, cancelToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -649,7 +649,7 @@ public class Jottacloud : IStreamingBackend, IRenameEnabledBackend
     {
         (var client, var _) = await GetClient(cancellationToken).ConfigureAwait(false);
         var destPath = "/" + m_path + newname;
-        using var req = await CreateRequest(HttpMethod.Post, oldname, "mv=" + Utility.RelaxedUri.UrlEncode(destPath), false, cancellationToken).ConfigureAwait(false);
+        using var req = await CreateRequest(HttpMethod.Post, oldname, "mv=" + Utility.UrlEncoding.UrlEncode(destPath), false, cancellationToken).ConfigureAwait(false);
         using var response = await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancellationToken,
             innerCancellationToken => client.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, innerCancellationToken)).ConfigureAwait(false);
 

--- a/Duplicati/Library/Backend/OAuthHelper/MultipartItem.cs
+++ b/Duplicati/Library/Backend/OAuthHelper/MultipartItem.cs
@@ -101,7 +101,7 @@ namespace Duplicati.Library
                 if (string.IsNullOrWhiteSpace(value))
                     Headers.Remove("Content-Disposition");
                 else
-                    Headers["Content-Disposition"] = string.Format("form-data; name=\"{0}\"", Library.Utility.RelaxedUri.UrlEncode(value));
+                    Headers["Content-Disposition"] = string.Format("form-data; name=\"{0}\"", Library.Utility.UrlEncoding.UrlEncode(value));
             }
         }
 
@@ -132,7 +132,7 @@ namespace Duplicati.Library
         }
         public MultipartItem SetHeader(string key, string value)
         {
-            return SetHeaderRaw(key, Library.Utility.RelaxedUri.UrlEncode(value));
+            return SetHeaderRaw(key, Library.Utility.UrlEncoding.UrlEncode(value));
         }
         public MultipartItem SetContentDisposition(string name, string filename = null)
         {
@@ -142,7 +142,7 @@ namespace Duplicati.Library
                 return this;
             }
 
-            return SetHeaderRaw("Content-Disposition", string.Format("form-data; name=\"{0}\"; filename=\"{1}\"", Library.Utility.RelaxedUri.UrlEncode(name), Library.Utility.RelaxedUri.UrlEncode(filename)));
+            return SetHeaderRaw("Content-Disposition", string.Format("form-data; name=\"{0}\"; filename=\"{1}\"", Library.Utility.UrlEncoding.UrlEncode(name), Library.Utility.UrlEncoding.UrlEncode(filename)));
         }
 
     }

--- a/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
+++ b/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs
@@ -680,7 +680,7 @@ namespace Duplicati.Library.Backend
             // Extract out the path to the backup root folder from the given URI
             var uri = new Utility.RelaxedUri(url);
 
-            return Task.FromResult(Utility.RelaxedUri.UrlDecode(uri.HostAndPath));
+            return Task.FromResult(Utility.UrlEncoding.UrlDecode(uri.HostAndPath));
         }
 
         protected Task<T> GetAsync<T>(string url, CancellationToken cancelToken)

--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -329,7 +329,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     /// <inheritdoc />
     public async Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, RelaxedUri.UrlPathEncode(m_prefix + remotename));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, UrlEncoding.UrlPathEncode(m_prefix + remotename));
         using var req = m_helper.CreateRequest(url, "PUT");
         await using var ts = stream.ObserveReadTimeout(_timeouts.ReadWriteTimeout, false);
 
@@ -343,7 +343,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     /// <inheritdoc />
     public async Task GetAsync(string remotename, Stream stream, CancellationToken cancelToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, RelaxedUri.UrlPathEncode(m_prefix + remotename));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, UrlEncoding.UrlPathEncode(m_prefix + remotename));
 
         try
         {
@@ -386,7 +386,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     {
         var plainurl = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container) + string.Format("?format=json&delimiter=/&limit={0}", PAGE_LIMIT);
         if (!string.IsNullOrEmpty(m_prefix))
-            plainurl += "&prefix=" + RelaxedUri.UrlEncode(m_prefix);
+            plainurl += "&prefix=" + UrlEncoding.UrlEncode(m_prefix);
 
         var url = plainurl;
 
@@ -417,7 +417,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
                 yield break;
 
             // Prepare next listing entry
-            url = plainurl + $"&marker={RelaxedUri.UrlEncode(items.Last().name ?? "")}";
+            url = plainurl + $"&marker={UrlEncoding.UrlEncode(items.Last().name ?? "")}";
         }
     }
 
@@ -438,7 +438,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     /// <inheritdoc />
     public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, RelaxedUri.UrlPathEncode(m_prefix + remotename));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, UrlEncoding.UrlPathEncode(m_prefix + remotename));
         using var req = m_helper.CreateRequest(url, "DELETE");
         using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, ct => m_helper.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, ct)).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
@@ -507,9 +507,9 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
 
     public async Task RenameAsync(string oldname, string newname, CancellationToken cancellationToken)
     {
-        var url = JoinUrls(await GetSimpleStorageEndPoint(cancellationToken).ConfigureAwait(false), m_container, RelaxedUri.UrlPathEncode(m_prefix + oldname));
+        var url = JoinUrls(await GetSimpleStorageEndPoint(cancellationToken).ConfigureAwait(false), m_container, UrlEncoding.UrlPathEncode(m_prefix + oldname));
         using var req = m_helper.CreateRequest(url, "COPY");
-        req.Headers.Add("Destination", "/" + m_container + "/" + RelaxedUri.UrlPathEncode(m_prefix + newname));
+        req.Headers.Add("Destination", "/" + m_container + "/" + UrlEncoding.UrlPathEncode(m_prefix + newname));
 
         using var response = await m_httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();

--- a/Duplicati/Library/Backend/SSHv2/KeyGenerator.cs
+++ b/Duplicati/Library/Backend/SSHv2/KeyGenerator.cs
@@ -132,7 +132,7 @@ namespace Duplicati.Library.Backend
 
             var b64 = sb.ToString().Trim();
             var pem = string.Format(pem_template, b64);
-            var uri = SSHv2.KEYFILE_URI + Duplicati.Library.Utility.RelaxedUri.UrlEncode(pem);
+            var uri = SSHv2.KEYFILE_URI + Duplicati.Library.Utility.UrlEncoding.UrlEncode(pem);
             var pub = key_name + " " + Convert.ToBase64String(public_key) + " " + username;
 
             res["privkey"] = b64_raw;

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -596,7 +596,7 @@ namespace Duplicati.Library.Backend
                 using (var ms = new MemoryStream())
                 using (var sr = new StreamWriter(ms))
                 {
-                    sr.Write(Utility.RelaxedUri.UrlDecode(inline));
+                    sr.Write(Utility.UrlEncoding.UrlDecode(inline));
                     sr.Flush();
 
                     ms.Position = 0;

--- a/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
+++ b/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
@@ -260,7 +260,7 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
     /// <returns></returns>
     private HttpRequestMessage CreateRequest(string remotename, string queryparams, HttpMethod? method = null)
     {
-        var request = new HttpRequestMessage(method == null ? HttpMethod.Get : method, $"{_url}{RelaxedUri.UrlEncode(remotename).Replace("+", "%20")}{(string.IsNullOrEmpty(queryparams) || queryparams.Trim().Length == 0 ? String.Empty : "?" + queryparams)}");
+        var request = new HttpRequestMessage(method == null ? HttpMethod.Get : method, $"{_url}{UrlEncoding.UrlEncode(remotename).Replace("+", "%20")}{(string.IsNullOrEmpty(queryparams) || queryparams.Trim().Length == 0 ? String.Empty : "?" + queryparams)}");
         request.Headers.UserAgent.ParseAdd($"Duplicati Tahoe-LAFS Client {Assembly.GetExecutingAssembly().GetName().Version?.ToString()}");
         return request;
     }
@@ -283,7 +283,7 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
         using var resp = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancellationToken,
             innerCancelToken =>
             {
-                using var request = CreateRequest(string.Empty, $"t=rename&from_name={RelaxedUri.UrlEncode(oldname)}&to_name={RelaxedUri.UrlEncode(newname)}", HttpMethod.Post);
+                using var request = CreateRequest(string.Empty, $"t=rename&from_name={UrlEncoding.UrlEncode(oldname)}&to_name={UrlEncoding.UrlEncode(newname)}", HttpMethod.Post);
                 return GetHttpClient().SendAsync(request, innerCancelToken);
             }).ConfigureAwait(false);
 

--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -190,7 +190,7 @@ namespace Duplicati.Library.Backend
                 m_path = "/" + m_path;
             m_path = Util.AppendDirSeparator(m_path, "/");
 
-            m_path = Utility.RelaxedUri.UrlDecode(m_path);
+            m_path = Utility.UrlEncoding.UrlDecode(m_path);
             m_rawurl = new Utility.RelaxedUri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path).ToString();
 
             int port = u.Port;
@@ -238,7 +238,7 @@ namespace Duplicati.Library.Backend
             if (path == null)
                 return;
 
-            var normalized = Utility.RelaxedUri.UrlDecode(path.Replace("+", "%2B"));
+            var normalized = Utility.UrlEncoding.UrlDecode(path.Replace("+", "%2B"));
 
             if (!normalized.StartsWith("/", StringComparison.Ordinal))
                 normalized = "/" + normalized;
@@ -264,17 +264,17 @@ namespace Duplicati.Library.Backend
                 }
                 else
                 {
-                    var decodedValue = Utility.RelaxedUri.UrlDecode(trimmed.Replace("+", "%2B"));
+                    var decodedValue = Utility.UrlEncoding.UrlDecode(trimmed.Replace("+", "%2B"));
                     return ExtractRelativeFromDecodedPath(decodedValue);
                 }
             }
 
-            var decodedPath = Utility.RelaxedUri.UrlDecode(hrefUri.AbsolutePath.Replace("+", "%2B"));
+            var decodedPath = Utility.UrlEncoding.UrlDecode(hrefUri.AbsolutePath.Replace("+", "%2B"));
             var name = ExtractRelativeFromDecodedPath(decodedPath);
             if (!string.IsNullOrEmpty(name))
                 return name;
 
-            var decodedHref = Utility.RelaxedUri.UrlDecode(trimmed.Replace("+", "%2B"));
+            var decodedHref = Utility.UrlEncoding.UrlDecode(trimmed.Replace("+", "%2B"));
             return ExtractRelativeFromDecodedPath(decodedHref);
         }
 
@@ -329,7 +329,7 @@ namespace Duplicati.Library.Backend
             if (string.IsNullOrWhiteSpace(hrefValue))
                 return null;
 
-            string name = Utility.RelaxedUri.UrlDecode(hrefValue.Replace("+", "%2B"));
+            string name = Utility.UrlEncoding.UrlDecode(hrefValue.Replace("+", "%2B"));
 
             string cmp_path;
 
@@ -611,7 +611,7 @@ namespace Duplicati.Library.Backend
 
         private HttpRequestMessage CreateRequest(string remotename, HttpMethod? method = null)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{m_url}{Utility.RelaxedUri.UrlEncode(remotename).Replace("+", "%20")}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{m_url}{Utility.UrlEncoding.UrlEncode(remotename).Replace("+", "%20")}");
             request.Headers.Add(HttpRequestHeader.UserAgent.ToString(), "Duplicati WEBDAV Client v" + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
 
             request.Headers.ConnectionClose = !m_useIntegratedAuthentication; // ConnectionClose is incompatible with integrated authentication
@@ -686,7 +686,7 @@ namespace Duplicati.Library.Backend
             try
             {
                 using var request = CreateRequest(oldname, new HttpMethod("MOVE"));
-                request.Headers.Add("Destination", $"{m_url}{Utility.RelaxedUri.UrlEncode(newname).Replace("+", "%20")}");
+                request.Headers.Add("Destination", $"{m_url}{Utility.UrlEncoding.UrlEncode(newname).Replace("+", "%20")}");
                 request.Headers.Add("Overwrite", "T");
 
                 using var response = await GetHttpClient().SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/Duplicati/Library/Main/SecretProviderHelper.cs
+++ b/Duplicati/Library/Main/SecretProviderHelper.cs
@@ -267,8 +267,8 @@ public static class SecretProviderHelper
             {
                 var uri = internalUriArguments[s];
                 var kp = uri.QueryParameters;
-                kp[k] = Library.Utility.RelaxedUri.UrlEncode(translated[v.Key]);
-                uri = uri.SetQuery(Library.Utility.RelaxedUri.BuildUriQuery(kp));
+                kp[k] = Library.Utility.UrlEncoding.UrlEncode(translated[v.Key]);
+                uri = uri.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(kp));
                 internalUriArguments[s] = uri;
             }
 

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -249,7 +249,7 @@ namespace Duplicati.Library.Modules.Builtin
                 }
                 else
                 {
-                    var values = Utility.RelaxedUri.ParseQueryString(extraData);
+                    var values = Utility.UrlEncoding.ParseQueryString(extraData);
                     m_extraValues = values.AllKeys
                         .Where(x => !string.IsNullOrWhiteSpace(x))
                         .ToDictionary(key => key, key => values[key]);

--- a/Duplicati/Library/RestAPI/Database/Backup.cs
+++ b/Duplicati/Library/RestAPI/Database/Backup.cs
@@ -139,11 +139,11 @@ namespace Duplicati.Server.Database
                 // We cannot use url.QueryParameters since it contains decoded parameter values, which
                 // breaks assumptions made by the decode_uri function in AppUtils.js. Since we are simply
                 // removing password parameters, we will leave the parameters as they are in the target URL.
-                filteredParameters = Library.Utility.RelaxedUri.ParseQueryString(url.Query, false);
+                filteredParameters = Library.Utility.UrlEncoding.ParseQueryString(url.Query, false);
                 foreach (var field in Connection.PasswordFieldNames)
                     filteredParameters.Remove(field);
             }
-            url = url.SetQuery(Duplicati.Library.Utility.RelaxedUri.BuildUriQuery(filteredParameters));
+            url = url.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters));
             this.TargetURL = url.ToString();
         }
 
@@ -172,11 +172,11 @@ namespace Duplicati.Server.Database
 
                     if (url.Query != null)
                     {
-                        var filteredParameters = Library.Utility.RelaxedUri.ParseQueryString(url.Query, false);
+                        var filteredParameters = Library.Utility.UrlEncoding.ParseQueryString(url.Query, false);
                         foreach (var field in Connection.PasswordFieldNames)
                             filteredParameters.Remove(field);
 
-                        url = url.SetQuery(Library.Utility.RelaxedUri.BuildUriQuery(filteredParameters));
+                        url = url.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters));
                         this.Sources[i] = SourceMasking.ReplaceUrl(this.Sources[i], url.ToString());
                     }
                 }
@@ -209,7 +209,7 @@ namespace Duplicati.Server.Database
                 var filteredParameters = url.QueryParameters;
                 foreach (var field in Connection.PasswordFieldNames)
                     filteredParameters.Remove(field);
-                url = url.SetQuery(Duplicati.Library.Utility.RelaxedUri.BuildUriQuery(filteredParameters));
+                url = url.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters));
                 target.TargetUrl = url.ToString();
             }
         }

--- a/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
+++ b/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
@@ -50,7 +50,7 @@ public static class QuerystringMasking
             return urlstring;
 
         var modified = false;
-        var query = Library.Utility.RelaxedUri.ParseQueryString(url.Query, false);
+        var query = Library.Utility.UrlEncoding.ParseQueryString(url.Query, false);
         foreach (var k in query.AllKeys)
         {
             if (k is null) continue;
@@ -63,7 +63,7 @@ public static class QuerystringMasking
 
         if (!modified) return urlstring;
 
-        url = url.SetQuery(Library.Utility.RelaxedUri.BuildUriQuery(query));
+        url = url.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(query));
         return url.ToString();
     }
 
@@ -92,7 +92,7 @@ public static class QuerystringMasking
         if (string.IsNullOrWhiteSpace(newUb.Query))
             return newUrl;
 
-        var newQuery = Library.Utility.RelaxedUri.ParseQueryString(newUb.Query, false);
+        var newQuery = Library.Utility.UrlEncoding.ParseQueryString(newUb.Query, false);
 
         var modified = false;
         foreach (var key in newQuery.AllKeys)
@@ -117,7 +117,7 @@ public static class QuerystringMasking
                             continue;
 
                         var prevUb = new Library.Utility.RelaxedUri(previousUrl);
-                        var prevQuery = Library.Utility.RelaxedUri.ParseQueryString(prevUb.Query ?? "", false);
+                        var prevQuery = Library.Utility.UrlEncoding.ParseQueryString(prevUb.Query ?? "", false);
                         prevValues = GetValuesCaseInsensitive(prevQuery, key);
                         if (prevValues != null && prevValues.Any(x => !Connection.IsPasswordPlaceholder(x)))
                             break;
@@ -139,7 +139,7 @@ public static class QuerystringMasking
         if (!modified)
             return newUrl;
 
-        newUb = newUb.SetQuery(Library.Utility.RelaxedUri.BuildUriQuery(newQuery));
+        newUb = newUb.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(newQuery));
 
         return newUb.ToString();
 

--- a/Duplicati/Library/Utility/RelaxedUri.cs
+++ b/Duplicati/Library/Utility/RelaxedUri.cs
@@ -108,7 +108,7 @@ namespace Duplicati.Library.Utility
                     if (Query == null)
                         m_queryParams = new NameValueCollection();
                     else
-                        m_queryParams = ParseQueryString(Query);
+                        m_queryParams = UrlEncoding.ParseQueryString(Query);
                 }
 
                 return m_queryParams;
@@ -165,7 +165,7 @@ namespace Duplicati.Library.Utility
             // produces are recognized as the same Windows path and round-trip cleanly.
             if (url.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
             {
-                var candidate = UrlDecode(url.Substring("file://".Length));
+                var candidate = UrlEncoding.UrlDecode(url.Substring("file://".Length));
                 // also accept the correctly-encoded file:///C:\ triple-slash form
                 if (candidate.StartsWith("/", StringComparison.Ordinal) && WINDOWS_PATH.IsMatch(candidate))
                     candidate = candidate.Substring(1);
@@ -191,7 +191,7 @@ namespace Duplicati.Library.Utility
                 if (path.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
                     path = path.Substring("file://".Length);
 
-                path = UrlDecode(path);
+                path = UrlEncoding.UrlDecode(path);
 
                 if (path.IndexOfAny(System.IO.Path.GetInvalidPathChars()) < 0)
                     try
@@ -213,9 +213,9 @@ namespace Duplicati.Library.Utility
             }
 
             this.Scheme = m.Groups["scheme"].Value;
-            var h = UrlDecode(m.Groups["hostname"].Success ? m.Groups["hostname"].Value : "");
+            var h = UrlEncoding.UrlDecode(m.Groups["hostname"].Success ? m.Groups["hostname"].Value : "");
 
-            var p = UrlDecode(m.Groups["path"].Success ? m.Groups["path"].Value : "");
+            var p = UrlEncoding.UrlDecode(m.Groups["path"].Success ? m.Groups["path"].Value : "");
             if (m.Groups["hostname"].Success && p.StartsWith("/", StringComparison.Ordinal))
                 p = p.Substring(1);
 
@@ -237,8 +237,8 @@ namespace Duplicati.Library.Utility
             this.Path = p;
 
             this.Query = m.Groups["query"].Success ? m.Groups["query"].Value : null;
-            this.Username = m.Groups["username"].Success ? UrlDecode(m.Groups["username"].Value) : null;
-            this.Password = m.Groups["password"].Success ? UrlDecode(m.Groups["password"].Value) : null;
+            this.Username = m.Groups["username"].Success ? UrlEncoding.UrlDecode(m.Groups["username"].Value) : null;
+            this.Password = m.Groups["password"].Success ? UrlEncoding.UrlDecode(m.Groups["password"].Value) : null;
             if (m.Groups["port"].Success)
                 this.Port = int.Parse(m.Groups["port"].Value);
             else
@@ -303,15 +303,15 @@ namespace Duplicati.Library.Utility
             if (!string.IsNullOrEmpty(username) || !string.IsNullOrEmpty(password))
             {
 
-                s += UrlEncode(username ?? "");
+                s += UrlEncoding.UrlEncode(username ?? "");
                 s += ":";
-                s += UrlEncode(password ?? "");
+                s += UrlEncoding.UrlEncode(password ?? "");
                 s += "@";
             }
 
             if (!string.IsNullOrEmpty(host))
             {
-                s += UrlPathEncode(host);
+                s += UrlEncoding.UrlPathEncode(host);
                 if (port != -1)
                     s += ":" + port.ToString();
             }
@@ -322,7 +322,7 @@ namespace Duplicati.Library.Utility
                 if (!string.IsNullOrEmpty(host) || (WINDOWS_PATH.IsMatch(path) && !path.StartsWith("/")))
                     s += "/";
 
-                s += string.Join('/', path.Split('/').Select(x => UrlPathEncode(x)));
+                s += string.Join('/', path.Split('/').Select(x => UrlEncoding.UrlPathEncode(x)));
             }
             if (!string.IsNullOrEmpty(query))
                 s += "?" + query;
@@ -392,191 +392,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// The regular expression that matches %20 type values in a querystring
-        /// </summary>
-        private static readonly System.Text.RegularExpressions.Regex RE_ESCAPECHAR = new System.Text.RegularExpressions.Regex(@"[^0-9a-zA-Z\-_.]", System.Text.RegularExpressions.RegexOptions.Compiled);
-
-        /// <summary>
-        /// Encodes a URL, like System.Web.HttpUtility.UrlEncode
-        /// </summary>
-        /// <returns>The encoded URL</returns>
-        /// <param name="value">The URL fragment to encode</param>
-        /// <param name="encoding">The encoding to use</param>
-        public static string UrlPathEncode(string value, System.Text.Encoding? encoding = null)
-        {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-
-            return UrlEncode(value, encoding, "%20");
-        }
-
-        /// <summary>
-        /// Encodes a URL, like System.Web.HttpUtility.UrlEncode
-        /// </summary>
-        /// <returns>The encoded URL</returns>
-        /// <param name="value">The URL fragment to encode</param>
-        /// <param name="encoding">The encoding to use</param>
-        public static string UrlEncode(string value, System.Text.Encoding? encoding = null, string spacevalue = "+")
-        {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-
-            encoding = encoding ?? System.Text.Encoding.UTF8;
-
-            var encoder = encoding.GetEncoder();
-            var inbuf = new char[1];
-            var outbuf = new byte[4];
-
-            return RE_ESCAPECHAR.Replace(value, (m) =>
-            {
-                if (m.Value == " ")
-                    return spacevalue;
-
-                inbuf[0] = m.Value[0];
-
-                try
-                {
-                    var len = encoder.GetBytes(inbuf, 0, 1, outbuf, 0, true);
-                    return "%" + BitConverter.ToString(outbuf, 0, len).Replace("-", "%");
-                }
-                catch
-                {
-                }
-
-                //Fallback
-                return m.Value;
-            });
-
-        }
-
-        /// <summary>
-        /// The regular expression that matches %20 type values in a querystring
-        /// </summary>
-        private static readonly System.Text.RegularExpressions.Regex RE_NUMBER = new System.Text.RegularExpressions.Regex(@"(\%(?<number>([0-9]|[a-f]|[A-F]){2}))|(\+)|(\%u(?<number>([0-9]|[a-f]|[A-F]){4}))", System.Text.RegularExpressions.RegexOptions.Compiled);
-
-        /// <summary>
-        /// Decodes a URL, like System.Web.HttpUtility.UrlDecode
-        /// </summary>
-        /// <returns>The decoded URL</returns>
-        /// <param name="value">The URL fragment to decode</param>
-        /// <param name="encoding">The encoding to use</param>
-        public static string UrlDecode(string value, System.Text.Encoding? encoding = null)
-        {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-
-            encoding = encoding ?? System.Text.Encoding.UTF8;
-
-            var decoder = encoding.GetDecoder();
-            var inbuf = new byte[8];
-            var outbuf = new char[8];
-
-            return RE_NUMBER.Replace(value, (m) =>
-            {
-                if (m.Value == "+")
-                    return " ";
-
-                try
-                {
-                    var hex = m.Groups["number"].Value;
-                    var bytelen = hex.Length / 2;
-                    Utility.HexStringAsByteArray(hex, inbuf);
-                    var c = decoder.GetChars(inbuf, 0, bytelen, outbuf, 0);
-                    return new string(outbuf, 0, c);
-                }
-                catch
-                {
-                }
-
-                //Fallback
-                return m.Value;
-            });
-
-        }
-
-        /// <summary>
-        /// The regular expression that matches a=b type values in a querystring
-        /// </summary>
-        private static readonly System.Text.RegularExpressions.Regex RE_URLPARAM = new System.Text.RegularExpressions.Regex(@"(?<key>[^\=\&]+)(\=(?<value>[^\&]*))?", System.Text.RegularExpressions.RegexOptions.Compiled);
-
-        /// <summary>
-        /// Parses the query string.
-        /// This is a local implementation of System.Web.HttpUtility.ParseQueryString, kept for consistent behavior (originally added due to Mono limitations)
-        /// </summary>
-        /// <returns>The parsed query string</returns>
-        /// <param name="query">The query to parse</param>
-        public static NameValueCollection ParseQueryString(string query)
-        {
-            return ParseQueryString(query, true);
-        }
-
-        /// <summary>
-        /// Parses the query string.
-        /// This is a local implementation of System.Web.HttpUtility.ParseQueryString, kept for consistent behavior (originally added due to Mono limitations)
-        /// </summary>
-        /// <returns>The parsed query string</returns>
-        /// <param name="query">The query to parse</param>
-        /// <param name="decodeValues">Whether to the parameter values should be decoded or not.</param>
-        public static NameValueCollection ParseQueryString(string query, bool decodeValues)
-        {
-            if (query == null)
-                throw new ArgumentNullException(nameof(query));
-            if (query.StartsWith("?", StringComparison.Ordinal))
-                query = query.Substring(1);
-            if (string.IsNullOrEmpty(query))
-                return new NameValueCollection(StringComparer.OrdinalIgnoreCase);
-
-            var result = new NameValueCollection(StringComparer.OrdinalIgnoreCase);
-            foreach (System.Text.RegularExpressions.Match m in RE_URLPARAM.Matches(query))
-            {
-                string value = m.Groups["value"].Success ? m.Groups["value"].Value : "";
-                if (decodeValues)
-                {
-                    value = UrlDecode(value);
-                }
-
-                result.Add(UrlDecode(m.Groups["key"].Value), value);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Build the querystring to be used in a URL
-        /// </summary>
-        /// <returns>The generated querystring</returns>
-        /// <param name="query">A collection of name value pairs to be translated into a query string</param>
-        /// <param name="delimiter">The delimiter to separate key value pairs in the query string</param>
-        public static string BuildUriQuery(NameValueCollection query, string delimiter)
-        {
-
-            if (query == null)
-                throw new ArgumentNullException(nameof(query));
-
-            StringBuilder builder = new StringBuilder();
-            foreach (var key in query.Cast<string>().Where(key => !string.IsNullOrEmpty(query[key])))
-            {
-                builder.Append(builder.Length == 0 ? string.Empty : delimiter)
-                       .Append(key)
-                       .Append("=")
-                       .Append(query[key]);
-            }
-
-            return builder.ToString();
-        }
-
-        /// <summary>
-        /// Build the querystring to be used in a URL
-        /// </summary>
-        /// <returns>The generated querystring</returns>
-        /// <param name="query">A collection of name value pairs to be translated into a query string that is
-        /// ampersand delimited.</param>
-        public static string BuildUriQuery(NameValueCollection query)
-        {
-            return BuildUriQuery(query, "&");
-        }
-
-        /// <summary>
         /// Builds a URL together using a base URL, a path and a query.
         /// </summary>
         /// <returns>The built together URL.</returns>
@@ -588,7 +403,7 @@ namespace Duplicati.Library.Utility
             var builder = new UriBuilder(url)
             {
                 Path = new UrlPath(ExtractPath(url)).Append(path).ToString(),
-                Query = query != null ? BuildUriQuery(query) : null
+                Query = query != null ? UrlEncoding.BuildUriQuery(query) : null
             };
             return builder.Uri.AbsoluteUri;
         }

--- a/Duplicati/Library/Utility/UrlEncoding.cs
+++ b/Duplicati/Library/Utility/UrlEncoding.cs
@@ -1,0 +1,224 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+
+#nullable enable
+
+namespace Duplicati.Library.Utility
+{
+    /// <summary>
+    /// Encoding and query string helpers for urls.
+    /// These do not parse urls, and are kept apart from the url parsing so the
+    /// parser can be replaced without touching the many callers that only need
+    /// to encode a value or build a query string.
+    /// </summary>
+    public static class UrlEncoding
+    {
+        /// <summary>
+        /// The regular expression that matches %20 type values in a querystring
+        /// </summary>
+        private static readonly System.Text.RegularExpressions.Regex RE_ESCAPECHAR = new System.Text.RegularExpressions.Regex(@"[^0-9a-zA-Z\-_.]", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>
+        /// Encodes a URL, like System.Web.HttpUtility.UrlEncode
+        /// </summary>
+        /// <returns>The encoded URL</returns>
+        /// <param name="value">The URL fragment to encode</param>
+        /// <param name="encoding">The encoding to use</param>
+        public static string UrlPathEncode(string value, System.Text.Encoding? encoding = null)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            return UrlEncode(value, encoding, "%20");
+        }
+
+        /// <summary>
+        /// Encodes a URL, like System.Web.HttpUtility.UrlEncode
+        /// </summary>
+        /// <returns>The encoded URL</returns>
+        /// <param name="value">The URL fragment to encode</param>
+        /// <param name="encoding">The encoding to use</param>
+        public static string UrlEncode(string value, System.Text.Encoding? encoding = null, string spacevalue = "+")
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            encoding = encoding ?? System.Text.Encoding.UTF8;
+
+            var encoder = encoding.GetEncoder();
+            var inbuf = new char[1];
+            var outbuf = new byte[4];
+
+            return RE_ESCAPECHAR.Replace(value, (m) =>
+            {
+                if (m.Value == " ")
+                    return spacevalue;
+
+                inbuf[0] = m.Value[0];
+
+                try
+                {
+                    var len = encoder.GetBytes(inbuf, 0, 1, outbuf, 0, true);
+                    return "%" + BitConverter.ToString(outbuf, 0, len).Replace("-", "%");
+                }
+                catch
+                {
+                }
+
+                //Fallback
+                return m.Value;
+            });
+
+        }
+
+        /// <summary>
+        /// The regular expression that matches %20 type values in a querystring
+        /// </summary>
+        private static readonly System.Text.RegularExpressions.Regex RE_NUMBER = new System.Text.RegularExpressions.Regex(@"(\%(?<number>([0-9]|[a-f]|[A-F]){2}))|(\+)|(\%u(?<number>([0-9]|[a-f]|[A-F]){4}))", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>
+        /// Decodes a URL, like System.Web.HttpUtility.UrlDecode
+        /// </summary>
+        /// <returns>The decoded URL</returns>
+        /// <param name="value">The URL fragment to decode</param>
+        /// <param name="encoding">The encoding to use</param>
+        public static string UrlDecode(string value, System.Text.Encoding? encoding = null)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            encoding = encoding ?? System.Text.Encoding.UTF8;
+
+            var decoder = encoding.GetDecoder();
+            var inbuf = new byte[8];
+            var outbuf = new char[8];
+
+            return RE_NUMBER.Replace(value, (m) =>
+            {
+                if (m.Value == "+")
+                    return " ";
+
+                try
+                {
+                    var hex = m.Groups["number"].Value;
+                    var bytelen = hex.Length / 2;
+                    Utility.HexStringAsByteArray(hex, inbuf);
+                    var c = decoder.GetChars(inbuf, 0, bytelen, outbuf, 0);
+                    return new string(outbuf, 0, c);
+                }
+                catch
+                {
+                }
+
+                //Fallback
+                return m.Value;
+            });
+
+        }
+
+        /// <summary>
+        /// The regular expression that matches a=b type values in a querystring
+        /// </summary>
+        private static readonly System.Text.RegularExpressions.Regex RE_URLPARAM = new System.Text.RegularExpressions.Regex(@"(?<key>[^\=\&]+)(\=(?<value>[^\&]*))?", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parses the query string.
+        /// This is a local implementation of System.Web.HttpUtility.ParseQueryString, kept for consistent behavior (originally added due to Mono limitations)
+        /// </summary>
+        /// <returns>The parsed query string</returns>
+        /// <param name="query">The query to parse</param>
+        public static NameValueCollection ParseQueryString(string query)
+        {
+            return ParseQueryString(query, true);
+        }
+
+        /// <summary>
+        /// Parses the query string.
+        /// This is a local implementation of System.Web.HttpUtility.ParseQueryString, kept for consistent behavior (originally added due to Mono limitations)
+        /// </summary>
+        /// <returns>The parsed query string</returns>
+        /// <param name="query">The query to parse</param>
+        /// <param name="decodeValues">Whether to the parameter values should be decoded or not.</param>
+        public static NameValueCollection ParseQueryString(string query, bool decodeValues)
+        {
+            if (query == null)
+                throw new ArgumentNullException(nameof(query));
+            if (query.StartsWith("?", StringComparison.Ordinal))
+                query = query.Substring(1);
+            if (string.IsNullOrEmpty(query))
+                return new NameValueCollection(StringComparer.OrdinalIgnoreCase);
+
+            var result = new NameValueCollection(StringComparer.OrdinalIgnoreCase);
+            foreach (System.Text.RegularExpressions.Match m in RE_URLPARAM.Matches(query))
+            {
+                string value = m.Groups["value"].Success ? m.Groups["value"].Value : "";
+                if (decodeValues)
+                {
+                    value = UrlDecode(value);
+                }
+
+                result.Add(UrlDecode(m.Groups["key"].Value), value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Build the querystring to be used in a URL
+        /// </summary>
+        /// <returns>The generated querystring</returns>
+        /// <param name="query">A collection of name value pairs to be translated into a query string</param>
+        /// <param name="delimiter">The delimiter to separate key value pairs in the query string</param>
+        public static string BuildUriQuery(NameValueCollection query, string delimiter)
+        {
+
+            if (query == null)
+                throw new ArgumentNullException(nameof(query));
+
+            StringBuilder builder = new StringBuilder();
+            foreach (var key in query.Cast<string>().Where(key => !string.IsNullOrEmpty(query[key])))
+            {
+                builder.Append(builder.Length == 0 ? string.Empty : delimiter)
+                       .Append(key)
+                       .Append("=")
+                       .Append(query[key]);
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Build the querystring to be used in a URL
+        /// </summary>
+        /// <returns>The generated querystring</returns>
+        /// <param name="query">A collection of name value pairs to be translated into a query string that is
+        /// ampersand delimited.</param>
+        public static string BuildUriQuery(NameValueCollection query)
+        {
+            return BuildUriQuery(query, "&");
+        }
+    }
+}

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -29,33 +29,6 @@ namespace Duplicati.UnitTest
     {
         [Test]
         [Category("UriUtility")]
-        public static void TestBuildUriQuery()
-        {
-            var query = new NameValueCollection { { "a", "b" } };
-            var queryUrl = Library.Utility.RelaxedUri.BuildUriQuery(query);
-            Assert.AreEqual("a=b", queryUrl);
-            query.Add(new NameValueCollection { { "c", "d" } });
-            queryUrl = Library.Utility.RelaxedUri.BuildUriQuery(query);
-            Assert.AreEqual("a=b&c=d", queryUrl);
-
-            // Test with space in value
-            query = new NameValueCollection { { "key", "value with space" } };
-            queryUrl = Library.Utility.RelaxedUri.BuildUriQuery(query);
-            Assert.AreEqual("key=value with space", queryUrl);
-
-            // Test with + in value
-            query = new NameValueCollection { { "key", "value+plus" } };
-            queryUrl = Library.Utility.RelaxedUri.BuildUriQuery(query);
-            Assert.AreEqual("key=value+plus", queryUrl);
-
-            // Test with % in value
-            query = new NameValueCollection { { "key", "value%percent" } };
-            queryUrl = Library.Utility.RelaxedUri.BuildUriQuery(query);
-            Assert.AreEqual("key=value%percent", queryUrl);
-        }
-
-        [Test]
-        [Category("UriUtility")]
         public static void TestUrlBuilder()
         {
             var baseUrl = "http://localhost";

--- a/Duplicati/UnitTest/UrlEncodingTests.cs
+++ b/Duplicati/UnitTest/UrlEncodingTests.cs
@@ -1,0 +1,161 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Specialized;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The url encoding and query string helpers do not follow the framework, and
+    /// backends depend on the differences: a space becomes a plus, a plus decodes
+    /// back to a space, the set of characters left alone is smaller than RFC 3986
+    /// asks for, and building a query does not encode at all. These tests write
+    /// that down, so a later replacement has something to fail against.
+    /// </summary>
+    public class UrlEncodingTests : BasicSetupHelper
+    {
+        [Test]
+        [Category("Utility")]
+        public static void SpaceIsEncodedPerHelper()
+        {
+            Assert.AreEqual("a+b", Library.Utility.UrlEncoding.UrlEncode("a b"));
+            Assert.AreEqual("a%20b", Library.Utility.UrlEncoding.UrlPathEncode("a b"));
+            Assert.AreEqual("a-b", Library.Utility.UrlEncoding.UrlEncode("a b", spacevalue: "-"));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void PlusDecodesToSpace()
+        {
+            // The framework leaves a plus alone, so this is one of the differences
+            Assert.AreEqual("a b", Library.Utility.UrlEncoding.UrlDecode("a+b"));
+            Assert.AreEqual("a b", Library.Utility.UrlEncoding.UrlDecode("a%20b"));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void MultiByteSequencesAreDecoded()
+        {
+            // Every %XX is matched on its own, so decoding a character that takes
+            // more than one byte only works because the decoder keeps its state
+            // between the matches
+            Assert.AreEqual("æ", Library.Utility.UrlEncoding.UrlDecode("%C3%A6"));
+            Assert.AreEqual("日本", Library.Utility.UrlEncoding.UrlDecode("%E6%97%A5%E6%9C%AC"));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void OnlyAlphanumericAndThreeSignsAreLeftAlone()
+        {
+            Assert.AreEqual("aA1-_.", Library.Utility.UrlEncoding.UrlEncode("aA1-_."));
+
+            // RFC 3986 counts the tilde as unreserved; this helper does not
+            Assert.AreEqual("%7E", Library.Utility.UrlEncoding.UrlEncode("~"));
+            Assert.AreEqual("%2F", Library.Utility.UrlEncoding.UrlEncode("/"));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void EncodingRoundTrips()
+        {
+            var value = "a b/c~d%e+f æ日本";
+            Assert.AreEqual(value, Library.Utility.UrlEncoding.UrlDecode(Library.Utility.UrlEncoding.UrlEncode(value)));
+            Assert.AreEqual(value, Library.Utility.UrlEncoding.UrlDecode(Library.Utility.UrlEncoding.UrlPathEncode(value)));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void QueryStringIsParsedCaseInsensitively()
+        {
+            var parsed = Library.Utility.UrlEncoding.ParseQueryString("?Key=value&other=a+b");
+
+            Assert.AreEqual("value", parsed["key"], "The keys are compared without case");
+            Assert.AreEqual("a b", parsed["other"], "The values are decoded");
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void QueryStringValuesCanBeLeftEncoded()
+        {
+            var parsed = Library.Utility.UrlEncoding.ParseQueryString("key=a+b", false);
+
+            Assert.AreEqual("a+b", parsed["key"]);
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void EmptyQueryStringGivesNoValues()
+        {
+            Assert.AreEqual(0, Library.Utility.UrlEncoding.ParseQueryString("").Count);
+            Assert.AreEqual(0, Library.Utility.UrlEncoding.ParseQueryString("?").Count);
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void QueryIsBuiltWithoutEncoding()
+        {
+            var query = new NameValueCollection { { "key", "value with space" } };
+
+            // The caller is responsible for encoding, which the backends rely on
+            Assert.AreEqual("key=value with space", Library.Utility.UrlEncoding.BuildUriQuery(query));
+            Assert.AreEqual("key=value with space", Library.Utility.UrlEncoding.BuildUriQuery(query, ";"));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void EmptyValuesAreLeftOutOfTheQuery()
+        {
+            var query = new NameValueCollection { { "a", "b" }, { "empty", "" }, { "c", "d" } };
+
+            Assert.AreEqual("a=b&c=d", Library.Utility.UrlEncoding.BuildUriQuery(query));
+            Assert.AreEqual("a=b;c=d", Library.Utility.UrlEncoding.BuildUriQuery(query, ";"));
+        }
+
+        [Test]
+        [Category("Utility")]
+        public static void TestBuildUriQuery()
+        {
+            var query = new NameValueCollection { { "a", "b" } };
+            var queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            Assert.AreEqual("a=b", queryUrl);
+            query.Add(new NameValueCollection { { "c", "d" } });
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            Assert.AreEqual("a=b&c=d", queryUrl);
+
+            // Test with space in value
+            query = new NameValueCollection { { "key", "value with space" } };
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            Assert.AreEqual("key=value with space", queryUrl);
+
+            // Test with + in value
+            query = new NameValueCollection { { "key", "value+plus" } };
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            Assert.AreEqual("key=value+plus", queryUrl);
+
+            // Test with % in value
+            query = new NameValueCollection { { "key", "value%percent" } };
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            Assert.AreEqual("key=value%percent", queryUrl);
+        }
+    }
+}

--- a/Duplicati/UnitTest/UtilityTests.cs
+++ b/Duplicati/UnitTest/UtilityTests.cs
@@ -629,17 +629,17 @@ namespace Duplicati.UnitTest
             Assert.AreEqual("ftp://host/x", Utility.GetUrlWithoutCredentials("mount|ftp://user:pass@host/x"));
 
             // An '@' after the first path separator is not userinfo and must survive
-            var decoded = RelaxedUri.UrlDecode(Utility.GetUrlWithoutCredentials("ftp://host/dir@name/x"));
+            var decoded = UrlEncoding.UrlDecode(Utility.GetUrlWithoutCredentials("ftp://host/dir@name/x"));
             StringAssert.Contains("dir@name", decoded);
 
-            decoded = RelaxedUri.UrlDecode(Utility.GetUrlWithoutCredentials("/mnt/data@x/y"));
+            decoded = UrlEncoding.UrlDecode(Utility.GetUrlWithoutCredentials("/mnt/data@x/y"));
             StringAssert.Contains("data@x", decoded);
 
             // A drive letter is not a scheme, so '@' in a Windows path is kept
-            decoded = RelaxedUri.UrlDecode(Utility.GetUrlWithoutCredentials(@"C:\backup@daily\x"));
+            decoded = UrlEncoding.UrlDecode(Utility.GetUrlWithoutCredentials(@"C:\backup@daily\x"));
             StringAssert.Contains("backup@daily", decoded);
 
-            decoded = RelaxedUri.UrlDecode(Utility.GetUrlWithoutCredentials(@"file://C:\backup@daily\x"));
+            decoded = UrlEncoding.UrlDecode(Utility.GetUrlWithoutCredentials(@"file://C:\backup@daily\x"));
             StringAssert.Contains("backup@daily", decoded);
 
             // Null and blank inputs pass through

--- a/Duplicati/WebserverCore/Endpoints/V2/ConnectionStrings.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/ConnectionStrings.cs
@@ -147,8 +147,8 @@ namespace Duplicati.WebserverCore.Endpoints.V2
 
             // Merge Query Parameters
             // Use decodeValues=false to preserve encoding
-            var csQuery = Duplicati.Library.Utility.RelaxedUri.ParseQueryString(csUri.Query ?? "", false);
-            var backupQuery = Duplicati.Library.Utility.RelaxedUri.ParseQueryString(backupUri.Query ?? "", false);
+            var csQuery = Duplicati.Library.Utility.UrlEncoding.ParseQueryString(csUri.Query ?? "", false);
+            var backupQuery = Duplicati.Library.Utility.UrlEncoding.ParseQueryString(backupUri.Query ?? "", false);
 
             var mergedQuery = new System.Collections.Specialized.NameValueCollection(backupQuery);
 
@@ -158,7 +158,7 @@ namespace Duplicati.WebserverCore.Endpoints.V2
                     mergedQuery[key] = csQuery[key];
             }
 
-            resultUri = resultUri.SetQuery(Duplicati.Library.Utility.RelaxedUri.BuildUriQuery(mergedQuery));
+            resultUri = resultUri.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(mergedQuery));
 
             return resultUri.ToString();
         }


### PR DESCRIPTION
`RelaxedUri` is three unrelated things on one type, and only one of them is the parser.

### The shape of the problem

- **relaxed url parsing** — the part #7111 renamed and the part that is eventually meant to go
- **url encoding and decoding** — `UrlEncode`, `UrlPathEncode`, `UrlDecode`
- **query string handling** — `ParseQueryString`, `BuildUriQuery`

The second and third have nothing to do with parsing; they are string operations that happen to live next door. But because they are static members of `RelaxedUri`, every file that only wants to encode a value has to name the parser to get at them.

That is what makes the parser look bigger than it is. #7097 was closed with:

> Closing this as the blast radius is too large, and the new `CompatUri` essentially just moves the unwanted logic into a new place with new places where it can fail.

This is an attempt at the same goal from the other end: rather than adding a shim, reduce what actually refers to the parser.

### What moves and what stays

The rule is whether the member constructs a `RelaxedUri`:

| Member | Constructs a RelaxedUri | |
| --- | --- | --- |
| `UrlEncode`, `UrlPathEncode`, `UrlDecode` | no | moves |
| `ParseQueryString` ×2 | no | moves |
| `BuildUriQuery` ×2 | no | moves |
| `ExtractPath` | `new RelaxedUri(url).Path` | stays |
| `UriBuilder` ×2 | via `ExtractPath` | stays |

The private `RE_ESCAPECHAR`, `RE_NUMBER` and `RE_URLPARAM` move with the members that use them. **The method bodies are not touched** — only the type they hang off. The parser now calls `UrlEncoding.UrlDecode` and friends itself, which is the right direction for that dependency.

### What it costs and what it buys

**72 call sites across 21 files** change qualifier. That is the bulk of the diff and it is mechanical.

What it buys is that those 72 sites stop being references to the parser. Three files — `MultipartItem.cs`, `KeyGenerator.cs` and `ReportHelper.cs` — stop naming it entirely. The rest are left with what they were always really doing, usually a single `new RelaxedUri(url)` in the constructor. That is the surface a parser replacement has to deal with, and it is now visible instead of buried under encoding calls.

I want to be straight about the accounting: this does not make the eventual removal small. It makes what is left be only the parts that genuinely parse.

**No delegating members are kept on `RelaxedUri`.** Leaving them would keep the references alive and defeat the purpose. Duplicati consumes this library in-repo only, so the blast radius is closed.

### Tests

`Duplicati/UnitTest/UrlEncodingTests.cs` writes down the behavior that differs from `System.Web.HttpUtility` and was not covered anywhere:

- `UrlEncode` turns a space into `+`, `UrlPathEncode` into `%20`
- `UrlDecode` turns `+` back into a space, which the framework does not
- the set left unencoded is `[0-9a-zA-Z-_.]`, so `~` is encoded even though RFC 3986 counts it as unreserved
- `BuildUriQuery` does no encoding at all, which the backends rely on
- `ParseQueryString` compares keys without case and tolerates a leading `?`

`TestBuildUriQuery` moved here from `UriUtilityTests`, which keeps the tests for the members that stayed.

**These are not red-to-green.** They pass before the move and after it; that is the point. They exist so the move can be shown not to have changed behavior, and so a later replacement of these helpers has something concrete to fail against.

### How this was verified

- The characterization tests were run against the tree before the move and were green
- `dotnet build Duplicati.slnx -c Debug` — clean, which is what covers the 72 call sites including `proprietary/`
- `Category=Utility|Category=UriUtility` — green after the move, same tests

No behavior change is claimed beyond that, and none is intended.

### What comes next

The next thing holding backends to the parser is `AuthOptionsHelper.Parse`, which takes a `RelaxedUri`; roughly 20 backends reach it through that. Detaching it would shrink the surface again.

One thing worth flagging for whoever does the replacement: `System.Uri` lowercases the host, and around fifteen backends use `HostAndPath` as a case sensitive remote path. On the #7097 branch this made the Box tests fail on all three runners. There is no compile error for it and most of those backends have no tests, so it needs to be handled deliberately rather than discovered.

Also noted while writing the tests, not fixed here: `UrlDecode` has a branch for the IIS style `%uXXXX` escape, but it feeds the four hex digits through the same byte path as `%XX`, so `%u00e6` decodes to `"\0"` rather than `æ`. The tests do not lock that in.
