### PR TITLE
Match url schemes without regard to case

### DIFF
--- a/Duplicati/Library/DynamicLoader/BackendLoader.cs
+++ b/Duplicati/Library/DynamicLoader/BackendLoader.cs
@@ -80,7 +80,7 @@ namespace Duplicati.Library.DynamicLoader
                     {
                         if (m_interfaces.ContainsKey(uri.Scheme))
                             return (IBackend)Activator.CreateInstance(m_interfaces[uri.Scheme].GetType(), url, newOpts);
-                        else if (uri.Scheme.EndsWith("s", StringComparison.Ordinal))
+                        else if (uri.Scheme.EndsWith("s", StringComparison.OrdinalIgnoreCase))
                         {
                             var tmpscheme = uri.Scheme.Substring(0, uri.Scheme.Length - 1);
                             if (m_interfaces.ContainsKey(tmpscheme))
@@ -130,7 +130,7 @@ namespace Duplicati.Library.DynamicLoader
                     IBackend b;
                     if (m_interfaces.TryGetValue(uri.Scheme, out b) && b != null)
                         return GetSupportedCommandsCached(b).ToList();
-                    else if (uri.Scheme.EndsWith("s", StringComparison.Ordinal))
+                    else if (uri.Scheme.EndsWith("s", StringComparison.OrdinalIgnoreCase))
                     {
                         var tmpscheme = uri.Scheme.Substring(0, uri.Scheme.Length - 1);
                         if (m_interfaces.TryGetValue(tmpscheme, out b) && b != null)

--- a/Duplicati/Library/DynamicLoader/DynamicLoader.cs
+++ b/Duplicati/Library/DynamicLoader/DynamicLoader.cs
@@ -89,7 +89,9 @@ namespace Duplicati.Library.DynamicLoader
                 lock (m_lock)
                     if (m_interfaces == null)
                     {
-                        var interfaces = new Dictionary<string, T>();
+                        // Url schemes are case insensitive (RFC 3986), and so are the
+                        // module keys derived from them, so the lookup must be too.
+                        var interfaces = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
                         // When loading, inject the built-ins first, so they can be replaced by subfolder matches
                         foreach (T b in BuiltInModules)
                             interfaces[GetInterfaceKey(b)] = b;

--- a/Duplicati/Library/DynamicLoader/RestoreDestinationProviderLoader.cs
+++ b/Duplicati/Library/DynamicLoader/RestoreDestinationProviderLoader.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.DynamicLoader
                     IRestoreDestinationProviderModule b;
                     if (m_interfaces.TryGetValue(uri.Scheme, out b) && b != null)
                         return GetSupportedCommandsCached(b).ToList();
-                    else if (uri.Scheme.EndsWith("s", StringComparison.Ordinal))
+                    else if (uri.Scheme.EndsWith("s", StringComparison.OrdinalIgnoreCase))
                     {
                         var tmpscheme = uri.Scheme.Substring(0, uri.Scheme.Length - 1);
                         if (m_interfaces.TryGetValue(tmpscheme, out b) && b != null)

--- a/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
+++ b/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
@@ -117,7 +117,7 @@ namespace Duplicati.Library.DynamicLoader
                     ISourceProviderModule b;
                     if (m_interfaces.TryGetValue(uri.Scheme, out b) && b != null)
                         return GetSupportedCommandsCached(b).ToList();
-                    else if (uri.Scheme.EndsWith("s", StringComparison.Ordinal))
+                    else if (uri.Scheme.EndsWith("s", StringComparison.OrdinalIgnoreCase))
                     {
                         var tmpscheme = uri.Scheme.Substring(0, uri.Scheme.Length - 1);
                         if (m_interfaces.TryGetValue(tmpscheme, out b) && b != null)

--- a/Duplicati/UnitTest/BackendLoaderSchemeTests.cs
+++ b/Duplicati/UnitTest/BackendLoaderSchemeTests.cs
@@ -1,0 +1,100 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using Duplicati.Library.DynamicLoader;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// A url scheme is case insensitive (RFC 3986), so the same url must resolve to the
+    /// same backend however the scheme is written. Reads module metadata only; no
+    /// network and no external programs.
+    /// </summary>
+    public class BackendLoaderSchemeTests : BasicSetupHelper
+    {
+        private static string CommandNames(IReadOnlyList<Library.Interface.ICommandLineArgument> commands)
+            => commands == null ? "<null>" : string.Join(",", commands.Select(x => x.Name).OrderBy(x => x));
+
+        // 'file' is deliberately not used here: the relaxed parser has a dedicated
+        // file:// branch that already normalizes the scheme to lower case, so it would
+        // pass without the loader being case insensitive at all.
+        private const string HOST_URL = "ssh://example.com/folder";
+        private const string HOST_URL_WITH_CREDENTIALS = "ssh://user:pw@example.com/folder";
+
+        [TestCase("SSH")]
+        [TestCase("SsH")]
+        [Category("Utility")]
+        public void SupportedCommandsAreTheSameWhateverTheSchemeCase(string scheme)
+        {
+            var lower = BackendLoader.GetSupportedCommands(HOST_URL);
+            Assert.IsNotNull(lower, "The ssh backend must be resolvable");
+            Assert.Greater(lower.Count, 0, "The ssh backend must report commands");
+
+            var mixed = BackendLoader.GetSupportedCommands(scheme + "://example.com/folder");
+            Assert.AreEqual(CommandNames(lower), CommandNames(mixed),
+                $"'{scheme}://' must resolve to the same backend as 'ssh://'");
+        }
+
+        [Test]
+        [Category("Utility")]
+        public void GetBackendIgnoresTheSchemeCase()
+        {
+            var lower = BackendLoader.GetBackend(HOST_URL_WITH_CREDENTIALS, new Dictionary<string, string>());
+            Assert.IsNotNull(lower, "The ssh backend must be resolvable");
+
+            var upper = BackendLoader.GetBackend("SSH://user:pw@example.com/folder", new Dictionary<string, string>());
+            Assert.IsNotNull(upper, "'SSH://' must resolve to a backend");
+            Assert.AreEqual(lower.GetType(), upper.GetType());
+        }
+
+        [Test]
+        [Category("Utility")]
+        public void TheTrailingSFallbackIgnoresTheSchemeCase()
+        {
+            // 'ftps' is not a backend of its own: the loader strips the trailing 's' and
+            // turns on use-ssl. That fallback has to work for an uppercase scheme too.
+            var lower = BackendLoader.GetSupportedCommands("ftps://example.com/folder");
+            Assert.IsNotNull(lower, "'ftps://' must resolve through the trailing-s fallback");
+            Assert.Greater(lower.Count, 0);
+
+            var upper = BackendLoader.GetSupportedCommands("FTPS://example.com/folder");
+            Assert.AreEqual(CommandNames(lower), CommandNames(upper),
+                "'FTPS://' must resolve the same way as 'ftps://'");
+        }
+
+        [Test]
+        [Category("Utility")]
+        public void EncryptionModulesAreFoundWhateverTheKeyCase()
+        {
+            // The loaders share one module dictionary, so the same rule applies to the
+            // modules that are looked up by file extension.
+            var lower = EncryptionLoader.GetSupportedCommands("aes");
+            Assert.IsNotNull(lower, "The aes module must be resolvable");
+
+            var upper = EncryptionLoader.GetSupportedCommands("AES");
+            Assert.AreEqual(CommandNames(lower), CommandNames(upper));
+        }
+    }
+}


### PR DESCRIPTION
A url scheme is case insensitive (RFC 3986), but `S3://bucket` or `SSH://host` do not resolve — they are reported as an unsupported backend.

Found while working on #7133. I left it out of that PR and said I would look at it separately; this is that.

Independent of #7133 — different files, so the two can merge in any order.

## Cause

The module dictionary the loaders look schemes up in is built without a comparer, in [DynamicLoader.cs](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/DynamicLoader/DynamicLoader.cs#L92):

```csharp
var interfaces = new Dictionary<string, T>();
```

The keys come from `ProtocolKey` / `FilenameExtension` / `Key` and are all lower case, while `RelaxedUri` keeps the scheme exactly as written. So `m_interfaces.ContainsKey(uri.Scheme)` misses for anything that is not already lower case.

Everything else at this layer already ignores case when matching keys:

| | |
|---|---|
| `GenericLoader.GetModule` | `m.Key.Equals(key, StringComparison.OrdinalIgnoreCase)` |
| `DynamicLoader.RemoveAllModulesExcept` | key set built with `StringComparer.OrdinalIgnoreCase` |
| `SecretProviderLoader` | `"default://"` compared with `OrdinalIgnoreCase` |
| `SendMail` | lower-cases `uri.Scheme` itself before comparing |

The dictionary is the odd one out.

## Fix

It is created in exactly one place and shared by every loader (Backend, Compression, Encryption, Parity, SourceProvider, RestoreDestinationProvider, Web, Generic), so the comparer is set there.

**Nothing can collide as a result.** All 35 protocol keys, and the extension and module keys, are lower case and remain unique when compared without case — I checked before changing it.

The trailing-`s` fallback that turns `ftps` into `ftp` plus `use-ssl` used `EndsWith("s", StringComparison.Ordinal)`, which an uppercase `FTPS` does not match, so without relaxing that too the fix would be half done for exactly the schemes that use the convention. That comparison is changed in the three loaders that have it.

## Tests

`BackendLoaderSchemeTests` pins one invariant — **the same url resolves the same way whatever the case of the scheme** — which avoids asserting anything about what the fallback resolves *to*:

| Test | |
|---|---|
| `SupportedCommandsAreTheSameWhateverTheSchemeCase` | `SSH://` and `SsH://` against `ssh://` |
| `GetBackendIgnoresTheSchemeCase` | `SSH://` returns the same backend type |
| `TheTrailingSFallbackIgnoresTheSchemeCase` | `FTPS://` resolves like `ftps://` |
| `EncryptionModulesAreFoundWhateverTheKeyCase` | `AES` like `aes`, since the loaders share the dictionary |

`file` is deliberately not used: the relaxed parser has a dedicated `file://` branch that already lower-cases the scheme, so a `file://` test passes without the loader being fixed at all. I wrote the tests with `file` first and three of them passed against unpatched code, which is how I found that out.

## Verification

- The five tests **fail on master** (5 of 5) and pass with the change
- Loader and url tests alongside them: 90 pass (`BackendLoaderSchemeTests`, `ParityLoaderTests`, `LocalizationLoaderTests`, `Category=UriUtility`)
- The full suite on three platforms is running on my fork; this machine is too slow for it (about 2.5 h against 56 min on CI), so CI here is the check

**Limits.** Extension matching for the compression and encryption modules becomes case insensitive too, since they share the dictionary. Every key in the tree is lower case today, so no currently resolvable name changes meaning, but it is a behaviour change and worth knowing about.
