### PR TITLE
Check the response status before treating a download as an archive

### DIFF
--- a/Duplicati/UnitTest/CommandLineOperationsTests.cs
+++ b/Duplicati/UnitTest/CommandLineOperationsTests.cs
@@ -97,6 +97,13 @@ namespace Duplicati.UnitTest
                     }
                     else
                     {
+                        // An error response is not a download. Without this check the error body
+                        // is written out as if it were the archive, and the length check below
+                        // compares it against the Content-Length of that same response, so it
+                        // passes. The failure then surfaces much later as a corrupt archive, and
+                        // the retry below never happens because nothing threw.
+                        response.EnsureSuccessStatusCode();
+
                         using var tmpFile = new TempFile();
                         Console.WriteLine($"Downloading file from {url} to: {tmpFile}");
                         var contentStream = await response.Content.ReadAsStreamAsync();

--- a/Duplicati/UnitTest/Issue6705.cs
+++ b/Duplicati/UnitTest/Issue6705.cs
@@ -72,6 +72,13 @@ public class Issue6705 : BasicSetupHelper
                 }
                 else
                 {
+                    // An error response is not a download. Without this check the error body is
+                    // written out as if it were the archive, and the length check below compares
+                    // it against the Content-Length of that same response, so it passes. The
+                    // failure then surfaces much later as a corrupt archive, and the retry below
+                    // never happens because nothing threw.
+                    response.EnsureSuccessStatusCode();
+
                     using var tmpFile = new TempFile();
                     Console.WriteLine($"Downloading file from {url} to: {tmpFile}");
                     var contentStream = await response.Content.ReadAsStreamAsync();


### PR DESCRIPTION
The ubuntu unit test job of #7128 failed with 24 failures, all of them `RestoreAcrossOperatingSystemsAsync`, and all of them in `OneTimeSetUp`:

```
OneTimeSetUp: System.IO.InvalidDataException :
  End of Central Directory record could not be found.
  at System.IO.Compression.ZipArchive.ReadEndOfCentralDirectory()
  ...
  at Duplicati.UnitTest.Issue6705.DownloadAndExtractBackupsAsync() ... line 159
```

The windows job passed 1479 tests and the macOS job 1460, so nothing was wrong with the change under test. The fixture archive downloaded from `testfiles.duplicati.com` was simply not a zip file.

## Why a transient download failure costs a whole run

`DownloadS3FileIfNewerAsync` never looks at the response status:

```csharp
using var response = await httpClient.SendAsync(request);

if (response.StatusCode == System.Net.HttpStatusCode.NotModified)
{
    Console.WriteLine("File has not been modified since last download.");
    return;
}
else
{
    using var tmpFile = new TempFile();
    var contentStream = await response.Content.ReadAsStreamAsync();
    ...
    long responseLength = response.Content.Headers.ContentLength ?? 0;
    long fileLength = new FileInfo(tmpFile).Length;
    if (responseLength != fileLength)
        throw new Exception($"Downloaded file length {fileLength} does not match response length {responseLength}");

    File.Move(tmpFile, destinationFilePath, true);
```

Anything that is not a 304 is written out as if it were the archive, error bodies included. The length check that follows compares the saved file against the `Content-Length` of that same error response, so it passes. Three consequences:

- the real cause, the HTTP status, is never reported
- the failure surfaces much later and in a misleading form, as a corrupt archive
- **the five retries never run**, because nothing threw — which is exactly the case they exist for

Adding `response.EnsureSuccessStatusCode()` after the 304 check makes the helper fail where the failure happens. The 304 check has to stay first: `EnsureSuccessStatusCode` would reject a 304 as well.

The helper is duplicated in two places, so both copies get the check:

- `Duplicati/UnitTest/Issue6705.cs`
- `Duplicati/UnitTest/CommandLineOperationsTests.cs`, which is also used by `GeneralBlackBoxTesting`

## Verification

`dotnet build Duplicati/UnitTest/Duplicati.UnitTest.csproj -c Release` succeeds. The only warning is the pre-existing CS0162 in `Duplicati/Server/Program.cs`.

**Limits.** I did not reproduce the original download failure: the host was serving the file again by the time I looked (`HTTP 200`, `Content-Length: 105118141`), which also confirms that failure was transient. So this is not a fix for the outage itself, only for the way the helper reports it — a failing download will now say what the server actually answered, and will use the retries it already had.
