### PR TITLE
Stop an aborted restore from reporting errors, blaming the backup and leaking temp files

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -69,6 +69,11 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// </summary>
             private readonly IWriteChannel<object> m_volume_request;
             /// <summary>
+            /// The task reader for the restore, used to tell an abort apart from a real failure
+            /// when the invariants are checked in <see cref="Dispose"/>.
+            /// </summary>
+            private readonly Common.ITaskReader m_taskreader;
+            /// <summary>
             /// The dictionary holding the cached blocks.
             /// </summary>
             private readonly MemoryCache m_block_cache;
@@ -152,10 +157,12 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// </summary>
             /// <param name="volume_request">Channel for submitting block requests from a volume.</param>
             /// <param name="readers">Number of readers accessing this dictionary. Used during shutdown / cleanup.</param>
-            private SleepableDictionary(IWriteChannel<object> volume_request, Options options, int readers)
+            /// <param name="taskreader">The task reader for the restore.</param>
+            private SleepableDictionary(IWriteChannel<object> volume_request, Options options, int readers, Common.ITaskReader taskreader)
             {
                 m_options = options;
                 m_volume_request = volume_request;
+                m_taskreader = taskreader;
                 var cache_options = new MemoryCacheOptions();
                 m_block_cache = new MemoryCache(cache_options);
                 m_block_cache_max = options.RestoreCacheMax;
@@ -197,13 +204,13 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// <param name="volume_request">CoCoL channel for submitting block requests from a volume.</param>
             /// <param name="options">The restore options.</param>
             /// <param name="readers">The number of readers accessing this dictionary. Used during shutdown / cleanup.</param>
-            /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+            /// <param name="taskreader">The task reader for the restore. Its progress token cancels the enumeration, and it is retained so that <see cref="Dispose"/> can tell an abort apart from a real failure.</param>
             /// <returns>A task that when awaited returns a new instance of the <see cref="SleepableDictionary"/> class.</returns>
-            public static async Task<SleepableDictionary> CreateAsync(LocalRestoreDatabase db, IWriteChannel<object> volume_request, Options options, int readers, CancellationToken cancellationToken)
+            public static async Task<SleepableDictionary> CreateAsync(LocalRestoreDatabase db, IWriteChannel<object> volume_request, Options options, int readers, Common.ITaskReader taskreader)
             {
-                var sd = new SleepableDictionary(volume_request, options, readers);
+                var sd = new SleepableDictionary(volume_request, options, readers, taskreader);
 
-                await foreach (var (block_id, volume_id) in db.GetBlocksAndVolumeIDsAsync(options.SkipMetadata, cancellationToken).ConfigureAwait(false))
+                await foreach (var (block_id, volume_id) in db.GetBlocksAndVolumeIDsAsync(options.SkipMetadata, taskreader.ProgressToken).ConfigureAwait(false))
                 {
                     var bc = sd.m_blockcount.TryGetValue(block_id, out var c);
                     sd.m_blockcount[block_id] = bc ? c + 1 : 1;
@@ -411,11 +418,19 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// </summary>
             public void Dispose()
             {
+                // These are self-checks for a completed restore: they ask whether every block
+                // and volume that was counted up front was also consumed. An aborted restore
+                // stops with work outstanding by definition, so leftovers are the expected
+                // outcome rather than a defect, and reporting them as errors describes the abort
+                // as a failure. The retirement check below is not suppressed, because it holds
+                // on every path.
+                var aborted = RestoreCancellation.IsAborted(m_taskreader);
+
                 // Verify that the tables are empty
                 var blockcount = m_blockcount.Sum(x => x.Value);
                 var volumecount = m_volumecount.Sum(x => x.Value);
 
-                if (blockcount != 0)
+                if (blockcount != 0 && !aborted)
                 {
                     var blocks = m_blockcount
                         .Where(x => x.Value != 0)
@@ -425,7 +440,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCountError", null, $"Block count in SleepableDictionarys block table is not zero: {blockcount}{Environment.NewLine}First 10 blocks: {blockids}");
                 }
 
-                if (volumecount != 0)
+                if (volumecount != 0 && !aborted)
                 {
                     var vols = m_volumecount
                         .Where(x => x.Value != 0)
@@ -435,7 +450,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     Logging.Log.WriteErrorMessage(LOGTAG, "VolumeCountError", null, $"Volume count in SleepableDictionarys volume table is not zero: {volumecount}{Environment.NewLine}First 10 volumes: {volids}");
                 }
 
-                if (m_block_cache.Count > 0)
+                if (m_block_cache.Count > 0 && !aborted)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCacheMismatch", null, $"Internal Block cache is not empty: {m_block_cache.Count}");
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCacheMismatch", null, $"First 10 block counts in cache ({m_blockcount.Count}): {string.Join(", ", m_blockcount.Take(10).Select(x => x.Value))}");
@@ -494,7 +509,7 @@ namespace Duplicati.Library.Main.Operation.Restore
             {
                 // Create a cache for the blocks,
                 using SleepableDictionary cache =
-                    await SleepableDictionary.CreateAsync(db, self.Output, options, fp_requests.Length, results.TaskControl.ProgressToken)
+                    await SleepableDictionary.CreateAsync(db, self.Output, options, fp_requests.Length, results.TaskControl)
                         .ConfigureAwait(false);
 
                 // The volume consumer will read blocks from the input channel (data blocks from the volumes) and store them in the cache.

--- a/Duplicati/Library/Main/Operation/Restore/FileLister.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileLister.cs
@@ -175,6 +175,16 @@ namespace Duplicati.Library.Main.Operation.Restore
                         await self.Output.WriteAsync(new FileRequest(file.ID, file.OriginalPath, file.TargetPath, file.Hash, file.Length, file.BlocksetID, IsAlternateDataStream: true, Version: version, BackupTimestamp: backupTimestamp)).ConfigureAwait(false);
                     sw_write_file?.Stop();
                 }
+                catch (Exception) when (RestoreCancellation.IsAborted(result.TaskControl))
+                {
+                    // An abort is an orderly shutdown that arrived by a different signal than
+                    // retirement, so it is reported the same way retirement is. This is also the
+                    // only process without a `catch (RetiredException)`, and consulting the token
+                    // covers both.
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "File lister cancelled");
+                    threw_exception = true;
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "FileListerError", ex, "Error during file listing");

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -564,6 +564,13 @@ namespace Duplicati.Library.Main.Operation.Restore
                     }
                     return;
                 }
+                catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                {
+                    // An abort is an orderly shutdown that arrived by a different signal than
+                    // retirement, so it is reported the same way retirement is.
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "File processor cancelled");
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "FileProcessingError", ex, "Error during file processing");

--- a/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
+++ b/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
@@ -32,6 +32,34 @@ namespace Duplicati.Library.Main.Operation.Restore
 {
 
     /// <summary>
+    /// Helper for telling a requested shutdown apart from a genuine failure in the restore
+    /// process network.
+    /// </summary>
+    internal static class RestoreCancellation
+    {
+        /// <summary>
+        /// Returns whether the restore has been aborted, i.e. whether the cancellation the
+        /// processes are seeing was asked for rather than caused by a fault.
+        /// </summary>
+        /// <param name="taskReader">The task reader whose tokens to consult.</param>
+        /// <returns><c>true</c> if the operation was aborted.</returns>
+        /// <remarks>
+        /// The tokens are consulted rather than the exception type. A cancellation is not
+        /// identifiable from its exception: <see cref="System.Net.Http.HttpClient"/> reports its
+        /// own request timeouts as <see cref="System.Threading.Tasks.TaskCanceledException"/>, so
+        /// keying off the type would silently reclassify real backend timeouts as a requested
+        /// shutdown. Consulting the token instead follows the existing precedent in
+        /// <c>BackendManager.Handler</c>.
+        ///
+        /// <see cref="Common.ITaskReader.StopToken"/> is deliberately not consulted: nothing in
+        /// the restore process network observes it, so no cancellation can originate there.
+        /// </remarks>
+        public static bool IsAborted(Common.ITaskReader taskReader)
+            => taskReader.ProgressToken.IsCancellationRequested
+                || taskReader.TransferToken.IsCancellationRequested;
+    }
+
+    /// <summary>
     /// Represents the type of block request.
     /// </summary>
     public enum BlockRequestType

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
@@ -90,8 +90,21 @@ namespace Duplicati.Library.Main.Operation.Restore
                         Logging.Log.WriteExplicitMessage(LOGTAG, "BlockVolumeReader", null, "Created BlockVolumeReader for volume {0} (ID: {1})", volume_name, volume_id);
 
                         sw_write?.Start();
-                        // Pass the decrypted volume to the `VolumeDecompressor` process.
-                        await self.Output.WriteAsync((volume_id, volume_wrapper)).ConfigureAwait(false);
+                        try
+                        {
+                            // Pass the decrypted volume to the `VolumeDecompressor` process.
+                            await self.Output.WriteAsync((volume_id, volume_wrapper)).ConfigureAwait(false);
+                        }
+                        catch (Exception)
+                        {
+                            // The handoff failed, so no other process took ownership and nothing
+                            // else will dispose the volume. Without this the decrypted temporary
+                            // file stays open and is left behind, because the volume reader holds
+                            // it without `FileShare.Delete` and `TempFile`'s finalizer therefore
+                            // cannot delete it.
+                            volume_wrapper.Dispose();
+                            throw;
+                        }
                         sw_write?.Stop();
                         Logging.Log.WriteExplicitMessage(LOGTAG, "DecryptVolume", null, "Passed decrypted volume {0} (ID: {1}) to next stage", volume_name, volume_id);
                     }

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
@@ -85,7 +85,11 @@ namespace Duplicati.Library.Main.Operation.Restore
                         {
                             f = await backend.GetDirectAsync(volume_name, hash, size, allowParityRepair: true, results.TaskControl.TransferToken).ConfigureAwait(false);
                         }
-                        catch (Exception)
+                        // An abort cancels the transfer token, so without the guard every
+                        // download the abort itself cancelled would be recorded as a defect in
+                        // the backup. The progress token is consulted as well because the
+                        // `BackendManager` gives up on a download for either of them.
+                        catch (Exception) when (!RestoreCancellation.IsAborted(results.TaskControl))
                         {
                             lock (results)
                                 results.BrokenRemoteFiles.Add(volume_name);
@@ -97,7 +101,17 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         // Pass the download handle (which may or may not have downloaded already) to the `VolumeDecryptor` process.
                         sw_write?.Start();
-                        await self.Output.WriteAsync((volume_id, volume_name, f)).ConfigureAwait(false);
+                        try
+                        {
+                            await self.Output.WriteAsync((volume_id, volume_name, f)).ConfigureAwait(false);
+                        }
+                        catch (Exception)
+                        {
+                            // The handoff failed, so the decryptor never took ownership of the
+                            // downloaded file and nothing else will dispose it.
+                            f.Dispose();
+                            throw;
+                        }
                         sw_write?.Stop();
                         Logging.Log.WriteExplicitMessage(LOGTAG, "DownloadVolume", null, "Passed volume {0} (ID: {1}) to next stage", volume_name, volume_id);
                     }
@@ -110,6 +124,16 @@ namespace Duplicati.Library.Main.Operation.Restore
                     {
                         Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", $"Read: {sw_read!.ElapsedMilliseconds}ms, Write: {sw_write!.ElapsedMilliseconds}ms, Wait: {sw_wait!.ElapsedMilliseconds}ms");
                     }
+                }
+                catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                {
+                    // An abort is an orderly shutdown that arrived by a different signal than
+                    // retirement, so it is reported the same way retirement is. The retirement
+                    // of the channels is still needed to tear the network down.
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "Volume downloader cancelled");
+                    self.Input.Retire();
+                    self.Output.Retire();
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
@@ -330,10 +330,44 @@ namespace Duplicati.Library.Main.Operation.Restore
                             Logging.Log.WriteProfilingMessage(LOGTAG, "CacheUsage", $"Max used cache size: {Duplicati.Library.Utility.Utility.FormatSizeString(cache_size_max_consumed)}");
                         }
                     }
+                    catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                    {
+                        // An abort is an orderly shutdown that arrived by a different signal
+                        // than retirement, so it is reported the same way retirement is.
+                        Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "Volume manager cancelled");
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         Logging.Log.WriteErrorMessage(LOGTAG, "VolumeManagerError", ex, "Error during volume manager");
                         throw;
+                    }
+                    finally
+                    {
+                        // Nothing else disposes what is left in the cache. `handle_evict` is
+                        // only reached from a `CacheEvict` request or from an eviction, so on
+                        // any early exit the cached volumes keep their decrypted temporary
+                        // files open. The finalizer in `TempFile` cannot recover them either,
+                        // because the volume reader holds the file without `FileShare.Delete`,
+                        // so the delete fails and is swallowed. On Windows that leaves the
+                        // files behind until the 30-day cleanup.
+                        //
+                        // Placed in a `finally` rather than in the catch blocks so it also
+                        // covers a non-exceptional exit, and it reuses `handle_evict` so that
+                        // `cache_size` and `cache_last_touched` stay consistent. `cache.Keys`
+                        // has to be copied because `handle_evict` removes from the dictionary.
+                        try
+                        {
+                            foreach (var volume_id in cache.Keys.ToList())
+                                handle_evict(volume_id);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Disposing a volume reaches a compression module's `Dispose`, and
+                            // an exception from there must not replace the exception that is
+                            // currently unwinding.
+                            Logging.Log.WriteWarningMessage(LOGTAG, "CacheDrainError", ex, "Failed to dispose the cached volumes");
+                        }
                     }
                 }
             );

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -544,5 +544,174 @@ namespace Duplicati.UnitTest
             Assert.IsTrue(File.Exists(restoredSmallFilePath), "The small file should have been restored");
             Assert.IsFalse(File.Exists(restoredLargeFilePath), "The large file should not have been restored");
         }
+
+        /// <summary>
+        /// An abort is a requested shutdown, so it should not report errors of its own, should
+        /// not blame the backup for a download it cancelled itself, and should not leave the
+        /// volumes it had cached behind on disk.
+        /// </summary>
+        [Test]
+        [Category("RestoreHandler")]
+        public async Task AbortedRestoreIsCleanAsync()
+        {
+            const int volumesBeforeAbort = 3;
+
+            var backupOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "200kb",
+                ["blocksize"] = "4kb"
+            };
+
+            // Enough distinct data to fill several volumes, so some are still cached when the
+            // abort lands
+            var rng = new Random(42);
+            var data = new byte[32 * 1024];
+            for (var i = 0; i < 40; i++)
+            {
+                rng.NextBytes(data);
+                File.WriteAllBytes(Path.Combine(this.DATAFOLDER, $"file{i}"), data);
+            }
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            // The decrypted volumes are created with `new TempFile()`, which resolves through
+            // TempFolder.SystemTempPath rather than through --tempdir, so that is what has to
+            // be redirected for the test to be able to count what is left behind.
+            var tempdir = Path.Combine(BASEFOLDER, "aborted-restore-temp");
+            Directory.CreateDirectory(tempdir);
+            var previousTempPath = Library.Utility.TempFolder.SystemTempPath;
+            Library.Utility.TempFolder.SystemTempPath = tempdir;
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var downloaded = 0;
+            var enoughDownloaded = new TaskCompletionSource();
+
+            // Used as a hook rather than as a source of errors: it always answers "no error",
+            // but it slows every volume download down so the restore cannot outrun the abort,
+            // and it signals once enough volumes have been fetched. Without this the abort
+            // would land at a different point on every machine.
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (!remotename.Contains(".dblock.", StringComparison.Ordinal))
+                    return false;
+
+                if (action != DeterministicErrorBackend.BackendAction.GetBefore)
+                    return false;
+
+                // Signalled before the delay rather than after it, so the abort is guaranteed
+                // to land while a download is still in flight
+                if (System.Threading.Interlocked.Increment(ref downloaded) >= volumesBeforeAbort)
+                    enoughDownloaded.TrySetResult();
+
+                System.Threading.Thread.Sleep(1500);
+                return false;
+            };
+
+            try
+            {
+                var restoreOptions = new Dictionary<string, string>(this.TestOptions)
+                {
+                    ["dblock-size"] = "200kb",
+                    ["blocksize"] = "4kb",
+                    ["restore-path"] = this.RESTOREFOLDER,
+                    ["restore-legacy"] = "false",
+                    // Force the blocks to come from the destination rather than from the source
+                    ["restore-with-local-blocks"] = "false",
+                    // Several downloaders so that requests are queued behind the slow one and
+                    // the abort has something in flight to cancel
+                    ["restore-volume-downloaders"] = "4",
+                    ["restore-volume-decryptors"] = "1",
+                    ["restore-volume-decompressors"] = "1",
+                    ["restore-file-processors"] = "1",
+                    ["tempdir"] = tempdir
+                    // restore-volume-cache-hint is deliberately left unset, which means
+                    // unlimited: the volumes stay cached, which is the state this test is about.
+                };
+
+                var beforeRestore = Directory.GetFiles(tempdir, "*", SearchOption.AllDirectories).ToHashSet(StringComparer.Ordinal);
+
+                var restoreErrors = new System.Collections.Concurrent.ConcurrentQueue<string>();
+                var cachedVolumes = 0;
+                // Spelled out rather than taken from the types, which are internal to
+                // Duplicati.Library.Main
+                const string restoreNamespace = "Duplicati.Library.Main.Operation.Restore.";
+                const string volumeManagerTag = restoreNamespace + "VolumeManager";
+
+                Library.Main.RestoreResults? restoreResults = null;
+                using var c = new Controller(new DeterministicErrorBackend().ProtocolKey + "://" + this.TARGETFOLDER, restoreOptions, null);
+                c.OnOperationStarted += r => restoreResults = (Library.Main.RestoreResults)r;
+
+                using (Library.Logging.Log.StartScope(e =>
+                {
+                    // Scoped to the restore process network. Controller logs FailedOperation of
+                    // its own on an abort, and how an aborted operation is classified is a
+                    // separate matter from what the network reports.
+                    if (e.Level == Library.Logging.LogMessageType.Error
+                        && e.Tag != null && e.Tag.StartsWith(restoreNamespace, StringComparison.Ordinal))
+                        restoreErrors.Enqueue($"{e.Tag.Split('.').Last()}/{e.Id}: {e.FormattedMessage}");
+
+                    // Guards against a vacuous pass: if nothing was ever cached there is
+                    // nothing for the abort to leave behind.
+                    if (e.Tag == volumeManagerTag && e.FormattedMessage != null
+                        && e.FormattedMessage.StartsWith("Caching volume", StringComparison.Ordinal))
+                        System.Threading.Interlocked.Increment(ref cachedVolumes);
+                }))
+                {
+                    var restoreTask = Task.Run(async () => await c.RestoreAsync(new[] { "*" }));
+
+                    var trigger = await Task.WhenAny(enoughDownloaded.Task, restoreTask, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false);
+                    if (trigger == restoreTask)
+                        Assert.Ignore("The restore finished before it could be aborted; the download hook is not slowing it down enough");
+                    if (trigger != enoughDownloaded.Task)
+                        Assert.Fail($"The restore did not download {volumesBeforeAbort} volumes within a minute");
+
+                    await c.AbortAsync().ConfigureAwait(false);
+
+                    var stopped = await Task.WhenAny(restoreTask, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false) == restoreTask;
+                    Assert.IsTrue(stopped, "The abort did not stop the restore within a minute");
+
+                    try
+                    {
+                        await restoreTask.ConfigureAwait(false);
+                        Assert.Fail("The aborted restore was expected to fault");
+                    }
+                    catch (Exception)
+                    {
+                        // The type is deliberately not asserted: which task in the network faults
+                        // first decides it, and classifying an aborted restore is a separate matter.
+                    }
+                }
+
+                // No GC.Collect anywhere: the point is that the volumes are disposed
+                // explicitly, and a forced collection would let a finalizer do that job.
+                var leftover = Directory.GetFiles(tempdir, "*", SearchOption.AllDirectories)
+                    .Where(x => !beforeRestore.Contains(x))
+                    .ToList();
+
+                // Checked on its own first: if nothing was ever cached the remaining
+                // assertions could pass without proving anything.
+                Assert.Greater(cachedVolumes, 0, "No volume was ever cached, so the test would pass without proving anything");
+
+                // The three claims are independent, so report all of them rather than only
+                // whichever happens to be checked first.
+                NUnit.Framework.Assert.Multiple(() =>
+                {
+                    Assert.AreEqual(0, restoreErrors.Count,
+                        $"An aborted restore reported errors:{Environment.NewLine}{string.Join(Environment.NewLine, restoreErrors)}");
+
+                    Assert.AreEqual(0, restoreResults!.BrokenRemoteFiles.Count(),
+                        $"An aborted restore blamed the backup for {string.Join(", ", restoreResults.BrokenRemoteFiles)}");
+
+                    Assert.AreEqual(0, leftover.Count,
+                        $"An aborted restore left temporary files behind:{Environment.NewLine}{string.Join(Environment.NewLine, leftover)}");
+                });
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+                Library.Utility.TempFolder.SystemTempPath = previousTempPath;
+            }
+        }
     }
 }


### PR DESCRIPTION
Aborting a restore is a requested shutdown, but the restore process network treats the cancellation it causes as a failure. It came up while I was chasing the flaky `RestoreVolumeCacheAsync` fixture (#7151): the abort that test issues on timeout reproducibly logged a wall of errors. I started out reading that as log noise. Two of the three symptoms turned out to have real consequences.

## What an abort does today

Aborting a restore produced these every time, across four separate configurations. A restore that completes normally logs none of them:

```
BlockManager/BlockCountError:      Block count in SleepableDictionarys block table is not zero: 1821
BlockManager/VolumeCountError:     Volume count in SleepableDictionarys volume table is not zero: 1821
VolumeManager/VolumeManagerError:  Error during volume manager
FileLister/FileListerError:        Error during file listing
VolumeDownloader/DownloadError     (only when a download was in flight)
Controller/FailedOperation:        The operation Restore has failed
```

**That number is not a file count.** It is the sum of the outstanding per-block and per-volume approval counters, so it scales with the block count of the restore. The `First 10 volumes: 5, 7` line printed alongside it showed only *two* distinct volumes actually left over. The leak is a few MB, but the number reads three orders of magnitude worse than it is.

### The temporary files are a real leak

`VolumeManager`'s volume cache is not drained on any exit path. The only thing that calls `volume.Dispose()` is `handle_evict`, reached from a `CacheEvict` request or from an LRU/disk-pressure eviction. Neither `catch (RetiredException)` nor `catch (Exception)` touches the cache, and there was no `finally`.

`TempFile` has a finalizer, but it cannot recover these. `BlockVolumeReader` opens the file with `FileShare.Read` and no `FileShare.Delete`, and `VolumeReaderBase` has no finalizer of its own. So `~TempFile`'s `File.Delete` fails with a sharing violation, the failure is swallowed by a bare `catch { }`, and `m_path` is never cleared. On Windows the decrypted volumes stay on disk until `RemoveOldApplicationTempFiles` reaches them 30 days later.

A second path leaks the same way: `VolumeDecryptor` builds a `VolumeWrapper` around the decrypted file and hands it to the next process. If that handoff fails — which is what a cancellation does — nothing owns the wrapper any more and nobody disposes it. `VolumeDownloader` has the same shape with the raw downloaded `TempFile`. This one only shows up under load, and it is what kept the new test red after the cache drain was in place.

### An aborted download is recorded as a defect in the backup

`VolumeDownloader` wrapped `GetDirectAsync` in an unconditional `catch (Exception)` that adds the volume to `results.BrokenRemoteFiles`. An abort cancels the transfer token, so every download the abort itself cancelled was reported as a broken remote file. That is a factual error in the result, not just noise.

### The five errors describe a requested stop as a failure

`BlockCountError` arrived as a warning in [`7c79535572c0ed2df6a9cc609b70a5a2ac7f06cc`](https://github.com/duplicati/duplicati/commit/7c79535572c0ed2df6a9cc609b70a5a2ac7f06cc) (2024-11-25), as a self-check for a *completed* restore — the comment it added above it still says `// Verify that the tables are empty` — and was promoted to an error in [`531471e3b554563791a786b696e2a9e18eed6431`](https://github.com/duplicati/duplicati/commit/531471e3b554563791a786b696e2a9e18eed6431) (2025-09-30), along with `VolumeCountError`. Neither change considered the abort path. An aborted restore stops with work outstanding by definition, so leftovers are the expected outcome there.

The other four are `OperationCanceledException` falling into a broad `catch (Exception)`. None of the six restore processes treated cancellation as anything but a fault.

## The change

**One shared predicate.** `RestoreCancellation.IsAborted(ITaskReader)` in `Restore/Interfaces.cs`, consulting `ProgressToken` and `TransferToken`.

**Not keyed off the exception type.** `HttpClient` reports its own request timeouts as `TaskCanceledException`, so a `when (ex is not OperationCanceledException)` guard would silently reclassify real backend timeouts as a requested shutdown and hide them. Consulting the tokens follows the existing precedent in `BackendManager.Handler`. `StopToken` is deliberately left out: nothing in the restore network observes it, so no cancellation can originate there.

**Five error sites now report an abort as an orderly shutdown.** A `catch (Exception) when (IsAborted(...))` in front of each broad catch, logging `CancelledProcess` at Verbose and rethrowing, in `VolumeManager`, `FileLister`, `VolumeDownloader` and `FileProcessor`; and the three invariant checks in `SleepableDictionary.Dispose` guarded. Verbose because all six processes already log `RetiredProcess` at Verbose on a normal exit — an abort is the same orderly shutdown reached by a different signal. Every site still rethrows, so the network still tears down and `RestoreHandler` still sees a failure.

`SleepableDictionary.CreateAsync` took a `CancellationToken` and discarded it after the enumeration; it now takes the `ITaskReader` and keeps it. One call site.

**`NotRetired` is deliberately not guarded.** `Dispose` only runs after every block handler has finished, and every path calls `cache.Retire()`, so it cannot misfire on an abort. It is a genuine "forgot to retire" detector and blinding it would cost real coverage.

**`BrokenRemoteFiles` is only recorded when the failure was not an abort.** The progress token is consulted as well as the transfer token, because `BackendManager` gives up on a download for either.

**The cache is drained in a `finally`.** It reuses `handle_evict` so `cache_size` and `cache_last_touched` stay consistent, copies `cache.Keys` because `handle_evict` removes from the dictionary, and is itself wrapped in try/catch — disposing a volume reaches a third-party compression module's `Dispose`, and an exception from there must not replace the `OperationCanceledException` that is unwinding. In a `finally` rather than in the catch blocks so it also covers a non-exceptional exit.

`VolumeWrapper.Dispose()` releases one reference, so this is correct even when another holder still has one; `VolumeDecompressor` always releases its own via `using var _ = volume;`.

**Both handoffs dispose what they could not pass on.**

## Testing

New test `RestoreHandlerTests.AbortedRestoreIsCleanAsync`. Three independent claims, all measured before and after:

| claim | before (3 runs) | after |
| --- | --- | --- |
| no error-level log from the restore namespace | 5, 6, 7 errors | 0 |
| `BrokenRemoteFiles` empty | 1, 2, 3 entries | 0 |
| no leftover temporary files | 2, 1, 1 files | 0 |

Applied in stages so each fix is attributable: the predicate and the five log sites alone took the errors to 0 and `BrokenRemoteFiles` to 0 while the files were still left behind; the cache drain took the isolated test green; the two handoff disposals were needed for the suite run, where the abort lands at a different point.

- `Category=RestoreHandler`: **34/34, twice** on the final tree
- new test in isolation: **3/3**

`RestoreVolumeCacheAsync` is excluded from the local runs — it is flaky on this machine for unrelated reasons and #7151 has the fix; CI passes it and covers it here.

Test notes worth stating, because each one hid the bug at some point:

- `DeterministicErrorBackend` is used as a *hook*, not an error source. It always answers "no error", but it delays each `dblock` fetch and signals a `TaskCompletionSource` before the delay, so the abort is guaranteed to land while a download is in flight rather than wherever the machine's speed happens to put it.
- `--tempdir` does not move these files. The decrypted volumes come from `new TempFile()` in `BackendManager.GetOperation`, which resolves through `TempFolder.SystemTempPath`, so that is what the test redirects.
- `restore-volume-cache-hint` is deliberately left unset. Setting it to `0b` disables the cache, which leaves nothing for the abort to leak, so the test would pass while proving nothing. There is an explicit assertion that at least one volume was cached, to catch exactly that.
- **No `GC.Collect()` anywhere.** The point is that the volumes are disposed explicitly; a forced collection would let a finalizer do the job and turn the red green for the wrong reason.
- `TestUtils.AssertResults` is used on the backup only. It fails on any warning, and an aborted restore legitimately warns.

## Found while reading, reported not fixed

- **`Controller` classifies an abort as `Fatal` with phase `Error`** and leaves `Interrupted` false, while the graceful abort path in the same file sets `Interrupted = true` under the comment `// Requested aborts are not failures.` This changes user-visible result classification (exit codes, report modules), so it belongs in its own PR.
- **`ReadFromEither` drops a value it has already consumed.** Both channels are read at once, so the read that loses the race stays outstanding and may already hold a volume by the time the loop exits. Its own comment says this is safe "because the shutdown only happens on failure termination", which stopped being true when the cancellation token was added. I wrote a fix for this and then backed it out: with the two handoff disposals in place it was not needed to make the test green, and I would rather not widen this PR on a path I cannot demonstrate.
- **Volumes buffered in the `DecompressionRequest` channel are unreachable.** The buffer holds up to `Environment.ProcessorCount` entries and each carries a reference, so a cached volume the drain released can still be held by a buffered request. CoCoL is a NuGet package and `VolumeManager` only holds the write end, so there is nowhere to drain from. Bounded by the buffer size, unlike the cache.
- **`SleepableDictionary.m_block_cache` is never disposed** on any path. Not abort-specific, and a plain `Dispose()` would not return the pooled buffers anyway — the post-eviction callback does not run, so it would need `Compact`/`Clear` and that is a behaviour change.
- **`FileProcessor` has three unconditional `BrokenLocalFiles.Add` calls**, the twin of the `BrokenRemoteFiles` problem fixed here. I left them alone because the argument is not the same: a local target file that was half-written when the abort landed arguably *is* suspect, whereas a download that was simply cancelled is not. Worth a maintainer's opinion.
