### PR TITLE
Drop the unused parts of the relaxed URL parser and pin the rest

### DIFF
--- a/Duplicati/Library/Utility/CommandLineArgumentMapper.cs
+++ b/Duplicati/Library/Utility/CommandLineArgumentMapper.cs
@@ -152,8 +152,6 @@ public static class CommandLineArgumentMapper
                 yield return new CommandLineArgument(name, argumentType ?? CommandLineArgument.ArgumentType.Boolean, shortDescription, longDescription, defaultValue);
             else if (propType.IsEnum)
                 yield return new CommandLineArgument(name, argumentType ?? CommandLineArgument.ArgumentType.String, shortDescription, longDescription, defaultValue, null, customAttr?.ValueList ?? Enum.GetNames(propType));
-            else if (propType == typeof(RelaxedUri))
-                yield return new CommandLineArgument(name, argumentType ?? CommandLineArgument.ArgumentType.String, shortDescription, longDescription, defaultValue);
             else if (propType == typeof(Uri))
                 yield return new CommandLineArgument(name, argumentType ?? CommandLineArgument.ArgumentType.String, shortDescription, longDescription, defaultValue);
             else if (propType == typeof(TimeSpan))
@@ -202,8 +200,6 @@ public static class CommandLineArgumentMapper
                     p.SetValue(obj, bool.Parse(value));
                 else if (propType.IsEnum)
                     p.SetValue(obj, Enum.Parse(propType, value, true));
-                else if (propType == typeof(RelaxedUri))
-                    p.SetValue(obj, new RelaxedUri(value));
                 else if (propType == typeof(TimeSpan))
                     p.SetValue(obj, Timeparser.ParseTimeSpan(value));
             }

--- a/Duplicati/Library/Utility/RelaxedUri.cs
+++ b/Duplicati/Library/Utility/RelaxedUri.cs
@@ -341,16 +341,6 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Creates a new instance with another host
-        /// </summary>
-        /// <returns>A new instance</returns>
-        /// <param name="host">The new hostname to use</param>
-        public RelaxedUri SetHost(string host)
-        {
-            return new RelaxedUri(Scheme, host, Path, Query, Username, Password, Port);
-        }
-
-        /// <summary>
         /// Creates a new instance with another path
         /// </summary>
         /// <returns>A new instance</returns>
@@ -379,16 +369,6 @@ namespace Duplicati.Library.Utility
         public RelaxedUri SetCredentials(string? username, string? password)
         {
             return new RelaxedUri(Scheme, Host, Path, Query, username, password, Port);
-        }
-
-        /// <summary>
-        /// Creates a new instance with another port
-        /// </summary>
-        /// <returns>A new instance</returns>
-        /// <param name="port">The new port to use</param>
-        public RelaxedUri SetPort(int port)
-        {
-            return new RelaxedUri(Scheme, Host, Path, Query, Username, Password, port);
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -165,5 +165,160 @@ namespace Duplicati.UnitTest
             var encoded = new Library.Utility.RelaxedUri("file://c:\\%40folder\\");
             Assert.AreEqual(a.Path, encoded.Path);
         }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestHostKeepsItsCase()
+        {
+            // System.Uri lowercases the host, this parser does not. #7097 replaced the
+            // parser with System.Uri and had to be closed because Box broke on exactly
+            // this difference, so it is pinned here for whoever tries again.
+            var uri = new Library.Utility.RelaxedUri("https://ExAmPle.COM/Some/Path");
+
+            Assert.AreEqual("ExAmPle.COM", uri.Host);
+            Assert.AreEqual("Some/Path", uri.Path);
+            Assert.IsTrue(uri.ToString().Contains("ExAmPle.COM"), "ToString must not change the host case");
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestSetSchemeOnlyChangesTheScheme()
+        {
+            var uri = new Library.Utility.RelaxedUri("http://user:pw@example.com:8080/a/b?x=1");
+            var changed = uri.SetScheme("https");
+
+            Assert.AreEqual("https", changed.Scheme);
+            Assert.AreEqual("http", uri.Scheme, "The original instance must not change");
+            Assert.AreEqual(uri.Host, changed.Host);
+            Assert.AreEqual(uri.Port, changed.Port);
+            Assert.AreEqual(uri.Path, changed.Path);
+            Assert.AreEqual(uri.Query, changed.Query);
+            Assert.AreEqual(uri.Username, changed.Username);
+            Assert.AreEqual(uri.Password, changed.Password);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestSetPathOnlyChangesThePath()
+        {
+            var uri = new Library.Utility.RelaxedUri("http://user:pw@example.com:8080/a/b?x=1");
+            var changed = uri.SetPath("c/d");
+
+            Assert.AreEqual("c/d", changed.Path);
+            Assert.AreEqual("a/b", uri.Path, "The original instance must not change");
+            Assert.AreEqual(uri.Scheme, changed.Scheme);
+            Assert.AreEqual(uri.Host, changed.Host);
+            Assert.AreEqual(uri.Port, changed.Port);
+            Assert.AreEqual(uri.Query, changed.Query);
+            Assert.AreEqual(uri.Username, changed.Username);
+            Assert.AreEqual(uri.Password, changed.Password);
+
+            Assert.AreEqual("", uri.SetPath(null).Path, "A null path becomes an empty path");
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestSetQueryOnlyChangesTheQuery()
+        {
+            var uri = new Library.Utility.RelaxedUri("http://user:pw@example.com:8080/a/b?x=1");
+            var changed = uri.SetQuery("y=2");
+
+            Assert.AreEqual("y=2", changed.Query);
+            Assert.AreEqual("x=1", uri.Query, "The original instance must not change");
+            Assert.AreEqual(uri.Scheme, changed.Scheme);
+            Assert.AreEqual(uri.Host, changed.Host);
+            Assert.AreEqual(uri.Port, changed.Port);
+            Assert.AreEqual(uri.Path, changed.Path);
+            Assert.AreEqual(uri.Username, changed.Username);
+            Assert.AreEqual(uri.Password, changed.Password);
+
+            Assert.IsNull(uri.SetQuery(null).Query, "A null query stays null");
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestSetCredentialsOnlyChangesTheCredentials()
+        {
+            var uri = new Library.Utility.RelaxedUri("http://user:pw@example.com:8080/a/b?x=1");
+            var changed = uri.SetCredentials("other", "secret");
+
+            Assert.AreEqual("other", changed.Username);
+            Assert.AreEqual("secret", changed.Password);
+            Assert.AreEqual("user", uri.Username, "The original instance must not change");
+            Assert.AreEqual(uri.Scheme, changed.Scheme);
+            Assert.AreEqual(uri.Host, changed.Host);
+            Assert.AreEqual(uri.Port, changed.Port);
+            Assert.AreEqual(uri.Path, changed.Path);
+            Assert.AreEqual(uri.Query, changed.Query);
+
+            var cleared = uri.SetCredentials(null, null);
+            Assert.IsNull(cleared.Username);
+            Assert.IsNull(cleared.Password);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestToStringRoundTripsThroughTheParser()
+        {
+            var uri = new Library.Utility.RelaxedUri("http://user:pw@example.com:8080/a/b?x=1");
+            var rebuilt = new Library.Utility.RelaxedUri(uri.ToString());
+
+            Assert.AreEqual(uri.Scheme, rebuilt.Scheme);
+            Assert.AreEqual(uri.Host, rebuilt.Host);
+            Assert.AreEqual(uri.Port, rebuilt.Port);
+            Assert.AreEqual(uri.Path, rebuilt.Path);
+            Assert.AreEqual(uri.Query, rebuilt.Query);
+            Assert.AreEqual(uri.Username, rebuilt.Username);
+            Assert.AreEqual(uri.Password, rebuilt.Password);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestHostAndPath()
+        {
+            Assert.AreEqual("example.com/a/b", new Library.Utility.RelaxedUri("http://example.com/a/b").HostAndPath);
+            Assert.AreEqual("example.com", new Library.Utility.RelaxedUri("http://example.com").HostAndPath);
+            Assert.AreEqual("a/b", new Library.Utility.RelaxedUri("http", null, "a/b").HostAndPath);
+            Assert.AreEqual("", new Library.Utility.RelaxedUri("http", null, null).HostAndPath);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestPathAndQuery()
+        {
+            Assert.AreEqual("a/b?x=1", new Library.Utility.RelaxedUri("http://example.com/a/b?x=1").PathAndQuery);
+            Assert.AreEqual("a/b", new Library.Utility.RelaxedUri("http://example.com/a/b").PathAndQuery);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestQueryParameters()
+        {
+            var query = new Library.Utility.RelaxedUri("http://example.com/?a=b&c=d").QueryParameters;
+            Assert.AreEqual("b", query["a"]);
+            Assert.AreEqual("d", query["c"]);
+            Assert.AreEqual("b", query["A"], "Keys are matched without regard to case");
+
+            var decoded = new Library.Utility.RelaxedUri("http://example.com/?a=x%20y&b=p+q").QueryParameters;
+            Assert.AreEqual("x y", decoded["a"], "%20 is decoded");
+            Assert.AreEqual("p q", decoded["b"], "+ is decoded as a space");
+
+            var repeated = new Library.Utility.RelaxedUri("http://example.com/?a=1&a=2").QueryParameters;
+            Assert.AreEqual("1,2", repeated["a"], "A repeated key keeps both values");
+
+            Assert.AreEqual(0, new Library.Utility.RelaxedUri("http://example.com/").QueryParameters.Count,
+                "A url without a query has no parameters");
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestRequireHost()
+        {
+            Assert.DoesNotThrow(() => new Library.Utility.RelaxedUri("http://example.com/a").RequireHost());
+
+            var withoutHost = new Library.Utility.RelaxedUri("http", null, "a", null, "user", "secret");
+            var ex = Assert.Throws<System.ArgumentException>(() => withoutHost.RequireHost());
+            Assert.IsFalse(ex!.Message.Contains("secret"), "The message must not carry the password");
+        }
     }
 }


### PR DESCRIPTION
Continues #7119 and #7130. Those two took dependencies off the relaxed URL parser. This one works on the parser itself, because what makes it hard to replace is not the number of callers — it is that its behaviour is largely unpinned.

#7097 is the evidence: replacing the parser with `System.Uri` lowercased the host, Box failed on all three platforms, and the PR was closed. No test covered that difference, so the next attempt would find it exactly the same way.

## Removes what nothing uses

**`RelaxedUri.SetHost` and `RelaxedUri.SetPort`** are declared and never called — no call site in `Duplicati/`, in `proprietary/`, or in the tests.

**`CommandLineArgumentMapper`** has a `RelaxedUri` branch on the describe side and on the assign side, but no class declares a property of that type, so neither branch can be reached. The `System.Uri` branch next to it is left alone.

Both are compiler-verified removals, and they shrink the surface a replacement has to reproduce.

## Pins the rest

The existing `UriUtilityTests` covers parsing through the constructor thoroughly — `TestUriParse` alone runs a 3×3×2×2×2 matrix — and covers nothing else. The accessors and the `Set*` methods, which is precisely what a replacement has to reproduce, had no tests at all:

| Member | Uses in the tree | Tests before |
|---|---|---|
| `QueryParameters` | 27 | 0 |
| `HostAndPath` | 20 | 0 |
| `SetQuery` | 15 | 0 |
| `SetScheme` | 12 | 0 |
| `RequireHost` | 10 | 0 |
| `SetPath` / `SetCredentials` | 5 / 5 | 0 |
| `PathAndQuery` | 1 | 0 |

Ten tests are added, in the existing file and under the existing `UriUtility` category:

- **`TestHostKeepsItsCase`** — `https://ExAmPle.COM/Some/Path` keeps `ExAmPle.COM`, through `ToString()` as well. This is the #7097 difference, and the test says so
- `Set*` — each changes only its own component, leaves the others alone, and does not mutate the original; `SetPath(null)` becomes an empty path, `SetQuery(null)` stays null
- `TestToStringRoundTripsThroughTheParser` — a url with credentials, port, path and query survives `ToString()` and being parsed again
- `HostAndPath` — all four branches of the accessor, including host without path and path without host
- `PathAndQuery` — with and without a query
- `QueryParameters` — parsing, `%20` and `+` decoding, case-insensitive key lookup, a repeated key keeping both values, and no query meaning no parameters
- `RequireHost` — throws without a host, and the message does not carry the password

## Scheme case is deliberately not pinned

The parser keeps the scheme verbatim ([RelaxedUri.cs](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Utility/RelaxedUri.cs#L215)), but the scheme lookup in `DynamicLoader` uses a `Dictionary<string, T>` with no comparer, so it is case-sensitive, and `SendMail` lowercases the scheme itself before comparing. An uppercase scheme therefore looks like it would fail to resolve a backend.

That reads like a defect rather than intended behaviour, so it is left out of this PR rather than written into a test that would cement it. Happy to look into it separately if you want.

## Verification

- `Category=UriUtility`: **87 tests pass** (the 10 new ones plus the existing matrix), 5 s
- The new tests pin existing behaviour, so they passed on the first run — no expectation was adjusted to make them pass
- The removals are covered by the build: `Duplicati.UnitTest` builds the library graph, and nothing broke

**Limits.** This does not move any caller off the parser; it makes the parser smaller and its behaviour explicit so that removing it later is checkable. I ran the wider suite on my fork rather than locally (this machine takes about 2.5 h for the full run against 56 min on CI), so CI here is the check for the other platforms.
