### PR TITLE
Make the restore notice a stop while it is running

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -419,18 +419,18 @@ namespace Duplicati.Library.Main.Operation.Restore
             public void Dispose()
             {
                 // These are self-checks for a completed restore: they ask whether every block
-                // and volume that was counted up front was also consumed. An aborted restore
-                // stops with work outstanding by definition, so leftovers are the expected
-                // outcome rather than a defect, and reporting them as errors describes the abort
-                // as a failure. The retirement check below is not suppressed, because it holds
-                // on every path.
-                var aborted = RestoreCancellation.IsAborted(m_taskreader);
+                // and volume that was counted up front was also consumed. A restore that was
+                // asked to stop or was aborted ends with work outstanding by definition, so
+                // leftovers are the expected outcome rather than a defect, and reporting them as
+                // errors describes a requested shutdown as a failure. The retirement check below
+                // is not suppressed, because it holds on every path.
+                var shutdown_requested = RestoreCancellation.IsShutdownRequested(m_taskreader);
 
                 // Verify that the tables are empty
                 var blockcount = m_blockcount.Sum(x => x.Value);
                 var volumecount = m_volumecount.Sum(x => x.Value);
 
-                if (blockcount != 0 && !aborted)
+                if (blockcount != 0 && !shutdown_requested)
                 {
                     var blocks = m_blockcount
                         .Where(x => x.Value != 0)
@@ -440,7 +440,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCountError", null, $"Block count in SleepableDictionarys block table is not zero: {blockcount}{Environment.NewLine}First 10 blocks: {blockids}");
                 }
 
-                if (volumecount != 0 && !aborted)
+                if (volumecount != 0 && !shutdown_requested)
                 {
                     var vols = m_volumecount
                         .Where(x => x.Value != 0)
@@ -450,7 +450,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     Logging.Log.WriteErrorMessage(LOGTAG, "VolumeCountError", null, $"Volume count in SleepableDictionarys volume table is not zero: {volumecount}{Environment.NewLine}First 10 volumes: {volids}");
                 }
 
-                if (m_block_cache.Count > 0 && !aborted)
+                if (m_block_cache.Count > 0 && !shutdown_requested)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCacheMismatch", null, $"Internal Block cache is not empty: {m_block_cache.Count}");
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCacheMismatch", null, $"First 10 block counts in cache ({m_blockcount.Count}): {string.Join(", ", m_blockcount.Take(10).Select(x => x.Value))}");

--- a/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/BlockManager.cs
@@ -69,6 +69,11 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// </summary>
             private readonly IWriteChannel<object> m_volume_request;
             /// <summary>
+            /// The task reader for the restore, used to tell an abort apart from a real failure
+            /// when the invariants are checked in <see cref="Dispose"/>.
+            /// </summary>
+            private readonly Common.ITaskReader m_taskreader;
+            /// <summary>
             /// The dictionary holding the cached blocks.
             /// </summary>
             private readonly MemoryCache m_block_cache;
@@ -152,10 +157,12 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// </summary>
             /// <param name="volume_request">Channel for submitting block requests from a volume.</param>
             /// <param name="readers">Number of readers accessing this dictionary. Used during shutdown / cleanup.</param>
-            private SleepableDictionary(IWriteChannel<object> volume_request, Options options, int readers)
+            /// <param name="taskreader">The task reader for the restore.</param>
+            private SleepableDictionary(IWriteChannel<object> volume_request, Options options, int readers, Common.ITaskReader taskreader)
             {
                 m_options = options;
                 m_volume_request = volume_request;
+                m_taskreader = taskreader;
                 var cache_options = new MemoryCacheOptions();
                 m_block_cache = new MemoryCache(cache_options);
                 m_block_cache_max = options.RestoreCacheMax;
@@ -197,13 +204,13 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// <param name="volume_request">CoCoL channel for submitting block requests from a volume.</param>
             /// <param name="options">The restore options.</param>
             /// <param name="readers">The number of readers accessing this dictionary. Used during shutdown / cleanup.</param>
-            /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+            /// <param name="taskreader">The task reader for the restore. Its progress token cancels the enumeration, and it is retained so that <see cref="Dispose"/> can tell an abort apart from a real failure.</param>
             /// <returns>A task that when awaited returns a new instance of the <see cref="SleepableDictionary"/> class.</returns>
-            public static async Task<SleepableDictionary> CreateAsync(LocalRestoreDatabase db, IWriteChannel<object> volume_request, Options options, int readers, CancellationToken cancellationToken)
+            public static async Task<SleepableDictionary> CreateAsync(LocalRestoreDatabase db, IWriteChannel<object> volume_request, Options options, int readers, Common.ITaskReader taskreader)
             {
-                var sd = new SleepableDictionary(volume_request, options, readers);
+                var sd = new SleepableDictionary(volume_request, options, readers, taskreader);
 
-                await foreach (var (block_id, volume_id) in db.GetBlocksAndVolumeIDsAsync(options.SkipMetadata, cancellationToken).ConfigureAwait(false))
+                await foreach (var (block_id, volume_id) in db.GetBlocksAndVolumeIDsAsync(options.SkipMetadata, taskreader.ProgressToken).ConfigureAwait(false))
                 {
                     var bc = sd.m_blockcount.TryGetValue(block_id, out var c);
                     sd.m_blockcount[block_id] = bc ? c + 1 : 1;
@@ -411,11 +418,19 @@ namespace Duplicati.Library.Main.Operation.Restore
             /// </summary>
             public void Dispose()
             {
+                // These are self-checks for a completed restore: they ask whether every block
+                // and volume that was counted up front was also consumed. An aborted restore
+                // stops with work outstanding by definition, so leftovers are the expected
+                // outcome rather than a defect, and reporting them as errors describes the abort
+                // as a failure. The retirement check below is not suppressed, because it holds
+                // on every path.
+                var aborted = RestoreCancellation.IsAborted(m_taskreader);
+
                 // Verify that the tables are empty
                 var blockcount = m_blockcount.Sum(x => x.Value);
                 var volumecount = m_volumecount.Sum(x => x.Value);
 
-                if (blockcount != 0)
+                if (blockcount != 0 && !aborted)
                 {
                     var blocks = m_blockcount
                         .Where(x => x.Value != 0)
@@ -425,7 +440,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCountError", null, $"Block count in SleepableDictionarys block table is not zero: {blockcount}{Environment.NewLine}First 10 blocks: {blockids}");
                 }
 
-                if (volumecount != 0)
+                if (volumecount != 0 && !aborted)
                 {
                     var vols = m_volumecount
                         .Where(x => x.Value != 0)
@@ -435,7 +450,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     Logging.Log.WriteErrorMessage(LOGTAG, "VolumeCountError", null, $"Volume count in SleepableDictionarys volume table is not zero: {volumecount}{Environment.NewLine}First 10 volumes: {volids}");
                 }
 
-                if (m_block_cache.Count > 0)
+                if (m_block_cache.Count > 0 && !aborted)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCacheMismatch", null, $"Internal Block cache is not empty: {m_block_cache.Count}");
                     Logging.Log.WriteErrorMessage(LOGTAG, "BlockCacheMismatch", null, $"First 10 block counts in cache ({m_blockcount.Count}): {string.Join(", ", m_blockcount.Take(10).Select(x => x.Value))}");
@@ -494,7 +509,7 @@ namespace Duplicati.Library.Main.Operation.Restore
             {
                 // Create a cache for the blocks,
                 using SleepableDictionary cache =
-                    await SleepableDictionary.CreateAsync(db, self.Output, options, fp_requests.Length, results.TaskControl.ProgressToken)
+                    await SleepableDictionary.CreateAsync(db, self.Output, options, fp_requests.Length, results.TaskControl)
                         .ConfigureAwait(false);
 
                 // The volume consumer will read blocks from the input channel (data blocks from the volumes) and store them in the cache.

--- a/Duplicati/Library/Main/Operation/Restore/FileLister.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileLister.cs
@@ -175,6 +175,16 @@ namespace Duplicati.Library.Main.Operation.Restore
                         await self.Output.WriteAsync(new FileRequest(file.ID, file.OriginalPath, file.TargetPath, file.Hash, file.Length, file.BlocksetID, IsAlternateDataStream: true, Version: version, BackupTimestamp: backupTimestamp)).ConfigureAwait(false);
                     sw_write_file?.Stop();
                 }
+                catch (Exception) when (RestoreCancellation.IsAborted(result.TaskControl))
+                {
+                    // An abort is an orderly shutdown that arrived by a different signal than
+                    // retirement, so it is reported the same way retirement is. This is also the
+                    // only process without a `catch (RetiredException)`, and consulting the token
+                    // covers both.
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "File lister cancelled");
+                    threw_exception = true;
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "FileListerError", ex, "Error during file listing");

--- a/Duplicati/Library/Main/Operation/Restore/FileLister.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileLister.cs
@@ -72,6 +72,21 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                 bool threw_exception = false;
 
+                // A stop asks the restore to finish what it is doing and stop, so the lister
+                // stops handing out work. It is checked per file rather than once up front
+                // because every file is written to the channel before any of the later stages
+                // run, so a single check would let a large fileset run to completion anyway.
+                // Returning is enough to wind the network down: RunTask retires the output
+                // channel, which is the same path a completed listing takes.
+                bool StopRequested()
+                {
+                    if (!result.TaskControl.StopToken.IsCancellationRequested)
+                        return false;
+
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "StoppedProcess", null, "File lister stopped, no further files will be restored");
+                    return true;
+                }
+
                 try
                 {
                     sw_get_files?.Start();
@@ -143,13 +158,21 @@ namespace Duplicati.Library.Main.Operation.Restore
                     // Send priority files first (marked with IsPriorityFile=true)
                     foreach (var file in priorityFileList)
                     {
+                        if (StopRequested())
+                            return;
+
                         var priorityFileRequest = new FileRequest(file.ID, file.OriginalPath, file.TargetPath, file.Hash, file.Length, file.BlocksetID, IsPriorityFile: true, Version: version, BackupTimestamp: backupTimestamp);
                         await self.Output.WriteAsync(priorityFileRequest).ConfigureAwait(false);
                     }
 
                     // Then send remaining files
                     foreach (var file in remainingFiles)
+                    {
+                        if (StopRequested())
+                            return;
+
                         await self.Output.WriteAsync(file.WithVersion(version, backupTimestamp)).ConfigureAwait(false);
+                    }
 
                     sw_write_file?.Stop();
 
@@ -165,17 +188,27 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         sw_write_folder?.Start();
                         foreach (var folder in folders)
+                        {
+                            if (StopRequested())
+                                return;
+
                             await self.Output.WriteAsync(folder.WithVersion(version, backupTimestamp)).ConfigureAwait(false);
+                        }
                         sw_write_folder?.Stop();
                     }
 
                     // Send the alternate data streams last, so their hosts are restored
                     sw_write_file?.Start();
                     foreach (var file in adsStreams)
+                    {
+                        if (StopRequested())
+                            return;
+
                         await self.Output.WriteAsync(new FileRequest(file.ID, file.OriginalPath, file.TargetPath, file.Hash, file.Length, file.BlocksetID, IsAlternateDataStream: true, Version: version, BackupTimestamp: backupTimestamp)).ConfigureAwait(false);
+                    }
                     sw_write_file?.Stop();
                 }
-                catch (Exception) when (RestoreCancellation.IsAborted(result.TaskControl))
+                catch (Exception) when (RestoreCancellation.IsShutdownRequested(result.TaskControl))
                 {
                     // An abort is an orderly shutdown that arrived by a different signal than
                     // retirement, so it is reported the same way retirement is. This is also the

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -564,6 +564,13 @@ namespace Duplicati.Library.Main.Operation.Restore
                     }
                     return;
                 }
+                catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                {
+                    // An abort is an orderly shutdown that arrived by a different signal than
+                    // retirement, so it is reported the same way retirement is.
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "File processor cancelled");
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     Logging.Log.WriteErrorMessage(LOGTAG, "FileProcessingError", ex, "Error during file processing");

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -125,8 +125,26 @@ namespace Duplicati.Library.Main.Operation.Restore
                         var file = await self.Input.ReadAsync().ConfigureAwait(false);
                         sw_file?.Stop();
 
+                        // A stop means "finish the current file and stop", so the check sits at
+                        // the top of the loop: whatever was being restored when the stop arrived
+                        // has already completed, and this file is not started. Files still sitting
+                        // in the channel buffer are dropped for the same reason.
+                        //
+                        // Returning is enough to wind the network down: the finally below retires
+                        // the block channels and releases the folder-metadata barrier, which is
+                        // the same path retirement takes.
+                        if (results.TaskControl.StopToken.IsCancellationRequested)
+                        {
+                            Logging.Log.WriteVerboseMessage(LOGTAG, "StoppedProcess", null, "{0} File processor stopped", my_id);
+                            return;
+                        }
+
                         // Check if this is a priority file and wait for all priority files to complete before processing non-priority files
-                        await WaitForPriorityFilesIfNeededAsync(file, modules, results.TaskControl.ProgressToken).ConfigureAwait(false);
+                        if (!await WaitForPriorityFilesIfNeededAsync(file, modules, results.TaskControl).ConfigureAwait(false))
+                        {
+                            Logging.Log.WriteVerboseMessage(LOGTAG, "StoppedProcess", null, "{0} File processor stopped while waiting for the priority files", my_id);
+                            return;
+                        }
 
                         Logging.Log.WriteExplicitMessage(LOGTAG, "FileRestored", null, "{0} Restoring file {1}", my_id, file.TargetPath);
 
@@ -564,7 +582,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     }
                     return;
                 }
-                catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                catch (Exception) when (RestoreCancellation.IsShutdownRequested(results.TaskControl))
                 {
                     // An abort is an orderly shutdown that arrived by a different signal than
                     // retirement, so it is reported the same way retirement is.
@@ -713,8 +731,9 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// </summary>
         /// <param name="file">The file request being processed.</param>
         /// <param name="modules">The loaded generic modules, used to dispatch the bulk-restore-start callback. May be null.</param>
-        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-        private static async Task WaitForPriorityFilesIfNeededAsync(FileRequest file, IEnumerable<IGenericModule>? modules, CancellationToken cancellationToken)
+        /// <param name="taskReader">The task reader, used to abandon the wait if a shutdown is requested.</param>
+        /// <returns><c>true</c> if the caller should carry on with the file; <c>false</c> if the wait was abandoned because the restore is stopping.</returns>
+        private static async Task<bool> WaitForPriorityFilesIfNeededAsync(FileRequest file, IEnumerable<IGenericModule>? modules, Common.ITaskReader taskReader)
         {
             if (file.IsPriorityFile)
             {
@@ -734,7 +753,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     // modules before signaling the other processors to continue.
                     try
                     {
-                        await RestoreHandler.InvokeBulkRestoreStartAsync(modules, cancellationToken).ConfigureAwait(false);
+                        await RestoreHandler.InvokeBulkRestoreStartAsync(modules, taskReader.ProgressToken).ConfigureAwait(false);
                     }
                     finally
                     {
@@ -754,9 +773,24 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                 if (shouldWait)
                 {
-                    await priority_files_completed.Task.ConfigureAwait(false);
+                    // The completion source is only ever signalled by a processor that handles a
+                    // priority file, so if the restore stops or is aborted before every priority
+                    // file has been emitted, nothing will release this wait. Without a token the
+                    // processor would sit here forever, and the restore's Task.WhenAll over the
+                    // process network would never return.
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(taskReader.ProgressToken, taskReader.StopToken);
+                    try
+                    {
+                        await priority_files_completed.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return false;
+                    }
                 }
             }
+
+            return true;
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
+++ b/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
@@ -32,6 +32,34 @@ namespace Duplicati.Library.Main.Operation.Restore
 {
 
     /// <summary>
+    /// Helper for telling a requested shutdown apart from a genuine failure in the restore
+    /// process network.
+    /// </summary>
+    internal static class RestoreCancellation
+    {
+        /// <summary>
+        /// Returns whether the restore has been aborted, i.e. whether the cancellation the
+        /// processes are seeing was asked for rather than caused by a fault.
+        /// </summary>
+        /// <param name="taskReader">The task reader whose tokens to consult.</param>
+        /// <returns><c>true</c> if the operation was aborted.</returns>
+        /// <remarks>
+        /// The tokens are consulted rather than the exception type. A cancellation is not
+        /// identifiable from its exception: <see cref="System.Net.Http.HttpClient"/> reports its
+        /// own request timeouts as <see cref="System.Threading.Tasks.TaskCanceledException"/>, so
+        /// keying off the type would silently reclassify real backend timeouts as a requested
+        /// shutdown. Consulting the token instead follows the existing precedent in
+        /// <c>BackendManager.Handler</c>.
+        ///
+        /// <see cref="Common.ITaskReader.StopToken"/> is deliberately not consulted: nothing in
+        /// the restore process network observes it, so no cancellation can originate there.
+        /// </remarks>
+        public static bool IsAborted(Common.ITaskReader taskReader)
+            => taskReader.ProgressToken.IsCancellationRequested
+                || taskReader.TransferToken.IsCancellationRequested;
+    }
+
+    /// <summary>
     /// Represents the type of block request.
     /// </summary>
     public enum BlockRequestType

--- a/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
+++ b/Duplicati/Library/Main/Operation/Restore/Interfaces.cs
@@ -38,11 +38,11 @@ namespace Duplicati.Library.Main.Operation.Restore
     internal static class RestoreCancellation
     {
         /// <summary>
-        /// Returns whether the restore has been aborted, i.e. whether the cancellation the
-        /// processes are seeing was asked for rather than caused by a fault.
+        /// Returns whether the restore is winding down because it was asked to, rather than
+        /// because something failed. Covers both an abort and an orderly stop.
         /// </summary>
         /// <param name="taskReader">The task reader whose tokens to consult.</param>
-        /// <returns><c>true</c> if the operation was aborted.</returns>
+        /// <returns><c>true</c> if the shutdown was requested.</returns>
         /// <remarks>
         /// The tokens are consulted rather than the exception type. A cancellation is not
         /// identifiable from its exception: <see cref="System.Net.Http.HttpClient"/> reports its
@@ -51,12 +51,16 @@ namespace Duplicati.Library.Main.Operation.Restore
         /// shutdown. Consulting the token instead follows the existing precedent in
         /// <c>BackendManager.Handler</c>.
         ///
-        /// <see cref="Common.ITaskReader.StopToken"/> is deliberately not consulted: nothing in
-        /// the restore process network observes it, so no cancellation can originate there.
+        /// <see cref="Common.ITaskReader.StopToken"/> is consulted because a stop leaves the same
+        /// traces an abort does. It stops the restore with work outstanding, so the invariant
+        /// checks in <c>BlockManager</c> see leftovers; and a download that had already failed
+        /// once is cancelled rather than retried by <c>BackendManager</c>, which is not evidence
+        /// that the backup is broken.
         /// </remarks>
-        public static bool IsAborted(Common.ITaskReader taskReader)
+        public static bool IsShutdownRequested(Common.ITaskReader taskReader)
             => taskReader.ProgressToken.IsCancellationRequested
-                || taskReader.TransferToken.IsCancellationRequested;
+                || taskReader.TransferToken.IsCancellationRequested
+                || taskReader.StopToken.IsCancellationRequested;
     }
 
     /// <summary>

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDecryptor.cs
@@ -90,8 +90,21 @@ namespace Duplicati.Library.Main.Operation.Restore
                         Logging.Log.WriteExplicitMessage(LOGTAG, "BlockVolumeReader", null, "Created BlockVolumeReader for volume {0} (ID: {1})", volume_name, volume_id);
 
                         sw_write?.Start();
-                        // Pass the decrypted volume to the `VolumeDecompressor` process.
-                        await self.Output.WriteAsync((volume_id, volume_wrapper)).ConfigureAwait(false);
+                        try
+                        {
+                            // Pass the decrypted volume to the `VolumeDecompressor` process.
+                            await self.Output.WriteAsync((volume_id, volume_wrapper)).ConfigureAwait(false);
+                        }
+                        catch (Exception)
+                        {
+                            // The handoff failed, so no other process took ownership and nothing
+                            // else will dispose the volume. Without this the decrypted temporary
+                            // file stays open and is left behind, because the volume reader holds
+                            // it without `FileShare.Delete` and `TempFile`'s finalizer therefore
+                            // cannot delete it.
+                            volume_wrapper.Dispose();
+                            throw;
+                        }
                         sw_write?.Stop();
                         Logging.Log.WriteExplicitMessage(LOGTAG, "DecryptVolume", null, "Passed decrypted volume {0} (ID: {1}) to next stage", volume_name, volume_id);
                     }

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
@@ -85,7 +85,11 @@ namespace Duplicati.Library.Main.Operation.Restore
                         {
                             f = await backend.GetDirectAsync(volume_name, hash, size, allowParityRepair: true, results.TaskControl.TransferToken).ConfigureAwait(false);
                         }
-                        catch (Exception)
+                        // An abort cancels the transfer token, so without the guard every
+                        // download the abort itself cancelled would be recorded as a defect in
+                        // the backup. The progress token is consulted as well because the
+                        // `BackendManager` gives up on a download for either of them.
+                        catch (Exception) when (!RestoreCancellation.IsAborted(results.TaskControl))
                         {
                             lock (results)
                                 results.BrokenRemoteFiles.Add(volume_name);
@@ -97,7 +101,17 @@ namespace Duplicati.Library.Main.Operation.Restore
 
                         // Pass the download handle (which may or may not have downloaded already) to the `VolumeDecryptor` process.
                         sw_write?.Start();
-                        await self.Output.WriteAsync((volume_id, volume_name, f)).ConfigureAwait(false);
+                        try
+                        {
+                            await self.Output.WriteAsync((volume_id, volume_name, f)).ConfigureAwait(false);
+                        }
+                        catch (Exception)
+                        {
+                            // The handoff failed, so the decryptor never took ownership of the
+                            // downloaded file and nothing else will dispose it.
+                            f.Dispose();
+                            throw;
+                        }
                         sw_write?.Stop();
                         Logging.Log.WriteExplicitMessage(LOGTAG, "DownloadVolume", null, "Passed volume {0} (ID: {1}) to next stage", volume_name, volume_id);
                     }
@@ -110,6 +124,16 @@ namespace Duplicati.Library.Main.Operation.Restore
                     {
                         Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", $"Read: {sw_read!.ElapsedMilliseconds}ms, Write: {sw_write!.ElapsedMilliseconds}ms, Wait: {sw_wait!.ElapsedMilliseconds}ms");
                     }
+                }
+                catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                {
+                    // An abort is an orderly shutdown that arrived by a different signal than
+                    // retirement, so it is reported the same way retirement is. The retirement
+                    // of the channels is still needed to tear the network down.
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "Volume downloader cancelled");
+                    self.Input.Retire();
+                    self.Output.Retire();
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeDownloader.cs
@@ -89,7 +89,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                         // download the abort itself cancelled would be recorded as a defect in
                         // the backup. The progress token is consulted as well because the
                         // `BackendManager` gives up on a download for either of them.
-                        catch (Exception) when (!RestoreCancellation.IsAborted(results.TaskControl))
+                        catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                         {
                             lock (results)
                                 results.BrokenRemoteFiles.Add(volume_name);
@@ -125,7 +125,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                         Logging.Log.WriteProfilingMessage(LOGTAG, "InternalTimings", $"Read: {sw_read!.ElapsedMilliseconds}ms, Write: {sw_write!.ElapsedMilliseconds}ms, Wait: {sw_wait!.ElapsedMilliseconds}ms");
                     }
                 }
-                catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                catch (Exception) when (RestoreCancellation.IsShutdownRequested(results.TaskControl))
                 {
                     // An abort is an orderly shutdown that arrived by a different signal than
                     // retirement, so it is reported the same way retirement is. The retirement

--- a/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
@@ -330,10 +330,44 @@ namespace Duplicati.Library.Main.Operation.Restore
                             Logging.Log.WriteProfilingMessage(LOGTAG, "CacheUsage", $"Max used cache size: {Duplicati.Library.Utility.Utility.FormatSizeString(cache_size_max_consumed)}");
                         }
                     }
+                    catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                    {
+                        // An abort is an orderly shutdown that arrived by a different signal
+                        // than retirement, so it is reported the same way retirement is.
+                        Logging.Log.WriteVerboseMessage(LOGTAG, "CancelledProcess", null, "Volume manager cancelled");
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         Logging.Log.WriteErrorMessage(LOGTAG, "VolumeManagerError", ex, "Error during volume manager");
                         throw;
+                    }
+                    finally
+                    {
+                        // Nothing else disposes what is left in the cache. `handle_evict` is
+                        // only reached from a `CacheEvict` request or from an eviction, so on
+                        // any early exit the cached volumes keep their decrypted temporary
+                        // files open. The finalizer in `TempFile` cannot recover them either,
+                        // because the volume reader holds the file without `FileShare.Delete`,
+                        // so the delete fails and is swallowed. On Windows that leaves the
+                        // files behind until the 30-day cleanup.
+                        //
+                        // Placed in a `finally` rather than in the catch blocks so it also
+                        // covers a non-exceptional exit, and it reuses `handle_evict` so that
+                        // `cache_size` and `cache_last_touched` stay consistent. `cache.Keys`
+                        // has to be copied because `handle_evict` removes from the dictionary.
+                        try
+                        {
+                            foreach (var volume_id in cache.Keys.ToList())
+                                handle_evict(volume_id);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Disposing a volume reaches a compression module's `Dispose`, and
+                            // an exception from there must not replace the exception that is
+                            // currently unwinding.
+                            Logging.Log.WriteWarningMessage(LOGTAG, "CacheDrainError", ex, "Failed to dispose the cached volumes");
+                        }
                     }
                 }
             );

--- a/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
+++ b/Duplicati/Library/Main/Operation/Restore/VolumeManager.cs
@@ -330,7 +330,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                             Logging.Log.WriteProfilingMessage(LOGTAG, "CacheUsage", $"Max used cache size: {Duplicati.Library.Utility.Utility.FormatSizeString(cache_size_max_consumed)}");
                         }
                     }
-                    catch (Exception) when (RestoreCancellation.IsAborted(results.TaskControl))
+                    catch (Exception) when (RestoreCancellation.IsShutdownRequested(results.TaskControl))
                     {
                         // An abort is an orderly shutdown that arrived by a different signal
                         // than retirement, so it is reported the same way retirement is.

--- a/Duplicati/Library/Main/Operation/RestoreHandler.cs
+++ b/Duplicati/Library/Main/Operation/RestoreHandler.cs
@@ -942,7 +942,19 @@ namespace Duplicati.Library.Main.Operation
             await database.DisposePoolAsync().ConfigureAwait(false);
 
             if (!await m_result.TaskControl.ProgressRendevouzAsync().ConfigureAwait(false))
+            {
+                // Recorded because otherwise a stopped restore is indistinguishable in the log
+                // from one that ran to the end.
+                Logging.Log.WriteInformationMessage(LOGTAG, "RestoreStopped", "Restore stopped on request after restoring {0} files", m_result.RestoredFiles);
+
+                // The temporary tables are dropped even on this path: leaving them behind on
+                // every stop is a real cost to the database. The restored-hash harvest is
+                // deliberately skipped, because it exists for --restore-all-files=unique and
+                // recording a partial restore as done would mislead the next one.
+                await database.DropRestoreTableAsync(cancellationToken).ConfigureAwait(false);
+                m_result.EndTime = DateTime.UtcNow;
                 return;
+            }
 
             m_result.OperationProgressUpdater.UpdatePhase(OperationPhase.Restore_PostRestoreVerify);
 

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -713,5 +713,128 @@ namespace Duplicati.UnitTest
                 Library.Utility.TempFolder.SystemTempPath = previousTempPath;
             }
         }
+
+        /// <summary>
+        /// A stop is a request to finish the current file and then stop, so the restore has to
+        /// notice it while it is running rather than carry on to the end of the backup.
+        /// </summary>
+        [Test]
+        [Category("RestoreHandler")]
+        public async Task StoppedRestoreStopsAsync()
+        {
+            const int fileCount = 40;
+            const int volumesBeforeStop = 3;
+
+            var backupOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "200kb",
+                ["blocksize"] = "4kb"
+            };
+
+            // Enough distinct data to fill several volumes, so the restore still has plenty of
+            // work left when the stop arrives
+            var rng = new Random(42);
+            var data = new byte[32 * 1024];
+            for (var i = 0; i < fileCount; i++)
+            {
+                rng.NextBytes(data);
+                File.WriteAllBytes(Path.Combine(this.DATAFOLDER, $"file{i}"), data);
+            }
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var downloaded = 0;
+            var enoughDownloaded = new TaskCompletionSource();
+
+            // Used as a hook rather than as a source of errors: it always answers "no error",
+            // but it slows every volume download down so the restore cannot outrun the stop,
+            // and it signals once enough volumes have been fetched.
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action != DeterministicErrorBackend.BackendAction.GetBefore
+                    || !remotename.Contains(".dblock.", StringComparison.Ordinal))
+                    return false;
+
+                if (System.Threading.Interlocked.Increment(ref downloaded) >= volumesBeforeStop)
+                    enoughDownloaded.TrySetResult();
+
+                System.Threading.Thread.Sleep(1500);
+                return false;
+            };
+
+            try
+            {
+                var restoreOptions = new Dictionary<string, string>(this.TestOptions)
+                {
+                    ["dblock-size"] = "200kb",
+                    ["blocksize"] = "4kb",
+                    ["restore-path"] = this.RESTOREFOLDER,
+                    ["restore-legacy"] = "false",
+                    // Force the blocks to come from the destination rather than from the source
+                    ["restore-with-local-blocks"] = "false",
+                    ["restore-volume-downloaders"] = "4",
+                    ["restore-volume-decryptors"] = "1",
+                    ["restore-volume-decompressors"] = "1",
+                    ["restore-file-processors"] = "1"
+                };
+
+                var restoreErrors = new System.Collections.Concurrent.ConcurrentQueue<string>();
+                // Spelled out rather than taken from the types, which are internal to
+                // Duplicati.Library.Main
+                const string restoreNamespace = "Duplicati.Library.Main.Operation.Restore.";
+
+                Library.Main.RestoreResults? restoreResults = null;
+                using var c = new Controller(new DeterministicErrorBackend().ProtocolKey + "://" + this.TARGETFOLDER, restoreOptions, null);
+                c.OnOperationStarted += r => restoreResults = (Library.Main.RestoreResults)r;
+
+                using (Library.Logging.Log.StartScope(e =>
+                {
+                    // Scoped to the restore process network; how a stopped operation is
+                    // classified is a separate matter from what the network reports.
+                    if (e.Level == Library.Logging.LogMessageType.Error
+                        && e.Tag != null && e.Tag.StartsWith(restoreNamespace, StringComparison.Ordinal))
+                        restoreErrors.Enqueue($"{e.Tag.Split('.').Last()}/{e.Id}: {e.FormattedMessage}");
+                }))
+                {
+                    var restoreTask = Task.Run(async () => await c.RestoreAsync(new[] { "*" }));
+
+                    var trigger = await Task.WhenAny(enoughDownloaded.Task, restoreTask, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false);
+                    if (trigger == restoreTask)
+                        Assert.Ignore("The restore finished before it could be stopped; the download hook is not slowing it down enough");
+                    if (trigger != enoughDownloaded.Task)
+                        Assert.Fail($"The restore did not download {volumesBeforeStop} volumes within a minute");
+
+                    await c.StopAsync().ConfigureAwait(false);
+
+                    // Bounded: a stop that does not stop the restore has to fail the test rather
+                    // than hang the run, since NUnit has no per-test timeout to fall back on.
+                    var grace = TimeSpan.FromMinutes(2);
+                    var stopped = await Task.WhenAny(restoreTask, Task.Delay(grace)).ConfigureAwait(false) == restoreTask;
+                    Assert.IsTrue(stopped, $"The restore did not stop within {grace.TotalMinutes:F0} minutes of being stopped");
+
+                    // A stopped restore is a requested shutdown, so it is expected to return
+                    // rather than fault.
+                    await restoreTask.ConfigureAwait(false);
+                }
+
+                NUnit.Framework.Assert.Multiple(() =>
+                {
+                    Assert.Less(restoreResults!.RestoredFiles, fileCount,
+                        $"The restore was stopped after {volumesBeforeStop} volumes but still restored all {fileCount} files, so the stop was ignored");
+
+                    Assert.AreEqual(0, restoreErrors.Count,
+                        $"A stopped restore reported errors:{Environment.NewLine}{string.Join(Environment.NewLine, restoreErrors)}");
+
+                    Assert.AreEqual(0, restoreResults.BrokenRemoteFiles.Count(),
+                        $"A stopped restore blamed the backup for {string.Join(", ", restoreResults.BrokenRemoteFiles)}");
+                });
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+            }
+        }
     }
 }

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -544,5 +544,174 @@ namespace Duplicati.UnitTest
             Assert.IsTrue(File.Exists(restoredSmallFilePath), "The small file should have been restored");
             Assert.IsFalse(File.Exists(restoredLargeFilePath), "The large file should not have been restored");
         }
+
+        /// <summary>
+        /// An abort is a requested shutdown, so it should not report errors of its own, should
+        /// not blame the backup for a download it cancelled itself, and should not leave the
+        /// volumes it had cached behind on disk.
+        /// </summary>
+        [Test]
+        [Category("RestoreHandler")]
+        public async Task AbortedRestoreIsCleanAsync()
+        {
+            const int volumesBeforeAbort = 3;
+
+            var backupOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "200kb",
+                ["blocksize"] = "4kb"
+            };
+
+            // Enough distinct data to fill several volumes, so some are still cached when the
+            // abort lands
+            var rng = new Random(42);
+            var data = new byte[32 * 1024];
+            for (var i = 0; i < 40; i++)
+            {
+                rng.NextBytes(data);
+                File.WriteAllBytes(Path.Combine(this.DATAFOLDER, $"file{i}"), data);
+            }
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            // The decrypted volumes are created with `new TempFile()`, which resolves through
+            // TempFolder.SystemTempPath rather than through --tempdir, so that is what has to
+            // be redirected for the test to be able to count what is left behind.
+            var tempdir = Path.Combine(BASEFOLDER, "aborted-restore-temp");
+            Directory.CreateDirectory(tempdir);
+            var previousTempPath = Library.Utility.TempFolder.SystemTempPath;
+            Library.Utility.TempFolder.SystemTempPath = tempdir;
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var downloaded = 0;
+            var enoughDownloaded = new TaskCompletionSource();
+
+            // Used as a hook rather than as a source of errors: it always answers "no error",
+            // but it slows every volume download down so the restore cannot outrun the abort,
+            // and it signals once enough volumes have been fetched. Without this the abort
+            // would land at a different point on every machine.
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (!remotename.Contains(".dblock.", StringComparison.Ordinal))
+                    return false;
+
+                if (action != DeterministicErrorBackend.BackendAction.GetBefore)
+                    return false;
+
+                // Signalled before the delay rather than after it, so the abort is guaranteed
+                // to land while a download is still in flight
+                if (System.Threading.Interlocked.Increment(ref downloaded) >= volumesBeforeAbort)
+                    enoughDownloaded.TrySetResult();
+
+                System.Threading.Thread.Sleep(1500);
+                return false;
+            };
+
+            try
+            {
+                var restoreOptions = new Dictionary<string, string>(this.TestOptions)
+                {
+                    ["dblock-size"] = "200kb",
+                    ["blocksize"] = "4kb",
+                    ["restore-path"] = this.RESTOREFOLDER,
+                    ["restore-legacy"] = "false",
+                    // Force the blocks to come from the destination rather than from the source
+                    ["restore-with-local-blocks"] = "false",
+                    // Several downloaders so that requests are queued behind the slow one and
+                    // the abort has something in flight to cancel
+                    ["restore-volume-downloaders"] = "4",
+                    ["restore-volume-decryptors"] = "1",
+                    ["restore-volume-decompressors"] = "1",
+                    ["restore-file-processors"] = "1",
+                    ["tempdir"] = tempdir
+                    // restore-volume-cache-hint is deliberately left unset, which means
+                    // unlimited: the volumes stay cached, which is the state this test is about.
+                };
+
+                var beforeRestore = Directory.GetFiles(tempdir, "*", SearchOption.AllDirectories).ToHashSet(StringComparer.Ordinal);
+
+                var restoreErrors = new System.Collections.Concurrent.ConcurrentQueue<string>();
+                var cachedVolumes = 0;
+                // Spelled out rather than taken from the types, which are internal to
+                // Duplicati.Library.Main
+                const string restoreNamespace = "Duplicati.Library.Main.Operation.Restore.";
+                const string volumeManagerTag = restoreNamespace + "VolumeManager";
+
+                Library.Main.RestoreResults? restoreResults = null;
+                using var c = new Controller(new DeterministicErrorBackend().ProtocolKey + "://" + this.TARGETFOLDER, restoreOptions, null);
+                c.OnOperationStarted += r => restoreResults = (Library.Main.RestoreResults)r;
+
+                using (Library.Logging.Log.StartScope(e =>
+                {
+                    // Scoped to the restore process network. Controller logs FailedOperation of
+                    // its own on an abort, and how an aborted operation is classified is a
+                    // separate matter from what the network reports.
+                    if (e.Level == Library.Logging.LogMessageType.Error
+                        && e.Tag != null && e.Tag.StartsWith(restoreNamespace, StringComparison.Ordinal))
+                        restoreErrors.Enqueue($"{e.Tag.Split('.').Last()}/{e.Id}: {e.FormattedMessage}");
+
+                    // Guards against a vacuous pass: if nothing was ever cached there is
+                    // nothing for the abort to leave behind.
+                    if (e.Tag == volumeManagerTag && e.FormattedMessage != null
+                        && e.FormattedMessage.StartsWith("Caching volume", StringComparison.Ordinal))
+                        System.Threading.Interlocked.Increment(ref cachedVolumes);
+                }))
+                {
+                    var restoreTask = Task.Run(async () => await c.RestoreAsync(new[] { "*" }));
+
+                    var trigger = await Task.WhenAny(enoughDownloaded.Task, restoreTask, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false);
+                    if (trigger == restoreTask)
+                        Assert.Ignore("The restore finished before it could be aborted; the download hook is not slowing it down enough");
+                    if (trigger != enoughDownloaded.Task)
+                        Assert.Fail($"The restore did not download {volumesBeforeAbort} volumes within a minute");
+
+                    await c.AbortAsync().ConfigureAwait(false);
+
+                    var stopped = await Task.WhenAny(restoreTask, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false) == restoreTask;
+                    Assert.IsTrue(stopped, "The abort did not stop the restore within a minute");
+
+                    try
+                    {
+                        await restoreTask.ConfigureAwait(false);
+                        Assert.Fail("The aborted restore was expected to fault");
+                    }
+                    catch (Exception)
+                    {
+                        // The type is deliberately not asserted: which task in the network faults
+                        // first decides it, and classifying an aborted restore is a separate matter.
+                    }
+                }
+
+                // No GC.Collect anywhere: the point is that the volumes are disposed
+                // explicitly, and a forced collection would let a finalizer do that job.
+                var leftover = Directory.GetFiles(tempdir, "*", SearchOption.AllDirectories)
+                    .Where(x => !beforeRestore.Contains(x))
+                    .ToList();
+
+                // Checked on its own first: if nothing was ever cached the remaining
+                // assertions could pass without proving anything.
+                Assert.Greater(cachedVolumes, 0, "No volume was ever cached, so the test would pass without proving anything");
+
+                // The three claims are independent, so report all of them rather than only
+                // whichever happens to be checked first.
+                NUnit.Framework.Assert.Multiple(() =>
+                {
+                    Assert.AreEqual(0, restoreErrors.Count,
+                        $"An aborted restore reported errors:{Environment.NewLine}{string.Join(Environment.NewLine, restoreErrors)}");
+
+                    Assert.AreEqual(0, restoreResults!.BrokenRemoteFiles.Count(),
+                        $"An aborted restore blamed the backup for {string.Join(", ", restoreResults.BrokenRemoteFiles)}");
+
+                    Assert.AreEqual(0, leftover.Count,
+                        $"An aborted restore left temporary files behind:{Environment.NewLine}{string.Join(Environment.NewLine, leftover)}");
+                });
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+                Library.Utility.TempFolder.SystemTempPath = previousTempPath;
+            }
+        }
     }
 }


### PR DESCRIPTION
> Depends on #7154 — see "Why this builds on #7154" below. Review that one first; this branch is #7154 plus one commit.

Pressing "stop after current file" during a restore does nothing at all. I found this while writing up the abort work in #7154 and chased it down separately.

## Measured

Same backup of 40 files, same options, stop issued once three volumes had been downloaded. The only difference between the columns is `--restore-legacy`:

| | new engine (default) | legacy engine |
| --- | --- | --- |
| files restored when the stop was issued | 1 / 40 | 22 / 40 |
| files restored at the end | **40 / 40** | **25 / 40** |
| time from stop to finish | 9.7s | 3.2s |
| `Interrupted` | False | False |
| Errors / Warnings | 0 / 0 | 0 / 1 |

The new engine ignores the stop completely, restores every remaining file, and returns a successful, uninterrupted restore.

## Root cause

`TaskControl.Stop()` communicates through exactly two channels: it completes `m_progress` with `false`, so `ProgressRendevouzAsync()` returns false, and it cancels `m_stopTcs`, so `StopToken` fires. **The new restore process network consults neither while it is running.**

- `Operation/Restore/` contained **no** `StopToken` reference at all.
- The only `ProgressRendevouzAsync` inside the network is in `VolumeManager`, and it runs once *before* the loop starts.
- `DoRunNewAsync`'s own check sits *after* the `Task.WhenAll` over the whole network — by then there is nothing left to stop.

The legacy `DoRunAsync` has twelve such checks and demonstrably stops, so stop support for restore was lost when the new engine became the default (`restore-legacy` defaults to `false`). I could not find an existing issue for it.

`BackendManager` does not compensate. Its `StopToken` use only shortens a retry delay, and the rendezvous that cancels an operation is only reached *after a failed attempt* — the happy path returns before it. So a restore whose downloads are succeeding is never slowed by a stop.

## The change

**The lister stops handing out work.** A check in each of `FileLister`'s four write loops. Per iteration rather than once up front, because every file is written to the channel before any later stage runs, so a single check would let a large fileset run to completion anyway.

**The file processors stop at a file boundary.** A check at the top of the loop, right after the read. That is what `ITaskCommander.Stop` documents — "This will finalize the current file and transfer": whatever was being restored when the stop arrived completes, and the next file is not started. Files already sitting in the channel buffer are dropped for the same reason.

**Nothing downstream needed a check.** Both exits wind the network down through the path a completed restore already takes: `RunTask` retires the lister's output channel, and `FileProcessor`'s existing `finally` retires the block channels and releases the folder-metadata barrier. From there the block handlers retire, `SleepableDictionary.Retire()` drops the reader count to zero and retires the volume-request channel, and `VolumeManager` and the downloaders, decryptors and decompressors follow. This is why the diff is small.

**The wait for the priority files had to become cancellable.** `priority_files_completed` is only ever signalled by a processor that handles a priority file, and the wait had no token and no timeout. Stopping before every priority file had been emitted would leave a processor waiting forever, so the network's `Task.WhenAll` would never return and the restore would hang instead of stopping. The wait now uses a token linked from the progress and stop tokens, and the processor returns instead of hanging.

**That also closes an existing abort hang.** The same wait ignores the abort token, so `AbortAsync` on a restore with outstanding priority files hangs today for the same reason. It needs a restore callback module that populates the priority list to be reachable — the built-in `FileRestoreDestinationProvider.GetPriorityFiles()` returns an empty array — which is why it does not show up in an ordinary restore.

**One predicate instead of two.** #7154 added `RestoreCancellation.IsAborted`, whose remark said `StopToken` was deliberately excluded because nothing in the network observed it. This change makes that untrue, so it becomes `IsShutdownRequested` and consults all three tokens. The reason for consulting tokens rather than exception types is unchanged and still documented: `HttpClient` reports its own request timeouts as `TaskCanceledException`, so keying off the type would reclassify real backend timeouts as a requested shutdown.

**A stopped restore says so, and cleans up its tables.** The early return at the post-network rendezvous was skipping the temp-table drop, the hash harvest and `EndTime`. It now logs one Information message — without it a stopped restore is indistinguishable in the log from one that ran to the end — and drops the temporary tables, since leaving them behind on every stop is a real cost to the database. The restored-hash harvest is deliberately still skipped: it exists for `--restore-all-files=unique`, and recording a partial restore as done would mislead the next one.

## Why this builds on #7154

Not a preference — stopping early produces exactly the state #7154 fixed:

- Leftover block and volume counters, so `BlockManager`'s invariant self-checks fire. #7154 is what suppresses them for a requested shutdown; without it a stop would log `BlockCountError`, `VolumeCountError` and `BlockCacheMismatch`.
- Volumes still in `VolumeManager`'s cache, whose decrypted temporary files nothing else disposes. #7154's `finally` drain covers it.

`BrokenRemoteFiles` is included in the same widening: during a stop, a download that had already failed once is cancelled rather than retried by `BackendManager`, and a download the stop cancelled is not evidence that the backup is broken.

## Testing

New test `RestoreHandlerTests.StoppedRestoreStopsAsync`, reusing #7154's scaffolding (`DeterministicErrorBackend` as a hook that answers "no error" but delays each `dblock` fetch and signals before the delay, so the stop lands at the same point on every machine).

| claim | before | after |
| --- | --- | --- |
| fewer files restored than the backup holds | **red** (40/40) | green (1/40) |
| no error-level log from the restore namespace | green | green |
| `BrokenRemoteFiles` empty | green | green |
| the restore stops within a bounded grace | n/a — it ran to the end instead | green |

- new test: **3/3** green; before the fix it failed with "still restored all 40 files"
- `Category=RestoreHandler`: **35/35, twice**
- The margin on the main assertion is not thin: I temporarily changed the bound to an impossible value to read the real number back, and a stopped restore ends at **1** of 40 files, not 39.
- The wait after the stop is bounded, so a stop that fails to stop the restore fails the test instead of hanging the run. NUnit has no per-test timeout to fall back on.
- `RestoreVolumeCacheAsync` is excluded from the local runs — it is flaky on my machine for unrelated reasons and #7151 has the fix; CI covers it.

**What I could not test.** The priority-file hang has no test. Reaching it needs a non-empty priority list, and there is no seam for it: `GenericLoader` exposes no module-registration method, so a fake restore callback module cannot be injected. The other route — `restore-path` beginning with `@` plus `RestoreDestinationProviderLoader.AddSourceProvider` — would mean a 16-member delegating fake provider registered in a process-wide static loader, which is a lot of scaffolding for one test and risks leaking into other fixtures. I would rather say it is unverified than imply otherwise. Worth noting that the priority-file synchronisation has **no** existing coverage either, for the same reason.

## Out of scope, reported

- **`Controller` still classifies a stopped restore as a plain success.** `Interrupted` is set to false unconditionally on the success path, so both engines report a stopped restore as uninterrupted — visible in the measurements above. This is the same `Controller` classification I flagged in #7154; it affects backup too and changes exit codes and report-module behaviour, so it belongs in its own PR.
- **The priority-file synchronisation is untested**, and `RendezvousBeforeProcessingFolderMetadataAsync` can over-decrement `file_processors_restoring_files` if a processor is cancelled while waiting in it (the caller sets `decremented` only after the await). Harmless today — a negative count still releases the barrier — but it is a latent trap.
- The four items reported in #7154 still stand.
