### PR TITLE
Split the xmpp target with System.Uri

### DIFF
--- a/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
@@ -217,19 +217,27 @@ namespace Duplicati.Library.Modules.Builtin
         /// <returns>The parts needed to connect.</returns>
         internal static XmppTarget ParseXmppTarget(string usernameOption)
         {
-            var uri = new Utility.RelaxedUri(usernameOption.Contains("://") ? usernameOption : "http://" + usernameOption);
-            var resource = uri.Path ?? "";
+            var uri = new Uri(usernameOption.Contains("://") ? usernameOption : "http://" + usernameOption);
+            var resource = uri.AbsolutePath;
             if (resource.StartsWith("/", StringComparison.Ordinal))
                 resource = resource.Substring(1);
 
             if (string.IsNullOrWhiteSpace(resource))
                 resource = "Duplicati";
 
+            // The user info is not decoded by System.Uri, so it is decoded here to keep
+            // the jid readable the same way it was before.
+            var userinfo = uri.UserInfo.Split(new[] { ':' }, 2);
+            var username = userinfo.Length > 0 && userinfo[0].Length > 0 ? Uri.UnescapeDataString(userinfo[0]) : null;
+            var password = userinfo.Length > 1 ? Uri.UnescapeDataString(userinfo[1]) : null;
+
             return new XmppTarget(
                 uri.Host,
-                uri.Username,
-                uri.Password,
-                uri.Port == -1 ? (uri.Scheme == "https" ? 5223 : 5222) : uri.Port,
+                username,
+                password,
+                // System.Uri answers with the scheme's default port when the jid does not
+                // name one, so the absence of a port is asked for directly.
+                uri.IsDefaultPort ? (uri.Scheme == "https" ? 5223 : 5222) : uri.Port,
                 resource);
         }
 

--- a/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendJabberMessage.cs
@@ -25,6 +25,9 @@ using System.Linq;
 using Duplicati.Library.Interface;
 using Duplicati.Library.ResultSerialization;
 using Artalk.Xmpp.Client;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
 
 namespace Duplicati.Library.Modules.Builtin
 {
@@ -195,16 +198,47 @@ namespace Duplicati.Library.Modules.Builtin
             return base.ReplaceTemplate(input, result, exception, subjectline);
         }
 
-        protected override void SendMessage(string subject, string body)
+        /// <summary>
+        /// The parts of the xmpp target needed to open a connection.
+        /// </summary>
+        /// <param name="Host">The server to connect to.</param>
+        /// <param name="Username">The user part of the jid.</param>
+        /// <param name="Password">The password from the jid, if it carries one.</param>
+        /// <param name="Port">The port to connect on, defaulted from the scheme.</param>
+        /// <param name="Resource">The xmpp resource, "Duplicati" when the jid has none.</param>
+        internal readonly record struct XmppTarget(string Host, string Username, string Password, int Port, string Resource);
+
+        /// <summary>
+        /// Splits the configured jid into the parts needed to connect. The value is a jid
+        /// rather than a url, so a scheme is prepended when it has none, and the url parser
+        /// is used to separate the user, server, port and resource.
+        /// </summary>
+        /// <param name="usernameOption">The value of the username option.</param>
+        /// <returns>The parts needed to connect.</returns>
+        internal static XmppTarget ParseXmppTarget(string usernameOption)
         {
-            var uri = new Utility.RelaxedUri(m_username.Contains("://") ? m_username : "http://" + m_username);
+            var uri = new Utility.RelaxedUri(usernameOption.Contains("://") ? usernameOption : "http://" + usernameOption);
             var resource = uri.Path ?? "";
             if (resource.StartsWith("/", StringComparison.Ordinal))
                 resource = resource.Substring(1);
 
             if (string.IsNullOrWhiteSpace(resource))
                 resource = "Duplicati";
-            using (ArtalkXmppClient client = new ArtalkXmppClient(uri.Host, uri.Username, string.IsNullOrWhiteSpace(m_password) ? uri.Password : m_password, uri.Port == -1 ? (uri.Scheme == "https" ? 5223 : 5222) : uri.Port))
+
+            return new XmppTarget(
+                uri.Host,
+                uri.Username,
+                uri.Password,
+                uri.Port == -1 ? (uri.Scheme == "https" ? 5223 : 5222) : uri.Port,
+                resource);
+        }
+
+        protected override void SendMessage(string subject, string body)
+        {
+            var target = ParseXmppTarget(m_username);
+            var resource = target.Resource;
+
+            using (ArtalkXmppClient client = new ArtalkXmppClient(target.Host, target.Username, string.IsNullOrWhiteSpace(m_password) ? target.Password : m_password, target.Port))
             {
                 client.Connect(resource);
                 try

--- a/Duplicati/UnitTest/XmppTargetTests.cs
+++ b/Duplicati/UnitTest/XmppTargetTests.cs
@@ -98,13 +98,14 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void AnUppercaseHttpsSchemeSelectsThePlainPort()
+        public void AnUppercaseHttpsSchemeAlsoSelectsTheTlsPort()
         {
-            // The scheme is compared as written, so an uppercase HTTPS:// does not select
-            // the TLS port. That looks unintended, but it is what happens today.
+            // A url scheme is case insensitive, so HTTPS:// has to mean the same as
+            // https://. It used to fall through to 5222 because the scheme was compared as
+            // written; System.Uri normalizes it, so the TLS port is now chosen.
             var target = SendJabberMessage.ParseXmppTarget("HTTPS://user@server.example.com");
 
-            Assert.AreEqual(5222, target.Port);
+            Assert.AreEqual(5223, target.Port);
         }
 
         [Test]

--- a/Duplicati/UnitTest/XmppTargetTests.cs
+++ b/Duplicati/UnitTest/XmppTargetTests.cs
@@ -1,0 +1,118 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Duplicati.Library.Modules.Builtin;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The value of send-xmpp-username is a jid rather than a url, and it is split with
+    /// the url parser. The splitting was inline in SendMessage, right before the client
+    /// connects, so it could not be checked without a server. These tests pin what it
+    /// produces.
+    /// </summary>
+    [TestFixture]
+    [Category("XmppTarget")]
+    public class XmppTargetTests
+    {
+        [Test]
+        public void APlainJidGetsTheDefaultPortAndResource()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("user@server.example.com");
+
+            Assert.AreEqual("server.example.com", target.Host);
+            Assert.AreEqual("user", target.Username);
+            Assert.IsNull(target.Password);
+            Assert.AreEqual(5222, target.Port);
+            Assert.AreEqual("Duplicati", target.Resource, "A jid without a resource gets a default one");
+        }
+
+        [Test]
+        public void APasswordInTheJidIsPickedUp()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("user:secret@server.example.com");
+
+            Assert.AreEqual("user", target.Username);
+            Assert.AreEqual("secret", target.Password);
+        }
+
+        [Test]
+        public void TheResourceComesFromThePath()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("user@server.example.com/laptop");
+
+            Assert.AreEqual("server.example.com", target.Host);
+            Assert.AreEqual("laptop", target.Resource);
+        }
+
+        [Test]
+        public void AnExplicitPortIsUsedAsGiven()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("user@server.example.com:5333");
+
+            Assert.AreEqual(5333, target.Port);
+        }
+
+        [Test]
+        public void TheHttpsSchemeSelectsTheTlsPort()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("https://user@server.example.com");
+
+            Assert.AreEqual(5223, target.Port);
+        }
+
+        [Test]
+        public void TheHttpSchemeSelectsThePlainPort()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("http://user@server.example.com");
+
+            Assert.AreEqual(5222, target.Port);
+        }
+
+        [Test]
+        public void AnUnrelatedSchemeSelectsThePlainPort()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("xmpps://user@server.example.com");
+
+            Assert.AreEqual(5222, target.Port, "Only 'https' selects the TLS port");
+        }
+
+        [Test]
+        public void AnUppercaseHttpsSchemeSelectsThePlainPort()
+        {
+            // The scheme is compared as written, so an uppercase HTTPS:// does not select
+            // the TLS port. That looks unintended, but it is what happens today.
+            var target = SendJabberMessage.ParseXmppTarget("HTTPS://user@server.example.com");
+
+            Assert.AreEqual(5222, target.Port);
+        }
+
+        [Test]
+        public void AnEscapedUserPartIsDecoded()
+        {
+            var target = SendJabberMessage.ParseXmppTarget("us%65r@server.example.com");
+
+            Assert.AreEqual("user", target.Username);
+        }
+    }
+}


### PR DESCRIPTION
Continues #7119, #7130, #7133, #7134, #7136 and #7137. Second application of the rule #7136 wrote down.

Two commits:

1. **`Separate the xmpp target parsing so it can be tested`** — no behaviour change
2. **`Split the xmpp target with System.Uri`** — the conversion, plus one fix that falls out of it

## Why this one is safe to convert

#7136 recorded that replacing the relaxed parser is safe where the authority is a real hostname, and not safe where the authority carries a case sensitive remote folder name — the `box://MyBackups/` shape that closed #7097.

`send-xmpp-username` is a jid: the authority is the xmpp server and the user info is the local part. Both are hostname-and-userinfo semantics, so a conformant parser does not change what they mean. With this, **`Duplicati.Library.Modules` no longer references the relaxed parser**.

## Commit 1: it could not be tested before

The splitting sat inline in `SendMessage`, on the line that constructs `ArtalkXmppClient` and connects, so there was no way to see what it produced without an xmpp server. It is now `ParseXmppTarget`, returning host, user, password, port and resource. The password override from `send-xmpp-password` stays at the call site since it does not come from the jid.

The nine tests were written against the relaxed parser and passed there first — same order of work as #7137.

`[assembly: InternalsVisibleTo("Duplicati.UnitTest")]` rather than a new public API, as in #7137 and [Filejump](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/Filejump/Filejump.cs#L30). Happy to make it public instead.

## Commit 2: three things that needed care

| | |
|---|---|
| **Default port** | `System.Uri` answers with the scheme's default port when the jid names none, so `Port == -1` is never true. The absence of a port is asked for with `IsDefaultPort` |
| **User info** | `System.Uri` does not decode it, so it is decoded explicitly, keeping `us%65r@server` reading as `user` |
| **Host case** | `System.Uri` lower-cases the host. An xmpp domainpart is a hostname and is only used to open the connection, so this does not change which server is reached |

Eight of the nine tests keep the expectations they were written with.

## Commit 2 also fixes a latent bug

A url scheme is case insensitive, but the scheme was compared as written:

```csharp
uri.Port == -1 ? (uri.Scheme == "https" ? 5223 : 5222) : uri.Port
```

so `HTTPS://user@server` chose the **plain port 5222** instead of the TLS port 5223, and the connection would not have been the one the user asked for. `System.Uri` normalizes the scheme, so 5223 is chosen now.

The test that pinned 5222 in commit 1 expects 5223 in commit 2. That expectation changed because the behaviour was fixed, not because the test was wrong about what the code used to do — the original is still visible in commit 1.

## What is deliberately left alone

`Duplicati/Library/Utility` still has four references and this PR does not touch them:

- [`Utility.GetUrlWithoutCredentials`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Utility/Utility.cs#L1888) sanitizes **backend** urls for display, so its authority can be a folder name. Converting it would show `box://mybackups` where the user configured `box://MyBackups` — the unsafe side of the rule
- `AuthIdOptionsHelper` builds the OAuth login url. The authority there is a real hostname, so it is on the safe side, but the emitted string changes shape (`https://host?type=x` against `https://host/?type=x`) and it is shown in the UI, so it wants its own PR. #7136 pinned its current output ready for that

Everything else — `Library/Backend`, `Library/Main`, `RestAPI`, `DynamicLoader`, `WebserverCore`, `BackendTool` — is on backend urls and is not convertible without deciding what to do about the folder-name-in-authority convention.

## Verification

- `XmppTargetTests`: **9 tests pass**, in commit 1 against the relaxed parser and in commit 2 against `System.Uri`, with only the uppercase-scheme expectation changed
- `grep RelaxedUri Duplicati/Library/Modules/**/*.cs`: **no matches**
- The full suite on three platforms runs on my fork rather than locally, so CI here is the check for the rest

**Limits.** No xmpp message was actually sent — I have no server to send to. What is shown is what the jid splits into, for the shapes above.
