### PR TITLE
Load the Hyper-V module when the PowerShell session starts

### DIFF
--- a/Duplicati/UnitTest/DiskImage/Helpers/WindowsDiskImageHelper.cs
+++ b/Duplicati/UnitTest/DiskImage/Helpers/WindowsDiskImageHelper.cs
@@ -41,6 +41,13 @@ namespace Duplicati.UnitTest.DiskImage.Helpers;
 /// </summary>
 internal sealed class PowerShellSession : IDisposable
 {
+    /// <summary>
+    /// How long the module load at session start is allowed to take. It is
+    /// deliberately far larger than a command budget, because it absorbs a cost
+    /// the commands would otherwise pay.
+    /// </summary>
+    private const int WarmUpTimeoutSeconds = 180;
+
     private Process? _process;
     private readonly object _lock = new();
     private bool _disposed;
@@ -111,6 +118,16 @@ internal sealed class PowerShellSession : IDisposable
 
         _process.BeginOutputReadLine();
         _process.BeginErrorReadLine();
+
+        // New-VHD is the first Hyper-V cmdlet the disk image tests reach, and
+        // PowerShell auto loads the module the first time it is used. On a cold
+        // machine that load has been measured at up to 26 seconds, which lands
+        // inside whichever operation happens to run first and is charged against
+        // that operation's budget. Paying it here keeps the per command budgets
+        // meaning what they say.
+        // Re-entering ExecuteScript is safe: this thread already holds the lock,
+        // and EnsureStarted returns straight away now that _process is set.
+        ExecuteScript("Import-Module Hyper-V -ErrorAction SilentlyContinue", WarmUpTimeoutSeconds);
     }
 
     /// <summary>


### PR DESCRIPTION
The disk image tests lose the occasional Windows run to a 30 second timeout inside `New-VHD`. The cost is PowerShell auto loading the Hyper-V module, and it is being charged against the operation that happens to go first.

### What happens today

`CreateDisk` sends this and gives it 30 seconds:

```csharp
var script = $@"New-VHD -Path '{imagePath}' -SizeBytes {sizeB + overheadBytes} -Fixed | Out-Null; Mount-DiskImage -ImagePath '{imagePath}' | Out-Null";
RunPowerShell(script);
```

`New-VHD` lives in the `Hyper-V` module, which PowerShell loads the first time a cmdlet from it is used. On a cold runner that load is slow, and because it happens inside the first command, the budget for that command has to cover both the load and the work.

A recent run on master lost a test to it:

```
Failed Test_FileSystem_FullDisk_AllBlocksAllocated_Async(52428800,GPT,FAT32) [34 s]
System.TimeoutException : PowerShell command timed out after 30 seconds.
Script: New-VHD -Path '...vhdx' -SizeBytes 69206016 -Fixed | Out-Null; Mount-DiskImage ...
```

### Where the time goes

Rather than guess, I instrumented `PowerShellSession.ExecuteScript` and ran the `DiskImageFileSystem` tests on five `windows-latest` runners — 1536 PowerShell calls ([run 31105200260](https://github.com/JamBalaya56562/duplicati/actions/runs/31105200260)).

| command | n | median | p95 | max |
| --- | ---: | ---: | ---: | ---: |
| **`New-VHD`** | 94 | 1,083 ms | 7,123 ms | **25,990 ms** |
| `$partition` (format) | 42 | 2,902 ms | 3,231 ms | 3,484 ms |
| `Set-Disk` | 321 | 136 ms | 2,100 ms | 2,197 ms |
| four others | 1,000+ | 27–105 ms | ≤250 ms | 2,367 ms |

`New-VHD` is the only outlier, and splitting it by position in the session says why:

| position in session | n | median | max |
| --- | ---: | ---: | ---: |
| **first** | 44 | 2,561 ms | **25,990 ms** |
| tenth | 36 | 1,062 ms | 1,087 ms |
| fifty-first | 14 | 1,061 ms | 1,099 ms |

The five slowest calls in the whole run were all the first `New-VHD` of a job — one per runner, at 26.0s, 12.9s, 7.7s, 7.5s and 7.1s. Every later one sits between 1.05 and 1.10 seconds with essentially no spread. Starting the PowerShell process itself measured 2 ms, so that is not the cost.

So it is not that the operation is slow, and not that it occasionally hangs. It is cold exactly once.

### The change

Load the module when the session starts:

```csharp
ExecuteScript("Import-Module Hyper-V -ErrorAction SilentlyContinue", WarmUpTimeoutSeconds);
```

The warm up gets a budget of its own, far clear of what it has been seen to need. **The 30 seconds each operation gets is unchanged**, so it still means what it says rather than being padded to hide a startup cost.

`-ErrorAction SilentlyContinue` keeps this from becoming a new failure mode where Hyper-V is not present. A warm up that times out is left to propagate rather than swallowed — continuing on a session whose marker is still in flight would desynchronise the next command.

### Does it work

Same instrumentation, same tests, with the warm up in place — three runners, 1055 calls ([run 31127370288](https://github.com/JamBalaya56562/duplicati/actions/runs/31127370288)):

| | before | after |
| --- | ---: | ---: |
| **worst call in the run** | **25,990 ms** | **4,539 ms** |
| calls over 10s | 2 | **0** |
| calls over 5s | 5 | **0** |
| `New-VHD` max | 25,990 ms | 4,539 ms |
| `New-VHD` p95 | 7,123 ms | 2,864 ms |

The warm up itself, over 24 sessions: median 273 ms, max 3,402 ms. The cost moved there, it is bounded, and it is cheap on repeat — the session is rebuilt per test, so this runs nine times a job and only the first pays anything.

`New-VHD` by position, after:

| position | n | median | max |
| --- | ---: | ---: | ---: |
| first (now second, after the warm up) | 27 | 2,046 ms | 4,539 ms |
| eleventh | 24 | 1,065 ms | 2,078 ms |
| fifty-second | 9 | 1,059 ms | 2,059 ms |

### Why not just raise the timeout

That was the first thing I considered, and the measurements argued against it. The operation is not slow — it is 1.05 seconds once warm. Raising the budget would keep the startup cost inside the operation and paper over it, and the number would have to be picked to cover a cost nobody had measured.

An inactivity timeout — waiting as long as output keeps arriving, failing when it stops — was the other candidate, and it is the shape this repo already uses for transfers via `ObserveReadTimeout`. But it does not fit here: the script pipes to `Out-Null`, so nothing arrives while the work is in progress and an inactivity timeout would behave exactly like the total one. Making it work would mean adding a heartbeat to the PowerShell side, which is a lot of machinery for a cost that turns out to be paid once.

### How this was verified

- Both tables are measured, not estimated; the runs are linked above
- `dotnet build Duplicati.slnx -c Debug` — clean

**The timeout never actually fired on my runners, before or after.** What the numbers show is that the first call is the dominant cost, that it reaches 26 of the 30 seconds available, and that warming up removes it. They do not show that the upstream failure will not recur — for that the only evidence is that the same first-call pattern is what the failure landed on.

The instrumentation used for the measurements is not part of this change.
