### PR TITLE
Build the OAuth login url with System.Uri

### DIFF
--- a/Duplicati/Library/Utility/Options/AuthIdOptionsHelper.cs
+++ b/Duplicati/Library/Utility/Options/AuthIdOptionsHelper.cs
@@ -72,12 +72,30 @@ public static class AuthIdOptionsHelper
     /// <param name="modulename">The name of the module to use.</param>
     /// <returns>The URL to use for obtaining an OAuth token.</returns>
     public static string GetOAuthLoginUrl(string modulename, string? oauthurl)
+        => BuildOAuthLoginUrl(modulename, string.IsNullOrWhiteSpace(oauthurl) ? DUPLICATI_OAUTH_SERVICE : oauthurl);
+
+    /// <summary>
+    /// Points a service url at the login endpoint for a module, by dropping the path and
+    /// adding the module to the query.
+    /// </summary>
+    /// <param name="modulename">The name of the module to use.</param>
+    /// <param name="oauthurl">The service url to use.</param>
+    /// <returns>The URL to use for obtaining an OAuth token.</returns>
+    private static string BuildOAuthLoginUrl(string modulename, string oauthurl)
     {
-        if (string.IsNullOrWhiteSpace(oauthurl))
-            oauthurl = DUPLICATI_OAUTH_SERVICE;
-        var u = new RelaxedUri(oauthurl);
-        var addr = u.SetPath("").SetQuery((u.Query ?? "") + (string.IsNullOrWhiteSpace(u.Query) ? "" : "&") + "type={0}");
-        return string.Format(addr.ToString(), modulename);
+        var u = new Uri(oauthurl);
+
+        var query = u.Query.TrimStart('?');
+        if (!string.IsNullOrWhiteSpace(query))
+            query += "&";
+
+        // Authority is only the host and port, so anything in front of the host has to be
+        // put back to avoid dropping credentials the service url was given with.
+        var userinfo = string.IsNullOrEmpty(u.UserInfo) ? "" : u.UserInfo + "@";
+
+        // Assembled rather than handed to UriBuilder, which would place a '/' between the
+        // host and the query and change the url that is shown to the user.
+        return $"{u.Scheme}://{userinfo}{u.Authority}?{query}type={modulename}";
     }
 
     /// <summary>
@@ -85,14 +103,7 @@ public static class AuthIdOptionsHelper
     /// </summary>
     /// <param name="modulename">The name of the module to use.</param>
     public static string GetOAuthLoginUrlNew(string modulename, string? oauthurl)
-    {
-        if (string.IsNullOrWhiteSpace(oauthurl))
-            oauthurl = DUPLICATI_OAUTH_SERVICE_NEW;
-
-        var u = new RelaxedUri(oauthurl);
-        var addr = u.SetPath("").SetQuery((u.Query ?? "") + (string.IsNullOrWhiteSpace(u.Query) ? "" : "&") + "type={0}");
-        return string.Format(addr.ToString(), modulename);
-    }
+        => BuildOAuthLoginUrl(modulename, string.IsNullOrWhiteSpace(oauthurl) ? DUPLICATI_OAUTH_SERVICE_NEW : oauthurl);
 
     /// <summary>
     /// The authentication ID option, without a prefix

--- a/Duplicati/UnitTest/AuthIdOptionsHelperTests.cs
+++ b/Duplicati/UnitTest/AuthIdOptionsHelperTests.cs
@@ -84,4 +84,27 @@ public class AuthIdOptionsHelperTests : BasicSetupHelper
         Assert.IsTrue(urlNew.StartsWith("https://"), $"Expected an https url, got '{urlNew}'");
         Assert.IsTrue(urlNew.EndsWith($"?type={module}"), $"Expected the type query at the end, got '{urlNew}'");
     }
+
+    [Test]
+    [Category("UriUtility")]
+    public static void CredentialsInTheServiceUrlAreKept()
+    {
+        // The path is dropped, but anything in front of the host is not: a service url
+        // given with credentials keeps them.
+        Assert.AreEqual("https://user:pw@example.com?type=googledrive",
+            AuthIdOptionsHelper.GetOAuthLoginUrl("googledrive", "https://user:pw@example.com/refresh"));
+    }
+
+    [Test]
+    [Category("UriUtility")]
+    public static void BracesInTheServiceUrlNoLongerBreakIt()
+    {
+        // The type parameter used to be inserted as a '{0}' placeholder and formatted in
+        // afterwards, which made any brace already in the url a format specifier: this
+        // threw FormatException instead of returning a url.
+        // Braces are not legal in a query, so they come back percent-encoded, which a
+        // server decodes to the same value.
+        Assert.AreEqual("https://example.com?a=%7Bb%7D&type=googledrive",
+            AuthIdOptionsHelper.GetOAuthLoginUrl("googledrive", "https://example.com/refresh?a={b}"));
+    }
 }


### PR DESCRIPTION
Continues #7119, #7130, #7133, #7134, #7136, #7137 and #7138. Third application of the rule #7136 wrote down: safe where the authority is a real hostname, unsafe where it carries a case sensitive remote folder name.

The authority here is the OAuth service's own hostname, so it is the safe kind. With this, **`Duplicati/Library/Utility/Options` no longer references the relaxed parser**.

## Why this is possible now

#7136 pinned the output of these two methods and deliberately did **not** convert them, because `UriBuilder` puts a `/` between the host and the query:

```
today            https://example.com?type=googledrive
UriBuilder       https://example.com/?type=googledrive
```

That url is shown to the user, so the shape matters. Assembling the string from `Uri.Scheme`, `Uri.UserInfo`, `Uri.Authority` and `Uri.Query` keeps it, and **the five tests pinned in #7136 pass unchanged**.

## Two things that needed care

**`Uri.Authority` is only the host and port**, so the user info is put back explicitly. A service url given with credentials would otherwise lose them silently. That was not covered by a test, so `CredentialsInTheServiceUrlAreKept` was added first and passed against the relaxed parser before anything was converted.

**The two methods differed only in which default they fall back to** and had the same four lines copied into both. They now share a private `BuildOAuthLoginUrl`.

## It also fixes a real failure

The module name was inserted as a `{0}` placeholder into the url and formatted in afterwards:

```csharp
var addr = u.SetPath("").SetQuery((u.Query ?? "") + ... + "type={0}");
return string.Format(addr.ToString(), modulename);
```

`--oauth-url` is a user-supplied option, so any brace in it became a format specifier. Measured before the change:

```
--oauth-url=https://example.com/refresh?a={b}
  -> System.FormatException : Input string was not in a correct format.
     Failure to parse near offset 23. Expected an ASCII digit.
```

So such a service url could not be used at all. Assembling the string directly removes the placeholder round trip and it works.

**Worth knowing:** the result comes back percent-encoded, `a=%7Bb%7D`. Braces are not legal in a query and `System.Uri` encodes them; a server decodes that to the same value. I had expected them to survive literally, they do not, and the test says what actually happens rather than what I assumed.

## Disclosed differences

Both the same as in #7137:

- `System.Uri` drops a port that is the default for the scheme, so `https://host:443` comes out as `https://host`. A non-default port is kept, which is covered
- `System.Uri` lower-cases the host. DNS is case insensitive so the service reached does not change, but the url shown in the UI can differ in case from what was configured

## What is left alone

[`Utility.GetUrlWithoutCredentials`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Utility/Utility.cs#L1888) is the only remaining use in `Library/Utility`, and it stays. It sanitizes **backend** urls for display, so its authority can be a remote folder name — the unsafe side of the rule. Converting it would show `box://mybackups` where the user wrote `box://MyBackups`.

## Verification

- `AuthIdOptionsHelperTests` and `Category=UriUtility`: **96 tests pass**
- The five expectations pinned in #7136 were **not touched**
- The brace case **failed before the change** with the `FormatException` above and passes after
- `grep RelaxedUri Duplicati/Library/Utility/Options/`: **no matches**
- The full suite on three platforms runs on my fork rather than locally, so CI here is the check for the rest

**Limits.** No OAuth login was actually performed. What is shown is the url string, for the shapes above.
