### PR TITLE
Parse the ftp, pcloud and tahoe urls with System.Uri

### DIFF
--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -32,6 +32,8 @@ using FluentFTP.Client.BaseClient;
 using FluentFTP.Exceptions;
 using CoreUtility = Duplicati.Library.Utility.Utility;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend
 {
 
@@ -262,13 +264,37 @@ namespace Duplicati.Library.Backend
         /// </summary>
         /// <param name="url">Configured url.</param>
         /// <param name="options">Configured options. cannot be null.</param>
+        /// <summary>
+        /// The parts of an ftp url that the backend connects with.
+        /// </summary>
+        /// <param name="Url">The sanitized url: the ftp scheme, no credentials, no query, and a path that ends with a separator.</param>
+        /// <param name="Username">The user from the url, or null when it has none.</param>
+        /// <param name="Password">The password from the url, or null when it has none.</param>
+        internal readonly record struct FtpUrl(Uri Url, string? Username, string? Password);
+
+        /// <summary>
+        /// Splits an ftp url into the parts the backend needs. The scheme of the sanitized
+        /// url is always ftp, so the ftps and aftp spellings end up the same way.
+        /// </summary>
+        /// <param name="url">The url to split.</param>
+        /// <returns>The parts the backend needs.</returns>
+        internal static FtpUrl ParseFtpUrl(string url)
+        {
+            var u = new Utility.RelaxedUri(url);
+            u.RequireHost();
+
+            var parsedurl = u.SetScheme("ftp").SetQuery(null).SetCredentials(null, null).ToString();
+            parsedurl = Util.AppendDirSeparator(parsedurl, "/");
+
+            return new FtpUrl(new Uri(parsedurl), u.Username, u.Password);
+        }
+
         public FTP(string url, Dictionary<string, string?> options)
         {
             _sslOptions = SslOptionsHelper.Parse(options);
             _sslValidator = new SslCertificateValidator(_sslOptions.AcceptAllCertificates, _sslOptions.AcceptSpecificCertificateHashes, _sslOptions.IgnoreRevocationFailure);
 
-            var u = new Utility.RelaxedUri(url);
-            u.RequireHost();
+            var u = ParseFtpUrl(url);
 
             var auth = AuthOptionsHelper.Parse(options, u.Username, u.Password);
             if (auth.HasUsername)
@@ -283,9 +309,7 @@ namespace Duplicati.Library.Backend
                     _userInfo.Password = auth.Password;
             }
 
-            var parsedurl = u.SetScheme("ftp").SetQuery(null).SetCredentials(null, null).ToString();
-            parsedurl = Util.AppendDirSeparator(parsedurl, "/");
-            _url = new Uri(parsedurl);
+            _url = u.Url;
 
             _listVerify = !CoreUtility.ParseBoolOption(options, CONFIG_KEY_DISABLE_UPLOAD_VERIFY);
             _relativePaths = ProtocolKey == "ftp"

--- a/Duplicati/Library/Backend/FTP/FTPBackend.cs
+++ b/Duplicati/Library/Backend/FTP/FTPBackend.cs
@@ -280,13 +280,34 @@ namespace Duplicati.Library.Backend
         /// <returns>The parts the backend needs.</returns>
         internal static FtpUrl ParseFtpUrl(string url)
         {
-            var u = new Utility.RelaxedUri(url);
-            u.RequireHost();
+            // The previous parser started the query at the first '?' and the backend dropped
+            // it. System.Uri has no query for the ftp scheme and keeps the '?' in the path
+            // instead, which would point the backup at a folder named after the options, so
+            // the query comes off the string before it is parsed. For aftp and ftps, which
+            // System.Uri does not know, this only removes what would have been the query.
+            var queryStart = url.IndexOf('?');
+            var u = new Uri(queryStart < 0 ? url : url.Substring(0, queryStart));
+            u.RequireHost(url);
+            u.RequireNoFragment(url);
 
-            var parsedurl = u.SetScheme("ftp").SetQuery(null).SetCredentials(null, null).ToString();
-            parsedurl = Util.AppendDirSeparator(parsedurl, "/");
+            // The user info is not decoded, so it is decoded here.
+            var userinfo = u.UserInfo.Split(new[] { ':' }, 2);
+            var username = userinfo.Length > 0 && userinfo[0].Length > 0 ? Uri.UnescapeDataString(userinfo[0]) : null;
+            var password = userinfo.Length > 1 ? Uri.UnescapeDataString(userinfo[1]) : null;
 
-            return new FtpUrl(new Uri(parsedurl), u.Username, u.Password);
+            // The port is carried over as it is. It is -1 for aftp and ftps, which have no
+            // registered default, and becomes 21 on the way out because the sanitized url is
+            // always ftp. The separator goes on the path rather than on the assembled url,
+            // which is where it ended up before.
+            var builder = new UriBuilder
+            {
+                Scheme = "ftp",
+                Host = u.Host,
+                Port = u.Port,
+                Path = Util.AppendDirSeparator(u.AbsolutePath, "/")
+            };
+
+            return new FtpUrl(builder.Uri, username, password);
         }
 
         public FTP(string url, Dictionary<string, string?> options)

--- a/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
+++ b/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
@@ -61,19 +61,36 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
         _certificateOptions = null!;
     }
 
-    public TahoeBackend(string url, Dictionary<string, string?> options)
+    /// <summary>
+    /// The url requests are built from.
+    /// </summary>
+    /// <param name="Url">The sanitized url: http or https, no credentials, no query, ending with a separator.</param>
+    internal readonly record struct TahoeUrl(string Url);
+
+    /// <summary>
+    /// Checks that the url names a Tahoe-LAFS directory capability and turns it into the
+    /// url requests are built from.
+    /// </summary>
+    /// <param name="url">The url to read.</param>
+    /// <param name="useSsl">Whether the requests go over https.</param>
+    /// <returns>The url requests are built from.</returns>
+    internal static TahoeUrl ParseTahoeUrl(string url, bool useSsl)
     {
-        //Validate URL
         var u = new RelaxedUri(url);
         u.RequireHost();
 
         if (!u.Path.StartsWith("uri/URI:DIR2:", StringComparison.Ordinal) && !u.Path.StartsWith("uri/URI%3ADIR2%3A", StringComparison.Ordinal))
             throw new UserInformationException(Strings.TahoeBackend.UnrecognizedUriError, "TahoeInvalidUri");
 
-        _certificateOptions = SslOptionsHelper.Parse(options);
+        var built = u.SetScheme(useSsl ? "https" : "http").SetQuery(null).SetCredentials(null, null).ToString();
 
-        _url = u.SetScheme(_certificateOptions.UseSSL ? "https" : "http").SetQuery(null).SetCredentials(null, null).ToString();
-        _url = Util.AppendDirSeparator(_url, "/");
+        return new TahoeUrl(Util.AppendDirSeparator(built, "/"));
+    }
+
+    public TahoeBackend(string url, Dictionary<string, string?> options)
+    {
+        _certificateOptions = SslOptionsHelper.Parse(options);
+        _url = ParseTahoeUrl(url, _certificateOptions.UseSSL).Url;
         _timeouts = TimeoutOptionsHelper.Parse(options);
     }
 

--- a/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
+++ b/Duplicati/Library/Backend/TahoeLAFS/TahoeBackend.cs
@@ -76,15 +76,31 @@ public class TahoeBackend : IStreamingBackend, IRenameEnabledBackend
     /// <returns>The url requests are built from.</returns>
     internal static TahoeUrl ParseTahoeUrl(string url, bool useSsl)
     {
-        var u = new RelaxedUri(url);
-        u.RequireHost();
+        var u = new System.Uri(url);
+        u.RequireHost(url);
+        u.RequireNoFragment(url);
 
-        if (!u.Path.StartsWith("uri/URI:DIR2:", StringComparison.Ordinal) && !u.Path.StartsWith("uri/URI%3ADIR2%3A", StringComparison.Ordinal))
+        // The check is made against the decoded path without its leading separator, which is
+        // what the previous parser handed over. Decoding happens once, so a doubly encoded
+        // colon still reaches the second spelling the way it did before.
+        var path = System.Uri.UnescapeDataString(u.AbsolutePath);
+        if (path.StartsWith("/", StringComparison.Ordinal))
+            path = path.Substring(1);
+
+        if (!path.StartsWith("uri/URI:DIR2:", StringComparison.Ordinal) && !path.StartsWith("uri/URI%3ADIR2%3A", StringComparison.Ordinal))
             throw new UserInformationException(Strings.TahoeBackend.UnrecognizedUriError, "TahoeInvalidUri");
 
-        var built = u.SetScheme(useSsl ? "https" : "http").SetQuery(null).SetCredentials(null, null).ToString();
+        // The escaped path is what goes into the url, and the separator goes on the path
+        // rather than on the assembled url, which is where it ended up before.
+        var builder = new UriBuilder
+        {
+            Scheme = useSsl ? "https" : "http",
+            Host = u.Host,
+            Port = u.Port,
+            Path = Util.AppendDirSeparator(u.AbsolutePath, "/")
+        };
 
-        return new TahoeUrl(Util.AppendDirSeparator(built, "/"));
+        return new TahoeUrl(builder.Uri.AbsoluteUri);
     }
 
     public TahoeBackend(string url, Dictionary<string, string?> options)

--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -142,11 +142,15 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
     /// <returns>The parts the backend needs.</returns>
     internal static PCloudUrl ParsePCloudUrl(string url)
     {
-        var uri = new Utility.RelaxedUri(url);
-        uri.RequireHost();
+        var uri = new Uri(url);
+        uri.RequireHost(url);
+        uri.RequireNoFragment(url);
+
+        // The path arrives escaped, where the previous parser handed it over decoded.
+        var path = Uri.UnescapeDataString(uri.AbsolutePath);
 
         // Ensure that the path is in the correct format, without starting or tailing slashes
-        return new PCloudUrl(uri.Host ?? "", uri.Path.TrimStart(PATH_SEPARATORS).TrimEnd(PATH_SEPARATORS).Trim());
+        return new PCloudUrl(uri.Host, path.TrimStart(PATH_SEPARATORS).TrimEnd(PATH_SEPARATORS).Trim());
     }
 
     public pCloudBackend(string url, Dictionary<string, string?> options)

--- a/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
+++ b/Duplicati/Library/Backend/pCloud/pCloudBackend.cs
@@ -128,11 +128,31 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
     /// </summary>
     /// <param name="url">URL in Duplicati Uri format</param>
     /// <param name="options">options to be used in the backend</param>
-    public pCloudBackend(string url, Dictionary<string, string?> options)
+    /// <summary>
+    /// The parts of a pcloud url that the backend configures itself from.
+    /// </summary>
+    /// <param name="Host">The pCloud api endpoint to talk to.</param>
+    /// <param name="Path">The remote folder, decoded, without leading or trailing separators or whitespace.</param>
+    internal readonly record struct PCloudUrl(string Host, string Path);
+
+    /// <summary>
+    /// Splits a pcloud url into the parts the backend needs.
+    /// </summary>
+    /// <param name="url">The url to split.</param>
+    /// <returns>The parts the backend needs.</returns>
+    internal static PCloudUrl ParsePCloudUrl(string url)
     {
         var uri = new Utility.RelaxedUri(url);
         uri.RequireHost();
-        _DnsName = uri.Host ?? "";
+
+        // Ensure that the path is in the correct format, without starting or tailing slashes
+        return new PCloudUrl(uri.Host ?? "", uri.Path.TrimStart(PATH_SEPARATORS).TrimEnd(PATH_SEPARATORS).Trim());
+    }
+
+    public pCloudBackend(string url, Dictionary<string, string?> options)
+    {
+        var uri = ParsePCloudUrl(url);
+        _DnsName = uri.Host;
 
         _Token = AuthIdOptionsHelper.Parse(options)
             .RequireCredentials(TOKEN_URL)
@@ -145,8 +165,7 @@ public class pCloudBackend : IStreamingBackend, IRenameEnabledBackend
         if (string.IsNullOrWhiteSpace(_DnsName))
             throw new UserInformationException(Strings.pCloudBackend.NoServerSpecified, "NopCloudServerSpecified");
 
-        // Ensure that the path is in the correct format, without starting or tailing slashes
-        _Path = uri.Path.TrimStart(PATH_SEPARATORS).TrimEnd(PATH_SEPARATORS).Trim();
+        _Path = uri.Path;
         _ServerUrl = _DnsName;
         _Timeouts = TimeoutOptionsHelper.Parse(options);
 

--- a/Duplicati/UnitTest/FtpUrlTests.cs
+++ b/Duplicati/UnitTest/FtpUrlTests.cs
@@ -103,11 +103,18 @@ namespace Duplicati.UnitTest
 
         [TestCase("aftp:///p")]
         [TestCase("ftps:///p")]
-        [TestCase("ftp:///p")]
-        [TestCase("ftp://")]
         public void AUrlWithoutAHostIsRejected(string url)
         {
             Assert.Throws<ArgumentException>(() => FTP.ParseFtpUrl(url), url);
+        }
+
+        [TestCase("ftp:///p")]
+        [TestCase("ftp://")]
+        public void AnFtpUrlWithoutAHostIsRejectedByTheParser(string url)
+        {
+            // ftp is a scheme that requires an authority, so these do not reach the check
+            // that produced the message about a missing hostname. aftp and ftps still do.
+            Assert.Throws<UriFormatException>(() => FTP.ParseFtpUrl(url), url);
         }
 
         [TestCase("ftp://host:99999/p")]
@@ -120,38 +127,54 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void AnEmptyUserWithAPasswordIsReadAsAMissingHost()
+        public void AnEmptyUserWithAPasswordIsNoLongerReadAsAMissingHost()
         {
-            var ex = Assert.Throws<ArgumentException>(() => FTP.ParseFtpUrl("ftp://:pass@host/p"));
-            Assert.IsFalse(ex!.Message.Contains("pass"), ex.Message);
+            // The previous parser read the ':' as the start of the authority and reported a
+            // missing hostname. The password is taken now, and the user stays unset, so the
+            // connection is made without credentials.
+            var parsed = FTP.ParseFtpUrl("ftp://:pass@host/p");
+            Assert.AreEqual("ftp://host/p/", parsed.Url.AbsoluteUri);
+            Assert.IsNull(parsed.Username);
+            Assert.AreEqual("pass", parsed.Password);
         }
 
         [Test]
-        public void APlusInThePathIsReadAsASpace()
+        public void APlusInThePathIsNoLongerASpace()
         {
-            Assert.AreEqual("ftp://host/a%20b/", FTP.ParseFtpUrl("ftp://host/a+b").Url.AbsoluteUri);
+            // The previous parser applied the query string rule that reads '+' as a space to
+            // the path as well. A url that has been through the parser carries %2B, so only a
+            // hand written url is affected - but for this backend it moves the remote folder.
+            Assert.AreEqual("ftp://host/a+b/", FTP.ParseFtpUrl("ftp://host/a+b").Url.AbsoluteUri);
         }
 
         [Test]
-        public void AHashInThePathIsPartOfTheFolderName()
+        public void AHashInThePathIsRejected()
         {
-            Assert.AreEqual("ftp://host/back%23up/", FTP.ParseFtpUrl("ftp://host/back#up/").Url.AbsoluteUri);
+            // The previous parser had no fragment and kept the '#' in the folder name.
+            // Accepting the url now would use "back" instead, so the user is told to write
+            // %23 rather than being sent to a different folder.
+            Assert.Throws<UserInformationException>(() => FTP.ParseFtpUrl("ftp://host/back#up/"));
         }
 
         [Test]
-        public void AnEncodedSeparatorBecomesARealSeparator()
+        public void AnEncodedSeparatorStaysEncoded()
         {
-            Assert.AreEqual("ftp://host/a/b/", FTP.ParseFtpUrl("ftp://host/a%2Fb").Url.AbsoluteUri);
+            // The previous parser decoded the path and the separator became a real one. The
+            // path handed to the client is unescaped again, so the folder is the same either
+            // way; only the url differs.
+            var parsed = FTP.ParseFtpUrl("ftp://host/a%2Fb");
+            Assert.AreEqual("ftp://host/a%2Fb/", parsed.Url.AbsoluteUri);
+            Assert.AreEqual("/a/b/", Uri.UnescapeDataString(parsed.Url.AbsolutePath));
         }
 
-        [TestCase("ftp://[fe80::1]/p")]
-        [TestCase("ftp://[fe80::1]:2121/p")]
-        [TestCase("ftp://münchen.de/p")]
-        public void AnIpv6OrNonAsciiHostIsRejected(string url)
+        [TestCase("ftp://[fe80::1]/p", "ftp://[fe80::1]/p/")]
+        [TestCase("ftp://[fe80::1]:2121/p", "ftp://[fe80::1]:2121/p/")]
+        [TestCase("ftp://münchen.de/p", "ftp://münchen.de/p/")]
+        public void AnIpv6OrNonAsciiHostIsAccepted(string url, string expected)
         {
-            // The host is percent encoded while the url is rebuilt, and the encoded form is
-            // not a host System.Uri can parse.
-            Assert.Throws<UriFormatException>(() => FTP.ParseFtpUrl(url), url);
+            // The previous parser percent encoded the host while it rebuilt the url, and the
+            // encoded form was not a host System.Uri could parse, so both of these failed.
+            Assert.AreEqual(expected, FTP.ParseFtpUrl(url).Url.AbsoluteUri, url);
         }
     }
 }

--- a/Duplicati/UnitTest/FtpUrlTests.cs
+++ b/Duplicati/UnitTest/FtpUrlTests.cs
@@ -1,0 +1,157 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Covers the sanitized url the ftp backend connects with. The expectations here were
+    /// measured against the parser that was in place before, so that replacing the parser
+    /// shows up as a failure rather than as a silent change.
+    /// </summary>
+    [TestFixture]
+    [Category("UriUtility")]
+    public class FtpUrlTests
+    {
+        [TestCase("ftp://host", "ftp://host/")]
+        [TestCase("ftp://host/", "ftp://host/")]
+        [TestCase("ftp://host/backup", "ftp://host/backup/")]
+        [TestCase("ftp://host/backup/", "ftp://host/backup/")]
+        [TestCase("ftp://host/a/b/c", "ftp://host/a/b/c/")]
+        [TestCase("ftp://host/a//b", "ftp://host/a//b/")]
+        [TestCase("ftp://host:2121/backup", "ftp://host:2121/backup/")]
+        // The ftp default port is left out of the sanitized url
+        [TestCase("ftp://host:21/backup", "ftp://host/backup/")]
+        [TestCase("ftp://host:0/p", "ftp://host:0/p/")]
+        // The sanitized scheme is always ftp, so the other two spellings arrive the same way
+        [TestCase("aftp://host/backup", "ftp://host/backup/")]
+        [TestCase("aftp://host:2121/backup", "ftp://host:2121/backup/")]
+        [TestCase("ftps://host/backup", "ftp://host/backup/")]
+        // A host name is not case sensitive and is already lower cased here, because the
+        // sanitized url has always been handed to System.Uri
+        [TestCase("ftp://HOST/Backup", "ftp://host/Backup/")]
+        [TestCase("ftp://host/My%20Folder", "ftp://host/My%20Folder/")]
+        [TestCase("ftp://host/a b", "ftp://host/a%20b/")]
+        [TestCase("ftp://host/M%C3%A4ppe", "ftp://host/M%C3%A4ppe/")]
+        [TestCase("ftp://host/%23hash", "ftp://host/%23hash/")]
+        [TestCase("ftp://host/a/../b", "ftp://host/b/")]
+        [TestCase("ftp://host/./a", "ftp://host/a/")]
+        // The query carries the backend options and is not part of the remote path. This is
+        // the case to watch: System.Uri has no query for the ftp scheme and would keep the
+        // '?' in the path, so the query has to come off the string before it is parsed.
+        [TestCase("ftp://host/p?x=1", "ftp://host/p/")]
+        [TestCase("aftp://host/p?x=1", "ftp://host/p/")]
+        [TestCase("ftps://host/p?x=1", "ftp://host/p/")]
+        // A '#' inside a query that is thrown away is not a fragment
+        [TestCase("ftp://host/p?a#b", "ftp://host/p/")]
+        [TestCase("ftp://user:secret@host/p", "ftp://host/p/")]
+        public void TheSanitizedUrlIsBuiltFromTheUrl(string url, string expected)
+        {
+            Assert.AreEqual(expected, FTP.ParseFtpUrl(url).Url.AbsoluteUri, url);
+        }
+
+        [TestCase("ftp://host/p", 21)]
+        // An input without a port, on a scheme that has no default, still lands on the ftp
+        // default. The `Port == -1` fallback in CreateClient is therefore unreachable.
+        [TestCase("aftp://host/p", 21)]
+        [TestCase("ftps://host/p", 21)]
+        [TestCase("ftp://host:2121/p", 2121)]
+        [TestCase("ftp://host:21/p", 21)]
+        public void ThePortIsNeverUnset(string url, int port)
+        {
+            Assert.AreEqual(port, FTP.ParseFtpUrl(url).Url.Port, url);
+        }
+
+        [TestCase("ftp://host/p", null, null)]
+        [TestCase("ftp://user@host/p", "user", null)]
+        [TestCase("ftp://user:secret@host/p", "user", "secret")]
+        // A colon with nothing after it is an empty password, not a missing one
+        [TestCase("ftp://user:@host/p", "user", "")]
+        [TestCase("ftp://us%65r:p%40ss@host/p", "user", "p@ss")]
+        [TestCase("ftp://user name@host/p", "user name", null)]
+        public void TheCredentialsAreDecoded(string url, string? username, string? password)
+        {
+            var parsed = FTP.ParseFtpUrl(url);
+            Assert.AreEqual(username, parsed.Username, url);
+            Assert.AreEqual(password, parsed.Password, url);
+        }
+
+        [TestCase("aftp:///p")]
+        [TestCase("ftps:///p")]
+        [TestCase("ftp:///p")]
+        [TestCase("ftp://")]
+        public void AUrlWithoutAHostIsRejected(string url)
+        {
+            Assert.Throws<ArgumentException>(() => FTP.ParseFtpUrl(url), url);
+        }
+
+        [TestCase("ftp://host:99999/p")]
+        [TestCase("ftp://user:p@ss@host/p")]
+        public void AUrlThatCannotBeParsedIsRejected(string url)
+        {
+            // Both of these already fail, because the sanitized url is handed to System.Uri.
+            var ex = Assert.Throws<UriFormatException>(() => FTP.ParseFtpUrl(url), url);
+            Assert.IsFalse(ex!.Message.Contains("ss"), ex.Message);
+        }
+
+        [Test]
+        public void AnEmptyUserWithAPasswordIsReadAsAMissingHost()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => FTP.ParseFtpUrl("ftp://:pass@host/p"));
+            Assert.IsFalse(ex!.Message.Contains("pass"), ex.Message);
+        }
+
+        [Test]
+        public void APlusInThePathIsReadAsASpace()
+        {
+            Assert.AreEqual("ftp://host/a%20b/", FTP.ParseFtpUrl("ftp://host/a+b").Url.AbsoluteUri);
+        }
+
+        [Test]
+        public void AHashInThePathIsPartOfTheFolderName()
+        {
+            Assert.AreEqual("ftp://host/back%23up/", FTP.ParseFtpUrl("ftp://host/back#up/").Url.AbsoluteUri);
+        }
+
+        [Test]
+        public void AnEncodedSeparatorBecomesARealSeparator()
+        {
+            Assert.AreEqual("ftp://host/a/b/", FTP.ParseFtpUrl("ftp://host/a%2Fb").Url.AbsoluteUri);
+        }
+
+        [TestCase("ftp://[fe80::1]/p")]
+        [TestCase("ftp://[fe80::1]:2121/p")]
+        [TestCase("ftp://münchen.de/p")]
+        public void AnIpv6OrNonAsciiHostIsRejected(string url)
+        {
+            // The host is percent encoded while the url is rebuilt, and the encoded form is
+            // not a host System.Uri can parse.
+            Assert.Throws<UriFormatException>(() => FTP.ParseFtpUrl(url), url);
+        }
+    }
+}

--- a/Duplicati/UnitTest/PCloudUrlTests.cs
+++ b/Duplicati/UnitTest/PCloudUrlTests.cs
@@ -66,43 +66,54 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void TheHostKeepsItsCase()
+        public void TheHostIsLowerCased()
         {
-            Assert.AreEqual("API.pCloud.com", pCloudBackend.ParsePCloudUrl("pcloud://API.pCloud.com/").Host);
+            // The previous parser kept the case. The endpoint is a host name, so this is only
+            // a normalization - but see AServerWrittenInAnotherCaseIsAccepted for what it
+            // means for the check against the known endpoints.
+            Assert.AreEqual("api.pcloud.com", pCloudBackend.ParsePCloudUrl("pcloud://API.pCloud.com/").Host);
         }
 
         [Test]
-        public void APlusInThePathIsReadAsASpace()
+        public void APlusInThePathIsNoLongerASpace()
         {
-            Assert.AreEqual("a b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a+b").Path);
+            // The previous parser applied the query string rule that reads '+' as a space to
+            // the path as well, which moved the remote folder.
+            Assert.AreEqual("a+b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a+b").Path);
         }
 
         [Test]
-        public void ADotSegmentInThePathIsKept()
+        public void ADotSegmentInThePathIsResolved()
         {
-            Assert.AreEqual("a/../b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a/../b").Path);
+            // The previous parser kept the segment as written.
+            Assert.AreEqual("b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a/../b").Path);
         }
 
         [Test]
-        public void ABackslashInThePathIsKept()
+        public void ABackslashInThePathBecomesASeparator()
         {
-            Assert.AreEqual("a\\b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a\\b").Path);
+            // The previous parser left it alone. The path is split on both separators
+            // everywhere it is used, so the folder ends up the same either way.
+            Assert.AreEqual("a/b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a\\b").Path);
         }
 
         [Test]
-        public void AHashInThePathIsPartOfTheFolderName()
+        public void AHashInThePathIsRejected()
         {
-            Assert.AreEqual("back#up", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/back#up").Path);
+            // The previous parser had no fragment and kept the '#' in the folder name.
+            Assert.Throws<UserInformationException>(() => pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/back#up"));
         }
 
         [Test]
-        public void AServerWrittenInAnotherCaseIsRejected()
+        public void AServerWrittenInAnotherCaseIsAccepted()
         {
-            // The server check compares the host against the known endpoints with the default
-            // comparer, so it is case sensitive even though the dictionary is not.
+            // The check compares the host against the known endpoints with the default
+            // comparer, so it is case sensitive even though the dictionary is not, and this
+            // url used to be rejected. The endpoints are written in lower case, so the host
+            // now matches one. The check itself is left as it is, so that every expectation
+            // that moved in this change traces back to the parser.
             var options = new Dictionary<string, string?> { ["authid"] = "x" };
-            var ex = Assert.Throws<UserInformationException>(() => new pCloudBackend("pcloud://API.pCloud.com/", options));
-            Assert.AreEqual("InvalidpCloudServerSpecified", ex!.HelpID);
+            Assert.DoesNotThrow(() => new pCloudBackend("pcloud://API.pCloud.com/", options).Dispose());
         }
 
         [Test]

--- a/Duplicati/UnitTest/PCloudUrlTests.cs
+++ b/Duplicati/UnitTest/PCloudUrlTests.cs
@@ -1,0 +1,123 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Covers how a pcloud url is split into the api endpoint and the remote folder. The
+    /// expectations here were measured against the parser that was in place before, so that
+    /// replacing the parser shows up as a failure rather than as a silent change.
+    /// </summary>
+    [TestFixture]
+    [Category("UriUtility")]
+    public class PCloudUrlTests
+    {
+        [TestCase("pcloud://api.pcloud.com", "api.pcloud.com", "")]
+        [TestCase("pcloud://api.pcloud.com/", "api.pcloud.com", "")]
+        // The folder name is on the server, so its case has to survive
+        [TestCase("pcloud://api.pcloud.com/Backup", "api.pcloud.com", "Backup")]
+        [TestCase("pcloud://api.pcloud.com/Backup/Sub/", "api.pcloud.com", "Backup/Sub")]
+        [TestCase("pcloud://api.pcloud.com//Backup//", "api.pcloud.com", "Backup")]
+        [TestCase("pcloud://api.pcloud.com/Backup\\", "api.pcloud.com", "Backup")]
+        [TestCase("pcloud://api.pcloud.com/My%20Folder", "api.pcloud.com", "My Folder")]
+        // The separators come off first and the whitespace after, so an encoded space at the
+        // edge is trimmed as well
+        [TestCase("pcloud://api.pcloud.com/%20Backup%20", "api.pcloud.com", "Backup")]
+        [TestCase("pcloud://api.pcloud.com:443/x", "api.pcloud.com", "x")]
+        [TestCase("pcloud://eapi.pcloud.com/x", "eapi.pcloud.com", "x")]
+        public void TheHostAndFolderAreTakenFromTheUrl(string url, string host, string path)
+        {
+            var parsed = pCloudBackend.ParsePCloudUrl(url);
+            Assert.AreEqual(host, parsed.Host, url);
+            Assert.AreEqual(path, parsed.Path, url);
+        }
+
+        [Test]
+        public void AUrlWithoutAHostIsRejected()
+        {
+            Assert.Throws<ArgumentException>(() => pCloudBackend.ParsePCloudUrl("pcloud:///x"));
+        }
+
+        [Test]
+        public void TheHostKeepsItsCase()
+        {
+            Assert.AreEqual("API.pCloud.com", pCloudBackend.ParsePCloudUrl("pcloud://API.pCloud.com/").Host);
+        }
+
+        [Test]
+        public void APlusInThePathIsReadAsASpace()
+        {
+            Assert.AreEqual("a b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a+b").Path);
+        }
+
+        [Test]
+        public void ADotSegmentInThePathIsKept()
+        {
+            Assert.AreEqual("a/../b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a/../b").Path);
+        }
+
+        [Test]
+        public void ABackslashInThePathIsKept()
+        {
+            Assert.AreEqual("a\\b", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/a\\b").Path);
+        }
+
+        [Test]
+        public void AHashInThePathIsPartOfTheFolderName()
+        {
+            Assert.AreEqual("back#up", pCloudBackend.ParsePCloudUrl("pcloud://api.pcloud.com/back#up").Path);
+        }
+
+        [Test]
+        public void AServerWrittenInAnotherCaseIsRejected()
+        {
+            // The server check compares the host against the known endpoints with the default
+            // comparer, so it is case sensitive even though the dictionary is not.
+            var options = new Dictionary<string, string?> { ["authid"] = "x" };
+            var ex = Assert.Throws<UserInformationException>(() => new pCloudBackend("pcloud://API.pCloud.com/", options));
+            Assert.AreEqual("InvalidpCloudServerSpecified", ex!.HelpID);
+        }
+
+        [Test]
+        public void AnUnknownServerIsRejected()
+        {
+            var options = new Dictionary<string, string?> { ["authid"] = "x" };
+            var ex = Assert.Throws<UserInformationException>(() => new pCloudBackend("pcloud://example.invalid/", options));
+            Assert.AreEqual("InvalidpCloudServerSpecified", ex!.HelpID);
+        }
+
+        [Test]
+        public void TheCredentialsAreCheckedBeforeTheServer()
+        {
+            var ex = Assert.Throws<UserInformationException>(() => new pCloudBackend("pcloud://example.invalid/", new Dictionary<string, string?>()));
+            Assert.AreEqual("MissingAuthID", ex!.HelpID);
+        }
+    }
+}

--- a/Duplicati/UnitTest/TahoeUrlTests.cs
+++ b/Duplicati/UnitTest/TahoeUrlTests.cs
@@ -46,15 +46,18 @@ namespace Duplicati.UnitTest
     [Category("UriUtility")]
     public class TahoeUrlTests
     {
-        [TestCase("tahoe://host/uri/URI:DIR2:a", "http://host/uri/URI%3ADIR2%3Aa/")]
+        // The previous parser percent encoded every character outside a small set while it
+        // rebuilt the url, so the colons of the capability went out as %3A. A colon is a legal
+        // path character and the literal form is the one the Tahoe-LAFS web api documents.
+        [TestCase("tahoe://host/uri/URI:DIR2:a", "http://host/uri/URI:DIR2:a/")]
         // An already encoded colon is left as it is
         [TestCase("tahoe://host/uri/URI%3ADIR2%3Aa", "http://host/uri/URI%3ADIR2%3Aa/")]
         // Decoding happens once, so a doubly encoded colon matches the second spelling the
         // dircap check accepts
         [TestCase("tahoe://host/uri/URI%253ADIR2%253Aa", "http://host/uri/URI%253ADIR2%253Aa/")]
-        [TestCase("tahoe://user:pw@host/uri/URI:DIR2:a", "http://host/uri/URI%3ADIR2%3Aa/")]
-        [TestCase("tahoe://host/uri/URI:DIR2:a?x=1", "http://host/uri/URI%3ADIR2%3Aa/")]
-        [TestCase("tahoe://host:3456/uri/URI:DIR2:aaa:bbb/sub", "http://host:3456/uri/URI%3ADIR2%3Aaaa%3Abbb/sub/")]
+        [TestCase("tahoe://user:pw@host/uri/URI:DIR2:a", "http://host/uri/URI:DIR2:a/")]
+        [TestCase("tahoe://host/uri/URI:DIR2:a?x=1", "http://host/uri/URI:DIR2:a/")]
+        [TestCase("tahoe://host:3456/uri/URI:DIR2:aaa:bbb/sub", "http://host:3456/uri/URI:DIR2:aaa:bbb/sub/")]
         public void TheRequestUrlIsBuiltFromTheUrl(string url, string expected)
         {
             Assert.AreEqual(expected, TahoeBackend.ParseTahoeUrl(url, false).Url, url);
@@ -63,7 +66,7 @@ namespace Duplicati.UnitTest
         [Test]
         public void TheSchemeFollowsTheSslOption()
         {
-            Assert.AreEqual("https://host/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a", true).Url);
+            Assert.AreEqual("https://host/uri/URI:DIR2:a/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a", true).Url);
         }
 
         [TestCase("tahoe://host/")]
@@ -82,49 +85,62 @@ namespace Duplicati.UnitTest
         }
 
         [Test]
-        public void TheHostKeepsItsCase()
+        public void TheHostIsLowerCased()
         {
-            Assert.AreEqual("http://HOST/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://HOST/uri/URI:DIR2:a", false).Url);
+            // The previous parser kept the case. A host name is not case sensitive, and the
+            // capability that names the directory is in the path, which does keep its case.
+            Assert.AreEqual("http://host/uri/URI:DIR2:a/", TahoeBackend.ParseTahoeUrl("tahoe://HOST/uri/URI:DIR2:a", false).Url);
         }
 
         [Test]
-        public void AWrittenDefaultPortIsKept()
+        public void AWrittenDefaultPortIsLeftOut()
         {
-            Assert.AreEqual("http://host:80/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://host:80/uri/URI:DIR2:a", false).Url);
+            // The previous parser wrote out whatever port the url named. The request goes to
+            // the same place either way.
+            Assert.AreEqual("http://host/uri/URI:DIR2:a/", TahoeBackend.ParseTahoeUrl("tahoe://host:80/uri/URI:DIR2:a", false).Url);
         }
 
         [Test]
-        public void APlusInThePathIsReadAsASpace()
+        public void APlusInThePathIsNoLongerASpace()
         {
-            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa%20b/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a+b", false).Url);
+            // The previous parser applied the query string rule that reads '+' as a space to
+            // the path as well.
+            Assert.AreEqual("http://host/uri/URI:DIR2:a+b/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a+b", false).Url);
         }
 
         [Test]
-        public void AnEncodedSeparatorBecomesARealSeparator()
+        public void AnEncodedSeparatorStaysEncodedInTheUrl()
         {
-            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri%2FURI:DIR2:a", false).Url);
+            // The capability check still sees a real separator, because it reads the decoded
+            // path, but the url keeps the encoded form now instead of turning it into a
+            // separator of its own.
+            Assert.AreEqual("http://host/uri%2FURI:DIR2:a/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri%2FURI:DIR2:a", false).Url);
         }
 
         [Test]
-        public void AHashInThePathIsPartOfTheName()
+        public void AHashInThePathIsRejected()
         {
-            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa%23b/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a#b", false).Url);
+            // The previous parser had no fragment and kept the '#' in the name.
+            Assert.Throws<UserInformationException>(() => TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a#b", false));
         }
 
         [Test]
-        public void ADotSegmentInThePathIsKept()
+        public void ADotSegmentInThePathIsResolvedAndBreaksTheCapability()
         {
-            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa/../b/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a/../b", false).Url);
+            // The previous parser kept the segment as written. Resolving it moves the path
+            // off the capability, so the url is reported as unrecognized rather than being
+            // sent to a directory the user did not name.
+            Assert.Throws<UserInformationException>(() => TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a/../b", false));
         }
 
         [Test]
-        public void AnIpv6HostProducesAUrlThatCannotBeParsedBack()
+        public void AnIpv6HostProducesAUrlThatCanBeParsedBack()
         {
-            // The host is percent encoded while the url is rebuilt, which leaves a string
-            // that GetDNSNamesAsync cannot parse back.
+            // The previous parser percent encoded the host, which left a string that
+            // GetDNSNamesAsync could not parse back.
             var built = TahoeBackend.ParseTahoeUrl("tahoe://[fe80::1]:3456/uri/URI:DIR2:a", false).Url;
-            Assert.AreEqual("http://%5Bfe80%3A%3A1%5D:3456/uri/URI%3ADIR2%3Aa/", built);
-            Assert.Throws<UriFormatException>(() => new Uri(built));
+            Assert.AreEqual("http://[fe80::1]:3456/uri/URI:DIR2:a/", built);
+            Assert.AreEqual("[fe80::1]", new Uri(built).Host);
         }
 
         private sealed class CapturingHandler : HttpMessageHandler
@@ -153,7 +169,7 @@ namespace Duplicati.UnitTest
                     break;
             });
 
-            Assert.AreEqual("http://example.invalid/uri/URI%3ADIR2%3Aaaa%3Abbb/?t=json", handler.LastUri?.OriginalString);
+            Assert.AreEqual("http://example.invalid/uri/URI:DIR2:aaa:bbb/?t=json", handler.LastUri?.OriginalString);
         }
     }
 }

--- a/Duplicati/UnitTest/TahoeUrlTests.cs
+++ b/Duplicati/UnitTest/TahoeUrlTests.cs
@@ -1,0 +1,159 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Covers the url the Tahoe-LAFS backend builds its requests from. The expectations here
+    /// were measured against the parser that was in place before, so that replacing the
+    /// parser shows up as a failure rather than as a silent change.
+    /// There is no Tahoe job in the backend test workflow, so the request url is also
+    /// asserted through the message handler seam rather than only through the parser.
+    /// </summary>
+    [TestFixture]
+    [Category("UriUtility")]
+    public class TahoeUrlTests
+    {
+        [TestCase("tahoe://host/uri/URI:DIR2:a", "http://host/uri/URI%3ADIR2%3Aa/")]
+        // An already encoded colon is left as it is
+        [TestCase("tahoe://host/uri/URI%3ADIR2%3Aa", "http://host/uri/URI%3ADIR2%3Aa/")]
+        // Decoding happens once, so a doubly encoded colon matches the second spelling the
+        // dircap check accepts
+        [TestCase("tahoe://host/uri/URI%253ADIR2%253Aa", "http://host/uri/URI%253ADIR2%253Aa/")]
+        [TestCase("tahoe://user:pw@host/uri/URI:DIR2:a", "http://host/uri/URI%3ADIR2%3Aa/")]
+        [TestCase("tahoe://host/uri/URI:DIR2:a?x=1", "http://host/uri/URI%3ADIR2%3Aa/")]
+        [TestCase("tahoe://host:3456/uri/URI:DIR2:aaa:bbb/sub", "http://host:3456/uri/URI%3ADIR2%3Aaaa%3Abbb/sub/")]
+        public void TheRequestUrlIsBuiltFromTheUrl(string url, string expected)
+        {
+            Assert.AreEqual(expected, TahoeBackend.ParseTahoeUrl(url, false).Url, url);
+        }
+
+        [Test]
+        public void TheSchemeFollowsTheSslOption()
+        {
+            Assert.AreEqual("https://host/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a", true).Url);
+        }
+
+        [TestCase("tahoe://host/")]
+        // The check is ordinal, so a different case is not the same prefix
+        [TestCase("tahoe://host/Uri/URI:DIR2:a")]
+        [TestCase("tahoe://host/uri/URI:DIR3:a")]
+        public void AUrlWithoutADirectoryCapabilityIsRejected(string url)
+        {
+            Assert.Throws<UserInformationException>(() => TahoeBackend.ParseTahoeUrl(url, false), url);
+        }
+
+        [Test]
+        public void AUrlWithoutAHostIsRejected()
+        {
+            Assert.Throws<ArgumentException>(() => TahoeBackend.ParseTahoeUrl("tahoe:///uri/URI:DIR2:a", false));
+        }
+
+        [Test]
+        public void TheHostKeepsItsCase()
+        {
+            Assert.AreEqual("http://HOST/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://HOST/uri/URI:DIR2:a", false).Url);
+        }
+
+        [Test]
+        public void AWrittenDefaultPortIsKept()
+        {
+            Assert.AreEqual("http://host:80/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://host:80/uri/URI:DIR2:a", false).Url);
+        }
+
+        [Test]
+        public void APlusInThePathIsReadAsASpace()
+        {
+            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa%20b/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a+b", false).Url);
+        }
+
+        [Test]
+        public void AnEncodedSeparatorBecomesARealSeparator()
+        {
+            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri%2FURI:DIR2:a", false).Url);
+        }
+
+        [Test]
+        public void AHashInThePathIsPartOfTheName()
+        {
+            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa%23b/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a#b", false).Url);
+        }
+
+        [Test]
+        public void ADotSegmentInThePathIsKept()
+        {
+            Assert.AreEqual("http://host/uri/URI%3ADIR2%3Aa/../b/", TahoeBackend.ParseTahoeUrl("tahoe://host/uri/URI:DIR2:a/../b", false).Url);
+        }
+
+        [Test]
+        public void AnIpv6HostProducesAUrlThatCannotBeParsedBack()
+        {
+            // The host is percent encoded while the url is rebuilt, which leaves a string
+            // that GetDNSNamesAsync cannot parse back.
+            var built = TahoeBackend.ParseTahoeUrl("tahoe://[fe80::1]:3456/uri/URI:DIR2:a", false).Url;
+            Assert.AreEqual("http://%5Bfe80%3A%3A1%5D:3456/uri/URI%3ADIR2%3Aa/", built);
+            Assert.Throws<UriFormatException>(() => new Uri(built));
+        }
+
+        private sealed class CapturingHandler : HttpMessageHandler
+        {
+            public Uri? LastUri { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastUri = request.RequestUri;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[\"dirnode\",{\"children\":{}}]", Encoding.UTF8, "text/plain")
+                });
+            }
+        }
+
+        [Test]
+        public void TheRequestGoesToTheUrlTheParserBuilt()
+        {
+            var handler = new CapturingHandler();
+            using var backend = new TahoeBackend("tahoe://example.invalid/uri/URI:DIR2:aaa:bbb/", new Dictionary<string, string?>(), handler);
+
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await foreach (var _ in backend.ListAsync(CancellationToken.None))
+                    break;
+            });
+
+            Assert.AreEqual("http://example.invalid/uri/URI%3ADIR2%3Aaaa%3Abbb/?t=json", handler.LastUri?.OriginalString);
+        }
+    }
+}


### PR DESCRIPTION
**Depends on #7145** — it adds `Duplicati/Library/Utility/UriExtensions.cs`, which all the remaining backends need. Until that merges, the first two commits here belong to it; they drop out of the diff on their own once it lands.

Continues after #7133, #7134, #7136, #7137, #7138 and #7145. This converts the three small remaining server-name backends, leaving **WEBDAV and SharePoint** as the last two.

## Read this part first: the ftp query

`ftp` is a scheme `System.Uri` knows, and **that scheme has no query component** — the `?` is escaped into the path instead. Measured on .NET 10.0.10:

| input | `AbsolutePath` | `Query` |
| --- | --- | --- |
| `ftp://host/p?x=1` | **`/p%3Fx=1`** | **empty** |
| `aftp://host/p?x=1` | `/p` | `?x=1` |
| `ftps://host/p?x=1` | `/p` | `?x=1` |

`BackendLoader.GetBackend` lifts the query into the options and then hands the **original url** to the constructor, so `ftp://host/backup?auth-username=x` is an ordinary input. Parsing it as it arrives would have pointed the backup at a folder literally named `backup?auth-username=x` — no error, just a different destination.

So the query is cut off the string before it is parsed, which is the rule the relaxed parser used too (its path group is `[^\?]*`). There is a test for it on all three schemes, and cutting first also keeps `ftp://host/p?a#b` behaving as before, since a `#` inside a discarded query is not a fragment.

## Shape

Two commits, as in #7145: extract the url handling into an `internal static` parse method per backend and pin what the current parser answers, then swap only those method bodies.

The seam follows the same rule — normalization driven by an option stays in the constructor, normalization decided by the url alone moves in:

- **ftp** builds the whole sanitized `Uri` inside the method, because the field it lands in is already a `System.Uri` (the code parsed twice before) and the assembly is the part worth checking.
- **tahoe** takes the ssl flag as an argument, so the scheme is still decided outside.
- **pcloud** keeps the check against the known api endpoints in the constructor. `RequireCredentials` runs between the host check and it, so moving it would change which error a misconfigured server without an authid reports.

## What changes for users

Measured before and after, not predicted. Every row has a test.

| | before | after |
| --- | --- | --- |
| a `+` in the path | a space | a plus |
| a `#` in the path | part of the name | reported to the user |
| a `..` segment | kept | resolved — for tahoe that moves the path off the capability, so the url is reported as unrecognized |
| an encoded separator | became a real separator | stays encoded in the url |
| the host | case kept (pcloud, tahoe) | lower cased |
| an ipv6 or non ascii host | `UriFormatException` (ftp), an unparseable url (tahoe) | **works** |
| `ftp:///p`, `ftp://` | the missing-hostname message | `UriFormatException` |
| `ftp://:pass@host/p` | rejected as having no hostname | empty user, password taken |
| a written default port (tahoe) | `http://host:80/…` | left out |
| a backslash in a pcloud path | kept | becomes a separator |
| the tahoe capability | `URI%3ADIR2%3A` | `URI:DIR2:` |
| `pcloud://API.pCloud.com/` | `InvalidpCloudServerSpecified` | accepted |

Notes on the ones that matter:

**The `#`** is the only change that turns a working setup into a hard error: an ftp folder called `back#up` has to be written `back%23up` now. The alternative is worse — for `aftp`/`ftps` the fragment would be dropped silently and the backup would move to a shorter path. The message says what to write.

**The tahoe capability** is bytes on the wire. The old parser percent-encoded everything outside `[0-9a-zA-Z\-_.]` while rebuilding the url, so the colons went out as `%3A`. A colon is a legal path character and the literal form is what the Tahoe-LAFS web api documents. **There is no tahoe job in `backendtests.yml`**, so the request url is asserted through the existing `HttpMessageHandler` seam instead — `http://example.invalid/uri/URI:DIR2:aaa:bbb/?t=json`.

**The pcloud endpoint case** is an incidental consequence. `PCLOUD_SERVERS` is built with `StringComparer.OrdinalIgnoreCase`, but `ContainsValue` compares *values* with the default comparer, so the check is case sensitive today and `pcloud://API.pCloud.com/` is rejected. The endpoints are written in lower case, so the lower-cased host now matches. **I left `ContainsValue` alone on purpose**, so that every expectation that moved in the second commit traces back to the parser and nothing else. Happy to send the comparer as a one-line follow-up if you want it made explicit.

**The `+`** was a query-string rule applied to paths. A url that has been through the old parser carries `%2B`, so only a hand-written url is affected — but here it does move the remote folder, not just a displayed string.

## Reported, not touched

Two pieces of unreachable code that I left alone so the diff stays about the parser:

- `FTPBackend.cs` `_url.Port == -1 ? 21 : _url.Port` — `_url` always has the `ftp` scheme, whose default port is 21, so `Port` is never `-1`. This was already true before this change. There is a test pinning `Port == 21` for an `aftp://` input so it is visible.
- `pCloudBackend.cs` `string.IsNullOrWhiteSpace(_DnsName)` — the endpoint check above it fires first for any whitespace host.

## Testing

- `--filter "Category=UriUtility"`: **237 passed** after the change, and 237 passed before it
- after swapping the three method bodies, **28 tests failed, every one of them a row in the table above**
- `dotnet build Duplicati.slnx`: 0 errors

**Limits of what I checked:** the credentialed `FTP Tests` and `pCloud Tests` jobs were not run locally. Tahoe has no job at all, so the message handler seam is the only measurement of its request url.
