### PR TITLE
Keep the fileset time when replacing a missing dlist file

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -3149,6 +3149,29 @@ namespace Duplicati.Library.Main.Database.Local
         }
 
         /// <summary>
+        /// Updates the timestamp of a fileset.
+        /// </summary>
+        /// <param name="fileSetId">The ID of the fileset to update.</param>
+        /// <param name="timestamp">The timestamp to record.</param>
+        /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes when the timestamp has been updated.</returns>
+        public async Task UpdateFilesetTimestampAsync(long fileSetId, DateTime timestamp, CancellationToken token)
+        {
+            await using var cmd = await m_connection.CreateCommandAsync(@"
+                UPDATE ""Fileset""
+                SET ""Timestamp"" = @Timestamp
+                WHERE ""ID"" = @FilesetId
+            ", token)
+                .ConfigureAwait(false);
+
+            await cmd.SetTransaction(m_rtr)
+                .SetParameterValue("@FilesetId", fileSetId)
+                .SetParameterValue("@Timestamp", Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(timestamp))
+                .ExecuteNonQueryAsync(true, token)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Removes all entries in the fileset entry table for a given fileset ID.
         /// </summary>
         /// <param name="filesetId">The fileset ID to clear.</param>

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -993,6 +993,15 @@ namespace Duplicati.Library.Main.Operation
                 .UpdateFullBackupStateInFilesetAsync(filesetid, filesetData.IsFullBackup, cancellationToken)
                 .ConfigureAwait(false);
 
+            // The fileset was created from the time in the filename. A dlist file that
+            // replaced an earlier one has a new name, and therefore a new time, so it
+            // records the time of the fileset it describes. Use that when it is present.
+            var recordedTime = filesetData.GetFilesetTime();
+            if (recordedTime.HasValue)
+                await restoredb
+                    .UpdateFilesetTimestampAsync(filesetid, recordedTime.Value, cancellationToken)
+                    .ConfigureAwait(false);
+
             // clear any existing fileset entries
             await restoredb.ClearFilesetEntriesAsync(filesetid, cancellationToken).ConfigureAwait(false);
 

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -440,7 +440,9 @@ namespace Duplicati.Library.Main.Operation
                             foreach (var p in m_options.ControlFiles.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
                                 fsw.AddControlFile(p, m_options.GetCompressionHintFromFilename(p));
 
-                        fsw.CreateFilesetFile(isfull);
+                        // The replacement file has a new name, and therefore a new time,
+                        // but it still describes the fileset at its original time.
+                        fsw.CreateFilesetFile(isfull, timestamp);
                         await db
                             .WriteFilesetAsync(fsw, filesetId, cancellationToken)
                             .ConfigureAwait(false);
@@ -685,7 +687,10 @@ namespace Duplicati.Library.Main.Operation
                 foreach (var p in m_options.ControlFiles.Split(new char[] { System.IO.Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
                     volumeWriter.AddControlFile(p, m_options.GetCompressionHintFromFilename(p));
 
-            volumeWriter.CreateFilesetFile(isPrevFull);
+            // The replacement file has a new name, and therefore a new time, but it still
+            // describes the fileset at its original time. Recording it keeps the time after
+            // a database recreate, which takes the time from the filename otherwise.
+            volumeWriter.CreateFilesetFile(isPrevFull, filesetTime);
             var newFilesetID = await db
                 .CreateFilesetAsync(volumeWriter.VolumeID, filesetTime, cancellationToken)
                 .ConfigureAwait(false);

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -534,7 +534,10 @@ namespace Duplicati.Library.Main.Operation
                                     .ConfigureAwait(false);
                             var volumeWriter = newEntry = new FilesetVolumeWriter(m_options, fileTime);
 
-                            await RunRepairDlistAsync(backendManager, db, volumeWriter, n, fileTime, cancellationToken).ConfigureAwait(false);
+                            // The replacement file needs a name that is not taken, but the fileset
+                            // itself keeps its original time: the fileset time is what orders the
+                            // backup versions, so moving it can renumber them.
+                            await RunRepairDlistAsync(backendManager, db, volumeWriter, n, timestamp, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception ex)
                         {

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -216,11 +216,20 @@ namespace Duplicati.Library.Main.Volumes
             AddMetaEntry(FilelistEntryType.Symlink, name, metahash, metasize, metablockhash, metablocklisthashes);
         }
 
-        public void CreateFilesetFile(bool isFullBackup)
+        /// <summary>
+        /// Writes the fileset file into the volume.
+        /// </summary>
+        /// <param name="isFullBackup">Whether the fileset is a full backup.</param>
+        /// <param name="filesetTime">
+        /// The time of the fileset, when it differs from the time in this volume's filename.
+        /// Only needed when replacing a dlist file, which has to be given a new name and
+        /// therefore a new time. Leave it out to keep using the filename.
+        /// </param>
+        public void CreateFilesetFile(bool isFullBackup, DateTime? filesetTime = null)
         {
             using (var sr = new StreamWriter(this.m_compression.CreateFile(FILESET_FILENAME, CompressionHint.Compressible, DateTime.UtcNow), ENCODING))
             {
-                sr.Write(FilesetData.GetFilesetInstance(isFullBackup));
+                sr.Write(FilesetData.GetFilesetInstance(isFullBackup, filesetTime));
             }
         }
 

--- a/Duplicati/Library/Main/Volumes/VolumeBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeBase.cs
@@ -31,13 +31,35 @@ namespace Duplicati.Library.Main.Volumes
             [JsonProperty("IsFullBackup")]
             public bool IsFullBackup { get; set; } = true;
 
-            public static string GetFilesetInstance(bool isFullBackup = true)
+            /// <summary>
+            /// The time of the fileset, when it is not the time in the filename.
+            /// A file is never given a name that has been used before, so a replacement
+            /// dlist file gets a new name and therefore a new time. Recording the fileset
+            /// time here keeps it available after a database recreate, which otherwise
+            /// takes the time from the filename. Absent means: use the filename.
+            /// </summary>
+            [JsonProperty("Timestamp", NullValueHandling = NullValueHandling.Ignore)]
+            public string Timestamp { get; set; }
+
+            public static string GetFilesetInstance(bool isFullBackup = true, DateTime? filesetTime = null)
             {
                 return JsonConvert.SerializeObject(new FilesetData
                 {
-                    IsFullBackup = isFullBackup
+                    IsFullBackup = isFullBackup,
+                    Timestamp = filesetTime.HasValue
+                        ? Library.Utility.Utility.SerializeDateTime(filesetTime.Value)
+                        : null
                 });
             }
+
+            /// <summary>
+            /// Gets the recorded fileset time, if the dlist file carries one.
+            /// </summary>
+            /// <returns>The fileset time, or null when it is absent or unreadable.</returns>
+            public DateTime? GetFilesetTime()
+                => !string.IsNullOrWhiteSpace(Timestamp) && Library.Utility.Utility.TryDeserializeDateTime(Timestamp, out var t)
+                    ? t
+                    : null;
         }
 
         protected class ManifestData

--- a/Duplicati/UnitTest/RepairFilesetTimestampTests.cs
+++ b/Duplicati/UnitTest/RepairFilesetTimestampTests.cs
@@ -1,0 +1,131 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A dlist file that is missing from the destination is replaced under a new name,
+/// because the old name is still registered. The fileset behind it must keep its
+/// original time regardless: that time is what orders the backup versions, so moving
+/// it can silently renumber the versions a user restores from.
+/// </summary>
+public class RepairFilesetTimestampTests : BasicSetupHelper
+{
+    private Dictionary<string, string> Options => TestOptions.Expand(new { no_encryption = true });
+
+    private string[] DlistFiles
+        => Directory.GetFiles(TARGETFOLDER, "*.dlist.*", SearchOption.TopDirectoryOnly)
+            .Select(x => Path.GetFileName(x))
+            .OrderBy(x => x)
+            .ToArray();
+
+    /// <summary>
+    /// The filesets as (version, time, full backup), ordered by version.
+    /// </summary>
+    private async Task<(long Version, DateTime Time, string IsFull)[]> GetFilesetsAsync()
+    {
+        using var c = new Library.Main.Controller("file://" + TARGETFOLDER, Options, null);
+        var result = await c.ListAsync();
+        return result.Filesets
+            .OrderBy(x => x.Version)
+            .Select(x => ((long)x.Version, x.Time, x.IsFullBackup.ToString()))
+            .ToArray();
+    }
+
+    private async Task RunBackupAsync(string filename)
+    {
+        File.WriteAllText(Path.Combine(DATAFOLDER, filename), filename);
+        using var c = new Library.Main.Controller("file://" + TARGETFOLDER, Options, null);
+        TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+    }
+
+    private async Task RunRepairAsync()
+    {
+        using var c = new Library.Main.Controller("file://" + TARGETFOLDER, Options, null);
+        TestUtils.AssertResults(await c.RepairAsync());
+    }
+
+    private static string Describe((long Version, DateTime Time, string IsFull)[] filesets)
+        => string.Join(" | ", filesets.Select(x => $"v{x.Version} {x.Time:O} full={x.IsFull}"));
+
+    [Test]
+    [Category("Targeted")]
+    public async Task RepairKeepsTheFilesetTimeWhenAllDlistFilesAreMissingAsync()
+    {
+        await RunBackupAsync("a.txt");
+        Thread.Sleep(1100);
+        await RunBackupAsync("b.txt");
+
+        var before = await GetFilesetsAsync();
+        var namesBefore = DlistFiles;
+        Assert.That(namesBefore.Length, Is.EqualTo(2));
+
+        foreach (var f in Directory.GetFiles(TARGETFOLDER, "*.dlist.*"))
+            File.Delete(f);
+
+        await RunRepairAsync();
+
+        var after = await GetFilesetsAsync();
+
+        Assert.That(after.Select(x => x.Time).ToArray(), Is.EqualTo(before.Select(x => x.Time).ToArray()),
+            $"Repair moved the filesets in time.{Environment.NewLine}before: {Describe(before)}{Environment.NewLine}after:  {Describe(after)}");
+        Assert.That(after.Select(x => x.IsFull).ToArray(), Is.EqualTo(before.Select(x => x.IsFull).ToArray()),
+            "Each version must still describe the same backup");
+
+        // The replacement files do get a new name, because the old one is still
+        // registered. That is expected; only the fileset time has to stay put.
+        Assert.That(DlistFiles.Length, Is.EqualTo(2));
+        Assert.That(DlistFiles, Is.Not.EqualTo(namesBefore));
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task RepairKeepsTheFilesetTimeWhenOneDlistFileIsMissingAsync()
+    {
+        await RunBackupAsync("a.txt");
+        Thread.Sleep(1100);
+        await RunBackupAsync("b.txt");
+
+        var before = await GetFilesetsAsync();
+
+        // Delete the older of the two, which is the one that can be pushed past the newer.
+        var oldest = Directory.GetFiles(TARGETFOLDER, "*.dlist.*").OrderBy(x => x).First();
+        File.Delete(oldest);
+
+        await RunRepairAsync();
+
+        var after = await GetFilesetsAsync();
+
+        Assert.That(after.Select(x => x.Time).ToArray(), Is.EqualTo(before.Select(x => x.Time).ToArray()),
+            $"Repair moved the fileset in time.{Environment.NewLine}before: {Describe(before)}{Environment.NewLine}after:  {Describe(after)}");
+        Assert.That(after.Select(x => x.IsFull).ToArray(), Is.EqualTo(before.Select(x => x.IsFull).ToArray()),
+            "Each version must still describe the same backup");
+    }
+}

--- a/Duplicati/UnitTest/RepairFilesetTimestampTests.cs
+++ b/Duplicati/UnitTest/RepairFilesetTimestampTests.cs
@@ -107,6 +107,38 @@ public class RepairFilesetTimestampTests : BasicSetupHelper
 
     [Test]
     [Category("Targeted")]
+    public async Task RepairKeepsTheFilesetTimeAcrossADatabaseRecreateAsync()
+    {
+        await RunBackupAsync("a.txt");
+        Thread.Sleep(1100);
+        await RunBackupAsync("b.txt");
+
+        var before = await GetFilesetsAsync();
+
+        foreach (var f in Directory.GetFiles(TARGETFOLDER, "*.dlist.*"))
+            File.Delete(f);
+
+        await RunRepairAsync();
+
+        var afterRepair = await GetFilesetsAsync();
+        Assert.That(afterRepair.Select(x => x.Time).ToArray(), Is.EqualTo(before.Select(x => x.Time).ToArray()),
+            $"Repair moved the filesets in time.{Environment.NewLine}before: {Describe(before)}{Environment.NewLine}after:  {Describe(afterRepair)}");
+
+        // Rebuilding the local database from the destination has to give the same times
+        // back. Keeping them only in the database would hold just until the next recreate,
+        // because a recreate takes the time from the file name.
+        File.Delete(DBFILE);
+        await RunRepairAsync();
+
+        var afterRecreate = await GetFilesetsAsync();
+        Assert.That(afterRecreate.Select(x => x.Time).ToArray(), Is.EqualTo(before.Select(x => x.Time).ToArray()),
+            $"Recreating the database lost the fileset times.{Environment.NewLine}before:   {Describe(before)}{Environment.NewLine}recreate: {Describe(afterRecreate)}");
+        Assert.That(afterRecreate.Select(x => x.IsFull).ToArray(), Is.EqualTo(before.Select(x => x.IsFull).ToArray()),
+            "Each version must still describe the same backup after a recreate");
+    }
+
+    [Test]
+    [Category("Targeted")]
     public async Task RepairKeepsTheFilesetTimeWhenOneDlistFileIsMissingAsync()
     {
         await RunBackupAsync("a.txt");


### PR DESCRIPTION
Repairing a dlist file that is missing from the destination moves the fileset forward in time, which can renumber the backup versions.

Found while investigating the ubuntu unit test failure on #7128, where `DisruptionTests.FilesetFilesAsync` reported version 1 as a partial backup where it had been a full one. That is a symptom of this; the cause is in `RepairHandler` and is present on master independently of that PR.

> **Updated after review.** The first version kept the time only in the local database, which is lost on a recreate. That gap is real and is now closed by the second commit, which records the time in the dlist instead. No filename is re-used. Details in the second half of this description.

## Cause

`RepairHandler` replaces a missing dlist under a new name, because the old name is still registered — the old registration is only marked `Deleted` [further down the same method](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Main/Operation/RepairHandler.cs#L707), so `ProbeUnusedFilenameNameAsync` always has to move at least one second forward. The probed time was then passed on as the time of the *fileset*:

```csharp
var fileTime = await FilesetVolumeWriter.ProbeUnusedFilenameNameAsync(db, m_options, timestamp, ...);
var volumeWriter = newEntry = new FilesetVolumeWriter(m_options, fileTime);
await RunRepairDlistAsync(backendManager, db, volumeWriter, n, fileTime, ...);
// -> CreateFilesetAsync(volumeWriter.VolumeID, filesetTime, ...)
```

The fileset time is what orders the backup versions, so every repaired fileset shifts. Measured on two backups five seconds apart:

```
dlist before: duplicati-20260809T101721Z.dlist.zip, duplicati-20260809T101726Z.dlist.zip
dlist after : duplicati-20260809T101722Z.dlist.zip, duplicati-20260809T101727Z.dlist.zip

filesets before: v0 19:17:26 | v1 19:17:21
filesets after : v0 19:17:27 | v1 19:17:22
```

Both moved by a second. This is not intermittent — the old name is always registered at probe time, so the shift always happens. Reordering follows when two filesets are close together: with a one second gap, repairing the newer one first takes `T+1`, and the older one then finds `T` and `T+1` taken and lands on `T+2`, past the newer one. Which is repaired first depends on the order of `tp.MissingVolumes`, which is why the CI symptom is intermittent while the shift is not.

For a user this means a repair can renumber the versions, so `--version=1` no longer selects the backup it selected before.

## First commit: the fileset keeps its time

The replacement file still gets a free name; the fileset it belongs to keeps the time it had. The other repair path in this file, for a fileset whose remote registration is missing, already works that way — it keeps the existing fileset and only gives the file a new name.

## Second commit: the time survives a recreate

Keeping the time only in the database holds until the database is recreated, because [`RecreateDatabaseHandler`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs#L327) creates the fileset from the time in the filename. So the time is recorded where the dlist can carry it, in the fileset file, next to `IsFullBackup`:

```
FilesetVolumeWriter.CreateFilesetFile(isFullBackup, filesetTime)
  -> FilesetData.GetFilesetInstance writes an optional "Timestamp"

RecreateDatabaseHandler.RecreateFilesetFromRemoteListAsync
  -> reads it right where it already reads IsFullBackup,
     then UpdateFilesetTimestampAsync
```

`IsFullBackup` already travels this way and is applied to the database on recreate, so this reuses that mechanism rather than adding one.

- **No filename is re-used.** The replacement file gets a new name and a new time, exactly as before. Only the fileset's own time is written down.
- **Absent means "use the filename".** Existing dlist files behave exactly as they do today, and an older version reading a newer dlist ignores an unknown field.
- **Only the two repair paths that rename a file pass the time.** The backup, synthetic filelist and purge paths are untouched and keep writing no `Timestamp` at all, so a normal backup's dlist is unchanged.

It also fixes the same divergence in the sibling path: when only the remote *registration* is missing, `RepairHandler` keeps the existing `filesetId` and re-uploads under a new name, so on master the database time and the filename time already disagree there, and a recreate already loses the fileset time. That path now records it too.

## Tests

`RepairFilesetTimestampTests`:

| Test | |
|---|---|
| `RepairKeepsTheFilesetTimeWhenAllDlistFilesAreMissingAsync` | every dlist deleted, then repaired |
| `RepairKeepsTheFilesetTimeAcrossADatabaseRecreateAsync` | repaired, then the local database deleted and rebuilt from the destination |
| `RepairKeepsTheFilesetTimeWhenOneDlistFileIsMissingAsync` | only the older one deleted — the one that can be pushed past the newer |

They assert the fileset times and the full/partial flag per version survive, and the first also asserts that the replacement files *do* get new names, since that part is expected.

## Verification

- The first two tests **fail on master**: `Repair moved the filesets in time`
- The recreate test **fails with only the first commit applied**: `Recreating the database lost the fileset times` — the review comment reproduced
- All three pass with both commits
- Repair, purge and recreate tests alongside them: 55 pass (`Issue6504`, `RepairHandlerTests`, `RepairWithMissingRemoteFiles`, `RecreateDatabase*`, `PurgeTest*`)

**Limits.** I did not reproduce the intermittent `FilesetFilesAsync` failure itself — 25 consecutive local runs on Windows all passed, which is why the tests pin the deterministic cause rather than the flake. The full suite on three platforms is left to CI. This does add a field to the dlist format, so if you would rather it were named differently, or carried somewhere else, say so and I will change it.
