### PR TITLE
Relax permission checks in debug

### DIFF
--- a/Duplicati/Library/Common/IO/Util.cs
+++ b/Duplicati/Library/Common/IO/Util.cs
@@ -63,6 +63,10 @@ namespace Duplicati.Library.Common.IO
         /// consulted from low-level components (such as the SQLite loader) without threading the
         /// value through every call. When the option is present without a value it is treated as
         /// enabled; values <c>false</c>, <c>0</c>, <c>no</c> and <c>off</c> disable it.
+        ///
+        /// In <c>DEBUG</c> builds the option defaults to <c>true</c> (after all explicit sources
+        /// are checked), so permission checks do not block local development. An explicit
+        /// <c>--allow-insecure-datafolder=false</c> still overrides this default.
         /// </summary>
         /// <returns><c>true</c> if the insecure data folder opt-in is set; otherwise <c>false</c>.</returns>
         public static bool AllowInsecureDataFolder()
@@ -108,7 +112,14 @@ namespace Duplicati.Library.Common.IO
                     return true;
             }
 
+#if DEBUG
+            // In debug builds the permission checks are relaxed by default to make local
+            // development easier. Users can still opt out explicitly via
+            // --allow-insecure-datafolder=false.
+            return true;
+#else
             return false;
+#endif
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/DataFolderSecurityTests.cs
+++ b/Duplicati/UnitTest/DataFolderSecurityTests.cs
@@ -286,6 +286,10 @@ namespace Duplicati.UnitTest
             if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _))
                 Assert.Ignore("Could not produce a non-canonical folder on this platform/filesystem");
 
+            // Explicitly opt out so the insecure folder is rejected even in DEBUG builds, where
+            // the option otherwise defaults to true.
+            Environment.SetEnvironmentVariable(Util.AllowInsecureDatafolderEnvVar, "false");
+
             var ex = Assert.Throws<UserInformationException>(
                 () => DataFolderManager.PrepareSecureDataFolder(dir, createIfMissing: true),
                 "A pre-existing folder with insecure permissions must be rejected");
@@ -322,6 +326,10 @@ namespace Duplicati.UnitTest
             if (SystemIO.IO_OS.DirectoryHasPermissionUserRWOnly(dir, false, out _))
                 Assert.Ignore("Could not produce a non-canonical folder on this platform/filesystem");
 
+            // Explicitly opt out so the insecure folder is rejected even in DEBUG builds, where
+            // the option otherwise defaults to true.
+            Environment.SetEnvironmentVariable(Util.AllowInsecureDatafolderEnvVar, "false");
+
             var ex = Assert.Throws<UserInformationException>(
                 () => DataFolderManager.VerifyDataFolderSecurityReadOnly(dir),
                 "Read-only verification must reject a non-canonical folder");
@@ -357,8 +365,14 @@ namespace Duplicati.UnitTest
         [Category("DataFolderSecurity")]
         public void AllowInsecureDataFolder_ReadsEnvironmentVariable()
         {
+            // With the env var unset, the default depends on the build configuration: DEBUG builds
+            // default to true (to ease local development), while release builds default to false.
             Environment.SetEnvironmentVariable(Util.AllowInsecureDatafolderEnvVar, null);
-            Assert.IsFalse(Util.AllowInsecureDataFolder(), "Unset env var should mean not allowed");
+#if DEBUG
+            Assert.IsTrue(Util.AllowInsecureDataFolder(), "Unset env var should default to true in DEBUG builds");
+#else
+            Assert.IsFalse(Util.AllowInsecureDataFolder(), "Unset env var should mean not allowed in release builds");
+#endif
 
             foreach (var truthy in new[] { "true", "1", "yes", "on", "" })
             {


### PR DESCRIPTION
In debug mode, permissions do not need to be enforced so it becomes easier to develop on the code.