### PR TITLE
Guard HyperV and MSSQL enumeration

### DIFF
--- a/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/HyperV.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/HyperV.cs
@@ -38,12 +38,12 @@ public class Hyperv : IFilesystemPlugin
         if (!OperatingSystem.IsWindows())
             return [];
 
-        var hypervUtility = new HyperVUtility();
-        if (!hypervUtility.IsHyperVInstalled || !new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
-            return [];
-
         try
         {
+            var hypervUtility = new HyperVUtility();
+            if (!hypervUtility.IsHyperVInstalled || !new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
+                return [];
+
             if (pathSegments.Length == 0)
             {
                 hypervUtility.QueryHyperVGuestsInfo(WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);

--- a/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/MSSQL.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/MSSQL.cs
@@ -36,12 +36,12 @@ public class MSSQL : IFilesystemPlugin
         if (!OperatingSystem.IsWindows())
             return [];
 
-        var mssqlUtility = new MSSQLUtility();
-        if (!mssqlUtility.IsMSSQLInstalled || !new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
-            return [];
-
         try
         {
+            var mssqlUtility = new MSSQLUtility();
+            if (!mssqlUtility.IsMSSQLInstalled || !new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
+                return [];
+
             mssqlUtility.QueryDBsInfo(WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);
 
             // Tier 1: Root Node Selection (%MSSQL%)


### PR DESCRIPTION
If the check for HyperV or MSSQL fails it will prevent showing the file tree.

With this PR, the check itself is now under try/catch so we return an empty list and log a warning instead of failing the list call.