### PR TITLE
Index the restore file table on the columns it is joined on

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalRestoreDatabase.cs
@@ -705,6 +705,20 @@ namespace Duplicati.Library.Main.Database.Local
                     ", token)
                         .ConfigureAwait(false);
 
+                    // Both of these are joined on when the missing blocks are collected, and
+                    // without them SQLite builds a transient index of its own for each join.
+                    await cmd.ExecuteNonQueryAsync($@"
+                        CREATE INDEX ""{m_tempfiletable}_BlocksetID""
+                        ON ""{m_tempfiletable}"" (""BlocksetID"")
+                    ", token)
+                        .ConfigureAwait(false);
+
+                    await cmd.ExecuteNonQueryAsync($@"
+                        CREATE INDEX ""{m_tempfiletable}_MetadataID""
+                        ON ""{m_tempfiletable}"" (""MetadataID"")
+                    ", token)
+                        .ConfigureAwait(false);
+
                     cmd.SetCommandAndParameters($@"
                         SELECT
                             COUNT(DISTINCT ""{m_tempfiletable}"".""Path""),

--- a/Duplicati/UnitTest/AutomaticIndexTests.cs
+++ b/Duplicati/UnitTest/AutomaticIndexTests.cs
@@ -1,0 +1,162 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// When a query joins on something there is no index for, SQLite builds a transient index
+    /// of its own and says so through its log. Each message is therefore a join that is not
+    /// covered by an index. Reported as issue #5976.
+    /// </summary>
+    [TestFixture]
+    // The SQLite log hook is process wide, so another test running at the same time would
+    // have its messages counted here as well.
+    [NonParallelizable]
+    [Category("AutomaticIndex")]
+    public class AutomaticIndexTests : BasicSetupHelper
+    {
+        /// <summary>
+        /// The temporary tables are named with a fresh GUID on every run, so the names have to
+        /// be reduced to the part that identifies the table before they can be compared.
+        /// </summary>
+        private static readonly Regex TempTableSuffix = new Regex("-[0-9A-Fa-f]{32}", RegexOptions.Compiled);
+
+        /// <summary>
+        /// The automatic indexes that an index cannot remove, and why.
+        /// </summary>
+        private static readonly HashSet<string> Accepted = new HashSet<string>(StringComparer.Ordinal)
+        {
+            // Aliases of subqueries, not of tables: the subquery is materialized without any
+            // index, so an index on the tables it reads does not remove these. Removing them
+            // means rewriting the queries.
+            //   LocalDatabase.VerifyConsistencyInnerAsync, the grouped blockset lengths
+            "B(BlocksetID)",
+            //   LocalDatabase.VerifyConsistencyInnerAsync, the grouped blocklist hash counts
+            "G(BlocksetID)",
+            //   LocalDeleteDatabase.GetWastedSpaceReportAsync, the grouped scan times
+            "B(VolumeID)",
+
+            // Temporary tables that are created, read by a single statement and dropped again.
+            // An explicit index on those costs the same as the transient one it would replace,
+            // so it is left to SQLite. All of these are in LocalTestDatabase.
+            "Blocklist(Hash)",
+            "BlocklistHashList(Hash)",
+            "CmpTable(Hash)",
+            "CmpTable(Name)",
+            "CmpTable(Path)",
+            "CmpTable(Size)"
+        };
+
+        [Test]
+        public async Task AutomaticIndexesStayWithinTheKnownSet()
+        {
+            SQLitePCL.Batteries_V2.Init();
+
+            var found = new Dictionary<string, string>(StringComparer.Ordinal);
+            var rc = SQLitePCL.raw.sqlite3_config_log((_, code, msg) =>
+            {
+                if (msg == null)
+                    return;
+
+                var m = Regex.Match(msg, @"automatic index on (?<t>.+)$", RegexOptions.IgnoreCase);
+                if (!m.Success)
+                    return;
+
+                // The log only names the alias the query used, so the call site is the only
+                // way to tell which query it was. The callback runs on the thread that
+                // prepared the statement, so its stack still holds the Duplicati frames.
+                var frames = new System.Diagnostics.StackTrace(true).GetFrames()
+                    .Select(f => new { Method = f.GetMethod(), File = f.GetFileName(), Line = f.GetFileLineNumber() })
+                    .Where(x => x.Method?.DeclaringType?.FullName?.StartsWith("Duplicati.Library.Main.", StringComparison.Ordinal) == true)
+                    .Select(x => $"      {x.Method!.DeclaringType!.Name}.{x.Method.Name} ({Path.GetFileName(x.File)}:{x.Line})")
+                    .Take(6);
+
+                var key = TempTableSuffix.Replace(m.Groups["t"].Value, "");
+                lock (found)
+                    if (!found.ContainsKey(key))
+                        found[key] = string.Join(Environment.NewLine, frames);
+            }, null);
+
+            // The hook can only be installed while SQLite is idle, so the test has to be able
+            // to say that it never got to look rather than passing quietly.
+            Assert.AreEqual(SQLitePCL.raw.SQLITE_OK, rc,
+                "Could not install the SQLite log hook, so nothing was observed");
+
+            try
+            {
+                var testopts = TestOptions.Expand(new { no_encryption = true });
+
+                // Large enough to span several blocks, so blocksets and blocklists are
+                // exercised rather than only single block files
+                var rng = new Random(42);
+                var data = new byte[1024 * 1024];
+                for (var i = 0; i < 3; i++)
+                {
+                    rng.NextBytes(data);
+                    File.WriteAllBytes(Path.Combine(DATAFOLDER, $"file-{i}.bin"), data);
+                }
+
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                    TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+                // A second version, so the queries that compare against an earlier fileset run
+                rng.NextBytes(data);
+                File.WriteAllBytes(Path.Combine(DATAFOLDER, "file-1.bin"), data);
+                File.WriteAllBytes(Path.Combine(DATAFOLDER, "file-3.bin"), data);
+
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                    TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                    TestUtils.AssertResults(await c.TestAsync(100));
+
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
+                    TestUtils.AssertResults(await c.CompactAsync());
+
+                var restoreopts = testopts.Expand(new { restore_path = RESTOREFOLDER });
+                using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, restoreopts, null))
+                    TestUtils.AssertResults(await c.RestoreAsync(["*"]));
+            }
+            finally
+            {
+                SQLitePCL.raw.sqlite3_config_log((SQLitePCL.strdelegate_log?)null, null);
+            }
+
+            var unexpected = found.Where(x => !Accepted.Contains(x.Key)).OrderBy(x => x.Key).ToList();
+            Assert.IsEmpty(unexpected,
+                $"SQLite had to build {unexpected.Count} automatic index(es) that are not in the known set. "
+                + $"Either add an index for the join, or record it in {nameof(Accepted)} with the reason it cannot be indexed:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, unexpected.Select(x => $"  {x.Key}{Environment.NewLine}{x.Value}")));
+        }
+    }
+}


### PR DESCRIPTION
Towards #5976. Deliberately not `Closes`, because the measurement did not support the fix suggested in the issue — please read "What this does not fix".

## What was measured

#5976 asks:

> the fix is to identify the places where the automatic index is registered, and issue a schema change that registers these index changes from the start

Nothing in the repository observes SQLite's log, so the first step was to install one. The new `AutomaticIndexTests` registers `sqlite3_config_log`, runs backup ×2 → test → compact → restore over 3 × 1 MiB files, and records every `automatic index on ...` message. SQLite names only the *alias* the query used, so the callback also captures the managed stack — it runs on the thread that prepared the statement, so the call site is still there.

**19 automatic indexes are built, and none of them is on a persistent table.**

| Automatic index | Call site | Kind |
| --- | --- | --- |
| `B(BlocksetID)` | `LocalDatabase.VerifyConsistencyInnerAsync` | alias of a materialized subquery |
| `G(BlocksetID)` | `LocalDatabase.VerifyConsistencyInnerAsync` | alias of a materialized subquery |
| `B(VolumeID)` | `LocalDeleteDatabase.GetWastedSpaceReportAsync` | alias of a materialized subquery |
| `Fileset-<guid>(BlocksetID)` | `LocalRestoreDatabase.FindMissingBlocksAsync` | temporary table |
| `Fileset-<guid>(MetadataID)` | `LocalRestoreDatabase.FindMissingBlocksAsync` | temporary table |
| `CmpTable-<guid>(Hash/Size/Path/Name)`, `BlocklistHashList-<guid>(Hash)`, `Blocklist-<guid>(Hash)` — 14 in all | the `CompareAsync` methods in `LocalTestDatabase` | temporary tables |

## What this changes

The temporary restore file table already gets explicit indexes on `ID`, `Path` and `TargetPath` once its rows are inserted, under the comment `//creating indexes after insertion is much faster`. `BlocksetID` and `MetadataID` were missing from that list even though `FindMissingBlocksAsync` joins on both, so SQLite had to build a transient index for each of them.

This adds those two indexes in the same place and the same form as the existing three. That is the entire production change: 14 added lines in one file.

## What this does not fix, and why

**A schema change cannot address any of the 19.** None of them is on a persistent table, so there is no table in the schema to add an index to.

The `B(BlocksetID)` in the issue text is not `BlocksetEntry` — it is the alias of the `LEFT OUTER JOIN (... GROUP BY ...) "B"` subquery in `VerifyConsistencyInnerAsync`. `BlocksetEntry("BlocksetID")` is in fact already covered three times: by the primary key from `5. Optimize BlockSet-Tables.sql`, by `nnc_BlocksetEntry` from `12. Performance Indexes.sql`, and by `BlocksetEntry_BlocksetID` from `17. Add BlocksetEntry index.sql`.

- The three subquery aliases need the queries rewritten, not an index. A materialized subquery has no index whatever the tables under it carry.
- The fourteen temporary tables in `LocalTestDatabase` are created, read by one statement, and dropped. An explicit index there costs what the transient index costs, so it is left to SQLite rather than added on the chance that it helps.

All 17 are listed in the test's `Accepted` set together with the reason, so they are not silently ignored — and anything *new* fails the test with the call site that produced it.

**The `PRAGMA optimize` failure in the issue title looks like a different cause.** An automatic index is a transient run-time structure and does not change the schema cookie, so it cannot produce `database schema has changed` (`SQLITE_SCHEMA`, 17). `Duplicati/Library/Main` creates temporary tables in 44 places, which is the usual source of that error. I could not reproduce the `PRAGMA optimize` failure itself, so this part is reasoning, not measurement.

**Related, not fixed here:** the `try`/`catch` in `LocalDatabase.DisposeAsync` wraps only the `CommitAsync`, so an exception from `PRAGMA optimize` itself escapes out of `DisposeAsync`. Glad to send that as its own PR if you want it.

## Testing

`AutomaticIndexesStayWithinTheKnownSet`, around the production change:

- **before** — fails, reporting `Fileset(BlocksetID)` and `Fileset(MetadataID)` as outside the recorded set, with `LocalRestoreDatabase.cs:1192` and `:1224` as the call sites
- **after** — passes

Existing restore fixtures (`RestoreHandlerTests`, `RestoreAllFilesTests`, `RestorePathTraversalTests`, `RestoreTaskOptionsTests`): 39 passed, 3 failed, 3 skipped. The three failures are `RestoreVolumeCacheAsync("0b", …)` with a `TaskCanceledException` out of `VolumeManager.ReadFromEitherAsync`. They fail identically without this change, and the unpatched run additionally failed `RestoreVolumeCacheAsync("1mb", null)`, which passes with it — so that fixture is unstable on my machine independently of this change.

No performance claim is made: run times moved between runs and I have not measured this in a way that would support one.
