### PR TITLE
Parse the ssh and smb urls with System.Uri

### DIFF
--- a/Duplicati/Library/Backend/SMB/SMBBackend.cs
+++ b/Duplicati/Library/Backend/SMB/SMBBackend.cs
@@ -136,18 +136,31 @@ public class SMBBackend : IStreamingBackend, IFolderEnabledBackend, IRenameEnabl
     /// <returns>The parts the backend needs.</returns>
     internal static SmbUrl ParseSmbUrl(string url)
     {
-        var uri = new Utility.RelaxedUri(url);
-        uri.RequireHost();
+        var uri = new Uri(url);
+        uri.RequireHost(url);
+        uri.RequireNoFragment(url);
 
-        var input = uri.Path.TrimEnd('/');
+        // The path arrives escaped and with its leading separator, where the previous
+        // parser handed it over decoded and without one. Decoding first keeps an
+        // encoded separator in the place it used to land in.
+        var path = Uri.UnescapeDataString(uri.AbsolutePath);
+        if (path.StartsWith("/", StringComparison.Ordinal))
+            path = path.Substring(1);
+
+        // The user info is not decoded, so it is decoded here.
+        var userinfo = uri.UserInfo.Split(new[] { ':' }, 2);
+        var username = userinfo.Length > 0 && userinfo[0].Length > 0 ? Uri.UnescapeDataString(userinfo[0]) : null;
+        var password = userinfo.Length > 1 ? Uri.UnescapeDataString(userinfo[1]) : null;
+
+        var input = path.TrimEnd('/');
         var slashIndex = input.IndexOf('/');  // Find first slash to separate share and path if present.
 
         return new SmbUrl(
-            uri.Host!,
+            uri.Host,
             slashIndex >= 0 ? input[..slashIndex] : input,
             slashIndex >= 0 ? input[(slashIndex + 1)..] : "",
-            uri.Username,
-            uri.Password);
+            username,
+            password);
     }
 
     /// <summary>

--- a/Duplicati/Library/Backend/SMB/SMBBackend.cs
+++ b/Duplicati/Library/Backend/SMB/SMBBackend.cs
@@ -29,6 +29,8 @@ using Duplicati.Library.Common.IO;
 using Duplicati.Library.Utility.Options;
 using Duplicati.Library.Utility;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend;
 
 /// <summary>
@@ -118,6 +120,37 @@ public class SMBBackend : IStreamingBackend, IFolderEnabledBackend, IRenameEnabl
     }
 
     /// <summary>
+    /// The parts of an smb url that the backend configures itself from.
+    /// </summary>
+    /// <param name="Host">The server to connect to. An IPv6 literal keeps its brackets.</param>
+    /// <param name="ShareName">The share, which is the first segment of the url path.</param>
+    /// <param name="Path">The path inside the share, without a trailing slash.</param>
+    /// <param name="Username">The user from the url, or null when it has none.</param>
+    /// <param name="Password">The password from the url, or null when it has none.</param>
+    internal readonly record struct SmbUrl(string Host, string ShareName, string Path, string? Username, string? Password);
+
+    /// <summary>
+    /// Splits an smb url into the parts the backend needs.
+    /// </summary>
+    /// <param name="url">The url to split.</param>
+    /// <returns>The parts the backend needs.</returns>
+    internal static SmbUrl ParseSmbUrl(string url)
+    {
+        var uri = new Utility.RelaxedUri(url);
+        uri.RequireHost();
+
+        var input = uri.Path.TrimEnd('/');
+        var slashIndex = input.IndexOf('/');  // Find first slash to separate share and path if present.
+
+        return new SmbUrl(
+            uri.Host!,
+            slashIndex >= 0 ? input[..slashIndex] : input,
+            slashIndex >= 0 ? input[(slashIndex + 1)..] : "",
+            uri.Username,
+            uri.Password);
+    }
+
+    /// <summary>
     /// Actual constructor for the backend that accepts the url and options
     /// </summary>
     /// <param name="url">URL in Duplicati Uri format</param>
@@ -129,12 +162,8 @@ public class SMBBackend : IStreamingBackend, IFolderEnabledBackend, IRenameEnabl
         if (options == null)
             throw new ArgumentNullException(nameof(options));
 
-        var uri = new Utility.RelaxedUri(url);
-        uri.RequireHost();
-        _DnsName = uri.Host ?? "";
-
-        var input = uri.Path.TrimEnd('/');
-        var slashIndex = input.IndexOf('/');  // Find first slash to separate server and share if present.
+        var uri = ParseSmbUrl(url);
+        _DnsName = uri.Host;
 
         var auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
         var authDomain = options.GetValueOrDefault(AUTH_DOMAIN_OPTION);
@@ -164,8 +193,8 @@ public class SMBBackend : IStreamingBackend, IFolderEnabledBackend, IRenameEnabl
         _connectionParameters = new SMBConnectionParameters(
             _DnsName,
             transportType,
-            slashIndex >= 0 ? input[..slashIndex] : input,
-            slashIndex >= 0 ? input[(slashIndex + 1)..] : "",
+            uri.ShareName,
+            uri.Path,
             authDomain,
             auth.Username,
             auth.Password,

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -34,6 +34,8 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend
 {
     public class SSHv2 : IStreamingBackend, IRenameEnabledBackend, IFolderEnabledBackend
@@ -79,11 +81,33 @@ namespace Duplicati.Library.Backend
             m_useAgent = true;
         }
 
+        /// <summary>
+        /// The parts of an ssh url that the backend configures itself from.
+        /// </summary>
+        /// <param name="Host">The server to connect to. An IPv6 literal keeps its brackets.</param>
+        /// <param name="Port">The port, or -1 when the url does not name one.</param>
+        /// <param name="Path">The remote path, decoded and without a leading slash.</param>
+        /// <param name="Username">The user from the url, or null when it has none.</param>
+        /// <param name="Password">The password from the url, or null when it has none.</param>
+        internal readonly record struct SshUrl(string Host, int Port, string Path, string? Username, string? Password);
+
+        /// <summary>
+        /// Splits an ssh url into the parts the backend needs.
+        /// </summary>
+        /// <param name="url">The url to split.</param>
+        /// <returns>The parts the backend needs.</returns>
+        internal static SshUrl ParseSshUrl(string url)
+        {
+            var uri = new Utility.RelaxedUri(url);
+            uri.RequireHost();
+
+            return new SshUrl(uri.Host!, uri.Port, uri.Path, uri.Username, uri.Password);
+        }
+
         public SSHv2(string url, Dictionary<string, string?> options)
         {
             m_options = options;
-            var uri = new Utility.RelaxedUri(url);
-            uri.RequireHost();
+            var uri = ParseSshUrl(url);
 
             var auth = AuthOptionsHelper.Parse(options, uri.Username, uri.Password);
             if (!auth.HasUsername)
@@ -112,7 +136,7 @@ namespace Duplicati.Library.Backend
                     m_path = "/" + m_path;
             }
 
-            m_server = uri.Host ?? "";
+            m_server = uri.Host;
 
             if (uri.Port > 0)
                 m_port = uri.Port;

--- a/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
+++ b/Duplicati/Library/Backend/SSHv2/SSHv2Backend.cs
@@ -98,10 +98,25 @@ namespace Duplicati.Library.Backend
         /// <returns>The parts the backend needs.</returns>
         internal static SshUrl ParseSshUrl(string url)
         {
-            var uri = new Utility.RelaxedUri(url);
-            uri.RequireHost();
+            var uri = new Uri(url);
+            uri.RequireHost(url);
+            uri.RequireNoFragment(url);
 
-            return new SshUrl(uri.Host!, uri.Port, uri.Path, uri.Username, uri.Password);
+            // The path arrives escaped and with its leading separator, where the previous
+            // parser handed it over decoded and without one. Decoding first keeps an
+            // encoded separator in the place it used to land in.
+            var path = Uri.UnescapeDataString(uri.AbsolutePath);
+            if (path.StartsWith("/", StringComparison.Ordinal))
+                path = path.Substring(1);
+
+            // The user info is not decoded, so it is decoded here.
+            var userinfo = uri.UserInfo.Split(new[] { ':' }, 2);
+            var username = userinfo.Length > 0 && userinfo[0].Length > 0 ? Uri.UnescapeDataString(userinfo[0]) : null;
+            var password = userinfo.Length > 1 ? Uri.UnescapeDataString(userinfo[1]) : null;
+
+            // ssh is not a scheme with a registered default port, so an url without one
+            // answers -1 here, the same way the previous parser did.
+            return new SshUrl(uri.Host, uri.Port, path, username, password);
         }
 
         public SSHv2(string url, Dictionary<string, string?> options)

--- a/Duplicati/Library/Utility/Strings.cs
+++ b/Duplicati/Library/Utility/Strings.cs
@@ -49,6 +49,7 @@ namespace Duplicati.Library.Utility.Strings
     {
         public static string UriParseError(string uri) { return LC.L(@"The Uri is invalid: {0}", uri); }
         public static string NoHostname(string uri) { return LC.L(@"The Uri is missing a hostname: {0}", uri); }
+        public static string FragmentNotAllowed(string uri) { return LC.L(@"The Uri has a fragment, so everything after the ""#"" is not part of the path. Write the ""#"" as %23 if it belongs to the path: {0}", uri); }
     }
     internal static class Utility
     {

--- a/Duplicati/Library/Utility/UriExtensions.cs
+++ b/Duplicati/Library/Utility/UriExtensions.cs
@@ -1,0 +1,73 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using Duplicati.Library.Interface;
+
+#nullable enable
+
+namespace Duplicati.Library.Utility
+{
+    /// <summary>
+    /// Checks that a backend url is usable, for the backends that have moved from
+    /// <see cref="RelaxedUri"/> to <see cref="System.Uri"/>.
+    /// These live here rather than in the backends because the messages are built from
+    /// <see cref="Strings.Uri"/> and <see cref="Utility.StripUrlUserInfo"/>, both of which
+    /// are internal to this assembly.
+    /// </summary>
+    public static class UriExtensions
+    {
+        /// <summary>
+        /// Throws if the url has no hostname.
+        /// </summary>
+        /// <param name="uri">The parsed url.</param>
+        /// <param name="originalUrl">The url as it was given, used for the message.</param>
+        /// <remarks>
+        /// Throws the same exception with the same message as <see cref="RelaxedUri.RequireHost"/>,
+        /// so a backend that moves to <see cref="System.Uri"/> keeps reporting this the way it did.
+        /// </remarks>
+        public static void RequireHost(this System.Uri uri, string originalUrl)
+        {
+            if (string.IsNullOrEmpty(uri.Host))
+                throw new ArgumentException(Strings.Uri.NoHostname(Utility.StripUrlUserInfo(originalUrl)));
+        }
+
+        /// <summary>
+        /// Throws if the url carries a fragment.
+        /// </summary>
+        /// <param name="uri">The parsed url.</param>
+        /// <param name="originalUrl">The url as it was given, used for the message.</param>
+        /// <remarks>
+        /// A "#" starts a fragment, so everything after it is not part of the path. The relaxed
+        /// parser had no fragment and kept those characters, which means accepting the url would
+        /// quietly move the backup to a different folder. This is told to the user instead, so
+        /// this one throws <see cref="UserInformationException"/> rather than matching
+        /// <see cref="RequireHost"/>: there is no earlier behaviour to keep, and the user has
+        /// something to fix.
+        /// </remarks>
+        public static void RequireNoFragment(this System.Uri uri, string originalUrl)
+        {
+            if (!string.IsNullOrEmpty(uri.Fragment))
+                throw new UserInformationException(
+                    Strings.Uri.FragmentNotAllowed(Utility.StripUrlUserInfo(originalUrl)), "UriHasFragment");
+        }
+    }
+}

--- a/Duplicati/UnitTest/SmbUrlTests.cs
+++ b/Duplicati/UnitTest/SmbUrlTests.cs
@@ -1,0 +1,111 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using Duplicati.Library.Backend;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Covers how an smb url is split into the server, the share and the path inside it.
+    /// The expectations here were measured against the parser that was in place before,
+    /// so that replacing the parser shows up as a failure rather than as a silent change.
+    /// </summary>
+    [TestFixture]
+    [Category("UriUtility")]
+    public class SmbUrlTests
+    {
+        [TestCase("smb://host/share", "host", "share", "")]
+        [TestCase("smb://host/share/", "host", "share", "")]
+        [TestCase("smb://host/share/sub/dir", "host", "share", "sub/dir")]
+        [TestCase("smb://host/share/sub/dir/", "host", "share", "sub/dir")]
+        [TestCase("smb://host", "host", "", "")]
+        [TestCase("smb://host/", "host", "", "")]
+        // An empty first segment leaves the share empty and puts everything in the path
+        [TestCase("smb://host//share/sub", "host", "", "share/sub")]
+        // The port has no meaning to this backend, so it is only skipped over
+        [TestCase("smb://host:445/share/sub", "host", "share", "sub")]
+        [TestCase("smb://host/My%20Share/My%20Folder", "host", "My Share", "My Folder")]
+        [TestCase("smb://host/share;name/x", "host", "share;name", "x")]
+        [TestCase("smb://[fe80::1]/share", "[fe80::1]", "share", "")]
+        // The cifs backend derives from this one and shares the parser
+        [TestCase("cifs://host/share/sub", "host", "share", "sub")]
+        public void TheShareIsTheFirstSegmentOfThePath(string url, string host, string share, string path)
+        {
+            var parsed = SMBBackend.ParseSmbUrl(url);
+            Assert.AreEqual(host, parsed.Host, url);
+            Assert.AreEqual(share, parsed.ShareName, url);
+            Assert.AreEqual(path, parsed.Path, url);
+        }
+
+        [TestCase("smb://user:pw@host/share/sub", "user", "pw")]
+        // A domain user is written with the '@' encoded
+        [TestCase("smb://user%40dom:p%40ss@host/share", "user@dom", "p@ss")]
+        public void TheCredentialsAreDecoded(string url, string? username, string? password)
+        {
+            var parsed = SMBBackend.ParseSmbUrl(url);
+            Assert.AreEqual(username, parsed.Username, url);
+            Assert.AreEqual(password, parsed.Password, url);
+        }
+
+        [Test]
+        public void AUrlWithoutAHostIsRejected()
+        {
+            Assert.Throws<ArgumentException>(() => SMBBackend.ParseSmbUrl("smb:///share"));
+        }
+
+        [Test]
+        public void TheHostKeepsItsCaseButTheShareAndPathAreWhatMatter()
+        {
+            var parsed = SMBBackend.ParseSmbUrl("smb://SERVER01/Share/Sub");
+            Assert.AreEqual("SERVER01", parsed.Host);
+            Assert.AreEqual("Share", parsed.ShareName);
+            Assert.AreEqual("Sub", parsed.Path);
+        }
+
+        [TestCase("smb://host/share\\sub")]
+        [TestCase("smb://host/share%5Csub")]
+        public void ABackslashDoesNotSeparateTheShareFromThePath(string url)
+        {
+            var parsed = SMBBackend.ParseSmbUrl(url);
+            Assert.AreEqual("share\\sub", parsed.ShareName, url);
+            Assert.AreEqual("", parsed.Path, url);
+        }
+
+        [Test]
+        public void APlusInThePathIsReadAsASpace()
+        {
+            Assert.AreEqual("a b", SMBBackend.ParseSmbUrl("smb://host/share/a+b").Path);
+        }
+
+        [Test]
+        public void AHashInTheShareIsPartOfTheShareName()
+        {
+            var parsed = SMBBackend.ParseSmbUrl("smb://host/share#1/x");
+            Assert.AreEqual("share#1", parsed.ShareName);
+            Assert.AreEqual("x", parsed.Path);
+        }
+    }
+}

--- a/Duplicati/UnitTest/SmbUrlTests.cs
+++ b/Duplicati/UnitTest/SmbUrlTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -77,35 +78,54 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void TheHostKeepsItsCaseButTheShareAndPathAreWhatMatter()
+        public void TheHostIsLowerCasedAndTheShareAndPathKeepTheirCase()
         {
+            // The previous parser kept the case of the host as well. A server name is not
+            // case sensitive, while the share and the path name things on the server, so
+            // those are the ones that have to survive.
             var parsed = SMBBackend.ParseSmbUrl("smb://SERVER01/Share/Sub");
-            Assert.AreEqual("SERVER01", parsed.Host);
+            Assert.AreEqual("server01", parsed.Host);
             Assert.AreEqual("Share", parsed.ShareName);
             Assert.AreEqual("Sub", parsed.Path);
         }
 
-        [TestCase("smb://host/share\\sub")]
-        [TestCase("smb://host/share%5Csub")]
-        public void ABackslashDoesNotSeparateTheShareFromThePath(string url)
+        [Test]
+        public void ABackslashSeparatesTheShareFromThePath()
         {
-            var parsed = SMBBackend.ParseSmbUrl(url);
-            Assert.AreEqual("share\\sub", parsed.ShareName, url);
-            Assert.AreEqual("", parsed.Path, url);
+            // The previous parser only split on '/', so the whole thing became the share
+            // name and the path was left empty. PATH_SEPARATORS already treats '\' as a
+            // separator everywhere else in this backend, so this makes it consistent.
+            var parsed = SMBBackend.ParseSmbUrl("smb://host/share\\sub");
+            Assert.AreEqual("share", parsed.ShareName);
+            Assert.AreEqual("sub", parsed.Path);
         }
 
         [Test]
-        public void APlusInThePathIsReadAsASpace()
+        public void AnEncodedBackslashStaysInTheShareName()
         {
-            Assert.AreEqual("a b", SMBBackend.ParseSmbUrl("smb://host/share/a+b").Path);
+            // Only the separator written as a separator is one; an encoded backslash is
+            // a character in the name.
+            var parsed = SMBBackend.ParseSmbUrl("smb://host/share%5Csub");
+            Assert.AreEqual("share\\sub", parsed.ShareName);
+            Assert.AreEqual("", parsed.Path);
         }
 
         [Test]
-        public void AHashInTheShareIsPartOfTheShareName()
+        public void APlusInThePathIsNoLongerASpace()
         {
-            var parsed = SMBBackend.ParseSmbUrl("smb://host/share#1/x");
-            Assert.AreEqual("share#1", parsed.ShareName);
-            Assert.AreEqual("x", parsed.Path);
+            // The previous parser applied the query string rule that reads '+' as a space
+            // to the path as well. A url that has been through the parser carries %2B, so
+            // only a hand written url is affected.
+            Assert.AreEqual("a+b", SMBBackend.ParseSmbUrl("smb://host/share/a+b").Path);
+        }
+
+        [Test]
+        public void AHashInTheShareIsRejected()
+        {
+            // The previous parser had no fragment and kept the '#' in the share name.
+            // Accepting the url now would use the share "share" instead, so the user is
+            // told to write %23 rather than being sent to a different share.
+            Assert.Throws<UserInformationException>(() => SMBBackend.ParseSmbUrl("smb://host/share#1/x"));
         }
     }
 }

--- a/Duplicati/UnitTest/SshUrlTests.cs
+++ b/Duplicati/UnitTest/SshUrlTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -99,49 +100,66 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void TheMessageForAMissingHostDoesNotCarryTheCredentials()
+        public void AnEmptyUserWithAPasswordIsNoLongerReadAsAMissingHost()
         {
-            var ex = Assert.Throws<ArgumentException>(() => SSHv2.ParseSshUrl("ssh://:pass@host/p"));
-            Assert.IsFalse(ex!.Message.Contains("pass"), ex.Message);
+            // The previous parser read the ':' as the start of the authority and reported
+            // a missing hostname. The password is taken now, and the missing user is what
+            // the constructor reports.
+            var parsed = SSHv2.ParseSshUrl("ssh://:pass@host/p");
+            Assert.AreEqual("host", parsed.Host);
+            Assert.IsNull(parsed.Username);
+            Assert.AreEqual("pass", parsed.Password);
         }
 
         [Test]
-        public void TheHostKeepsItsCase()
+        public void TheHostIsLowerCased()
         {
-            Assert.AreEqual("Host.Example.COM", SSHv2.ParseSshUrl("ssh://Host.Example.COM/p").Host);
+            // The previous parser kept the case. A host name is a dns name, a netbios name
+            // or an ip literal, and none of those are case sensitive, so this only matters
+            // for the backends that read a remote folder name out of the authority instead.
+            Assert.AreEqual("host.example.com", SSHv2.ParseSshUrl("ssh://Host.Example.COM/p").Host);
         }
 
         [Test]
-        public void APlusInThePathIsReadAsASpace()
+        public void APlusInThePathIsNoLongerASpace()
         {
-            Assert.AreEqual("a b", SSHv2.ParseSshUrl("ssh://host/a+b").Path);
+            // The previous parser applied the query string rule that reads '+' as a space
+            // to the path as well. A url that has been through the parser carries %2B, so
+            // only a hand written url is affected.
+            Assert.AreEqual("a+b", SSHv2.ParseSshUrl("ssh://host/a+b").Path);
         }
 
         [Test]
-        public void AHashInThePathIsPartOfTheFolderName()
+        public void AHashInThePathIsRejected()
         {
-            Assert.AreEqual("backup#1/", SSHv2.ParseSshUrl("ssh://host/backup#1/").Path);
+            // The previous parser had no fragment and kept the '#' in the folder name.
+            // Accepting the url now would move the backup to "backup" instead, so the
+            // user is told to write %23 rather than being sent somewhere else.
+            Assert.Throws<UserInformationException>(() => SSHv2.ParseSshUrl("ssh://host/backup#1/"));
         }
 
         [Test]
-        public void ADotSegmentInThePathIsKept()
+        public void ADotSegmentInThePathIsResolved()
         {
-            Assert.AreEqual("a/../b", SSHv2.ParseSshUrl("ssh://host/a/../b").Path);
+            // The previous parser kept the segment as written.
+            Assert.AreEqual("b", SSHv2.ParseSshUrl("ssh://host/a/../b").Path);
         }
 
         [Test]
-        public void AnUnencodedAtSignInThePasswordIsReadAsPartOfTheHost()
+        public void AnUnencodedAtSignInThePasswordIsRejected()
         {
-            var parsed = SSHv2.ParseSshUrl("ssh://user:p@ss@host/p");
-            Assert.AreEqual("ss@host", parsed.Host);
-            Assert.AreEqual("user", parsed.Username);
-            Assert.AreEqual("p", parsed.Password);
+            // The previous parser read the last '@' as the separator, so the password was
+            // cut at the first one and the rest ended up in the host name, which then
+            // failed to resolve when connecting. It is reported here instead.
+            var ex = Assert.Throws<UriFormatException>(() => SSHv2.ParseSshUrl("ssh://user:p@ss@host/p"));
+            Assert.IsFalse(ex!.Message.Contains("ss"), ex.Message);
         }
 
         [Test]
-        public void APortOutsideTheValidRangeIsAccepted()
+        public void APortOutsideTheValidRangeIsRejected()
         {
-            Assert.AreEqual(99999, SSHv2.ParseSshUrl("ssh://host:99999/p").Port);
+            // The previous parser passed it on and the connection failed later.
+            Assert.Throws<UriFormatException>(() => SSHv2.ParseSshUrl("ssh://host:99999/p"));
         }
     }
 }

--- a/Duplicati/UnitTest/SshUrlTests.cs
+++ b/Duplicati/UnitTest/SshUrlTests.cs
@@ -1,0 +1,147 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using Duplicati.Library.Backend;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Covers how an ssh url is split into the parts the backend connects with.
+    /// The expectations here were measured against the parser that was in place before,
+    /// so that replacing the parser shows up as a failure rather than as a silent change.
+    /// </summary>
+    [TestFixture]
+    [Category("UriUtility")]
+    public class SshUrlTests
+    {
+        [TestCase("ssh://host", "host", -1, "")]
+        [TestCase("ssh://host/", "host", -1, "")]
+        [TestCase("ssh://host/backup", "host", -1, "backup")]
+        [TestCase("ssh://host/backup/", "host", -1, "backup/")]
+        [TestCase("ssh://host/a/b/c", "host", -1, "a/b/c")]
+        // The query carries the backend options and is not part of the remote path
+        [TestCase("ssh://host/p?ssh-fingerprint=x", "host", -1, "p")]
+        [TestCase("ssh://host:2222/backup", "host", 2222, "backup")]
+        // 22 is the ssh port, but it is not a default the url parser knows, so it is kept
+        [TestCase("ssh://host:22/backup", "host", 22, "backup")]
+        // The constructor only takes a port that is greater than zero, so this leaves the default
+        [TestCase("ssh://host:0/backup", "host", 0, "backup")]
+        [TestCase("ssh://[1:2:3::4]:22/p", "[1:2:3::4]", 22, "p")]
+        [TestCase("ssh://[fe80::1]/p", "[fe80::1]", -1, "p")]
+        public void TheHostPortAndPathAreTakenFromTheUrl(string url, string host, int port, string path)
+        {
+            var parsed = SSHv2.ParseSshUrl(url);
+            Assert.AreEqual(host, parsed.Host, url);
+            Assert.AreEqual(port, parsed.Port, url);
+            Assert.AreEqual(path, parsed.Path, url);
+        }
+
+        // The path is what names the remote folder, so its case has to survive
+        [TestCase("ssh://host/Backup/SubDir", "Backup/SubDir")]
+        [TestCase("ssh://host/My%20Folder/x", "My Folder/x")]
+        [TestCase("ssh://host/M%C3%A4ppe/", "Mäppe/")]
+        [TestCase("ssh://host/über/", "über/")]
+        // An encoded '#' belongs to the folder name
+        [TestCase("ssh://host/%23hash/", "#hash/")]
+        // The path is decoded before the leading separator is dropped, so this stays absolute
+        [TestCase("ssh://host/%2Fabs", "/abs")]
+        [TestCase("ssh://host/a//b", "a//b")]
+        // A '%' that starts nothing is left alone
+        [TestCase("ssh://host/100%done", "100%done")]
+        public void ThePathIsDecodedAndKeepsItsCase(string url, string path)
+        {
+            Assert.AreEqual(path, SSHv2.ParseSshUrl(url).Path, url);
+        }
+
+        [TestCase("ssh://host/p", null, null)]
+        [TestCase("ssh://user@host/p", "user", null)]
+        [TestCase("ssh://user:secret@host/p", "user", "secret")]
+        // A colon with nothing after it is an empty password, not a missing one
+        [TestCase("ssh://user:@host/p", "user", "")]
+        [TestCase("ssh://us%65r:p%40ss@host/p", "user", "p@ss")]
+        [TestCase("ssh://user%20name:p%3Ass@host/p", "user name", "p:ss")]
+        [TestCase("ssh://user name@host/p", "user name", null)]
+        public void TheCredentialsAreDecoded(string url, string? username, string? password)
+        {
+            var parsed = SSHv2.ParseSshUrl(url);
+            Assert.AreEqual(username, parsed.Username, url);
+            Assert.AreEqual(password, parsed.Password, url);
+        }
+
+        [TestCase("ssh:///p")]
+        [TestCase("ssh://")]
+        public void AUrlWithoutAHostIsRejected(string url)
+        {
+            Assert.Throws<ArgumentException>(() => SSHv2.ParseSshUrl(url), url);
+        }
+
+        [Test]
+        public void TheMessageForAMissingHostDoesNotCarryTheCredentials()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => SSHv2.ParseSshUrl("ssh://:pass@host/p"));
+            Assert.IsFalse(ex!.Message.Contains("pass"), ex.Message);
+        }
+
+        [Test]
+        public void TheHostKeepsItsCase()
+        {
+            Assert.AreEqual("Host.Example.COM", SSHv2.ParseSshUrl("ssh://Host.Example.COM/p").Host);
+        }
+
+        [Test]
+        public void APlusInThePathIsReadAsASpace()
+        {
+            Assert.AreEqual("a b", SSHv2.ParseSshUrl("ssh://host/a+b").Path);
+        }
+
+        [Test]
+        public void AHashInThePathIsPartOfTheFolderName()
+        {
+            Assert.AreEqual("backup#1/", SSHv2.ParseSshUrl("ssh://host/backup#1/").Path);
+        }
+
+        [Test]
+        public void ADotSegmentInThePathIsKept()
+        {
+            Assert.AreEqual("a/../b", SSHv2.ParseSshUrl("ssh://host/a/../b").Path);
+        }
+
+        [Test]
+        public void AnUnencodedAtSignInThePasswordIsReadAsPartOfTheHost()
+        {
+            var parsed = SSHv2.ParseSshUrl("ssh://user:p@ss@host/p");
+            Assert.AreEqual("ss@host", parsed.Host);
+            Assert.AreEqual("user", parsed.Username);
+            Assert.AreEqual("p", parsed.Password);
+        }
+
+        [Test]
+        public void APortOutsideTheValidRangeIsAccepted()
+        {
+            Assert.AreEqual(99999, SSHv2.ParseSshUrl("ssh://host:99999/p").Port);
+        }
+    }
+}


### PR DESCRIPTION
Continues the work towards deleting `RelaxedUri`, after #7133, #7134, #7136, #7137 and #7138.

## Why only these two backends

I went through every `RelaxedUri` use in the tree first, because the answer decides how far this can go.

`System.Uri` lower-cases the authority. That is fine when the authority is a server name, and fatal when it is a remote folder name — which is what #7097 ran into and what the TODO in `RelaxedUri.cs` records.

- **24 sites read a case sensitive remote name out of the authority** (`box://`, `dropbox://`, `openstack://`, plus B2, S3, Idrivee2, Jottacloud, Mega, GoogleDrive, and others). These have to keep the current parser.
- **About 30 sites take an arbitrary backend url**, change the query and round-trip it with `ToString()` — `BackendLoader`, `Controller`, `SecretProviderHelper`, `QuerystringMasking`, `Database/Backup.cs`. They see the folder-name urls too, so they have to keep it as well.
- **Five backends read a real server name**: SMB, SSHv2, WEBDAV, SharePoint, Tahoe-LAFS.

This PR converts **SSHv2 and SMB**, which are the two with the same shape: authority is a server name, path is a remote path. A server name is a DNS name, a NetBIOS name or an IP literal, and none of those are case sensitive; both backends hand it straight to a resolver rather than using it to name anything remote.

`FTPBackend.cs` and `pCloudBackend.cs` are deliberately left alone in this PR so it would not collide with #7144.

## Shape

Two commits, so the extraction can be read separately from the parser change.

1. **Extract and pin.** Each backend gets an `internal record struct` and an `internal static` parse method, in the same form as `ParseXmppTarget` from #7138, and the tests record what the current parser answers for each url. No behaviour change.
2. **Swap the parser.** Only the body of the two parse methods changes.

The seam sits in a different place in the two backends, on purpose: **normalization driven by an option stays in the constructor, normalization decided by the url alone moves into the parse method.** So SSH keeps its `ssh-relative-path` handling in the constructor — pulling it in would force the parse method to take the options dictionary — while SMB takes the share out of the first path segment inside the parse method, because that split is a pure function of the url and is the thing worth asserting.

`RequireHost` and the new `RequireNoFragment` went into `Duplicati.Library.Utility` as extension methods on `System.Uri`. The missing-host message is built from `Strings.Uri.NoHostname` and `Utility.StripUrlUserInfo`, **both internal to that assembly**, so a backend cannot reproduce it — putting the check there is what keeps the message and the exception type identical to `RelaxedUri.RequireHost()`. The other five backends can use the same two methods when they convert.

`RequireNoFragment` throws `UserInformationException` rather than matching `RequireHost`, because there is no earlier behaviour to preserve there and the user has something to fix.

`IsDefaultPort` is not needed here, unlike in #7138: `ssh`, `smb` and `cifs` have no registered default port, so `Port` is `-1` when the url names none — the same answer the old parser gave. There is a test pinning that, so if a future runtime registers one it fails in the unit job instead of silently moving everyone to a different port.

## What changes for users

Every one of these is covered by a test, and each expectation was measured before and after rather than predicted.

| | before | after |
| --- | --- | --- |
| `ssh://Host.Example.COM/p` | host `Host.Example.COM` | host `host.example.com` |
| `ssh://host/a+b` | path `a b` | path `a+b` |
| `ssh://host/backup#1/` | path `backup#1/` | **reported to the user** |
| `ssh://host/a/../b` | path `a/../b` | path `b` |
| `ssh://user:p@ss@host/p` | host `ss@host`, password `p` | **reported to the user** |
| `ssh://host:99999/p` | port 99999 | **reported to the user** |
| `ssh://:pass@host/p` | rejected as having no hostname | empty user, password `pass` |
| `smb://host/share\sub` | share `share\sub`, path empty | share `share`, path `sub` |

Three of these deserve a note.

**The `+`** was a query-string rule (`UrlEncoding.UrlDecode` maps `+` to a space) applied to paths, where it does not belong. A url that has been through `RelaxedUri.ToString()` carries `%2B`, so this only reaches someone who hand-wrote a `+` on the command line.

**The `#`** is the one I was least comfortable leaving alone. `System.Uri` reads it as a fragment, so `ssh://host/backup#1/` would silently become `backup` — a different folder, with no error. Rather than accept that, `RequireNoFragment` reports it and tells the user to write `%23`. `ssh://host/%23hash/` is unaffected and is pinned by a test. If you would rather keep the old meaning, dropping that call and building the path from `GetComponents(UriComponents.Path | UriComponents.Fragment, UriFormat.UriEscaped)` restores it in one line.

**The unencoded `@`** was already broken: the old regex cut the password at the first `@` and let the rest into the host name, so `ssh://user:p@ss@host/p` connected to `ss@host` and failed to resolve. It is now reported at construction. The `UriFormatException` message is "Invalid URI: The hostname could not be parsed." and does not echo the url, so no credentials leak; there is a test asserting that.

`smb://host/share\sub` starting to work is a fix — `PATH_SEPARATORS` in that same file already treats `\` as a separator everywhere downstream, so the constructor was the odd one out. An encoded `%5C` stays part of the share name, with its own test.

## Testing

- `--filter "Category=UriUtility"`: **151 passed** after the change, and 151 passed before it as well
- after swapping the parser body, exactly **11 tests failed, all of them rows in the table above** — nothing unpredicted moved, which is what the two-commit shape is for
- `dotnet build Duplicati.slnx`: 0 errors

**Limits of what I checked:** the credentialed backend jobs (`SshTests`, `CIFSTests`) were not run locally. I followed their urls by hand — `ssh://testuser:testpassword@127.0.0.1:3000` and `smb://localhost/testshare1/new/?...` — and both parse identically before and after, but that is reasoning, not a measurement.
