### PR TITLE
Let the restore cache test say what actually went wrong

### DIFF
--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -264,8 +264,21 @@ namespace Duplicati.UnitTest
             using var c = new Controller("file://" + this.TARGETFOLDER, opts, null);
             TestUtils.AssertResults(await c.BackupAsync([this.DATAFOLDER]));
 
-            // Start a 30 second timeout
-            var timeout_task = System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(30));
+            // This timeout is here to catch a deadlock, not to police throughput, so it has to
+            // outlast the point where the restore itself starts suspecting one. The deadlock
+            // threshold is a minute per 10 MB of volume size, so a minute for the 1 MB volumes
+            // used here, and BlockManager only warns about a possible deadlock at twice that.
+            // Anything shorter gives up before the restore would even complain, which turns a
+            // slow-but-working configuration into a failure - and two of the cache sizes under
+            // test are meant to be slow on purpose: with the cache disabled, or capped at a
+            // single volume, one 1 KiB block costs a fresh download and decrypt of a whole
+            // 1 MiB volume. On a four core machine the slowest case here has been measured
+            // between two and four minutes, varying by more than a factor of two between runs
+            // of the same case, so the budget is set well clear of that rather than close to
+            // it. Overshooting costs nothing when the restore works, and the wait after the
+            // abort below is bounded, so even a genuine hang fails rather than stalling.
+            var timeout = TimeSpan.FromMinutes(10);
+            var timeout_task = System.Threading.Tasks.Task.Delay(timeout);
 
             var restore_task = System.Threading.Tasks.Task.Run(async () =>
             {
@@ -277,8 +290,33 @@ namespace Duplicati.UnitTest
             if (t == timeout_task)
             {
                 await c.AbortAsync().ConfigureAwait(false);
-                await restore_task; // Ensure we wait for the restore task to complete
-                Assert.Fail("Restore timed out");
+
+                // Give the abort a bounded amount of time to land. Waiting on the restore
+                // without a bound is what this used to do, and an abort that does not stop the
+                // restore then hangs the test run rather than failing it - there is no test
+                // level timeout to fall back on.
+                var abort_grace = TimeSpan.FromMinutes(1);
+                var aborted = await System.Threading.Tasks.Task
+                    .WhenAny(restore_task, System.Threading.Tasks.Task.Delay(abort_grace))
+                    .ConfigureAwait(false) == restore_task;
+
+                if (aborted)
+                {
+                    // The abort just issued is what makes the restore fault, so its
+                    // cancellation must not replace the diagnosis below. Anything else the
+                    // restore threw is still worth surfacing.
+                    try
+                    {
+                        await restore_task.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+
+                    Assert.Fail($"Restore did not finish within {timeout.TotalSeconds:F0}s");
+                }
+
+                Assert.Fail($"Restore did not finish within {timeout.TotalSeconds:F0}s, and did not stop within {abort_grace.TotalSeconds:F0}s of being aborted");
             }
             else if (t == restore_task)
                 // Throw any exceptions it might have


### PR DESCRIPTION
`RestoreHandlerTests.RestoreVolumeCacheAsync` fails 6 or 7 of its 15 cases on my four-core Windows machine and passes on all three CI runners. It came up as noise in the regression runs for #7141 and #7149, so I chased it down. Test-only change; no product code is touched.

## What the failure actually was

Every failure looked like this:

```
System.Threading.Tasks.TaskCanceledException : A task was canceled.
   at CoCoL.Channel`1.ReadAsync(ITwoPhaseOffer offer)
   at …Restore.VolumeManager.ReadFromEither.ReadFromEitherAsync(CancellationToken token)
   at …RestoreHandler.DoRunNewAsync(…)
```

which reads like a cancellation race inside the restore. It is not. It is the test destroying its own error message:

```csharp
var t = await Task.WhenAny(timeout_task, restore_task);
if (t == timeout_task)
{
    await c.AbortAsync().ConfigureAwait(false);
    await restore_task;                 // rethrows the cancellation the abort just caused
    Assert.Fail("Restore timed out");   // never reached
}
```

The restore exceeds the 30 second budget → the test aborts the controller → `AbortAsync` cancels `ProgressToken` → `VolumeManager`'s pending channel read faults → `await restore_task` rethrows it **before** `Assert.Fail("Restore timed out")` runs. So the one line that would have explained the failure was unreachable, and what surfaced instead was the abort's own side effect.

I went in expecting a race between channel retirement and cancellation on normal shutdown. That was wrong, and worth stating: `ProgressToken` is cancelled from exactly one place, `TaskControl.Terminate()`, whose only caller is `Controller.AbortAsync()`. Normal completion does not cancel it, and neither does Stop.

## Three changes, all in the test

**The abort's cancellation no longer replaces the diagnosis.** Wrapped so the failure says the restore did not finish in time. Anything else the restore threw is still surfaced.

**The wait after the abort is bounded.** It used to be unbounded, with the comment "Ensure we wait for the restore task to complete". NUnit has no per-test timeout to fall back on, so an abort that does not stop the restore hangs the entire test run instead of failing it. **That happened to me: it sat for three hours, using 27 seconds of CPU, before I noticed.** A restore that will not stop is now a failure that says exactly that.

**The budget is 10 minutes rather than 30 seconds.** Reasoning below.

## Why 30 seconds was the wrong number

The timeout is there to catch a deadlock — that is what the commit that added the abort said. So it has to outlast the point where the restore itself starts suspecting one:

- `RestoreHandler` sets the deadlock threshold to one minute per 10 MB of volume size. With `dblock-size=1mb` that is one minute.
- `BlockManager` only warns `"…has been in flight for over N milliseconds. This may be a deadlock."` at **twice** that — 120 seconds.

A 30 second budget gives up before the restore would even complain. And two of the five cache sizes under test are **slow by design**:

- `0b` disables the cache, so every block request re-downloads, re-decrypts and re-opens a whole 1 MiB volume to extract one 1 KiB block; only same-volume concurrent requests coalesce.
- `1mb` caps the cache at exactly one volume's worth, so it holds one volume at a time and evicts and re-downloads on every alternation.

`5mb`, `1gb` and unset all fit every volume and are fast. That is exactly the pass/fail split, and it is why `channel_size` never mattered.

Measured here, whole-test durations for the slowest case across three runs of the *same* case:

| case | run A | run B | run C |
| --- | --- | --- | --- |
| `0b`, `0` | 1:47.96 | **3:48.40** | 1:57.91 |
| `0b`, `1` | 1:19.11 | 2:44.35 | 1:46.46 |
| `0b`, null | 0:55.07 | 1:46.52 | 1:33.73 |
| all 12 others | ≤1:17 | ≤0:43 | ≤0:46 |

More than a factor of two between runs of one case. I first tried 3 minutes; `0b`,`0` failed at 3m57s. 5 minutes passed twice but left only a slim margin against that spread, so I did not want to call it fixed on two green runs. 10 minutes is roughly 2.5× the worst observed value.

Overshooting costs nothing when the restore works — a passing case returns as soon as it finishes — and because the post-abort wait is now bounded, even a genuine hang fails within about 11 minutes instead of stalling forever.

## It is slowness, not a deadlock

With the budget raised, **all 15 cases pass and no `BlockRequestTimeout` warning appears anywhere** — the restore never suspects a deadlock. That is the measurement that says the right fix is the budget and not something in the restore.

## What I deliberately did not do

**I did not swallow the cancellation in `VolumeManager`.** That token was added so an abort can break a deadlocked restore out of a channel read; swallowing `OperationCanceledException` there would turn "terminate now" into a silent clean exit and make Abort-during-deadlock hang again. Stop would not be affected either way, since Stop never cancels `ProgressToken` — but Abort would, and that is the territory of #6461 and #7105.

**I did not disable or `[Explicit]` the test.** The slow cases are the ones with the most to say about the cache logic.

## Testing

- 10 minutes: **15/15**, three separate runs of the suite before and while settling on the value
- 3 minutes: `0b`,`0` fails at 3m57s — the measurement that ruled out 3 minutes
- before the change: 6 of 15 fail, all with `TaskCanceledException`; after the diagnosis fix alone, the same 6 fail with `Restore did not finish within 30s` and zero `TaskCanceledException`
- CI was green on this test before this PR, so CI can only show absence of regression here; the flakiness itself is only reproducible on a slower machine

## Two things found while reading, reported not fixed

- `ReadFromEither`'s comment says "the shutdown only happens on failure termination". That has been untrue since the cancellation token was added to make Abort work during a deadlock.
- Nothing in the new restore network observes `StopToken`, and `ProgressRendevouzAsync()` is only called once, before `VolumeManager`'s loop. So a Stop is not noticed until the whole network has drained. That looks related to #6461/#7105 and I intend to look at it separately.
