### PR TITLE
Look up the entry in Idrivee2 instead of answering that it is missing

### DIFF
--- a/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
+++ b/Duplicati/Library/Backend/Idrivee2/Idrivee2Backend.cs
@@ -26,6 +26,8 @@ using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend
 {
     public class Idrivee2Backend : IStreamingBackend, IFolderEnabledBackend, ILockingBackend
@@ -105,6 +107,24 @@ namespace Duplicati.Library.Backend
                 throw new UserInformationException(Strings.Idrivee2Backend.NoKeySecretError, "Idrivee2NoKeySecret");
 
             _options = options;
+        }
+
+        /// <summary>
+        /// Constructor for testing, using a supplied client instead of connecting.
+        /// </summary>
+        /// <param name="url">The backend url.</param>
+        /// <param name="options">The backend options.</param>
+        /// <param name="client">The client to use.</param>
+        /// <remarks>
+        /// The argument count differs from the public constructor on purpose: the backend
+        /// loader instantiates backends with Activator.CreateInstance(type, url, options)
+        /// and does not bind optional parameters, so an extra optional argument on the
+        /// public constructor would stop it from being found.
+        /// </remarks>
+        internal Idrivee2Backend(string url, Dictionary<string, string?> options, IS3Client client)
+            : this(url, options)
+        {
+            _s3Client = client;
         }
 
         /// <inheritdoc />
@@ -277,8 +297,15 @@ namespace Duplicati.Library.Backend
         }
 
         /// <inheritdoc/>
-        public Task<IFileEntry?> GetEntryAsync(string path, CancellationToken cancellationToken)
-            => Task.FromResult<IFileEntry?>(null);
+        public async Task<IFileEntry?> GetEntryAsync(string path, CancellationToken cancellationToken)
+        {
+            // An empty path is the root of the bucket, which needs no lookup
+            if (string.IsNullOrWhiteSpace(path))
+                return new FileEntry(string.Empty) { IsFolder = true };
+
+            var con = await GetConnection(cancellationToken).ConfigureAwait(false);
+            return await con.GetFileEntryAsync(_bucket, GetFullKey(path), cancellationToken).ConfigureAwait(false);
+        }
 
         public async Task RenameAsync(string oldname, string newname, CancellationToken cancellationToken)
         {

--- a/Duplicati/Library/Interface/IFolderEnabledBackend.cs
+++ b/Duplicati/Library/Interface/IFolderEnabledBackend.cs
@@ -50,10 +50,12 @@ public interface IFolderEnabledBackend : IBackend
     /// </summary>
     /// <param name="path">The path to get</param>
     /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>The file or folder entry</returns>
+    /// <returns>The file or folder entry, or null when it does not exist</returns>
     /// <remarks>
     /// The paths returned should be only the filenames or folder names, not the full path.
     /// Folders should end with the operating system's directory separator.
+    /// Null means the entry does not exist: callers pass that straight on, so it must not
+    /// be used to say that the backend cannot answer.
     /// </remarks>
     Task<IFileEntry?> GetEntryAsync(string path, CancellationToken cancellationToken);
 }

--- a/Duplicati/UnitTest/Idrivee2EntryLookupTests.cs
+++ b/Duplicati/UnitTest/Idrivee2EntryLookupTests.cs
@@ -1,0 +1,155 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Common.IO;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// GetEntryAsync looks up a single file or folder. A null answer means the entry does
+    /// not exist, and callers pass that straight through, so a backend that always answers
+    /// null reports every path as missing.
+    /// </summary>
+    [TestFixture]
+    [Category("Idrivee2")]
+    public class Idrivee2EntryLookupTests
+    {
+        /// <summary>
+        /// Records what GetFileEntryAsync was asked for and answers with a set entry.
+        /// Everything else is unused by these tests.
+        /// </summary>
+        private sealed class RecordingS3Client : IS3Client
+        {
+            public string? AskedBucket;
+            public string? AskedKey;
+            public int Calls;
+            public IFileEntry? Answer;
+
+            public Task<IFileEntry?> GetFileEntryAsync(string bucketName, string keyName, CancellationToken cancellationToken)
+            {
+                Calls++;
+                AskedBucket = bucketName;
+                AskedKey = keyName;
+                return Task.FromResult(Answer);
+            }
+
+            public IAsyncEnumerable<IFileEntry> ListBucketAsync(string bucketName, string prefix, bool recursive, CancellationToken cancellationToken)
+                => throw new NotImplementedException();
+            public Task AddBucketAsync(string bucketName, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public Task DeleteObjectAsync(string bucketName, string keyName, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public Task RenameFileAsync(string bucketName, string source, string target, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public Task GetFileStreamAsync(string bucketName, string keyName, Stream target, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public string? GetDnsHost()
+                => throw new NotImplementedException();
+            public Task AddFileStreamAsync(string bucketName, string keyName, Stream source, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public Task<DateTime?> GetObjectLockUntilAsync(string bucketName, string keyName, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public Task SetObjectLockUntilAsync(string bucketName, string keyName, DateTime lockUntilUtc, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public void Dispose() { }
+        }
+
+        private static Dictionary<string, string?> Options() => new()
+        {
+            ["access_key_id"] = "id",
+            ["access_key_secret"] = "secret"
+        };
+
+        private static Idrivee2Backend Create(RecordingS3Client client, string url = "e2://mybucket/some/prefix/")
+            => new Idrivee2Backend(url, Options(), client);
+
+        [Test]
+        public async Task TheEntryFromTheClientIsReturned()
+        {
+            var client = new RecordingS3Client { Answer = new FileEntry("file.txt", 42) };
+            using var backend = Create(client);
+
+            var entry = await backend.GetEntryAsync("file.txt", CancellationToken.None);
+
+            Assert.IsNotNull(entry, "The entry the client answered with must be returned");
+            Assert.AreEqual("file.txt", entry!.Name);
+            Assert.AreEqual(42, entry.Size);
+        }
+
+        [Test]
+        public async Task ThePrefixFromTheUrlIsAppliedToTheKey()
+        {
+            var client = new RecordingS3Client { Answer = new FileEntry("file.txt") };
+            using var backend = Create(client);
+
+            await backend.GetEntryAsync("file.txt", CancellationToken.None);
+
+            Assert.AreEqual("some/prefix/file.txt", client.AskedKey,
+                "The key has to carry the prefix from the url, as it does for every other operation");
+        }
+
+        [Test]
+        public async Task TheBucketFromTheUrlIsUsed()
+        {
+            var client = new RecordingS3Client { Answer = new FileEntry("file.txt") };
+            using var backend = Create(client);
+
+            await backend.GetEntryAsync("file.txt", CancellationToken.None);
+
+            Assert.AreEqual("mybucket", client.AskedBucket);
+        }
+
+        [Test]
+        public async Task AMissingEntryStaysMissing()
+        {
+            var client = new RecordingS3Client { Answer = null };
+            using var backend = Create(client);
+
+            Assert.IsNull(await backend.GetEntryAsync("gone.txt", CancellationToken.None),
+                "A null answer from the client means the entry does not exist");
+            Assert.AreEqual(1, client.Calls);
+        }
+
+        [Test]
+        public async Task TheRootIsAnsweredWithoutAskingTheClient()
+        {
+            var client = new RecordingS3Client();
+            using var backend = Create(client);
+
+            var entry = await backend.GetEntryAsync("", CancellationToken.None);
+
+            Assert.IsNotNull(entry);
+            Assert.IsTrue(entry!.IsFolder, "The root of the bucket is a folder");
+            Assert.AreEqual(0, client.Calls, "The root does not need a lookup");
+        }
+    }
+}


### PR DESCRIPTION
`Idrivee2.GetEntryAsync` was a stub answering null for every path:

```csharp
public Task<IFileEntry?> GetEntryAsync(string path, CancellationToken cancellationToken)
    => Task.FromResult<IFileEntry?>(null);
```

Null is not "the backend cannot answer", it is "the entry does not exist", and [the caller passes it straight on](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs#L94):

```csharp
var entry = await backend.GetEntryAsync(BackendSourceFileEntry.NormalizePathTo(path, '/'), cancellationToken);
return entry == null ? null : BackendSourceFileEntry.FromFileEntry(this, path, entry);
```

## What it costs, and what it does not

`IFolderEnabledBackend` is wrapped in `BackendSourceProvider` by `SourceProviderLoader` and `RestoreDestinationProviderLoader`, so **using Idrivee2 as a source or as a restore destination answers that every path is missing**.

**Using it as a backup destination is not affected** — `GetEntryAsync` is only reached through the folder-enabled path. The blast radius is limited to those two uses.

Of the ten backends implementing the interface, eight look the entry up. `Idrivee2` and `SSHv2` were the two stubs.

## The implementation is the one S3 already has

`Idrivee2` holds the same [`IS3Client`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/S3/IS3Client.cs#L115) and has the same bucket and key handling as [`S3Backend`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/S3/S3Backend.cs#L497), so this is that implementation rather than a new one. It is `async` here only because Idrivee2 creates its client on first use.

## The interface did not say what null means

That is how a stub returning it came to look acceptable, so it is written down next to the method now:

> Null means the entry does not exist: callers pass that straight on, so it must not be used to say that the backend cannot answer.

## About the test seam

`GetConnection` returns `_s3Client` when it is already set, so an `internal` constructor taking an `IS3Client` avoids any connection.

Its argument count differs from the public constructor **on purpose**: the backend loader instantiates with `Activator.CreateInstance(type, url, options)` and does not bind optional parameters, so an extra optional argument on the public constructor would stop it from being found. That is in a comment in the code as well, since it is not obvious.

## Tests

`Idrivee2EntryLookupTests` uses a recording `IS3Client`, so no network:

| Test | |
|---|---|
| `TheEntryFromTheClientIsReturned` | the answer is passed back |
| `ThePrefixFromTheUrlIsAppliedToTheKey` | `e2://mybucket/some/prefix/` + `file.txt` asks for `some/prefix/file.txt` |
| `TheBucketFromTheUrlIsUsed` | asks in `mybucket` |
| `AMissingEntryStaysMissing` | a null answer stays null, and the client was asked |
| `TheRootIsAnsweredWithoutAskingTheClient` | an empty path is the bucket root, no lookup |

**All five fail without this change.**

## SSHv2 is left alone

It has the same stub, but its client is the concrete `SftpClient`. Giving it the same treatment means changing that field to `ISftpClient` across put, get, list, delete, create folder and rename — a larger change than this one, and it belongs on its own. Happy to send it separately.

#7101 is the same method in Box, where the requested path was not used for the lookup.

## Verification

- `Idrivee2EntryLookupTests` and the S3 tests alongside them: **15 pass**
- The five new tests **fail on master**
- The full suite on three platforms runs on my fork rather than locally, so CI here is the check for the rest

**Limits.** Nothing was run against a real iDrive e2 account. What is shown is that the backend asks the client for the right bucket and key and passes the answer through.
