### PR TITLE
Add check for misconfigured filters

### DIFF
--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -631,6 +631,11 @@ namespace Duplicati.Library.Main.Operation
             // If there is no filter, we set an empty filter to simplify the code
             m_filter = filter ?? new Library.Utility.FilterExpression();
 
+            // Warn about a likely misconfigured filter that excludes everything but has no includes
+            if (Library.Utility.FilterExpression.IsExcludeAllBeforeIncludes(m_filter))
+                Logging.Log.WriteWarningMessage(LOGTAG, "FilterExcludesAll", null,
+                    "The filter has an \"exclude all\" rule that appears before any include rules. This is likely a misconfiguration; no files will be backed up. Please check the filter settings.");
+
             Task parallelScanner = null;
             try
             {
@@ -751,6 +756,12 @@ namespace Duplicati.Library.Main.Operation
                     // Send the actual filelist
                     var uploadedNewFileset = await Backup.UploadRealFilelist.RunAsync(m_result, db, backendManager, m_options, filesetvolume, filesetid, m_result.TaskControl, lastTempVolumeIncomplete)
                         .ConfigureAwait(false);
+
+                    // Warn if the backup examined only folders and/or symlinks but no actual files,
+                    // as this is likely a misconfiguration (e.g. wrong source path or over-aggressive filter)
+                    if (uploadedNewFileset && !m_result.PartialBackup && m_result.ExaminedFiles == 0)
+                        Logging.Log.WriteWarningMessage(LOGTAG, "NoFilesInBackup", null,
+                            "The backup completed but no files were processed. This is likely a misconfiguration; please check the source paths and filter settings.");
 
                     // Wait for upload completion
                     m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Backup_WaitForUpload);

--- a/Duplicati/Library/Utility/FilterExpression.cs
+++ b/Duplicati/Library/Utility/FilterExpression.cs
@@ -590,6 +590,82 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// Checks if the filter has an "exclude everything" rule (e.g. <c>*</c>) that
+        /// appears before any include rules in the evaluation order, which would cause
+        /// all files to be excluded regardless of later includes. This is typically a
+        /// misconfiguration.
+        /// </summary>
+        /// <param name="filter">The filter to examine</param>
+        /// <returns>
+        /// <c>true</c> if an exclude-all rule is encountered before any include rule
+        /// in the filter's evaluation order; <c>false</c> otherwise.
+        /// </returns>
+        public static bool IsExcludeAllBeforeIncludes(IFilter? filter)
+        {
+            return CheckExcludeAllBeforeIncludes(filter);
+        }
+
+        /// <summary>
+        /// Recursively walks the filter tree in evaluation order (First before Second
+        /// in <see cref="JoinedFilterExpression"/>). Returns <c>true</c> if an
+        /// exclude-all expression is found before any include expression.
+        /// </summary>
+        private static bool CheckExcludeAllBeforeIncludes(IFilter? filter)
+        {
+            if (filter == null || filter.Empty)
+                return false;
+
+            if (filter is FilterExpression expression)
+            {
+                if (expression.Result)
+                    return false; // Include expression — not misconfigured from here
+                else
+                    return IsExcludeAllExpression(expression); // Exclude expression — check if it matches everything
+            }
+
+            if (filter is JoinedFilterExpression joined)
+            {
+                // First is evaluated before Second (short-circuit OR).
+                // If First is an exclude-all, it swallows everything before Second can match.
+                if (CheckExcludeAllBeforeIncludes(joined.First))
+                    return true;
+
+                // If First contains includes, they are evaluated first and the
+                // exclude-all in Second is a valid default-deny, not a misconfiguration.
+                AnalyzeFilters(joined.First, out var firstHasIncludes, out _);
+                if (firstHasIncludes)
+                    return false;
+
+                // First has no includes, so check Second
+                return CheckExcludeAllBeforeIncludes(joined.Second);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if a <see cref="FilterExpression"/> with <c>Result = false</c> (exclude)
+        /// contains an entry that matches every path (e.g. <c>*</c>).
+        /// </summary>
+        private static bool IsExcludeAllExpression(FilterExpression expression)
+        {
+            if (expression.Type == FilterType.Empty || expression.m_filters == null)
+                return false;
+
+            foreach (var entry in expression.m_filters)
+            {
+                // A "*" wildcard matches every path
+                if (entry.Type == FilterType.Wildcard && entry.Filter == "*")
+                    return true;
+                // A regex that matches everything also excludes all
+                if (entry.Type == FilterType.Regexp && entry.Filter == "^(.*)$")
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Utility function to match a filter with a default fall-through value
         /// </summary>
         /// <param name="filter">The filter to evaluate</param>

--- a/Duplicati/UnitTest/DirectListHandlerTests.cs
+++ b/Duplicati/UnitTest/DirectListHandlerTests.cs
@@ -27,7 +27,8 @@ namespace Duplicati.UnitTest
             {
                 using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
                 {
-                    TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+                    // The source folder is intentionally empty, so the NoFilesInBackup warning is expected
+                    TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }), ignoredWarnings: ["NoFilesInBackup"]);
                     var sets = await c.ListFilesetsAsync();
                     Assert.That(sets.Filesets.Count(), Is.EqualTo(i + 1));
                 }

--- a/Duplicati/UnitTest/FilterTest.cs
+++ b/Duplicati/UnitTest/FilterTest.cs
@@ -440,5 +440,83 @@ namespace Duplicati.UnitTest
             Assert.IsTrue(filter.Matches("target-file.txt", out var result, out _));
             Assert.IsTrue(result, "Include filter should report a positive match result");
         }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesDetectsWildcardExcludeAll()
+        {
+            // A "*" exclude with no includes is the canonical "exclude everything" misconfiguration
+            var filter = new FilterExpression("*", false);
+            Assert.IsTrue(FilterExpression.IsExcludeAllBeforeIncludes(filter));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesDetectsRegexExcludeAll()
+        {
+            // A regex that matches everything, used as an exclude with no includes
+            var filter = new FilterExpression("[.*]", false);
+            Assert.IsTrue(FilterExpression.IsExcludeAllBeforeIncludes(filter));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesNotTriggeredByIncludeAll()
+        {
+            // A "*" include is not an "exclude everything" filter
+            var filter = new FilterExpression("*", true);
+            Assert.IsFalse(FilterExpression.IsExcludeAllBeforeIncludes(filter));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesNotTriggeredBySpecificExcludesOnly()
+        {
+            // Specific excludes without a catch-all are not "exclude everything"
+            var filter = new FilterExpression("*.tmp", false);
+            Assert.IsFalse(FilterExpression.IsExcludeAllBeforeIncludes(filter));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesNotTriggeredByIncludesThenExcludeAll()
+        {
+            // Include rules BEFORE exclude-all is a valid default-deny pattern
+            IFilter includeFilter = new FilterExpression("*.txt", true);
+            IFilter excludeFilter = new FilterExpression("*", false);
+            var filter = FilterExpression.Combine(includeFilter, excludeFilter);
+            Assert.IsFalse(FilterExpression.IsExcludeAllBeforeIncludes(filter));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesTriggeredByExcludeAllThenIncludes()
+        {
+            // Exclude-all BEFORE include rules is misconfigured — the exclude-all
+            // swallows everything before includes can match
+            IFilter excludeFilter = new FilterExpression("*", false);
+            IFilter includeFilter = new FilterExpression("*.txt", true);
+            var filter = FilterExpression.Combine(excludeFilter, includeFilter);
+            Assert.IsTrue(FilterExpression.IsExcludeAllBeforeIncludes(filter));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesNotTriggeredByEmptyFilter()
+        {
+            Assert.IsFalse(FilterExpression.IsExcludeAllBeforeIncludes(new FilterExpression()));
+            Assert.IsFalse(FilterExpression.IsExcludeAllBeforeIncludes(null));
+        }
+
+        [Test]
+        [Category("Filter")]
+        public static void IsExcludeAllBeforeIncludesDetectsJoinedExcludeAll()
+        {
+            // Two specific excludes joined together, one of which is "*", with no includes
+            var filter = FilterExpression.Combine(
+                new FilterExpression("*.tmp", false),
+                new FilterExpression("*", false));
+            Assert.IsTrue(FilterExpression.IsExcludeAllBeforeIncludes(filter));
+        }
     }
 }

--- a/Duplicati/UnitTest/FilterTest.cs
+++ b/Duplicati/UnitTest/FilterTest.cs
@@ -172,7 +172,8 @@ namespace Duplicati.UnitTest
             {
                 var backupResults = await c.BackupAsync(new string[] { DATAFOLDER }, excludefilter);
                 Assert.AreEqual(0, backupResults.Errors.Count());
-                Assert.AreEqual(0, backupResults.Warnings.Count());
+                // The source now contains no files, so the NoFilesInBackup warning is expected
+                Assert.AreEqual(0, backupResults.Warnings.Count(x => !x.Contains("NoFilesInBackup")));
             }
 
             // Check we now have only one folder and no files

--- a/Duplicati/UnitTest/Issue4988.cs
+++ b/Duplicati/UnitTest/Issue4988.cs
@@ -56,8 +56,9 @@ public class Issue4988 : BasicSetupHelper
         Directory.CreateDirectory(emptyFolder);
 
         // Step 2: Backup empty folder
+        // The source contains no files, so the NoFilesInBackup warning is expected
         using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
-            TestUtils.AssertResults(await c.BackupAsync([emptyFolder]));
+            TestUtils.AssertResults(await c.BackupAsync([emptyFolder]), ignoredWarnings: ["NoFilesInBackup"]);
 
         // Step 3: Find the dblock created
         var dblockPath = Directory.GetFiles(TARGETFOLDER, "*.dblock*", SearchOption.TopDirectoryOnly).First();

--- a/Duplicati/UnitTest/IssueTests.cs
+++ b/Duplicati/UnitTest/IssueTests.cs
@@ -472,8 +472,9 @@ namespace Duplicati.UnitTest
             Directory.CreateDirectory(original_dir);
 
             // Backup the files
+            // The source contains only an empty folder, so the NoFilesInBackup warning is expected
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
-                TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+                TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]), ignoredWarnings: ["NoFilesInBackup"]);
 
             // Sleep to ensure timestamps are different
             await Task.Delay(1000);

--- a/Duplicati/UnitTest/ProblematicPathTests.cs
+++ b/Duplicati/UnitTest/ProblematicPathTests.cs
@@ -155,11 +155,12 @@ namespace Duplicati.UnitTest
 
             // Backup with verbatim asterisk in include filter should include
             // one directory in Linux and zero directories in Windows.
+            // On Windows zero files are examined, so the NoFilesInBackup warning is expected there.
             filter = new FilterExpression("@" + SystemIO.IO_OS.PathCombine(dirWithAsterisk, file));
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
                 var backupResults = await c.BackupAsync(new[] { this.DATAFOLDER }, filter);
-                TestUtils.AssertResults(backupResults);
+                TestUtils.AssertResults(backupResults, ignoredWarnings: ["NoFilesInBackup"]);
                 Assert.AreEqual(verbatimAsteriskShouldMatchCount, backupResults.ExaminedFiles);
             }
         }


### PR DESCRIPTION
This PR adds a small sanity check on filters where it looks to see if the filters are configured to unconditionally exclude everything. If this happens, a warning is emitted.

Since it is not possible to statically evaluate if a given filter will exclude everything, there is also a back-stop detection after the backup completes that looks at examined files. If no files were examined, this is also treated as a warning.

Overall, the goal is to prevent cases where the backups run sucessfully but do not contain any files. With this change, a warning is logged so it is visible that something is not right.