### PR TITLE
Remove unused Uri alias

### DIFF
--- a/Duplicati/CommandLine/SecretTool/Program.cs
+++ b/Duplicati/CommandLine/SecretTool/Program.cs
@@ -26,7 +26,6 @@ using System.CommandLine.Parsing;
 using Duplicati.Library.DynamicLoader;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
-using Uri = System.Uri;
 
 namespace Duplicati.CommandLine.SecretTool;
 

--- a/Duplicati/CommandLine/ServerUtil/Settings.cs
+++ b/Duplicati/CommandLine/ServerUtil/Settings.cs
@@ -21,12 +21,10 @@
 
 using System.Text.Json;
 using Duplicati.Library.AutoUpdater;
-using Duplicati.Library.DynamicLoader;
 using Duplicati.Library.Encryption;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using Duplicati.Library.Utility;
-using Uri = System.Uri;
 using Utility = Duplicati.Library.Utility.Utility;
 
 namespace Duplicati.CommandLine.ServerUtil;

--- a/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
+++ b/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
@@ -24,7 +24,6 @@ using System.CommandLine.Binding;
 using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Encryption;
 using Duplicati.Library.Main;
-using Uri = System.Uri;
 using Utility = Duplicati.Library.Utility.Utility;
 
 namespace Duplicati.CommandLine.ServerUtil;

--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/Program.cs
@@ -34,7 +34,6 @@ using Duplicati.Server;
 using Duplicati.Server.Database;
 using Duplicati.WebserverCore.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Uri = System.Uri;
 
 namespace Duplicati.GUI.TrayIcon
 {

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
@@ -25,7 +25,6 @@ using Azure.Storage.Blobs.Models;
 using System.Runtime.CompilerServices;
 using Duplicati.Library.Common.IO;
 using Duplicati.Library.Interface;
-using Uri = System.Uri;
 using Duplicati.Library.Utility.Options;
 using Duplicati.Library.Utility;
 using Azure.Core.Pipeline;

--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -20,7 +20,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Net;
-using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 using Duplicati.Library.Common.IO;
@@ -32,7 +31,6 @@ using FluentFTP;
 using FluentFTP.Client.BaseClient;
 using FluentFTP.Exceptions;
 using CoreUtility = Duplicati.Library.Utility.Utility;
-using Uri = System.Uri;
 
 namespace Duplicati.Library.Backend
 {

--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -25,7 +25,6 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using Duplicati.Library.Backend.pCloud;
 using Duplicati.Library.Utility;
-using Uri = System.Uri;
 using System.Runtime.CompilerServices;
 using Duplicati.Library.Utility.Options;
 

--- a/Duplicati/Library/Modules/Builtin/HttpReportStatus.cs
+++ b/Duplicati/Library/Modules/Builtin/HttpReportStatus.cs
@@ -31,7 +31,6 @@ using System.Threading.Tasks;
 using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Utility;
-using Uri = System.Uri;
 
 namespace Duplicati.Library.Modules.Builtin
 {

--- a/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendHttpMessage.cs
@@ -29,7 +29,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Duplicati.Library.Utility;
-using Uri = System.Uri;
 using System.Threading;
 
 namespace Duplicati.Library.Modules.Builtin

--- a/Duplicati/Library/Modules/Builtin/SendTelegramMessage.cs
+++ b/Duplicati/Library/Modules/Builtin/SendTelegramMessage.cs
@@ -27,7 +27,6 @@ using System.Threading.Tasks;
 using Duplicati.Library.Interface;
 using Duplicati.Library.ResultSerialization;
 using Duplicati.Library.Utility;
-using Uri = System.Uri;
 
 namespace Duplicati.Library.Modules.Builtin;
 

--- a/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
+++ b/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
@@ -30,7 +30,6 @@ using CoCoL;
 using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Logging;
 using Duplicati.Library.Utility;
-using Uri = System.Uri;
 
 namespace Duplicati.Library.RemoteControl;
 


### PR DESCRIPTION
After renaming the `Utility.Uri` class to `RelaxedUri` there is no longer a clash with `System.Uri`. This PR removes some places where `using Uri = System.Uri;` was set previously, but is no longer needed.