### PR TITLE
Write down what stops the relaxed URL parser from being replaced

### DIFF
--- a/Duplicati/Library/Utility/RelaxedUri.cs
+++ b/Duplicati/Library/Utility/RelaxedUri.cs
@@ -36,6 +36,21 @@ namespace Duplicati.Library.Utility
     // but it does not make sense to support "invalid" urls as that increases the complexity
     // of the code and potentially introduces ambiguity for the user.
 
+    // The commandline is not the only problem, though. Several backends take a
+    // case sensitive remote name out of the authority component:
+    //
+    //   box://MyBackups/Sub/   -> BoxBackend reads uri.HostAndPath as the remote path
+    //   dropbox://MyBackups/   -> Dropbox reads UrlDecode(uri.HostAndPath)
+    //   openstack://MyBucket   -> OpenStackStorage reads uri.Host as the container
+    //
+    // An RFC 3986 conformant parser lower-cases the authority, which destroys those
+    // names. #7097 replaced this class with System.Uri and the Box.com tests failed on
+    // all three platforms, plus CloudStack, with "The requested folder does not exist".
+    // Replacing the parser therefore also means either changing that url convention or
+    // taking the authority from the original string. TestHostAndPathKeepsTheFolderCase
+    // in UriUtilityTests covers this so it fails in the normal unit test job rather than
+    // only in the backend tests, which need credentials.
+
     /// <summary>
     /// Represents a relaxed parsing of a URL.
     /// The goal is to cover as many types of url's as possible,

--- a/Duplicati/UnitTest/AuthIdOptionsHelperTests.cs
+++ b/Duplicati/UnitTest/AuthIdOptionsHelperTests.cs
@@ -1,0 +1,87 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+using Duplicati.Library.Utility.Options;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Pins the OAuth login url that eight backends expose as their token url. The url is
+/// currently built through the relaxed parser, and the exact string it produces is not
+/// what System.UriBuilder would produce for the same input, so it is written down here
+/// before anyone changes how it is built.
+/// </summary>
+public class AuthIdOptionsHelperTests : BasicSetupHelper
+{
+    [Test]
+    [Category("UriUtility")]
+    public static void TheServicePathIsReplacedByTheTypeQuery()
+    {
+        // Note there is no '/' between the host and the '?': the relaxed parser omits it
+        // when the path is empty. System.UriBuilder would emit 'https://example.com/?...'
+        // instead, which is equivalent per RFC 3986 but not the same string.
+        Assert.AreEqual("https://example.com?type=googledrive",
+            AuthIdOptionsHelper.GetOAuthLoginUrl("googledrive", "https://example.com/refresh"));
+    }
+
+    [Test]
+    [Category("UriUtility")]
+    public static void AnExistingQueryIsKept()
+    {
+        Assert.AreEqual("https://example.com?a=b&type=box.com",
+            AuthIdOptionsHelper.GetOAuthLoginUrl("box.com", "https://example.com/refresh?a=b"));
+    }
+
+    [Test]
+    [Category("UriUtility")]
+    public static void ThePortIsKept()
+    {
+        Assert.AreEqual("https://example.com:8443?type=dropbox",
+            AuthIdOptionsHelper.GetOAuthLoginUrl("dropbox", "https://example.com:8443/refresh"));
+    }
+
+    [Test]
+    [Category("UriUtility")]
+    public static void GetOAuthLoginUrlNewFormatsTheSameWay()
+    {
+        Assert.AreEqual("https://example.com?type=pcloud",
+            AuthIdOptionsHelper.GetOAuthLoginUrlNew("pcloud", "https://example.com/refresh"));
+    }
+
+    [TestCase("jottacloud")]
+    [TestCase("onedrivev2")]
+    [Category("UriUtility")]
+    public static void TheDefaultServiceIsUsedWhenNoUrlIsGiven(string module)
+    {
+        // The host is deliberately not asserted: both defaults are overridable through the
+        // DUPLICATI_OAUTH_SERVICE environment variable, so only the shape is pinned.
+        var url = AuthIdOptionsHelper.GetOAuthLoginUrl(module, null);
+        Assert.IsTrue(url.StartsWith("https://"), $"Expected an https url, got '{url}'");
+        Assert.IsTrue(url.EndsWith($"?type={module}"), $"Expected the type query at the end, got '{url}'");
+
+        var urlNew = AuthIdOptionsHelper.GetOAuthLoginUrlNew(module, null);
+        Assert.IsTrue(urlNew.StartsWith("https://"), $"Expected an https url, got '{urlNew}'");
+        Assert.IsTrue(urlNew.EndsWith($"?type={module}"), $"Expected the type query at the end, got '{urlNew}'");
+    }
+}

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -320,5 +320,30 @@ namespace Duplicati.UnitTest
             var ex = Assert.Throws<System.ArgumentException>(() => withoutHost.RequireHost());
             Assert.IsFalse(ex!.Message.Contains("secret"), "The message must not carry the password");
         }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestHostAndPathKeepsTheFolderCase()
+        {
+            // Several backends take a case sensitive remote name out of the authority:
+            // BoxBackend reads HostAndPath as the remote path, Dropbox reads
+            // UrlDecode(HostAndPath), and OpenStackStorage reads Host as the container.
+            // An RFC 3986 conformant parser lower-cases the authority, which is why #7097
+            // failed the Box.com tests on all three platforms, and CloudStack, with "The
+            // requested folder does not exist". That only showed up in the backend tests,
+            // which need credentials, so it is pinned here as well.
+            var box = new Library.Utility.RelaxedUri("box://MyBackups/Sub/");
+            Assert.AreEqual("MyBackups", box.Host);
+            Assert.AreEqual("MyBackups/Sub/", box.HostAndPath);
+
+            var container = new Library.Utility.RelaxedUri("openstack://MyContainer");
+            Assert.AreEqual("MyContainer", container.Host);
+            Assert.AreEqual("MyContainer", container.HostAndPath);
+
+            // The same has to survive being written back out and parsed again, because
+            // that is how the url reaches the backend after being edited in the UI.
+            var roundtrip = new Library.Utility.RelaxedUri(box.ToString());
+            Assert.AreEqual(box.HostAndPath, roundtrip.HostAndPath);
+        }
     }
 }


### PR DESCRIPTION
Continues #7119, #7130, #7133 and #7134. **No behaviour change** — this records a constraint and pins the output that depends on it.

Before picking the next thing to convert, I went to find out what #7097 actually failed on. It turns out the answer changes what "replace the relaxed parser" means, so it seemed worth writing down rather than leaving in a closed PR.

## What #7097 failed on

The failing jobs were **Box.com Tests on all three platforms** plus **CloudStack Tests**, and the error was:

```
Unittest failed: Duplicati.Library.Interface.FolderMissingException:
The requested folder does not exist
```

Nothing in Box is wrong. It is the shape of the urls. Several backends take a **case sensitive remote name out of the authority component**:

| Url | What the backend reads |
|---|---|
| `box://MyBackups/Sub/` | [`uri.HostAndPath`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/Box/BoxBackend.cs#L111) as the remote path |
| `dropbox://MyBackups/` | [`UrlDecode(uri.HostAndPath)`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/Dropbox/Dropbox.cs#L51) |
| `openstack://MyBucket` | [`uri.Host`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs#L112) as the container |

An RFC 3986 conformant parser lower-cases the authority, so `MyBackups` becomes `mybackups` and the folder is gone. Nothing about that is intermittent, which is why it failed on three platforms at once.

So replacing the parser also means either changing that url convention, which is user facing, or taking the authority out of the original string. That is a decision for you rather than something I should quietly work around, which is why this PR only makes it visible.

## What this changes

**The comment on the class.** It currently says that since Mono is gone *"the only problem is the commandline"*. That is not the case, so the measured reason is recorded next to it, with the three backends and the #7097 outcome.

**`TestHostAndPathKeepsTheFolderCase`.** Pins the values those backends actually read — `Host` and `HostAndPath` for `box://MyBackups/Sub/` and `openstack://MyContainer` — plus the write-out-and-parse-again round trip, since that is how a url reaches the backend after being edited in the UI.

The point is *where* it now fails. #7133 pinned host case at the parser level, but the consequence for the backends was only covered by the Box, Dropbox and CloudStack tests, which need credentials and which a contributor cannot run. Now the same mistake fails in the ordinary unit test job.

**`AuthIdOptionsHelperTests`.** Six cases pinning the OAuth login url. Eight backends expose it as their token url and it had **no tests at all**.

It is also the last use of the parser in `Duplicati/Library/Utility`, so it is the obvious next conversion — and it is not safe to convert blind. With an empty path the parser emits:

```
https://host?type=box.com
```

with no `/` before the `?`, where `System.UriBuilder` emits `https://host/?type=box.com`. Equivalent per RFC 3986, not the same string, and this one is shown in the UI. Pinning it first is what makes that change checkable. I did not convert it in this PR for that reason.

## One observation, left alone

`DUPLICATI_OAUTH_SERVICE_NEW` reads the `DUPLICATI_OAUTH_SERVICE` environment variable rather than `DUPLICATI_OAUTH_SERVICE_NEW`. I could not tell whether that is deliberate — one override for both services would be a reasonable intent — so it is untouched and not pinned by a test. The default-service test asserts only the shape of the url, never the host, so it does not depend on the environment either way.

## Verification

- `Category=UriUtility`: **94 tests pass** (the new ones plus the existing set), 11 s
- The new tests pin existing behaviour, so they passed on the first run; no expectation was adjusted to make them pass, including the missing `/` above
- The full suite on three platforms runs on my fork rather than locally, so CI here is the check for the rest

**Limits.** This does not move anything off the parser and does not change behaviour. It makes the blocker explicit and puts the current output under test. Whether the convention changes, or the parser stays, is your call.
