### PR TITLE
Take the parent of a directory entry, not the entry itself

### DIFF
--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -659,7 +659,14 @@ namespace Duplicati.Library.Main.Operation
                     {
                         if (!options.Dryrun)
                         {
-                            var folderpath = SystemIO.IO_OS.PathGetDirectoryName(targetpath);
+                            // A directory entry's path ends with a separator, and PathGetDirectoryName
+                            // only strips that separator, so asking it directly answers with the entry
+                            // itself rather than with its parent. The guard below then always passes,
+                            // and a real folder is created where the entry belongs - a folder in place
+                            // of a symlink, and what is left behind if the symlink cannot be created
+                            // afterwards.
+                            var folderpath = SystemIO.IO_OS.PathGetDirectoryName(
+                                targetpath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
                             // Only create the folder if the folder path is different from the target path
                             // (i.e., targetpath is not a root-level folder)
                             // Also skip if the folder is outside the target destination

--- a/Duplicati/UnitTest/SymLinkTests.cs
+++ b/Duplicati/UnitTest/SymLinkTests.cs
@@ -179,5 +179,66 @@ namespace Duplicati.UnitTest
                 }
             }
         }
+
+        /// <summary>
+        /// Restores a directory symlink through both restore engines. The legacy engine applies
+        /// the stored metadata itself, and that is where a folder used to be created at the
+        /// symlink's own path, so this is the only test that covers it.
+        /// </summary>
+        [Test]
+        [Category("SymLink")]
+        public async Task SymlinkRestoreCreatesNoFolderAtItsOwnPathAsync([Values(true, false)] bool legacyRestore)
+        {
+            // Create symlink target directory with files in it
+            const string targetDirName = "target";
+            var targetDir = systemIO.PathCombine(this.DATAFOLDER, targetDirName);
+            systemIO.DirectoryCreate(targetDir);
+            foreach (var file in new[] { "a.txt", "b.txt", "c.txt" })
+                TestUtils.WriteFile(systemIO.PathCombine(targetDir, file), Encoding.Default.GetBytes(file));
+
+            const string symlinkDirName = "symlink";
+            var symlinkDir = systemIO.PathCombine(this.DATAFOLDER, symlinkDirName);
+            try
+            {
+                systemIO.CreateSymlink(symlinkDir, targetDir, asDir: true);
+            }
+            catch (Exception e)
+            {
+                // If client cannot create symlinks, mark test as ignored
+                Assert.Ignore($"Client could not create a symbolic link. Error reported: {e.Message}");
+            }
+
+            using (Controller c = new("file://" + this.TARGETFOLDER, this.TestOptions, null))
+            {
+                var backupResults = await c.BackupAsync(new[] { this.DATAFOLDER });
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(0, backupResults.Warnings.Count());
+            }
+
+            Dictionary<string, string> restoreOptions = new(this.TestOptions)
+            {
+                ["restore-path"] = this.RESTOREFOLDER,
+                // The stored target is in the source folder, which is outside the restore target
+                ["allow-restore-outside-target-directory"] = "true",
+                ["restore-legacy"] = legacyRestore.ToString()
+            };
+
+            using (Controller c = new("file://" + this.TARGETFOLDER, restoreOptions, null))
+            {
+                var restoreResults = await c.RestoreAsync(null);
+                Assert.AreEqual(0, restoreResults.Errors.Count());
+
+                // The legacy engine used to report "Creating missing folder <path> for target
+                // <path>\" here, because the parent of a directory entry was computed as the
+                // entry itself.
+                Assert.AreEqual(0, restoreResults.Warnings.Count(),
+                    $"warnings: {string.Join("; ", restoreResults.Warnings)}");
+
+                var restored = systemIO.PathCombine(this.RESTOREFOLDER, symlinkDirName);
+                Assert.That(systemIO.IsSymlink(restored), Is.True, "the restored path is not a symlink");
+                Assert.That(systemIO.PathGetFullPath(systemIO.GetSymlinkTarget(restored)),
+                    Is.EqualTo(systemIO.PathGetFullPath(targetDir)));
+            }
+        }
     }
 }


### PR DESCRIPTION
Towards #2640. Deliberately not `Closes` — most of that report is already fixed and one part of it is a feature request. See "The rest of #2640" below.

## The bug

#2640's debug log has these two lines:

```
Creating missing folder t:\restore_test\...\My Documents for target t:\restore_test\...\My Documents\
Failed to apply metadata to file: "t:\restore_test\...\My Documents\", message: File already exists: t:\...\My Documents
```

Note the two paths on the first line: they are **the same path**, one with a trailing separator and one without. That is `ApplyStoredMetadataAsync` in the legacy restore engine:

```csharp
var folderpath = SystemIO.IO_OS.PathGetDirectoryName(targetpath);
// Only create the folder if the folder path is different from the target path
// (i.e., targetpath is not a root-level folder)
if (!string.IsNullOrEmpty(folderpath) && folderpath != targetpath && …)
```

A directory entry's stored path ends with a separator (`SnapshotBase` appends one to folder entries), and `Path.GetDirectoryName` only strips that separator — `C:\a\b\` gives `C:\a\b`. So `folderpath` is **the entry itself**, not its parent, and the guard that was written to catch exactly this compares against the untrimmed path, so the separator makes it pass every time.

A real folder is then created where the entry belongs. For a directory symlink that is a folder in place of a link. `WriteMetadata` deletes it again before calling `CreateSymlink`, so today the end state is correct — but:

- **every legacy restore of a directory symlink emits a `CreateMissingFolder` warning**, right now, with no unusual options; and
- if `CreateSymlink` then fails — on Windows it needs Developer Mode or `SeCreateSymbolicLinkPrivilege` — the folder is what remains. **That is the empty folder #2640 reports.**

The fix trims the separator before asking for the parent. The block's intent is left intact: a genuinely missing parent is still created, which is what `CreateSymlink` needs.

**The new restore engine was never affected** — it applies metadata through `FileProcessor` and does not go through `ApplyStoredMetadataAsync`.

## Why this survived nine years

The legacy engine's symlink path has **no test on Windows at all**:

- `RestorePathTraversalTests` starts with `if (OperatingSystem.IsWindows()) Assert.Ignore("Symlink tests are not supported on Windows");` — and it is the only test that parameterises symlink behaviour over `restore-legacy`;
- `SymLinkTests` runs on Windows but never sets `restore-legacy`, so it only ever exercises the new engine.

The new test closes that hole. It parameterises `[Values(true, false)] bool legacyRestore` and **does not skip Windows** — that skip is what kept this alive. It keeps the existing capability guard, so a client that genuinely cannot create symlinks reports *Ignored* rather than *Failed*.

## Testing

Measured both directions on Windows 11 with Developer Mode enabled, so the symlinks are really created (0 skipped):

| | `legacyRestore=true` | `legacyRestore=false` | rest of `SymLinkTests` |
| --- | --- | --- | --- |
| before | **fails** | passes | passes |
| after | passes | passes | passes |

The failure before the fix is on the warning count, and it names the warning:

```
warnings: [Warning-…RestoreHandler-CreateMissingFolder]: Creating missing folder
…\restored\symlink for target …\restored\symlink\
```

which is the same shape as the line in the issue. `--filter "FullyQualifiedName~SymLinkTests"`: 6 passed, 0 skipped after the fix.

Regression set (`RestorePathTraversalTests`, `Issue6068`, `BorderTests`, `RestoreHandlerTests`, `SymLinkTests`): 61 passed, 3 skipped, 6 failed — all six are `RestoreVolumeCacheAsync` with a `TaskCanceledException` out of `VolumeManager.ReadFromEitherAsync`. **They are not related to this change**: on unmodified master the same run fails *seven* of them, including one that passes with the change. That fixture is unstable on my machine.

I paid particular attention to whether plain folder entries now behave differently, since their parent also changes from "the entry itself" to the real parent. They do not: `CreateDirectoryStructureAsync` pre-creates every folder entry before metadata is applied, so `CreateFolderIfNotExists` still returns false and still warns about nothing.

## The rest of #2640

Reported in 2017 against 2.0.1.73. What I found while checking whether it still reproduces:

| claim | status |
| --- | --- |
| directory symlinks restore as empty folders | **fixed** — the target is stored as `CoreSymlinkTarget` and `FileRestoreDestinationProvider` calls `CreateSymlink`; `SymLinkTests` verifies the round trip on Windows CI |
| file symlinks are not restored at all | **fixed in code** — same call site with `asDir: false`. But **no test anywhere covers a file symlink**; every existing symlink test passes `asDir: true` |
| directory junctions restore as empty folders | **partly.** A junction is detected and stored, because `FileInfo.LinkTarget` resolves mount points as well as symlinks, and the restore produces a working redirect — but as a *symlink*. There is no `CreateJunction` anywhere in the tree, so the reparse tag is not round-tripped (`IO_REPARSE_TAG_SYMLINK` where the source had `IO_REPARSE_TAG_MOUNT_POINT`). Whether that matters is a product call |
| file hardlinks restore as ordinary copies | **still true, by design.** `WindowsSnapshot.HardlinkTargetID` returns null, `hardlink-policy` is documented as Linux/macOS only, `HardlinkTargetId` is used solely to *exclude* paths during backup, the default `HardlinkStrategy.All` short-circuits even that, and there is no link-creation API in the tree. A feature request, not a bug |

So I would not close #2640 on this PR.

## One more thing, reported not fixed

`--skip-metadata` on restore silently suppresses symlink creation. The backup side stores `CoreSymlinkTarget` **regardless** of `--skip-metadata` — `MetadataGenerator` returns an empty dictionary and `MetadataPreProcess` adds the target on top of it, deliberately treating the target as the entry's identity rather than as metadata. The restore side disagrees: both engines gate the whole metadata application, which is the only path that creates a symlink, behind `SkipMetadata`. So a stored symlink is simply not created, and nothing says why. The option descriptions promise otherwise — `skip-metadata` is "metadata, such as file timestamps", and `symlink-policy` says "a restore will recreate the symlink as a link".

I left it out of this PR because the fix is not small: the symlink's metadata block is excluded from the restore block set when `--skip-metadata` is on, so requesting it needs the refcount union in `GetBlocksAndVolumeIDsAsync` narrowed to symlink entries (counting all of it, or none of it, makes `BlockManager` either complain at dispose or throw), and the legacy engine needs the same narrowing in `FindMissingBlocksAsync` before the containing dblock is downloaded at all. Happy to send it as its own PR.
