### PR TITLE
Take the URL credentials instead of the relaxed URL parser in AuthOptionsHelper

### DIFF
--- a/Duplicati/Library/Backend/AliyunOSS/AliyunOSSBackend.cs
+++ b/Duplicati/Library/Backend/AliyunOSS/AliyunOSSBackend.cs
@@ -59,7 +59,7 @@ namespace Duplicati.Library.Backend.AliyunOSS
             var uri = new Utility.RelaxedUri(url?.Trim() ?? "");
             var prefix = uri.HostAndPath?.TrimPath();
 
-            var auth = AuthOptionsHelper.ParseWithAlias(options, uri, OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET)
+            var auth = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET)
                 .RequireCredentials();
 
             _ossOptions = new AliyunOSSOptions()

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -113,7 +113,7 @@ namespace Duplicati.Library.Backend.AzureBlob
 
             var containerName = (uri.Host ?? "").ToLowerInvariant();
 
-            var auth = AuthOptionsHelper.ParseWithAlias(options, uri, AZURE_ACCOUNT_NAME_OPTION, AZURE_ACCESS_KEY_OPTION);
+            var auth = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, AZURE_ACCOUNT_NAME_OPTION, AZURE_ACCESS_KEY_OPTION);
             var timeouts = TimeoutOptionsHelper.Parse(options);
 
             var sasToken = options.GetValueOrDefault(AZURE_ACCESS_SAS_TOKEN_OPTION);

--- a/Duplicati/Library/Backend/Backblaze/B2.cs
+++ b/Duplicati/Library/Backend/Backblaze/B2.cs
@@ -208,7 +208,7 @@ public class B2 : IStreamingBackend, ILockingBackend, IRenameEnabledBackend
         if (options.TryGetValue(B2_CREATE_BUCKET_TYPE_OPTION, out var option1))
             _bucketType = option1;
 
-        var auth = AuthOptionsHelper.ParseWithAlias(options, uri, B2_ID_OPTION, B2_KEY_OPTION);
+        var auth = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, B2_ID_OPTION, B2_KEY_OPTION);
 
         if (!auth.HasUsername)
             throw new UserInformationException(Strings.B2.NoB2UserIDError, "B2MissingUserID");

--- a/Duplicati/Library/Backend/DrimeCloud/DrimeBackend.cs
+++ b/Duplicati/Library/Backend/DrimeCloud/DrimeBackend.cs
@@ -194,7 +194,7 @@ public class DrimeBackend : IBackend, IStreamingBackend //, IRenameEnabledBacken
 
         // Get API token or parse auth options
         _apiToken = options.GetValueOrDefault(API_TOKEN_OPTION);
-        _authOptions = AuthOptionsHelper.Parse(options, uri);
+        _authOptions = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
 
         if (string.IsNullOrWhiteSpace(_apiToken) && (!_authOptions.HasUsername || !_authOptions.HasPassword))
             throw new UserInformationException(Strings.DrimeCloud.MissingCredentialsError, "DrimeCloudMissingCredentials");

--- a/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
+++ b/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
@@ -136,6 +136,12 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
     public DuplicatiBackend(string url, Dictionary<string, string?> options)
     {
         var uri = new Utility.RelaxedUri(url);
+
+        // Keep the credentials from the supplied url: uri is replaced with the
+        // endpoint below, which does not carry them.
+        var urlUsername = uri.Username;
+        var urlPassword = uri.Password;
+
         if (string.IsNullOrWhiteSpace(uri.HostAndPath))
             uri = new Utility.RelaxedUri(DEFAULT_ENDPOINT);
         else
@@ -157,7 +163,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
         _backup_id = options.GetValueOrDefault(BACKUP_ID_OPTION) ?? string.Empty;
         if (string.IsNullOrEmpty(_backup_id))
             throw new ArgumentException(Strings.DuplicatiBackend.ErrorMissingBackupId, BACKUP_ID_OPTION);
-        _auth = AuthOptionsHelper.ParseWithAlias(options, new Utility.RelaxedUri(url), AUTH_API_ID_OPTION, AUTH_API_KEY_OPTION)
+        _auth = AuthOptionsHelper.ParseWithAlias(options, urlUsername, urlPassword, AUTH_API_ID_OPTION, AUTH_API_KEY_OPTION)
             .RequireCredentials();
 
         _authTimeout = Utility.Utility.ParseTimespanOption(options, AUTH_TIMEOUT_OPTION, DEFAULT_AUTH_TIMEOUT);

--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -272,7 +272,7 @@ namespace Duplicati.Library.Backend
             var u = new Utility.RelaxedUri(url);
             u.RequireHost();
 
-            var auth = AuthOptionsHelper.Parse(options, u);
+            var auth = AuthOptionsHelper.Parse(options, u.Username, u.Password);
             if (auth.HasUsername)
             {
                 _userInfo = new NetworkCredential()

--- a/Duplicati/Library/Backend/File/FileBackend.cs
+++ b/Duplicati/Library/Backend/File/FileBackend.cs
@@ -119,7 +119,7 @@ namespace Duplicati.Library.Backend
         {
             var uri = new Utility.RelaxedUri(url);
             var path = uri.HostAndPath;
-            var auth = AuthOptionsHelper.Parse(options, uri);
+            var auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
             m_timeouts = TimeoutOptionsHelper.Parse(options);
             m_username = auth.Username;
             m_password = auth.Password;

--- a/Duplicati/Library/Backend/Filejump/Filejump.cs
+++ b/Duplicati/Library/Backend/Filejump/Filejump.cs
@@ -139,7 +139,7 @@ namespace Duplicati.Library.Backend
                 m_path = $"/{m_path}/";
 
             m_api_token = options.GetValueOrDefault(API_TOKEN_OPTION);
-            m_authOptions = AuthOptionsHelper.Parse(options, u);
+            m_authOptions = AuthOptionsHelper.Parse(options, u.Username, u.Password);
             if (string.IsNullOrWhiteSpace(m_api_token) && (!m_authOptions.HasUsername || !m_authOptions.HasPassword))
                 throw new ArgumentException("Either an API token, or username/password are required for filejump authentication.");
 

--- a/Duplicati/Library/Backend/Filen/FilenBackend.cs
+++ b/Duplicati/Library/Backend/Filen/FilenBackend.cs
@@ -96,7 +96,7 @@ public class FilenBackend : IStreamingBackend, IRenameEnabledBackend
         var uri = new Utility.RelaxedUri(url);
         _path = uri.HostAndPath;
 
-        _auth = AuthOptionsHelper.Parse(options, uri)
+        _auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password)
             .RequireCredentials();
 
         _moveToTrash = Utility.Utility.ParseBoolOption(options, MoveToTrashOption);

--- a/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
@@ -98,7 +98,7 @@ namespace Duplicati.Library.Backend
                 _prefix = Util.AppendDirSeparator(_prefix, "/");
 
             _timeouts = TimeoutOptionsHelper.Parse(options);
-            _auth = AuthOptionsHelper.ParseWithAlias(options, uri, AUTH_USERNAME_OPTION, AUTH_PASSWORD_OPTION);
+            _auth = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, AUTH_USERNAME_OPTION, AUTH_PASSWORD_OPTION);
             if (!_auth.HasUsername)
                 throw new UserInformationException(Strings.Idrivee2Backend.NoKeyIdError, "Idrivee2NoKeyId");
             if (!_auth.HasPassword)

--- a/Duplicati/Library/Backend/Mega/MegaBackend.cs
+++ b/Duplicati/Library/Backend/Mega/MegaBackend.cs
@@ -75,7 +75,7 @@ namespace Duplicati.Library.Backend.Mega
         {
             var uri = new Utility.RelaxedUri(url);
 
-            var auth = AuthOptionsHelper.Parse(options, uri);
+            var auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
             if (options.ContainsKey("auth-two-factor-key"))
                 m_twoFactorKey = options["auth-two-factor-key"];
 

--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -117,7 +117,7 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
         if (m_prefix.StartsWith("/", StringComparison.Ordinal))
             m_prefix = m_prefix.Substring(1);
 
-        var auth = AuthOptionsHelper.Parse(options, uri);
+        var auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
 
         options.TryGetValue(DOMAINNAME_OPTION, out m_domainName);
         options.TryGetValue(TENANTNAME_OPTION, out m_tenantName);

--- a/Duplicati/Library/Backend/S3/S3Backend.cs
+++ b/Duplicati/Library/Backend/S3/S3Backend.cs
@@ -247,7 +247,7 @@ namespace Duplicati.Library.Backend
             m_prefix = uri.Path;
             var timeout = TimeoutOptionsHelper.Parse(options);
 
-            var auth = AuthOptionsHelper.ParseWithAlias(options, uri, AUTH_USERNAME_OPTION, AUTH_PASSWORD_OPTION);
+            var auth = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, AUTH_USERNAME_OPTION, AUTH_PASSWORD_OPTION);
 
             if (!auth.HasUsername)
                 throw new UserInformationException(Strings.S3Backend.NoAMZUserIDError, "S3NoAmzUserID");

--- a/Duplicati/Library/Backend/SMB/SMBBackend.cs
+++ b/Duplicati/Library/Backend/SMB/SMBBackend.cs
@@ -136,7 +136,7 @@ public class SMBBackend : IStreamingBackend, IFolderEnabledBackend, IRenameEnabl
         var input = uri.Path.TrimEnd('/');
         var slashIndex = input.IndexOf('/');  // Find first slash to separate server and share if present.
 
-        var auth = AuthOptionsHelper.Parse(options, uri);
+        var auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
         var authDomain = options.GetValueOrDefault(AUTH_DOMAIN_OPTION);
         var transport = options.GetValueOrDefault(TRANSPORT_OPTION);
 

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -85,7 +85,7 @@ namespace Duplicati.Library.Backend
             var uri = new Utility.RelaxedUri(url);
             uri.RequireHost();
 
-            var auth = AuthOptionsHelper.Parse(options, uri);
+            var auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
             if (!auth.HasUsername)
                 throw new UserInformationException(Strings.SSHv2Backend.UsernameRequired, "UsernameNotSpecified");
 

--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -175,7 +175,7 @@ namespace Duplicati.Library.Backend
 
             if (!useIntegratedAuthentication)
             {
-                var auth = AuthOptionsHelper.Parse(options, u);
+                var auth = AuthOptionsHelper.Parse(options, u.Username, u.Password);
                 // No validation here, maybe at least username should be set?
                 useUsername = auth.Username;
                 usePassword = auth.Password;

--- a/Duplicati/Library/Backend/TencentCOS/COSBackend.cs
+++ b/Duplicati/Library/Backend/TencentCOS/COSBackend.cs
@@ -125,7 +125,7 @@ namespace Duplicati.Library.Backend.TencentCOS
         {
             var uri = new Utility.RelaxedUri(url?.Trim() ?? "");
             var prefix = uri.HostAndPath?.Trim()?.Trim('/')?.Trim('\\');
-            var auth = AuthOptionsHelper.ParseWithAlias(options, uri, COS_SECRET_ID, COS_SECRET_KEY)
+            var auth = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, COS_SECRET_ID, COS_SECRET_KEY)
                 .RequireCredentials();
 
             var bucket = options.GetValueOrDefault(COS_BUCKET);

--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -162,7 +162,7 @@ namespace Duplicati.Library.Backend
             var u = new Utility.RelaxedUri(url);
             u.RequireHost();
             m_dnsName = u.Host ?? "";
-            var auth = AuthOptionsHelper.Parse(options, u);
+            var auth = AuthOptionsHelper.Parse(options, u.Username, u.Password);
             if (auth.HasUsername)
             {
                 m_userInfo = new NetworkCredential() { Domain = "" };

--- a/Duplicati/Library/Utility/Options/AuthOptionsHelper.cs
+++ b/Duplicati/Library/Utility/Options/AuthOptionsHelper.cs
@@ -56,16 +56,17 @@ public static class AuthOptionsHelper
     /// Parses the authentication options from a dictionary
     /// </summary>
     /// <param name="options">The dictionary to parse</param>
-    /// <param name="uri">The URI to get the default values from</param>
+    /// <param name="uriUsername">The username embedded in the backend URL, if any</param>
+    /// <param name="uriPassword">The password embedded in the backend URL, if any</param>
     /// <param name="username">The name of the username options</param>
     /// <param name="password">The name of the password options</param>
     /// <returns>The parsed authentication options</returns>
-    public static AuthOptions ParseWithAlias(IReadOnlyDictionary<string, string?> options, RelaxedUri uri, string username, string password)
+    public static AuthOptions ParseWithAlias(IReadOnlyDictionary<string, string?> options, string? uriUsername, string? uriPassword, string username, string password)
     {
         // Prefer the primary name, if set
         var optionUsername = options.GetValueOrDefault(username);
         var optionPassword = options.GetValueOrDefault(password);
-        var parsedOptions = Parse(options, uri);
+        var parsedOptions = Parse(options, uriUsername, uriPassword);
 
         if (string.IsNullOrWhiteSpace(optionUsername))
             optionUsername = parsedOptions.Username;
@@ -79,10 +80,11 @@ public static class AuthOptionsHelper
     /// Parses the authentication options from a dictionary
     /// </summary>
     /// <param name="options">The dictionary to parse</param>
-    /// <param name="uri">The URI to get the default values from</param>
+    /// <param name="uriUsername">The username embedded in the backend URL, if any</param>
+    /// <param name="uriPassword">The password embedded in the backend URL, if any</param>
     /// <param name="prefix">An optional prefix for the options</param>
     /// <returns>The parsed authentication options</returns>
-    public static AuthOptions Parse(IReadOnlyDictionary<string, string?> options, RelaxedUri uri, string? prefix = null)
+    public static AuthOptions Parse(IReadOnlyDictionary<string, string?> options, string? uriUsername, string? uriPassword, string? prefix = null)
     {
         var optionUsername = options.GetValueOrDefault($"{prefix}{AuthUsernameOption}");
         var optionPassword = options.GetValueOrDefault($"{prefix}{AuthPasswordOption}");
@@ -90,11 +92,11 @@ public static class AuthOptionsHelper
         // Prefer the URL values, if set
         string? username = null;
         string? password = null;
-        if (!string.IsNullOrEmpty(uri.Username))
+        if (!string.IsNullOrEmpty(uriUsername))
         {
-            username = uri.Username;
-            if (!string.IsNullOrEmpty(uri.Password))
-                password = uri.Password;
+            username = uriUsername;
+            if (!string.IsNullOrEmpty(uriPassword))
+                password = uriPassword;
             else if (!string.IsNullOrWhiteSpace(optionPassword))
                 password = optionPassword;
         }

--- a/Duplicati/UnitTest/AuthOptionsHelperTests.cs
+++ b/Duplicati/UnitTest/AuthOptionsHelperTests.cs
@@ -1,0 +1,275 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+using System.Collections.Generic;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Utility.Options;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Tests for <see cref="AuthOptionsHelper"/>, which resolves the credentials every
+/// backend uses from the backend URL and the option dictionary. The precedence rules
+/// are not obvious, so they are pinned here.
+/// </summary>
+[TestFixture]
+public class AuthOptionsHelperTests
+{
+    private const string UsernameOption = AuthOptionsHelper.AuthUsernameOption;
+    private const string PasswordOption = AuthOptionsHelper.AuthPasswordOption;
+    private const string AliasUsernameOption = "api-id";
+    private const string AliasPasswordOption = "api-key";
+    private const string Prefix = "custom-";
+
+    private static Dictionary<string, string?> Opts(params (string Key, string? Value)[] entries)
+    {
+        var result = new Dictionary<string, string?>();
+        foreach (var (key, value) in entries)
+            result[key] = value;
+        return result;
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void UrlCredentialsWinOverOptions()
+    {
+        var result = AuthOptionsHelper.Parse(
+            Opts((UsernameOption, "option-user"), (PasswordOption, "option-pass")),
+            "url-user", "url-pass");
+
+        Assert.That(result.Username, Is.EqualTo("url-user"));
+        Assert.That(result.Password, Is.EqualTo("url-pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void UrlUsernameIsCombinedWithTheOptionPassword()
+    {
+        var result = AuthOptionsHelper.Parse(
+            Opts((UsernameOption, "option-user"), (PasswordOption, "option-pass")),
+            "url-user", null);
+
+        Assert.That(result.Username, Is.EqualTo("url-user"), "The URL username wins");
+        Assert.That(result.Password, Is.EqualTo("option-pass"), "The password falls back to the option");
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void UrlUsernameWithoutAnyPasswordLeavesThePasswordUnset()
+    {
+        var result = AuthOptionsHelper.Parse(Opts(), "url-user", null);
+
+        Assert.That(result.Username, Is.EqualTo("url-user"));
+        Assert.That(result.Password, Is.Null);
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void OptionsAreUsedWhenTheUrlHasNoUsername()
+    {
+        var result = AuthOptionsHelper.Parse(
+            Opts((UsernameOption, "option-user"), (PasswordOption, "option-pass")),
+            null, null);
+
+        Assert.That(result.Username, Is.EqualTo("option-user"));
+        Assert.That(result.Password, Is.EqualTo("option-pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void OptionPasswordIsIgnoredWithoutAUsername()
+    {
+        var result = AuthOptionsHelper.Parse(Opts((PasswordOption, "option-pass")), null, null);
+
+        Assert.That(result.Username, Is.Null);
+        Assert.That(result.Password, Is.Null, "A password without a username is not returned");
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void OptionUsernameWithoutAPasswordLeavesThePasswordUnset()
+    {
+        var result = AuthOptionsHelper.Parse(Opts((UsernameOption, "option-user")), null, null);
+
+        Assert.That(result.Username, Is.EqualTo("option-user"));
+        Assert.That(result.Password, Is.Null);
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void NothingSetGivesNoCredentials()
+    {
+        var result = AuthOptionsHelper.Parse(Opts(), null, null);
+
+        Assert.That(result.Username, Is.Null);
+        Assert.That(result.Password, Is.Null);
+        Assert.That(result.HasUsername, Is.False);
+        Assert.That(result.HasPassword, Is.False);
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void ThePrefixSelectsTheOptionNames()
+    {
+        var options = Opts(
+            (UsernameOption, "unprefixed-user"),
+            (PasswordOption, "unprefixed-pass"),
+            ($"{Prefix}{UsernameOption}", "prefixed-user"),
+            ($"{Prefix}{PasswordOption}", "prefixed-pass"));
+
+        var result = AuthOptionsHelper.Parse(options, null, null, Prefix);
+
+        Assert.That(result.Username, Is.EqualTo("prefixed-user"));
+        Assert.That(result.Password, Is.EqualTo("prefixed-pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void ThePrefixedLookupIgnoresTheUnprefixedOptions()
+    {
+        var result = AuthOptionsHelper.Parse(
+            Opts((UsernameOption, "unprefixed-user"), (PasswordOption, "unprefixed-pass")),
+            null, null,
+            Prefix);
+
+        Assert.That(result.Username, Is.Null);
+        Assert.That(result.Password, Is.Null);
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void AliasOptionsWinOverTheUrl()
+    {
+        var result = AuthOptionsHelper.ParseWithAlias(
+            Opts((AliasUsernameOption, "alias-user"), (AliasPasswordOption, "alias-pass")),
+            "url-user", "url-pass",
+            AliasUsernameOption,
+            AliasPasswordOption);
+
+        Assert.That(result.Username, Is.EqualTo("alias-user"), "The backend specific option name takes precedence");
+        Assert.That(result.Password, Is.EqualTo("alias-pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void WithoutAliasOptionsTheUrlIsUsed()
+    {
+        var result = AuthOptionsHelper.ParseWithAlias(
+            Opts(),
+            "url-user", "url-pass",
+            AliasUsernameOption,
+            AliasPasswordOption);
+
+        Assert.That(result.Username, Is.EqualTo("url-user"));
+        Assert.That(result.Password, Is.EqualTo("url-pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void WithoutAliasOptionsTheGenericOptionsAreUsed()
+    {
+        var result = AuthOptionsHelper.ParseWithAlias(
+            Opts((UsernameOption, "option-user"), (PasswordOption, "option-pass")),
+            null, null,
+            AliasUsernameOption,
+            AliasPasswordOption);
+
+        Assert.That(result.Username, Is.EqualTo("option-user"));
+        Assert.That(result.Password, Is.EqualTo("option-pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void TheAliasUsernameCombinesWithTheUrlPassword()
+    {
+        var result = AuthOptionsHelper.ParseWithAlias(
+            Opts((AliasUsernameOption, "alias-user")),
+            "url-user", "url-pass",
+            AliasUsernameOption,
+            AliasPasswordOption);
+
+        Assert.That(result.Username, Is.EqualTo("alias-user"));
+        Assert.That(result.Password, Is.EqualTo("url-pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void GetOptionsUsesThePrefix()
+    {
+        var arguments = AuthOptionsHelper.GetOptions(Prefix);
+
+        Assert.That(arguments.Length, Is.EqualTo(2));
+        Assert.That(arguments[0].Name, Is.EqualTo($"{Prefix}{UsernameOption}"));
+        Assert.That(arguments[1].Name, Is.EqualTo($"{Prefix}{PasswordOption}"));
+        Assert.That(arguments[1].Type, Is.EqualTo(CommandLineArgument.ArgumentType.Password));
+    }
+
+    [TestCase("user", "pass", true)]
+    [TestCase("user", null, false)]
+    [TestCase(null, "pass", false)]
+    [TestCase(null, null, false)]
+    [TestCase(" ", "pass", false)]
+    [TestCase("user", " ", false)]
+    [Category("Utility")]
+    public void IsValidRequiresBothValues(string? username, string? password, bool expected)
+    {
+        Assert.That(new AuthOptionsHelper.AuthOptions(username, password).IsValid(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void RequireCredentialsReturnsTheInstanceWhenValid()
+    {
+        var auth = new AuthOptionsHelper.AuthOptions("user", "pass");
+
+        Assert.That(auth.RequireCredentials(), Is.SameAs(auth));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void RequireCredentialsThrowsWhenIncomplete()
+    {
+        var ex = Assert.Throws<UserInformationException>(
+            () => new AuthOptionsHelper.AuthOptions("user", null).RequireCredentials());
+
+        Assert.That(ex!.HelpID, Is.EqualTo("UsernameAndPasswordRequired"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void GetCredentialsReturnsBothValues()
+    {
+        var (username, password) = new AuthOptionsHelper.AuthOptions("user", "pass").GetCredentials();
+
+        Assert.That(username, Is.EqualTo("user"));
+        Assert.That(password, Is.EqualTo("pass"));
+    }
+
+    [Test]
+    [Category("Utility")]
+    public void GetCredentialsThrowsWhenIncomplete()
+    {
+        Assert.Throws<UserInformationException>(
+            () => new AuthOptionsHelper.AuthOptions(null, "pass").GetCredentials());
+    }
+}

--- a/proprietary/Office365/OptionsHelper.cs
+++ b/proprietary/Office365/OptionsHelper.cs
@@ -101,7 +101,8 @@ internal static class OptionsHelper
 
     internal static ParsedOptions ParseAndValidateOptions(string url, Dictionary<string, string?> options)
     {
-        var _authOptions = AuthOptionsHelper.ParseWithAlias(options, new Library.Utility.RelaxedUri(url), OFFICE_CLIENT_OPTION, OFFICE_SECRET_OPTION)
+        var uri = new Library.Utility.RelaxedUri(url);
+        var _authOptions = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, OFFICE_CLIENT_OPTION, OFFICE_SECRET_OPTION)
             .RequireCredentials();
         var _tenantId = options.GetValueOrDefault(OFFICE_TENANT_OPTION)!;
         if (string.IsNullOrWhiteSpace(_tenantId))


### PR DESCRIPTION
Continues #7119. `AuthOptionsHelper` reads exactly two things from the URL it is handed — `Username` and `Password` — but its signature took the whole `RelaxedUri`:

```csharp
public static AuthOptions Parse(IReadOnlyDictionary<string, string?> options, RelaxedUri uri, string? prefix = null)
public static AuthOptions ParseWithAlias(IReadOnlyDictionary<string, string?> options, RelaxedUri uri, string username, string password)
```

`Scheme`, `Host`, `Path` and `Query` are never touched. The type dependency alone forced every backend that handles credentials to go through the relaxed URL parser. Passing the two values directly removes the last reference to `RelaxedUri` from `Duplicati/Library/Utility/Options` — it is now the only helper there that took a URL at all.

Since removing the relaxed parser outright was tried in #7097 and closed, this takes the dependencies off one at a time instead.

## What changed

The parse logic is untouched; only the parameters are. The 19 call sites are the same mechanical expansion:

```diff
- AuthOptionsHelper.Parse(options, uri)
+ AuthOptionsHelper.Parse(options, uri.Username, uri.Password)
```

One call site is not mechanical. In `DuplicatiBackend` the `uri` local is replaced by the endpoint further down, which is why the old code re-parsed the url at the call:

```csharp
var uri = new Utility.RelaxedUri(url);
...
uri = new Utility.RelaxedUri(endpoint);   // uri no longer holds the credentials
...
_auth = AuthOptionsHelper.ParseWithAlias(options, new Utility.RelaxedUri(url), ...)
```

The credentials are now captured before `uri` is reassigned, which keeps the behaviour and drops the third parse of the same string.

This is a breaking change for out-of-tree callers, in the same way #7119 was.

## Tests

`AuthOptionsHelper` had **no test coverage at all**, which is uncomfortable for the code that resolves credentials for every backend. `AuthOptionsHelperTests` adds 24 cases pinning the precedence rules, including the ones that are easy to get wrong:

- the URL credentials win over `auth-username` / `auth-password`
- a URL username combines with an option password when the URL has none
- **an alias option name (`--b2-accountid`, `--duplicati-auth-apiid`, …) wins over the URL** — the least obvious rule of the three
- a password without a username is not returned
- `prefix` selects the option names, and the unprefixed ones are then ignored
- `RequireCredentials` / `GetCredentials` throw `UserInformationException` with `UsernameAndPasswordRequired`

These were written against the old signature and **passed before this change**, so they are a check on the refactor rather than a description of it. They pass unchanged afterwards — only the call in the test file was updated, never an expectation.

## Verification

- `AuthOptionsHelperTests`: 24/24 before the change, 24/24 after
- `dotnet build Duplicati.slnx -c Debug`: succeeds, 0 warnings — this is what caught the 19th call site, in `proprietary/Office365/OptionsHelper.cs`
- Full unit suite with the CI filter on Windows: 1299 passed, 212 skipped, 5 failed

The 5 failures are not from this change. Re-running them on the same machine **without** this change reproduces 4 of them identically:

| Test | with the change | baseline |
|---|---|---|
| `RenameCaseChangeUSNAsync(True)` | `Win32Exception: Access denied` in `GetJournalService` | same |
| `RestoreVolumeCacheAsync("0b","0")` | `TaskCanceledException` | same |
| `RestoreVolumeCacheAsync("0b","1")` | `TaskCanceledException` | same |
| `RestoreVolumeCacheAsync("0b",null)` | `TaskCanceledException` | same |
| `RestoreVolumeCacheAsync("1mb",null)` | `TaskCanceledException` | **passed** |

The USN one needs an elevated shell, which mine is not. The `RestoreVolumeCacheAsync` cases cancel after 40–60 s; the full suite took 2 h 30 m on this machine against 56 m for the CI windows job, so they look load sensitive, and the fifth passing in the isolated baseline run fits that. I have not investigated them further — they are a separate matter from this change.

**Limits.** Most backends need real credentials and are `Integration`, so their credential paths have no automated coverage. What is shown is that everything compiles, that all 19 sites are the same substitution, and that the helper's own behaviour is now pinned by tests that predate the change. CI across the three platforms is the remaining check.
