### PR TITLE
Build the update download urls with System.Uri

### DIFF
--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -32,6 +32,9 @@ using System.Net.Http;
 using System.Threading;
 using Duplicati.Library.Common.IO;
 using JsonSignature;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
 
 namespace Duplicati.Library.AutoUpdater
 {
@@ -322,6 +325,36 @@ namespace Duplicati.Library.AutoUpdater
         }
 
         /// <summary>
+        /// Builds the list of urls to try when downloading an update package.
+        /// Each alternate url is pointed at the package name taken from the first package
+        /// url, and the alternates are tried first, in the order they were configured.
+        /// </summary>
+        /// <param name="packageUrls">The urls listed in the update package.</param>
+        /// <param name="alternateUrls">The configured alternate urls, empty if none.</param>
+        /// <returns>The urls to try, in order.</returns>
+        internal static List<string> BuildDownloadUrls(IEnumerable<string> packageUrls, IEnumerable<string> alternateUrls)
+        {
+            var updates = packageUrls.ToList();
+            var alternates = alternateUrls.ToArray();
+            if (alternates.Length == 0)
+                return updates;
+
+            var packagepath = new Uri(updates[0]).AbsolutePath.TrimStart('/');
+            var packagename = packagepath.Split('/').Last();
+
+            foreach (var alt_url in alternates.Reverse())
+            {
+                var alt_uri = new Uri(alt_url);
+                var path_components = alt_uri.AbsolutePath.TrimStart('/').Split('/');
+                var path = string.Join("/", path_components.Take(path_components.Count() - 1).Union(new string[] { packagename }));
+
+                updates.Insert(0, new UriBuilder(alt_uri) { Path = path }.Uri.ToString());
+            }
+
+            return updates;
+        }
+
+        /// <summary>
         /// Downloads the update package
         /// </summary>
         /// <param name="version">The version to download</param>
@@ -331,25 +364,11 @@ namespace Duplicati.Library.AutoUpdater
         /// <returns>True if the download was successful, otherwise false</returns>
         public static bool DownloadUpdate(UpdateInfo version, PackageEntry package, string targetPath, Action<double>? progress = null)
         {
-            var updates = package.RemoteUrls.ToList();
-
             // If alternate update URLs are specified,
             // we look for packages there as well
-            if (AutoUpdateSettings.UsesAlternateURLs)
-            {
-                var packagepath = new Library.Utility.RelaxedUri(updates[0]).Path;
-                var packagename = packagepath.Split('/').Last();
-
-                foreach (var alt_url in AutoUpdateSettings.URLs.Reverse())
-                {
-                    var alt_uri = new Library.Utility.RelaxedUri(alt_url);
-                    var path_components = alt_uri.Path.Split('/');
-                    var path = string.Join("/", path_components.Take(path_components.Count() - 1).Union(new string[] { packagename }));
-
-                    var new_path = alt_uri.SetPath(path);
-                    updates.Insert(0, new_path.ToString());
-                }
-            }
+            var updates = BuildDownloadUrls(
+                package.RemoteUrls,
+                AutoUpdateSettings.UsesAlternateURLs ? AutoUpdateSettings.URLs : []);
 
             using (var tempfilename = new Library.Utility.TempFile())
             {

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -346,7 +346,10 @@ namespace Duplicati.Library.AutoUpdater
             {
                 var alt_uri = new Uri(alt_url);
                 var path_components = alt_uri.AbsolutePath.TrimStart('/').Split('/');
-                var path = string.Join("/", path_components.Take(path_components.Count() - 1).Union(new string[] { packagename }));
+                // Concat, not Union: Union de-duplicates across the whole sequence, so a
+                // mirror path that repeats a component lost it, and a component named
+                // after the package swallowed the filename.
+                var path = string.Join("/", path_components.Take(path_components.Count() - 1).Concat(new string[] { packagename }));
 
                 updates.Insert(0, new UriBuilder(alt_uri) { Path = path }.Uri.ToString());
             }

--- a/Duplicati/UnitTest/UpdateDownloadUrlTests.cs
+++ b/Duplicati/UnitTest/UpdateDownloadUrlTests.cs
@@ -1,0 +1,134 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using Duplicati.Library.AutoUpdater;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The urls an update is downloaded from are built by pointing every configured
+    /// alternate url at the package name from the update package. The building was
+    /// inside DownloadUpdate and could not be checked without downloading, so these
+    /// tests pin what it produces.
+    /// </summary>
+    [TestFixture]
+    [Category("UpdateDownloadUrl")]
+    public class UpdateDownloadUrlTests
+    {
+        private const string PACKAGE = "https://updates.duplicati.com/beta/duplicati-2.1.0.5.zip";
+
+        [Test]
+        public void WithoutAlternatesThePackageUrlsAreUsedAsTheyAre()
+        {
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE, "https://mirror.example.com/duplicati-2.1.0.5.zip"], []);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(PACKAGE, result[0]);
+            Assert.AreEqual("https://mirror.example.com/duplicati-2.1.0.5.zip", result[1]);
+        }
+
+        [Test]
+        public void AnAlternateIsPointedAtThePackageNameAndTriedFirst()
+        {
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com/duplicati/latest.manifest"]);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("https://mirror.example.com/duplicati/duplicati-2.1.0.5.zip", result[0]);
+            Assert.AreEqual(PACKAGE, result[1], "The original package url stays as the last resort");
+        }
+
+        [Test]
+        public void AlternatesKeepTheirConfiguredOrder()
+        {
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE],
+            [
+                "https://first.example.com/a/latest.manifest",
+                "https://second.example.com/b/latest.manifest"
+            ]);
+
+            Assert.AreEqual(3, result.Count);
+            Assert.AreEqual("https://first.example.com/a/duplicati-2.1.0.5.zip", result[0]);
+            Assert.AreEqual("https://second.example.com/b/duplicati-2.1.0.5.zip", result[1]);
+            Assert.AreEqual(PACKAGE, result[2]);
+        }
+
+        [Test]
+        public void AQueryOnAnAlternateIsKept()
+        {
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com/d/latest.manifest?token=abc"]);
+
+            Assert.AreEqual("https://mirror.example.com/d/duplicati-2.1.0.5.zip?token=abc", result[0]);
+        }
+
+        [Test]
+        public void APortOnAnAlternateIsKept()
+        {
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com:8443/d/latest.manifest"]);
+
+            Assert.AreEqual("https://mirror.example.com:8443/d/duplicati-2.1.0.5.zip", result[0]);
+        }
+
+        [Test]
+        public void AnExplicitDefaultPortOnAnAlternateIsNormalizedAway()
+        {
+            // A port that is the default for the scheme is dropped, because System.Uri
+            // normalizes it at parse time. The relaxed parser used to keep it, so this is
+            // the one place where the string differs. The two urls are the same url, and
+            // the result is only used to issue the download request.
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com:443/d/latest.manifest"]);
+
+            Assert.AreEqual("https://mirror.example.com/d/duplicati-2.1.0.5.zip", result[0]);
+        }
+
+        [Test]
+        public void AnAlternateWithASinglePathSegmentIsReplacedEntirely()
+        {
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com/latest.manifest"]);
+
+            Assert.AreEqual("https://mirror.example.com/duplicati-2.1.0.5.zip", result[0]);
+        }
+
+        [Test]
+        public void AnAlternateWithoutAPathGetsThePackageName()
+        {
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com"]);
+
+            Assert.AreEqual("https://mirror.example.com/duplicati-2.1.0.5.zip", result[0]);
+        }
+
+        [Test]
+        public void APathSegmentEqualToThePackageNameSwallowsTheFilename()
+        {
+            // The path components are combined with Union, not Concat, so a component that
+            // already equals the package name is de-duplicated and the filename is lost.
+            // That looks unintended, but it is what happens today, so it is pinned rather
+            // than changed here.
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE],
+                ["https://mirror.example.com/duplicati-2.1.0.5.zip/latest.manifest"]);
+
+            Assert.AreEqual("https://mirror.example.com/duplicati-2.1.0.5.zip", result[0]);
+        }
+    }
+}

--- a/Duplicati/UnitTest/UpdateDownloadUrlTests.cs
+++ b/Duplicati/UnitTest/UpdateDownloadUrlTests.cs
@@ -103,6 +103,27 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
+        public void ARepeatedPathSegmentOnAnAlternateIsKept()
+        {
+            // The components were combined with Union, which de-duplicates, so a mirror
+            // path that repeats a segment came out one segment short and pointed at a
+            // location that does not exist.
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com/duplicati/duplicati/latest.manifest"]);
+
+            Assert.AreEqual("https://mirror.example.com/duplicati/duplicati/duplicati-2.1.0.5.zip", result[0]);
+        }
+
+        [Test]
+        public void ARepeatedPathSegmentThatIsNotAdjacentIsAlsoKept()
+        {
+            // Union de-duplicates across the whole sequence, so the repeat did not have to
+            // be next to itself to be lost.
+            var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com/a/b/a/latest.manifest"]);
+
+            Assert.AreEqual("https://mirror.example.com/a/b/a/duplicati-2.1.0.5.zip", result[0]);
+        }
+
+        [Test]
         public void AnAlternateWithASinglePathSegmentIsReplacedEntirely()
         {
             var result = UpdaterManager.BuildDownloadUrls([PACKAGE], ["https://mirror.example.com/latest.manifest"]);
@@ -119,16 +140,14 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void APathSegmentEqualToThePackageNameSwallowsTheFilename()
+        public void APathSegmentEqualToThePackageNameKeepsTheFilename()
         {
-            // The path components are combined with Union, not Concat, so a component that
-            // already equals the package name is de-duplicated and the filename is lost.
-            // That looks unintended, but it is what happens today, so it is pinned rather
-            // than changed here.
+            // The same de-duplication removed the package name itself when a directory in
+            // the mirror path happened to be named after it.
             var result = UpdaterManager.BuildDownloadUrls([PACKAGE],
                 ["https://mirror.example.com/duplicati-2.1.0.5.zip/latest.manifest"]);
 
-            Assert.AreEqual("https://mirror.example.com/duplicati-2.1.0.5.zip", result[0]);
+            Assert.AreEqual("https://mirror.example.com/duplicati-2.1.0.5.zip/duplicati-2.1.0.5.zip", result[0]);
         }
     }
 }


### PR DESCRIPTION
Continues #7119, #7130, #7133, #7134 and #7136.

Two commits, independent of each other:

1. **`Build the update download urls with System.Uri`** — no behaviour change except one documented string difference
2. **`Keep repeated path components in an alternate update url`** — a defect fix, found by the first commit and verified afterwards

The second can be dropped on its own if you would rather have it separately.

---

## Commit 1: the conversion

#7136 wrote down when the relaxed parser can be replaced and when it cannot: safe where the authority is a real hostname, unsafe where the authority carries a case sensitive remote folder name — which is what closed #7097. **This is the first place that rule is actually applied.**

The urls here are the update package urls and the alternate mirror urls from `AUTOUPDATER_{AppName}_URLS`. Both have a real hostname in the authority, so a conformant parser does not change their meaning. With this, **`Duplicati.Library.AutoUpdater` no longer references the relaxed parser at all**.

### The building is now testable

The url building sat inside `DownloadUpdate`, right next to the download, so there was no way to check what it produced without downloading something. It is now a separate `BuildDownloadUrls(packageUrls, alternateUrls)`, with `UsesAlternateURLs` still decided at the call site.

`[assembly: InternalsVisibleTo("Duplicati.UnitTest")]` is used rather than making the helper public, following [Filejump](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/Filejump/Filejump.cs#L30), [pCloud](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/pCloud/pCloudBackend.cs#L32) and [LocalDatabase](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Main/Database/Local/LocalDatabase.cs#L39). Happy to make it public instead if you prefer.

### Order of work

Deliberately in this order, after what happened with #7097:

1. extract the building, unchanged, still on the relaxed parser
2. write the tests, **8 of 8 passing** against that
3. swap the parser for `System.Uri`
4. same tests, same expectations, **still passing** — no expectation was adjusted

### One string level difference

`System.Uri` normalizes a port that is the default for the scheme, so an alternate given as `https://host:443/d/x` comes out as `https://host/d/x`. The relaxed parser kept the `:443`. A non-default port such as `:8443` is kept by both, which is also covered.

It is the same url, and the result is only used to issue the download request, so nothing downstream can tell the difference — but it *is* a change, so it has its own test (`AnExplicitDefaultPortOnAnAlternateIsNormalizedAway`) with the reason in a comment.

---

## Commit 2: the defect

The first commit noted that the path components were combined with `Union` rather than `Concat`, and pinned the result rather than changing it. Looking into it properly, **the effect is wider than the case that was pinned**, and it is a defect.

`Union` de-duplicates across the whole sequence, so it is enough for a mirror path to contain the same component twice. Measured before the fix — 3 of 11 tests failing:

| Alternate url | Expected | Was |
|---|---|---|
| `.../duplicati/duplicati/latest.manifest` | `.../duplicati/duplicati/duplicati-2.1.0.5.zip` | `.../duplicati/duplicati-2.1.0.5.zip` |
| `.../a/b/a/latest.manifest` | `.../a/b/a/duplicati-2.1.0.5.zip` | `.../a/b/duplicati-2.1.0.5.zip` |
| `.../duplicati-2.1.0.5.zip/latest.manifest` | `.../duplicati-2.1.0.5.zip/duplicati-2.1.0.5.zip` | `.../duplicati-2.1.0.5.zip` |

The repeat does not have to be adjacent. A mirror's directory layout is chosen by whoever runs it, so a path like `/duplicati/duplicati/` is an ordinary thing to have.

### What it costs

The download loop tries each url in turn and swallows failures, so normally the effect is that **the mirror quietly is not used** and the official url serves the update instead. Where the mirror was configured because the official url is *not reachable* — which is the reason to set `AUTOUPDATER_{AppName}_URLS` at all — the update cannot be downloaded.

Installations without that variable set never reach this code, so the blast radius is limited to deployments using a mirror.

`Concat` instead of `Union` is the whole fix. Nothing else changes.

I could not find an existing issue for this.

### About one changed expectation

`APathSegmentEqualToThePackageNameSwallowsTheFilename` from commit 1 is now `APathSegmentEqualToThePackageNameKeepsTheFilename`, with the opposite expectation. That expectation changed because the behaviour was fixed, not because the test was wrong about what the code used to do — the original is still visible in commit 1.

---

## Verification

- `UpdateDownloadUrlTests`: **11 tests**, and `UpdateCheckIntervalSettingTests` alongside them — **15 pass** in total
- Commit 1: 8 of 8 passing before the parser swap, unchanged after
- Commit 2: 3 of 11 failing before the fix (table above), all passing after
- `grep RelaxedUri Duplicati/Library/AutoUpdater/**/*.cs`: **no matches**
- The full suite on three platforms runs on my fork rather than locally, so CI here is the check for the rest

**Limits.** No actual update download was exercised, and I have no mirror to test against. What is shown is what the url building produces, for the shapes above.
