### PR TITLE
Register the database queries with the slow query monitor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -67,3 +67,8 @@ end_of_line = crlf
 
 [*.js]
 indent_size = 2
+
+[Duplicati/Library/Main/**.cs]
+# The database queries must go through the extension overloads that register with
+# SlowQueryMonitor; see BannedSymbols.txt in that project.
+dotnet_diagnostic.RS0030.severity = error

--- a/Duplicati/Library/Main/BannedSymbols.txt
+++ b/Duplicati/Library/Main/BannedSymbols.txt
@@ -1,0 +1,6 @@
+M:Microsoft.Data.Sqlite.SqliteCommand.ExecuteReaderAsync;Call the ExecuteReaderAsync extension with writeLog so the query is registered with SlowQueryMonitor
+M:Microsoft.Data.Sqlite.SqliteCommand.ExecuteReaderAsync(System.Threading.CancellationToken);Call the ExecuteReaderAsync extension with writeLog so the query is registered with SlowQueryMonitor
+M:System.Data.Common.DbCommand.ExecuteNonQueryAsync;Call the ExecuteNonQueryAsync extension with writeLog so the query is registered with SlowQueryMonitor
+M:System.Data.Common.DbCommand.ExecuteNonQueryAsync(System.Threading.CancellationToken);Call the ExecuteNonQueryAsync extension with writeLog so the query is registered with SlowQueryMonitor
+M:System.Data.Common.DbCommand.ExecuteScalarAsync;Call the ExecuteScalarAsync extension with writeLog so the query is registered with SlowQueryMonitor
+M:System.Data.Common.DbCommand.ExecuteScalarAsync(System.Threading.CancellationToken);Call the ExecuteScalarAsync extension with writeLog so the query is registered with SlowQueryMonitor

--- a/Duplicati/Library/Main/Database/ExtensionMethods.cs
+++ b/Duplicati/Library/Main/Database/ExtensionMethods.cs
@@ -35,6 +35,19 @@ namespace Duplicati.Library.Main.Database;
 /// <summary>
 /// Extension method for <see cref="IDbCommand"/>
 /// </summary>
+/// <remarks>
+/// These are what register a query with <see cref="SlowQueryMonitor"/>, so a query that is
+/// executed through the command's own methods instead is invisible to it, no matter how long
+/// it runs or how low the threshold is set.
+///
+/// Adding a <c>(this SqliteCommand, CancellationToken)</c> overload would not help: an
+/// applicable instance method always wins over an extension method. There is a proof of that
+/// in this file - <see cref="ExecuteScalarAsync(SqliteCommand, bool, string?, Dictionary{string, object?}?, CancellationToken)"/>
+/// calls <c>self.ExecuteScalarAsync(cancellationToken)</c>, which would be an unbounded
+/// recursion if the extension were picked. So the call has to name the overload it wants, and
+/// <c>writeLog: false</c> is the one that registers with the monitor without also writing a
+/// profiling record.
+/// </remarks>
 public static partial class ExtensionMethods
 {
 
@@ -160,6 +173,11 @@ public static partial class ExtensionMethods
     /// <param name="writeLog">Whether to write a log entry.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns>A task that when awaited contains the number of rows affected.</returns>
+    /// <remarks>
+    /// Without a log entry this deliberately skips <see cref="SlowQueryMonitor"/> as well. The
+    /// callers are the per-block loops in the backup, where registering every statement would
+    /// put a lock and a dictionary insert in the innermost loop. It is not an oversight.
+    /// </remarks>
     public static Task<int> ExecuteNonQueryPerformanceSensitiveAsync(this SqliteCommand self, bool writeLog, CancellationToken cancellationToken)
     {
         if (!writeLog)
@@ -328,18 +346,6 @@ public static partial class ExtensionMethods
     /// Executes the command asynchronously and returns the first column of the first row in the result set.
     /// </summary>
     /// <param name="self">The <see cref="SqliteCommand"/> instance to execute on.</param>
-    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
-    /// <returns>A task that when awaited contains the first column of the first row in the result set, or null if no rows are returned.</returns>
-    public static async Task<object?> ExecuteScalarAsync(this SqliteCommand self, CancellationToken cancellationToken)
-    {
-        return await self.ExecuteScalarAsync(true, null, null, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Executes the command asynchronously and returns the first column of the first row in the result set.
-    /// </summary>
-    /// <param name="self">The <see cref="SqliteCommand"/> instance to execute on.</param>
     /// <param name="cmdtext">The command text to execute.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns>A task that when awaited contains the first column of the first row in the result set, or null if no rows are returned.</returns>
@@ -435,6 +441,11 @@ public static partial class ExtensionMethods
     /// <param name="writeLog">Whether to write a log entry.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns>A task that when awaited contains the first column of the first row in the result set as an Int64, or the default value if no rows are returned or the value cannot be converted.</returns>
+    /// <remarks>
+    /// Without a log entry this deliberately skips <see cref="SlowQueryMonitor"/> as well. The
+    /// callers are the per-block loops in the backup, where registering every statement would
+    /// put a lock and a dictionary insert in the innermost loop. It is not an oversight.
+    /// </remarks>
     public static async Task<long> ExecuteScalarInt64PerformanceSensitiveAsync(this SqliteCommand self, bool writeLog, CancellationToken cancellationToken)
     {
         if (!writeLog)

--- a/Duplicati/Library/Main/Database/ExtensionMethods.cs
+++ b/Duplicati/Library/Main/Database/ExtensionMethods.cs
@@ -32,6 +32,10 @@ using Microsoft.Data.Sqlite;
 
 namespace Duplicati.Library.Main.Database;
 
+// This file is the layer that wraps the command's own execute methods, so it is the one place
+// that has to call them. Everywhere else in this project the ban applies; see BannedSymbols.txt.
+#pragma warning disable RS0030
+
 /// <summary>
 /// Extension method for <see cref="IDbCommand"/>
 /// </summary>

--- a/Duplicati/Library/Main/Database/Local/LocalBackupDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalBackupDatabase.cs
@@ -464,7 +464,7 @@ namespace Duplicati.Library.Main.Database.Local
                         ")
                         .ConfigureAwait(false);
 
-                    await using (var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+                    await using (var reader = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                         while (await reader.ReadAsync(token).ConfigureAwait(false))
                         {
                             var id = reader.ConvertValueToInt64(0);
@@ -1167,7 +1167,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetParameterValue("@Path", path)
                 .SetParameterValue("@FilesetId", filesetid);
 
-            await using var rd = await m_findfileCommand.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await m_findfileCommand.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             if (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 oldModified = new DateTime(rd.ConvertValueToInt64(1), DateTimeKind.Utc);
@@ -1212,7 +1212,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@FileId", fileid);
 
-            await using var rd = await m_selectfilemetadatahashandsizeCommand.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await m_selectfilemetadatahashandsizeCommand.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             if (await rd.ReadAsync(token).ConfigureAwait(false))
                 return (
                     rd.ConvertValueToString(1) ?? throw new InvalidOperationException("Metadata hash is null"),
@@ -1694,7 +1694,7 @@ namespace Duplicati.Library.Main.Database.Local
 
                     if (exclusionPredicate(path, size))
                         await cmdDelete.SetParameterValue("@FileId", row.ConvertValueToInt64(1))
-                            .ExecuteNonQueryAsync(token) // Not logging because we log the full operation
+                            .ExecuteNonQueryAsync(writeLog: false, token) // Not logging because we log the full operation
                             .ConfigureAwait(false);
                 }
 
@@ -1785,7 +1785,7 @@ namespace Duplicati.Library.Main.Database.Local
                     RemoteVolumeState.Verified.ToString()
                 ]);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return rd.ConvertValueToString(0) ?? throw new Exception("Unexpected null value for volume name");
         }
@@ -1921,7 +1921,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@FilesetId", fileSetId);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 yield return new Interface.USNJournalDataEntry
@@ -1968,7 +1968,7 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetParameterValue("@JournalId", entry.JournalId)
                         .SetParameterValue("@NextUsn", entry.NextUsn)
                         .SetParameterValue("@ConfigHash", entry.ConfigHash)
-                        .ExecuteNonQueryAsync(token) // Not logging, as we log the whole operation
+                        .ExecuteNonQueryAsync(writeLog: false, token) // Not logging, as we log the whole operation
                         .ConfigureAwait(false);
 
                     if (c != 1)
@@ -2004,7 +2004,7 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetParameterValue("@FilesetId", fileSetId)
                         .SetParameterValue("@VolumeName", entry.Volume)
                         .SetParameterValue("@JournalId", entry.JournalId)
-                        .ExecuteNonQueryAsync(token) // Not logging, as we log the whole operation
+                        .ExecuteNonQueryAsync(writeLog: false, token) // Not logging, as we log the whole operation
                         .ConfigureAwait(false);
                 }
 

--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -598,7 +598,7 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExpandInClauseParameterMssqliteAsync("@FilesetIds", tmptable, token)
                 .ConfigureAwait(false);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 var name = rd.ConvertValueToString(0) ?? string.Empty;
@@ -729,7 +729,7 @@ namespace Duplicati.Library.Main.Database.Local
             ", token)
                 .ConfigureAwait(false);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new KeyValuePair<long, DateTime>(
                     rd.ConvertValueToInt64(0),
@@ -845,7 +845,7 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExpandInClauseParameterMssqliteAsync("@Name", tmptable, token)
                 .ConfigureAwait(false);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new KeyValuePair<string, long>(rd.ConvertValueToString(0) ?? "", rd.ConvertValueToInt64(1));
         }
@@ -862,7 +862,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@Name", file);
 
-            await using (var rd = await m_selectremotevolumeCommand.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await m_selectremotevolumeCommand.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 if (await rd.ReadAsync(token).ConfigureAwait(false))
                     return new RemoteVolumeEntry(
                         rd.ConvertValueToInt64(0),
@@ -908,7 +908,7 @@ namespace Duplicati.Library.Main.Database.Local
         {
             m_selectremotevolumesCommand.SetTransaction(m_rtr);
             await using var rd = await m_selectremotevolumesCommand
-                .ExecuteReaderAsync(token)
+                .ExecuteReaderAsync(writeLog: false, token)
                 .ConfigureAwait(false);
 
             while (await rd.ReadAsync(token).ConfigureAwait(false))
@@ -1357,7 +1357,7 @@ namespace Duplicati.Library.Main.Database.Local
                     await m_removeremotevolumeCommand
                         .SetTransaction(m_rtr)
                         .SetParameterValue("@Name", name)
-                        .ExecuteNonQueryAsync(token) // Not logging because we log the whole operation
+                        .ExecuteNonQueryAsync(writeLog: false, token) // Not logging because we log the whole operation
                         .ConfigureAwait(false);
 
             // Validate before commiting changes
@@ -1493,7 +1493,7 @@ namespace Duplicati.Library.Main.Database.Local
             ")
                 .SetParameterValues(values);
 
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                     res.Add(rd.ConvertValueToInt64(0));
 
@@ -1504,7 +1504,7 @@ namespace Duplicati.Library.Main.Database.Local
                     FROM ""Fileset""
                     ORDER BY ""Timestamp"" DESC
                 ");
-                await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+                await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                     while (await rd.ReadAsync(token).ConfigureAwait(false))
                         res.Add(rd.ConvertValueToInt64(0));
 
@@ -1543,7 +1543,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ORDER BY ""Timestamp"" DESC
             ")
                 .SetParameterValues(args);
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                     res.Add(rd.ConvertValueToInt64(0));
 
@@ -1568,7 +1568,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@Timestamp", Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(filesetTime));
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             if (!await rd.ReadAsync(token).ConfigureAwait(false))
                 return false;
             var isFullBackup = rd.GetInt32(0);
@@ -1590,7 +1590,7 @@ namespace Duplicati.Library.Main.Database.Local
             ")
                 .SetTransaction(m_rtr);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new KeyValuePair<string, string>(
                     rd.ConvertValueToString(0) ?? "",
@@ -1721,7 +1721,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ")
                         .SetParameterValue("@Key", kp.Key)
                         .SetParameterValue("@Value", kp.Value)
-                        .ExecuteNonQueryAsync(token) // Not logging, as we log the whole operation
+                        .ExecuteNonQueryAsync(writeLog: false, token) // Not logging, as we log the whole operation
                         .ConfigureAwait(false);
                 }
         }
@@ -1966,7 +1966,7 @@ namespace Duplicati.Library.Main.Database.Local
                         ");
                         cmd.SetParameterValue("@Type", RemoteVolumeType.Files.ToString());
                         cmd.SetParameterValue("@State", RemoteVolumeState.Deleted.ToString());
-                        await using var reader = await cmd.ExecuteReaderAsync(token)
+                        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, token)
                             .ConfigureAwait(false);
                         if (await reader.ReadAsync(token).ConfigureAwait(false))
                             throw new DatabaseInconsistencyException($"Detected 1 fileset with missing volume: FilesetId = {reader.ConvertValueToInt64(0)}, Time = ({ParseFromEpochSeconds(reader.ConvertValueToInt64(1))}), unmatched VolumeID {reader.ConvertValueToInt64(2)}");
@@ -2013,7 +2013,7 @@ namespace Duplicati.Library.Main.Database.Local
                         cmd.SetParameterValue("@Type", RemoteVolumeType.Files.ToString());
                         cmd.SetParameterValue("@DeletedState", RemoteVolumeState.Deleted.ToString());
                         cmd.SetParameterValue("@DeletingState", RemoteVolumeState.Deleting.ToString());
-                        await using var reader = await cmd.ExecuteReaderAsync(token)
+                        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, token)
                             .ConfigureAwait(false);
                         if (await reader.ReadAsync(token).ConfigureAwait(false))
                             throw new DatabaseInconsistencyException($"Detected 1 volume with missing filesets: VolumeId = {reader.ConvertValueToInt64(0)}, Name = {reader.ConvertValueToString(1)}, State = {reader.ConvertValueToString(2)}");
@@ -2190,7 +2190,7 @@ namespace Duplicati.Library.Main.Database.Local
             cmd.SetTransaction(m_rtr)
                 .SetParameterValue("@VolumeId", volumeid);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new Block(
                     rd.ConvertValueToString(0) ?? throw new Exception("Hash is null"),
@@ -2488,7 +2488,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetParameterValue("@SymlinkBlocksetId", SYMLINK_BLOCKSET_ID);
 
             string? lastpath = null;
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var blocksetID = rd.ConvertValueToInt64(0, -1);
@@ -2515,7 +2515,7 @@ namespace Duplicati.Library.Main.Database.Local
             cmd.SetParameterValue("@FilesetId", filesetId);
 
             string? lastFilePath = null;
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 if (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var more = false;
@@ -2743,7 +2743,7 @@ namespace Duplicati.Library.Main.Database.Local
 
                     c2.SetTransaction(db.Transaction);
                     using (new Logging.Timer(LOGTAG, "CreateFilteredFilenameTable", "Filtering paths"))
-                    await using (var rd = await c2.ExecuteReaderAsync(token).ConfigureAwait(false))
+                    await using (var rd = await c2.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                         while (await rd.ReadAsync(token).ConfigureAwait(false))
                         {
                             var p = rd.ConvertValueToString(0) ?? "";
@@ -2751,7 +2751,7 @@ namespace Duplicati.Library.Main.Database.Local
                             {
                                 await cmd
                                     .SetParameterValue("@Path", p)
-                                    .ExecuteNonQueryAsync(token) // Not logging as we log the whole operation
+                                    .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the whole operation
                                     .ConfigureAwait(false);
                             }
                         }
@@ -3018,7 +3018,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetParameterValue("@VolumeId", volumeid)
                 .SetParameterValue("@HashesPerBlock", blocksize / hashsize);
 
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var blockhash = rd.ConvertValueToString(0);
@@ -3131,7 +3131,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .ConfigureAwait(false);
 
             await using var rd = await cmd.SetTransaction(m_rtr)
-                .ExecuteReaderAsync(token)
+                .ExecuteReaderAsync(writeLog: false, token)
                 .ConfigureAwait(false);
 
             while (await rd.ReadAsync(token).ConfigureAwait(false))
@@ -3174,7 +3174,7 @@ namespace Duplicati.Library.Main.Database.Local
 
             await using var rd = await cmd.SetTransaction(m_rtr)
                 .SetParameterValue("@FilesetId", filesetID)
-                .ExecuteReaderAsync(token)
+                .ExecuteReaderAsync(writeLog: false, token)
                 .ConfigureAwait(false);
 
             if (await rd.ReadAsync(token).ConfigureAwait(false))

--- a/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
@@ -285,7 +285,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetParameterValue("@Type", RemoteVolumeType.Files.ToString())
                 .SetParameterValue("@State", RemoteVolumeState.Deleting.ToString());
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new KeyValuePair<string, long>(
                     rd.ConvertValueToString(0) ?? "",
@@ -315,7 +315,7 @@ namespace Duplicati.Library.Main.Database.Local
                     ORDER BY ""Timestamp"" DESC
                 ");
 
-            await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             int version = 0;
             while (await reader.ReadAsync(token).ConfigureAwait(false))
             {
@@ -556,7 +556,7 @@ namespace Duplicati.Library.Main.Database.Local
                         ORDER BY ""B"".""Sorttime"" ASC
                     ");
 
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                     yield return new VolumeUsage(
                         rd.ConvertValueToString(0) ?? "",
@@ -1069,7 +1069,7 @@ namespace Duplicati.Library.Main.Database.Local
                         AND ""B"".""Size"" IS NOT NULL
                 ");
 
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var name = rd.ConvertValueToString(0) ?? "";

--- a/Duplicati/Library/Main/Database/Local/LocalListAffectedDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListAffectedDatabase.cs
@@ -182,7 +182,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .ExpandInClauseParameterMssqliteAsync("@Names", tmptable, token)
                 .ConfigureAwait(false);
             await using var rd = await cmd
-                .ExecuteReaderAsync(token)
+                .ExecuteReaderAsync(writeLog: false, token)
                 .ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
@@ -269,7 +269,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .ExpandInClauseParameterMssqliteAsync("@Names", tmptable, token)
                 .ConfigureAwait(false);
             await using var rd = await cmd
-                .ExecuteReaderAsync(token)
+                .ExecuteReaderAsync(writeLog: false, token)
                 .ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new ListResultFile()
@@ -319,7 +319,7 @@ namespace Duplicati.Library.Main.Database.Local
                 foreach ((var x, var i) in slice.Select((x, i) => (x, i)))
                     cmd.SetParameterValue($"@Message{i}", "%" + x + "%");
 
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                     yield return new ListResultRemoteLog()
                     {
@@ -414,7 +414,7 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExpandInClauseParameterMssqliteAsync("@Names", tmptable, token)
                 .ConfigureAwait(false);
             await using var rd = await cmd
-                .ExecuteReaderAsync(token)
+                .ExecuteReaderAsync(writeLog: false, token)
                 .ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new ListResultRemoteVolume()

--- a/Duplicati/Library/Main/Database/Local/LocalListChangesDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListChangesDatabase.cs
@@ -452,7 +452,7 @@ namespace Duplicati.Library.Main.Database.Local
                         foreach (var s in p)
                             await cmd
                                 .SetParameterValue("@Path", s)
-                                .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                 .ConfigureAwait(false);
 
                     string whereClause;
@@ -541,7 +541,7 @@ namespace Duplicati.Library.Main.Database.Local
                     await cmd2.PrepareAsync(token).ConfigureAwait(false);
 
                     await using var rd = await cmd
-                        .ExecuteReaderAsync(token)
+                        .ExecuteReaderAsync(writeLog: false, token)
                         .ConfigureAwait(false);
 
                     using (new Logging.Timer(LOGTAG, "AddFromDb", $"Evaluating paths and updating table"))
@@ -557,7 +557,7 @@ namespace Duplicati.Library.Main.Database.Local
                                     .SetParameterValue("@MetaHash", values[2])
                                     .SetParameterValue("@Size", values[3])
                                     .SetParameterValue("@Type", values[4])
-                                    .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                    .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                     .ConfigureAwait(false);
                             }
                         }
@@ -783,7 +783,7 @@ namespace Duplicati.Library.Main.Database.Local
                     {
                         cmd.SetCommandAndParameters(sql);
                         foreach (var type in elTypes)
-                            await foreach (var s in ReaderToStringListAsync(await cmd.SetParameterValue("@Type", (int)type).ExecuteReaderAsync(token).ConfigureAwait(false), token).ConfigureAwait(false))
+                            await foreach (var s in ReaderToStringListAsync(await cmd.SetParameterValue("@Type", (int)type).ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false), token).ConfigureAwait(false))
                                 yield return new Tuple<Interface.ListChangesChangeType, Interface.ListChangesElementType, string>(changeType, type, s ?? "");
                     }
 

--- a/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
@@ -494,7 +494,7 @@ namespace Duplicati.Library.Main.Database.Local
                     SELECT DISTINCT ""Path""
                     FROM ""{table}""
                 ");
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var s = rd.ConvertValueToString(0) ?? "";
@@ -582,7 +582,7 @@ namespace Duplicati.Library.Main.Database.Local
                             await foreach (var n in SelectFolderEntriesAsync(cmd, pathprefix, tmpnames.Tablename, token).Distinct().ConfigureAwait(false))
                                 await c2
                                     .SetParameterValue("@Path", n)
-                                    .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                    .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                     .ConfigureAwait(false);
 
                         await c2.ExecuteNonQueryAsync($@"

--- a/Duplicati/Library/Main/Database/Local/LocalLockDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalLockDatabase.cs
@@ -116,7 +116,7 @@ namespace Duplicati.Library.Main.Database.Local
                 {whereClause}
             ");
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 var name = rd.ConvertValueToString(0) ?? string.Empty;

--- a/Duplicati/Library/Main/Database/Local/LocalPurgeDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalPurgeDatabase.cs
@@ -111,7 +111,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ")
                     .SetParameterValue("@FilesetId", id);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             if (!await rd.ReadAsync(token).ConfigureAwait(false))
                 throw new Exception($"No remote volume found for fileset with id {id}");
             else
@@ -134,7 +134,7 @@ namespace Duplicati.Library.Main.Database.Local
                     FROM ""FilesetEntry""
                 )
             ");
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             if (await rd.ReadAsync(token).ConfigureAwait(false))
                 return rd.ConvertValueToInt64(0, 0);
             else
@@ -308,7 +308,7 @@ namespace Duplicati.Library.Main.Database.Local
                     using (new Logging.Timer(LOGTAG, "ApplyFilter", "Inserting paths into table"))
                         foreach (var s in p)
                             await cmd.SetParameterValue("@Path", s)
-                                .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                 .ConfigureAwait(false);
 
                     await cmd.SetCommandAndParameters($@"
@@ -358,7 +358,7 @@ namespace Duplicati.Library.Main.Database.Local
 
                     using (new Logging.Timer(LOGTAG, "ApplyFilter", "Iterating files with filter"))
                     {
-                        await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                        await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                         while (await rd.ReadAsync(token).ConfigureAwait(false))
                         {
                             rd.GetValues(values);
@@ -367,7 +367,7 @@ namespace Duplicati.Library.Main.Database.Local
                             {
                                 await cmd2
                                     .SetParameterValue("@FileId", values[1])
-                                    .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                    .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                     .ConfigureAwait(false);
                             }
                         }

--- a/Duplicati/Library/Main/Database/Local/LocalRecreateDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalRecreateDatabase.cs
@@ -955,7 +955,7 @@ namespace Duplicati.Library.Main.Database.Local
                                 await m_insertBlocklistHashCommand
                                     .SetParameterValue("@Index", index++)
                                     .SetParameterValue("@Hash", hash)
-                                    .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                    .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                     .ConfigureAwait(false);
                             }
                         }
@@ -1113,7 +1113,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@VolumeId", volumeid);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return rd.ConvertValueToString(0) ?? "";
         }
@@ -1233,7 +1233,7 @@ namespace Duplicati.Library.Main.Database.Local
             }
 
             await using var rd = await cmd
-                .ExecuteReaderAsync(token)
+                .ExecuteReaderAsync(writeLog: false, token)
                 .ConfigureAwait(false);
 
             while (await rd.ReadAsync(token).ConfigureAwait(false))
@@ -1535,7 +1535,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ";
             cmd.Parameters.AddWithValue("@VolumeType", RemoteVolumeType.Blocks.ToString());
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 yield return new MetadataBlockInfo(

--- a/Duplicati/Library/Main/Database/Local/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalRepairDatabase.cs
@@ -106,7 +106,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@Name", filelist);
 
-            var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
 
             if (!await rd.ReadAsync(token).ConfigureAwait(false))
                 throw new Exception($"No such remote file: {filelist}");
@@ -195,7 +195,7 @@ namespace Duplicati.Library.Main.Database.Local
             ")
                 .SetTransaction(m_rtr);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 yield return new KeyValuePair<long, DateTime>(
@@ -965,7 +965,7 @@ namespace Duplicati.Library.Main.Database.Local
                             .ConfigureAwait(false);
 
                         await cmd.SetTransaction(m_rtr)
-                            .ExecuteNonQueryAsync()
+                            .ExecuteNonQueryAsync(writeLog: false, default)
                             .ConfigureAwait(false);
                     }
                 }

--- a/Duplicati/Library/Main/Database/Local/LocalRestoreDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalRestoreDatabase.cs
@@ -544,7 +544,7 @@ namespace Duplicati.Library.Main.Database.Local
                             {
                                 await cmd
                                     .SetParameterValue("@Path", s)
-                                    .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                    .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                     .ConfigureAwait(false);
                             }
 
@@ -590,7 +590,7 @@ namespace Duplicati.Library.Main.Database.Local
                                     FROM ""{m_tempfiletable}""
                                 )
                             ");
-                            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+                            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                                     sb.AppendLine(rd.ConvertValueToString(0));
 
@@ -654,7 +654,7 @@ namespace Duplicati.Library.Main.Database.Local
 
                         using (new Logging.Timer(LOGTAG, "ApplyFilter", "Iterating files with filter"))
                         {
-                            await using var rd = await cmd.ExecuteReaderAsync(token)
+                            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token)
                                 .ConfigureAwait(false);
                             while (await rd.ReadAsync(token).ConfigureAwait(false))
                             {
@@ -675,7 +675,7 @@ namespace Duplicati.Library.Main.Database.Local
                                         .SetParameterValue("@Path", values[1])
                                         .SetParameterValue("@BlocksetID", values[2])
                                         .SetParameterValue("@MetadataID", values[3])
-                                        .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                        .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                         .ConfigureAwait(false);
                                 }
                             }
@@ -714,7 +714,7 @@ namespace Duplicati.Library.Main.Database.Local
                             ""Blockset""
                         WHERE ""{m_tempfiletable}"".""BlocksetID"" = ""Blockset"".""ID""
                     ");
-                    await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+                    await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                     {
                         var filecount = 0L;
                         var filesize = 0L;
@@ -761,7 +761,7 @@ namespace Duplicati.Library.Main.Database.Local
             ")
                 .SetTransaction(m_rtr);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             var filecount = 0L;
             var filesize = 0L;
             if (await rd.ReadAsync(token).ConfigureAwait(false))
@@ -802,7 +802,7 @@ namespace Duplicati.Library.Main.Database.Local
                 SELECT ""Path""
                 FROM ""{m_tempfiletable}""
             ");
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var path = rd.ConvertValueToString(0);
@@ -857,7 +857,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetParameterValue("@FilesetId", filesetId);
 
             await insertCmd.ExpandInClauseParameterMssqliteAsync("@ParentPaths", parentTable, token).ConfigureAwait(false);
-            await insertCmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            await insertCmd.ExecuteNonQueryAsync(writeLog: false, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -876,7 +876,7 @@ namespace Duplicati.Library.Main.Database.Local
             ")
                 .SetTransaction(m_rtr);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 var id = rd.ConvertValueToInt64(0);
@@ -897,7 +897,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr);
 
             await delCmd.ExpandInClauseParameterMssqliteAsync("@Ids", tmptable, token).ConfigureAwait(false);
-            await delCmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            await delCmd.ExecuteNonQueryAsync(writeLog: false, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1578,7 +1578,7 @@ namespace Duplicati.Library.Main.Database.Local
                         ""BlocksetEntry"".""Index""
                 ")
                     .SetTransaction(db.Transaction);
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 if (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var more = true;
@@ -1775,7 +1775,7 @@ namespace Duplicati.Library.Main.Database.Local
                         ""B"".""Index""
                 ")
                     .SetTransaction(db.Transaction);
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 var more = await rd.ReadAsync(token).ConfigureAwait(false);
 
                 while (more)
@@ -1842,7 +1842,7 @@ namespace Duplicati.Library.Main.Database.Local
             // Now it is likely to restore all files from front to back. Large files will always be done last.
             // One could also use like the average block number in a volume, that needs to be measured.
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
             {
                 yield return new RemoteVolume(
@@ -1936,7 +1936,7 @@ namespace Duplicati.Library.Main.Database.Local
                     {
                         await c.SetParameterValue("@Hash", s.Key)
                             .SetParameterValue("@Size", s.Value)
-                            .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                            .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                             .ConfigureAwait(false);
                     }
 
@@ -1958,7 +1958,7 @@ namespace Duplicati.Library.Main.Database.Local
                 {
                     await using var c = m_db.Connection.CreateCommand(@$"DROP TABLE IF EXISTS ""{m_tmptable}""")
                         .SetTransaction(m_db.Transaction);
-                    await c.ExecuteNonQueryAsync().ConfigureAwait(false);
+                    await c.ExecuteNonQueryAsync(writeLog: false, default).ConfigureAwait(false);
                     await m_db.Transaction.CommitAsync().ConfigureAwait(false);
                 }
             }
@@ -2056,7 +2056,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ")
                     .SetTransaction(m_db.Transaction);
 
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 if (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var more = true;
@@ -2110,7 +2110,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ")
                     .SetTransaction(m_db.Transaction);
 
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 if (await rd.ReadAsync(token).ConfigureAwait(false))
                 {
                     var more = true;
@@ -2216,7 +2216,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@Verified", !onlyNonVerified);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return new FileToRestore(
                     rd.ConvertValueToInt64(0), rd.ConvertValueToString(1) ?? "", rd.ConvertValueToString(2) ?? "", rd.ConvertValueToInt64(3));
@@ -2256,7 +2256,7 @@ namespace Duplicati.Library.Main.Database.Local
         {
             await using var cmd = m_connection.CreateCommand($@"DROP TABLE IF EXISTS ""{tableName}""")
                 .SetTransaction(m_rtr);
-            await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            await cmd.ExecuteNonQueryAsync(writeLog: false, token).ConfigureAwait(false);
             await m_rtr.CommitAsync(token: token).ConfigureAwait(false);
         }
 
@@ -2286,7 +2286,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ")
                     .SetTransaction(m_rtr)
                     .SetParameterValue("@TargetFileId", targetfileid);
-                await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                await cmd.ExecuteNonQueryAsync(writeLog: false, token).ConfigureAwait(false);
             }
             finally
             {
@@ -2319,7 +2319,7 @@ namespace Duplicati.Library.Main.Database.Local
                     AND ""{m_tempfiletable}"".""DataVerified"" = 1
             ")
                 .SetTransaction(m_rtr);
-            var added = await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            var added = await cmd.ExecuteNonQueryAsync(writeLog: false, token).ConfigureAwait(false);
             // Commit so the appended hashes are durable and visible to the separate
             // connection used by the next version's restore (which reads this table to
             // exclude already-restored files).
@@ -2356,7 +2356,7 @@ namespace Duplicati.Library.Main.Database.Local
                 )
             ")
                 .SetTransaction(m_rtr);
-            return await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            return await cmd.ExecuteNonQueryAsync(writeLog: false, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2390,7 +2390,7 @@ namespace Duplicati.Library.Main.Database.Local
             ")
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@MaxSize", maxSize);
-            return await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            return await cmd.ExecuteNonQueryAsync(writeLog: false, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2421,7 +2421,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ")
                     .SetTransaction(m_rtr);
 
-                await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                     yield return new FileRequest(
                         rd.ConvertValueToInt64(0),
@@ -2525,7 +2525,7 @@ namespace Duplicati.Library.Main.Database.Local
                 ")
                     .SetTransaction(m_rtr);
 
-                await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                 while (await reader.ReadAsync(token).ConfigureAwait(false))
                     yield return (
                         reader.ConvertValueToInt64(0),
@@ -2566,7 +2566,7 @@ namespace Duplicati.Library.Main.Database.Local
                     .SetTransaction(transaction)
                     .SetParameterValue("@BlocksetID", blocksetID);
 
-                await using var reader = await cmd.ExecuteReaderAsync(token)
+                await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, token)
                     .ConfigureAwait(false);
                 for (long i = 0; await reader.ReadAsync(token).ConfigureAwait(false); i++)
                     yield return new BlockRequest(
@@ -2616,7 +2616,7 @@ namespace Duplicati.Library.Main.Database.Local
                     .SetTransaction(transaction)
                     .SetParameterValue("@FileID", fileID);
 
-                await using var reader = await cmd.ExecuteReaderAsync(token)
+                await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, token)
                     .ConfigureAwait(false);
                 for (long i = 0; await reader.ReadAsync(token).ConfigureAwait(false); i++)
                 {
@@ -2685,7 +2685,7 @@ namespace Duplicati.Library.Main.Database.Local
                     .SetTransaction(transaction)
                     .SetParameterValue("@VolumeID", VolumeID);
 
-                await using var reader = await cmd.ExecuteReaderAsync(token)
+                await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, token)
                     .ConfigureAwait(false);
                 while (await reader.ReadAsync(token).ConfigureAwait(false))
                     yield return (
@@ -2976,7 +2976,7 @@ namespace Duplicati.Library.Main.Database.Local
                 m_hasUpdates = false;
                 await using var rd = await m_statUpdateCommand
                     .SetTransaction(m_db.Transaction)
-                    .ExecuteReaderAsync(token)
+                    .ExecuteReaderAsync(writeLog: false, token)
                     .ConfigureAwait(false);
 
                 var filesprocessed = 0L;
@@ -3135,7 +3135,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetTransaction(m_rtr)
                 .SetParameterValue("@BlocksetID", FOLDER_BLOCKSET_ID);
 
-            await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
             while (await rd.ReadAsync(token).ConfigureAwait(false))
                 yield return rd.ConvertValueToString(0) ?? "";
         }
@@ -3291,7 +3291,7 @@ namespace Duplicati.Library.Main.Database.Local
 
                 using (new Logging.Timer(LOGTAG, "CheckLocalSourceExists", "Checking if local source files exist"))
                 {
-                    await using (var rd = await cmdReader.ExecuteReaderAsync(token).ConfigureAwait(false))
+                    await using (var rd = await cmdReader.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                     {
                         while (await rd.ReadAsync(token).ConfigureAwait(false))
                         {
@@ -3300,7 +3300,7 @@ namespace Duplicati.Library.Main.Database.Local
                             {
                                 await cmd
                                     .SetParameterValue("@Path", sourcepath)
-                                    .ExecuteNonQueryAsync(token) // Not logging as we log the total time
+                                    .ExecuteNonQueryAsync(writeLog: false, token) // Not logging as we log the total time
                                     .ConfigureAwait(false);
                             }
                             else

--- a/Duplicati/Library/Main/Database/Local/LocalTestDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalTestDatabase.cs
@@ -242,7 +242,7 @@ namespace Duplicati.Library.Main.Database.Local
                         RemoteVolumeState.Uploaded.ToString()
                 ]);
 
-                await using (var rd = await cmd.ExecuteReaderAsync(token))
+                await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token))
                     while (await rd.ReadAsync(token))
                         yield return new RemoteVolume(rd);
 
@@ -279,7 +279,7 @@ namespace Duplicati.Library.Main.Database.Local
                     .SetParameterValue("@State1", RemoteVolumeState.Uploaded.ToString())
                     .SetParameterValue("@State2", RemoteVolumeState.Verified.ToString())
                     .SetParameterValues(tp.Item2)
-                    .ExecuteReaderAsync(token))
+                    .ExecuteReaderAsync(writeLog: false, token))
                     while (await rd.ReadAsync(token))
                         files.Add(new RemoteVolume(rd));
 
@@ -312,7 +312,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetParameterValue("@Type", RemoteVolumeType.Index.ToString())
                 .ExpandInClauseParameterMssqlite("@States", [RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString()]);
 
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                     files.Add(new RemoteVolume(rd));
 
@@ -341,7 +341,7 @@ namespace Duplicati.Library.Main.Database.Local
                 .SetParameterValue("@Type", RemoteVolumeType.Blocks.ToString())
                 .ExpandInClauseParameterMssqlite("@States", [RemoteVolumeState.Uploaded.ToString(), RemoteVolumeState.Verified.ToString()]);
 
-            await using (var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
                 while (await rd.ReadAsync(token).ConfigureAwait(false))
                     files.Add(new RemoteVolume(rd));
 
@@ -655,7 +655,7 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetParameterValue("@TypeMissing", (int)Interface.TestEntryStatus.Missing)
                         .SetParameterValue("@TypeModified", (int)Interface.TestEntryStatus.Modified);
 
-                    await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                    await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                     while (await rd.ReadAsync(token).ConfigureAwait(false))
                         yield return new KeyValuePair<Interface.TestEntryStatus, string>(
                             (Interface.TestEntryStatus)rd.ConvertValueToInt64(0),
@@ -853,7 +853,7 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetParameterValue("@TypeMissing", (int)Interface.TestEntryStatus.Missing)
                         .SetParameterValue("@TypeModified", (int)Interface.TestEntryStatus.Modified);
 
-                    await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                    await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                     while (await rd.ReadAsync(token).ConfigureAwait(false))
                         yield return new KeyValuePair<Interface.TestEntryStatus, string>((Interface.TestEntryStatus)rd.ConvertValueToInt64(0), rd.ConvertValueToString(1) ?? "");
 
@@ -1096,7 +1096,7 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetParameterValue("@TypeMissing", (int)Library.Interface.TestEntryStatus.Missing)
                         .SetParameterValue("@TypeModified", (int)Library.Interface.TestEntryStatus.Modified);
 
-                    await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                    await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                     while (await rd.ReadAsync(token).ConfigureAwait(false))
                         yield return new KeyValuePair<Duplicati.Library.Interface.TestEntryStatus, string>((Duplicati.Library.Interface.TestEntryStatus)rd.ConvertValueToInt64(0), rd.ConvertValueToString(1) ?? "");
 
@@ -1313,7 +1313,7 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetParameterValue("@TypeMissing", (int)Library.Interface.TestEntryStatus.Missing)
                         .SetParameterValue("@TypeModified", (int)Library.Interface.TestEntryStatus.Modified);
 
-                    await using var rd = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+                    await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
                     while (await rd.ReadAsync(token).ConfigureAwait(false))
                         yield return new KeyValuePair<Library.Interface.TestEntryStatus, string>(
                             (Library.Interface.TestEntryStatus)rd.ConvertValueToInt64(0),

--- a/Duplicati/Library/Main/Database/Sync/LocalSyncDatabase.cs
+++ b/Duplicati/Library/Main/Database/Sync/LocalSyncDatabase.cs
@@ -115,7 +115,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
     {
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"DELETE FROM ""PendingOperation"";";
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken);
     }
 
     /// <summary>
@@ -138,7 +138,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         cmd.Parameters.AddWithValue("@modified", lastModified.ToUniversalTime().ToString("O"));
         cmd.Parameters.AddWithValue("@hash", (object?)contentHash ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@verified", DateTime.UtcNow.ToString("O"));
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken);
     }
 
     /// <summary>
@@ -168,7 +168,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         cmd.Parameters.AddWithValue("@size", (object?)size ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@hash", (object?)hash ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@startedAt", Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(DateTime.UtcNow));
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken);
     }
 
     /// <summary>
@@ -179,7 +179,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"DELETE FROM ""RemoteInventory"" WHERE ""RelativePath"" = @path;";
         cmd.Parameters.AddWithValue("@path", relativePath);
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken);
     }
 
     /// <summary>
@@ -191,7 +191,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"DELETE FROM ""PendingOperation"" WHERE ""Path"" = @path;";
         cmd.Parameters.AddWithValue("@path", path);
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken);
     }
 
     /// <summary>
@@ -202,7 +202,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"SELECT ""RelativePath"", ""Size"", ""LastModified"", ""ContentHash"" FROM ""RemoteInventory"" WHERE ""RelativePath"" = @path;";
         cmd.Parameters.AddWithValue("@path", relativePath);
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken);
         if (await reader.ReadAsync(cancellationToken))
         {
             return new InventoryItem
@@ -275,7 +275,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
             cmd.Parameters.AddWithValue("@prefixlen", prefix.Length);
         }
 
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return new InventoryItem
@@ -312,7 +312,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"SELECT ""ID"", ""Path"", ""Operation"", ""Size"", ""Hash"", ""StartedAt"", ""Attempts"" FROM ""PendingOperation"" WHERE ""Path"" = @path;";
         cmd.Parameters.AddWithValue("@path", path);
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken);
         if (await reader.ReadAsync(cancellationToken))
         {
             return ReadPendingOperation(reader, cancellationToken);
@@ -353,7 +353,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
     {
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"SELECT COUNT(*) FROM ""RemoteInventory"";";
-        return Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken)) > 0;
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync(writeLog: false, cancellationToken)) > 0;
     }
 
     /// <summary>
@@ -365,7 +365,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
     {
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"SELECT COUNT(*) FROM ""PendingOperation"";";
-        return Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken)) > 0;
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync(writeLog: false, cancellationToken)) > 0;
     }
 
     /// <summary>
@@ -375,7 +375,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
     {
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"SELECT ""RelativePath"", ""Size"", ""LastModified"", ""ContentHash"" FROM ""RemoteInventory"";";
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
             yield return new InventoryItem
@@ -396,7 +396,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
     {
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"SELECT ""ID"", ""Path"", ""Operation"", ""Size"", ""Hash"", ""StartedAt"", ""Attempts"" FROM ""PendingOperation"";";
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
             yield return ReadPendingOperation(reader, cancellationToken);
@@ -418,7 +418,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         cmd.Parameters.AddWithValue("@operation", operation);
         cmd.Parameters.AddWithValue("@path", path);
         cmd.Parameters.AddWithValue("@data", (object?)data ?? DBNull.Value);
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken);
 
         // Throttle the audit-log purge so we don't run a DELETE on every logged
         // operation. The RemoteOperationTimestamp index makes the purge itself cheap
@@ -439,7 +439,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = @"DELETE FROM ""RemoteOperation"" WHERE ""Timestamp"" < @threshold;";
         cmd.Parameters.AddWithValue("@threshold", Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(threshold));
-        await cmd.ExecuteNonQueryAsync(cancellationToken);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken);
     }
 
     /// <summary>
@@ -474,7 +474,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
             {
                 using var cmd = m_connection.CreateCommand();
                 cmd.CommandText = $@"DROP TABLE IF EXISTS ""{m_name}"";";
-                await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+                await cmd.ExecuteNonQueryAsync(writeLog: false, default).ConfigureAwait(false);
             }
             catch
             {
@@ -495,7 +495,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
         var name = $"SyncTemp-{Library.Utility.Utility.GetHexGuid()}";
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = $@"CREATE TEMPORARY TABLE ""{name}"" ({columnDefinition});";
-        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken).ConfigureAwait(false);
         return new TempTable(m_connection, name);
     }
 
@@ -532,7 +532,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
                 cmd.SetParameterValue($"@s{n}", slice[i].Size);
                 cmd.SetParameterValue($"@m{n}", slice[i].ModifiedUtc.ToString("O"));
             }
-            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await cmd.ExecuteNonQueryAsync(writeLog: false, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -586,7 +586,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
             WHERE ri.""RelativePath"" IS NULL
             ORDER BY lf.""RelativePath"";
         ";
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return new SyncPlanRow
@@ -642,7 +642,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
                {hashClause}
             ORDER BY lf.""RelativePath"";
         ";
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return new SyncPlanRow
@@ -679,7 +679,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
               AND po.""Path"" IS NULL
             ORDER BY ri.""RelativePath"";
         ";
-        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using var reader = await cmd.ExecuteReaderAsync(writeLog: false, cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return new SyncPlanRow
@@ -701,7 +701,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
     {
         using var cmd = m_connection.CreateCommand();
         cmd.CommandText = $@"SELECT COUNT(*) FROM ""{tableName}"";";
-        return Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false), null);
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync(writeLog: false, cancellationToken).ConfigureAwait(false), null);
     }
 
     /// <summary>
@@ -717,7 +717,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
             LEFT JOIN ""RemoteInventory"" ri ON ri.""RelativePath"" = lf.""RelativePath""
             WHERE ri.""RelativePath"" IS NULL;
         ";
-        return Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false), null);
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync(writeLog: false, cancellationToken).ConfigureAwait(false), null);
     }
 
     /// <summary>
@@ -737,7 +737,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
                OR ri.""LastModified"" < lf.""LastModified""
                {hashClause};
         ";
-        return Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false), null);
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync(writeLog: false, cancellationToken).ConfigureAwait(false), null);
     }
 
     /// <summary>
@@ -754,7 +754,7 @@ public class LocalSyncDatabase : IDisposable, IBackendManagerDatabase
             WHERE lf.""RelativePath"" IS NULL
               AND po.""Path"" IS NULL;
         ";
-        return Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false), null);
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync(writeLog: false, cancellationToken).ConfigureAwait(false), null);
     }
 
     /// <summary>

--- a/Duplicati/Library/Main/Database/TemporaryDbValueList.cs
+++ b/Duplicati/Library/Main/Database/TemporaryDbValueList.cs
@@ -222,7 +222,7 @@ internal class TemporaryDbValueList : IDisposable, IAsyncDisposable
             for (int i = 0; i < slice.Length; i++)
                 _cmd.SetParameterValue(parameterNames[i], slice[i]);
 
-            await _cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+            await _cmd.ExecuteNonQueryAsync(writeLog: false, default).ConfigureAwait(false);
         }
     }
 

--- a/Duplicati/Library/Main/Duplicati.Library.Main.csproj
+++ b/Duplicati/Library/Main/Duplicati.Library.Main.csproj
@@ -8,6 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Keeps the database queries on the overloads that register with SlowQueryMonitor.
+         An extension method cannot win against the command's own methods, so the ban is
+         the only thing that stops the bare call shape from coming back. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" PrivateAssets="all" />
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CoCoL" Version="1.8.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StreamJsonRpc" Version="2.25.29" />

--- a/Duplicati/UnitTest/SQLiteTests.cs
+++ b/Duplicati/UnitTest/SQLiteTests.cs
@@ -19,7 +19,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Main.Database;
@@ -120,6 +122,83 @@ namespace Duplicati.UnitTest
                 command.ExpandInClauseParameter("@List", list);
                 Assert.AreEqual(1, await command.ExecuteScalarInt64Async(CancellationToken.None).ConfigureAwait(false));
             }
+        }
+
+        /// <summary>
+        /// Registers a function that takes longer than the monitor threshold. It is not
+        /// deterministic so it cannot be folded away while the statement is prepared, and
+        /// because the reader steps once while it is being created, the wait lands inside the
+        /// call under test rather than in the read loop.
+        /// </summary>
+        private static void AddSlowFunction(SqliteConnection connection, TimeSpan duration)
+            => connection.CreateFunction<long>("slow_marker", () => { Thread.Sleep(duration); return 1L; }, isDeterministic: false);
+
+        /// <summary>
+        /// Collects the warnings written while the body runs.
+        /// </summary>
+        /// <remarks>
+        /// The scope has to be established before the monitor is started: the log scope is held
+        /// in an <see cref="System.Threading.AsyncLocal{T}"/> and the monitor reports from a
+        /// <see cref="Timer"/> callback, which captures the execution context when it is created.
+        /// Controller does it in this order for the same reason. The queue is concurrent because
+        /// the timer thread writes while the test thread reads.
+        /// </remarks>
+        private static async Task<List<Library.Logging.LogEntry>> WarningsWhileAsync(TimeSpan threshold, Func<Task> body)
+        {
+            var captured = new System.Collections.Concurrent.ConcurrentQueue<Library.Logging.LogEntry>();
+            using (Library.Logging.Log.StartScope(e => captured.Enqueue(e)))
+            {
+                using var monitor = SlowQueryMonitor.StartMonitoring(threshold);
+
+                // A threshold below one second is read as a request to disable monitoring, so
+                // this also guards against the positive test passing quietly.
+                Assert.IsNotNull(monitor, "Slow query monitoring was not started");
+
+                await body().ConfigureAwait(false);
+            }
+
+            return captured.Where(e => e.Level == Library.Logging.LogMessageType.Warning && e.Id == "SlowQueryDetected").ToList();
+        }
+
+        [Test]
+        [Category("SQLite")]
+        public async Task ASlowReaderIsReportedAsync()
+        {
+            using var tf = new TempFile();
+            using var connection = await CreateDummyDatabaseAsync(tf).ConfigureAwait(false);
+            AddSlowFunction(connection, TimeSpan.FromSeconds(2.5));
+
+            var warnings = await WarningsWhileAsync(TimeSpan.FromSeconds(1), async () =>
+            {
+                await using var cmd = connection.CreateCommand();
+                cmd.CommandText = "SELECT slow_marker()";
+                await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, CancellationToken.None).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+
+            Assert.IsNotEmpty(warnings, "The query ran for longer than the threshold but was not reported");
+            Assert.IsTrue(warnings[0].FormattedMessage.Contains("slow_marker"), warnings[0].FormattedMessage);
+        }
+
+        [Test]
+        [Category("SQLite")]
+        public async Task AReaderRunThroughTheCommandsOwnMethodIsNotReportedAsync()
+        {
+            using var tf = new TempFile();
+            using var connection = await CreateDummyDatabaseAsync(tf).ConfigureAwait(false);
+            AddSlowFunction(connection, TimeSpan.FromSeconds(2.0));
+
+            var warnings = await WarningsWhileAsync(TimeSpan.FromSeconds(1), async () =>
+            {
+                await using var cmd = connection.CreateCommand();
+                cmd.CommandText = "SELECT slow_marker()";
+                // Deliberately the shape the rest of the codebase must not use. It binds to the
+                // command's own method rather than to the extension, so the monitor never sees
+                // it. This stays true even if a (SqliteCommand, CancellationToken) extension is
+                // added later, because an instance method wins over an extension method.
+                await using var rd = await cmd.ExecuteReaderAsync(CancellationToken.None).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+
+            Assert.IsEmpty(warnings, "The query was reported, so the shape is no longer the unmonitored one");
         }
     }
 }


### PR DESCRIPTION
`SlowQueryMonitor` cannot see the queries it exists to report. Found while trying to diagnose #7127, where the reporter set `--long-database-query-threshold` to one minute, watched a query run for five, and got no warning.

This does not fix #7127. See "About #7127" at the end for what I measured there.

## The problem

The monitor itself is fine. It is a periodic sweep that reports queries **still running** (`SlowQueryMonitor.cs`, the timer and `CheckSlowQueries`), so a query that never finishes is exactly what it is built to catch.

But registration only happens inside the extension methods in `Database/ExtensionMethods.cs`, and none of their `ExecuteReaderAsync` overloads takes a lone `CancellationToken`. So a call written as

```csharp
await cmd.ExecuteReaderAsync(token)
```

binds to `SqliteCommand`'s **own** method and is never registered. `ExecuteNonQueryAsync` and `ExecuteScalarAsync` have the same problem via `DbCommand`. **122 call sites** were in that shape: 80 readers, 36 non-queries, 6 scalars.

`WriteFilesetAsync` — where #7127 hangs — is one of them, which is why no threshold could ever have produced a warning there.

**Adding an overload that matches the bare shape would not help**, because an applicable instance method always wins over an extension method. There is a proof of that in the file already: the four-argument `ExecuteScalarAsync` calls `self.ExecuteScalarAsync(cancellationToken)`, which would be an unbounded recursion if the extension were picked. It is not, so the instance method wins — and the single-argument `ExecuteScalarAsync` extension was therefore unreachable dead code. Removed.

So the call has to name the overload it wants.

## Shape

Four commits, so the guard can be dropped on its own.

1. **Write down why the command's own methods must not be called** — remove the unreachable extension, put the recursion proof in the class docs, and record that the two `...PerformanceSensitiveAsync` methods skip the monitor *deliberately* (their callers are the per-block loops in the backup, where registering every statement would put a lock and a dictionary insert in the innermost loop). That bypass read like an oversight; now it says otherwise.
2. **Run the database queries through the monitored overload** — 122 sites, every hunk the same one-token edit inserting `writeLog: false`.
3. **The tests.**
4. **The guard.**

`writeLog: false` is behaviour-neutral: the overload forwards with a null command text and null values, both null-guarded, so the command text, parameters and transaction are untouched and the return type is unchanged. With `writeLog` false no profiling record is written and the printable command text is never built. The only difference is the registration. `writeLog: true` would have added two log records and a regex pass at all 122 sites.

The four non-queries that took no token at all now pass `default`, which is the token they already used.

## Tests

- **positive** — a query that runs longer than the threshold, executed through the monitored overload, produces the warning and the warning carries the sql
- **negative control** — the same query through the command's own method produces nothing. This is the executable proof of the shadowing rule, and it stays green even if someone later adds an extension matching the bare shape

Reverting the positive test's call to the bare shape makes **only that test** fail, so it tests what it claims to.

Three things about the setup are easy to get wrong and are commented in the code: the log scope has to be established *before* the monitor starts, because the scope lives in an `AsyncLocal` and the monitor reports from a `Timer` callback that captures the execution context when it is created (`Controller` does it in this order for the same reason); anything under a second is read as a request to disable monitoring, so the test asserts the monitor actually started; and the sink is a `ConcurrentQueue` because the timer thread writes while the test reads.

## The guard

`Microsoft.CodeAnalysis.BannedApiAnalyzers`, scoped to `Duplicati.Library.Main`, with `RS0030` set to error for that project in `.editorconfig`. Nothing in the language prevents the bare shape from returning by copy-paste, and a test that scans source text would be evadable by a local variable or a line break.

Worth noting: the analyzer flagged **exactly the seven calls inside `ExtensionMethods.cs`** — the layer that has to make them — and nothing else. That is an independent check, by the compiler rather than by my grep, that commit 2 missed nothing. That file disables the rule once with the reason rather than seven times.

**This is the first analyzer package in the repository**, so it is a separate commit. If you would rather not take it, drop commit 4; the rest stands on its own. The limitation is that it only covers `Library.Main` — the other callers of these methods are not monitored by design.

## Known limitation, not fixed here

On the monitored path the `QueryScope` is disposed when the reader is returned, so time spent in the caller's `ReadAsync` loop is still unmonitored. Only `ExecuteReaderEnumerableAsync` keeps the scope alive across the loop. It does not matter for #7127, where the time is spent in the first `sqlite3_step`, and fixing it properly means either returning a reader that owns the scope or moving callers to `ExecuteReaderEnumerableAsync` — both larger changes.

Also worth saying: the default threshold is 30 minutes, so reproduction instructions for a hang need `--long-database-query-threshold=10s` to get useful output quickly.

## Testing

- `--filter "Category=SQLite"`: 4 passed (2 existing, 2 new)
- reverting the positive test's call to the bare shape: 1 failed, 3 passed — the expected one
- `dotnet build Duplicati.slnx`: 0 errors
- `RS0030` violations outside `ExtensionMethods.cs`: 0

## About #7127

I could not reproduce it, and the hypothesis I went in with is refuted. Recording it here so the next person does not repeat the work.

The theory was that `PRAGMA optimize` (which runs at the end of every operation and is the only writer of `sqlite_stat1` in the tree) leaves statistics describing a nearly empty database after a small first backup, and that the second backup then plans `LIST_FOLDERS_AND_SYMLINKS` badly. To test it I built one database at the reporter's largest size — 1,111 folders / 11,110 files, the case reported as taking over an hour — and swapped the statistics underneath it, so the data was identical and only the statistics changed:

| statistics | FOLDERS_AND_SYMLINKS (1,111 rows) | FILESETS (11,110 rows) | `SCAN` steps |
| --- | --- | --- | --- |
| from the large backup | 0.054 s | 0.443 s | 0 |
| none at all | 0.048 s | 0.357 s | 0 |
| from the small backup | 0.065 s | 0.396 s | 0 |

Both queries in `WriteFilesetAsync` finish in well under a second in every configuration, and no plan contains a single `SCAN`. Also confirmed while there: `ENABLE_STAT4` is absent from this build of SQLite, so only `sqlite_stat1` exists.

I then ran the same scenario on all three CI operating systems, with this branch's monitored overloads and `--long-database-query-threshold=1s`:

| runner | small first backup | 11,110 files / 1,111 folders | third backup, unchanged | queries over 1 s |
| --- | --- | --- | --- | --- |
| windows-latest | 0.1 s | **15.2 s** | 3.7 s | **none** |
| macos-latest | 0.1 s | **16.9 s** | 2.3 s | **none** |
| ubuntu-latest | 0.1 s | **10.7 s** | 5.2 s | **none** |

The case reported as taking over an hour finishes in ten to seventeen seconds on every platform, and **not one query anywhere exceeded a single second**. The CI runners were faster than my own machine (81–130 s for the same backup), so machine speed does not explain it either.

What differs between my setup and the reporter's, as far as I know: my test files are at most 1 KiB with a 10 KiB blocksize, so `BlocklistHash` is empty on every run — though that only matters for the file query, and only for blocksets over ~3 MiB, so the reporter's small-file tree would have had none either; and I ran through the test fixture rather than a real install on Windows 10.

So #7127 stays open, and I have stopped guessing at it. **That is the argument for this PR.** Nobody outside the reporter's machine can reproduce it, and on that machine the one tool that would say which query is at fault has never been able to see it. With this PR in, `--long-database-query-threshold=10s` gives the query text and a running elapsed figure every ten seconds — the attribution that is currently impossible to obtain.
