### PR TITLE
Stop reporting a requested shutdown as a failure

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -603,7 +603,12 @@ namespace Duplicati.Library.Main
 
                     if (resultSetter.EndTime.Ticks == 0)
                         resultSetter.EndTime = DateTime.UtcNow;
-                    resultSetter.Interrupted = false;
+
+                    // The operation returned, but if a stop was requested it returned early, so
+                    // the run did not cover everything it was asked to. Its numbers must not be
+                    // recorded as the latest state of the backup, which is what this flag decides
+                    // (see Runner.UpdateMetadata).
+                    resultSetter.Interrupted = m_currentTaskControl?.StopToken.IsCancellationRequested == true;
 
                     // The post-operation result/log writes target the backup LocalDatabase schema
                     // (Operation, LogData, DeletedVolume tables). The sync database has its own
@@ -674,6 +679,46 @@ namespace Duplicati.Library.Main
                     await OperationCompleteAsync(result, null, filter).ConfigureAwait(false);
 
                     return result;
+                }
+                // Handle an abort requested through AbortAsync, which reaches this point as a
+                // cancellation. Reported the way the run-script abort above is: the user asked
+                // for it, so it is not a failure of the backup.
+                //
+                // The guard consults the token rather than the exception type. The progress token
+                // is only ever cancelled by TaskControl.Terminate, so a cancellation from anything
+                // else - an HttpClient request timeout, which surfaces as a TaskCanceledException,
+                // or the caller's own token - still falls through to the failure path below.
+                catch (OperationCanceledException) when (m_currentTaskControl?.ProgressToken.IsCancellationRequested == true)
+                {
+                    ReportModulesHandler?.OperationException = null; // Requested aborts are not failures.
+                    resultSetter.EndTime = DateTime.UtcNow;
+                    resultSetter.Interrupted = true;
+
+                    // Information rather than an error: the operation did what it was told to do.
+                    // Fatal is deliberately not set, and the phase is left alone, so the operation
+                    // is not presented as having errored.
+                    Logging.Log.WriteInformationMessage(LOGTAG, "TerminatedOperation", "Terminating operation {0} by request", m_options.MainAction);
+
+                    try
+                    {
+                        // Write logs to previous operation if database exists.
+                        // Sync uses its own database schema
+                        if (File.Exists(m_options.Dbpath) && !m_options.Dryrun && m_options.MainAction != OperationMode.Sync)
+                            await using (var db = await LocalDatabase.CreateLocalDatabaseAsync(m_options.Dbpath, null, true, null, CancellationToken.None).ConfigureAwait(false))
+                                await db.WriteResultsAndCommitAsync(result, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch (Exception we)
+                    {
+                        Logging.Log.WriteWarningMessage(LOGTAG, "FailedWriteOperation", we, we.Message);
+                    }
+
+                    // Reported without the exception: ReportHelper forces the Fatal level whenever
+                    // it is given one, regardless of the result's own classification.
+                    await OperationCompleteAsync(result, null, filter).ConfigureAwait(false);
+
+                    // Still propagated. Callers rely on an abort surfacing as an exception rather
+                    // than as a returned result.
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -1361,7 +1361,7 @@ namespace Duplicati.UnitTest
             this.ModifySourceFiles();
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
-                IBackupResults? results = null;
+                IBackupResults results = null;
                 var startedTcs = new TaskCompletionSource<bool>();
                 c.OnOperationStarted += r =>
                 {
@@ -1392,7 +1392,7 @@ namespace Duplicati.UnitTest
                 }
 
                 Assert.IsNotNull(results, "OnOperationStarted never fired, so there is no result to inspect");
-                Assert.AreNotEqual(ParsedResultType.Fatal, results!.ParsedResult,
+                Assert.AreNotEqual(ParsedResultType.Fatal, results.ParsedResult,
                     "An abort the user asked for was reported as a fatal failure");
                 Assert.IsTrue(results.Interrupted,
                     "An aborted backup was not marked as interrupted, so its partial numbers are recorded as the new truth");
@@ -1465,7 +1465,7 @@ namespace Duplicati.UnitTest
             try
             {
                 using var c = new Controller(failtarget, options, null);
-                IBackupResults? results = null;
+                IBackupResults results = null;
                 c.OnOperationStarted += r => results = (IBackupResults)r;
 
                 try
@@ -1480,7 +1480,7 @@ namespace Duplicati.UnitTest
                 }
 
                 Assert.IsNotNull(results, "OnOperationStarted never fired, so there is no result to inspect");
-                Assert.AreEqual(ParsedResultType.Fatal, results!.ParsedResult,
+                Assert.AreEqual(ParsedResultType.Fatal, results.ParsedResult,
                     "A cancellation that nobody requested was not reported as a failure");
                 Assert.IsFalse(results.Interrupted,
                     "A cancellation that nobody requested was reported as a requested interruption");

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -1344,5 +1344,148 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(4, listResults.Filesets.Count());
             }
         }
+
+        /// <summary>
+        /// An abort is something the user asked for, so it must not be reported the way a
+        /// crash is. The exception is still expected to propagate.
+        /// </summary>
+        [Test]
+        [Category("Disruption")]
+        public async Task AbortedBackupIsNotReportedAsFatalAsync()
+        {
+            var options = new Dictionary<string, string>(this.TestOptions) { ["dblock-size"] = "10mb" };
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            this.ModifySourceFiles();
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                IBackupResults? results = null;
+                var startedTcs = new TaskCompletionSource<bool>();
+                c.OnOperationStarted += r =>
+                {
+                    results = (IBackupResults)r;
+                    ((BackupResults)r).OperationProgressUpdater.PhaseChanged += (phase, previousPhase) =>
+                    {
+                        if (phase == OperationPhase.Backup_ProcessingFiles)
+                            startedTcs.TrySetResult(true);
+                    };
+                };
+
+                Task backupTask = c.BackupAsync(new[] { this.DATAFOLDER });
+
+                if (await Task.WhenAny(startedTcs.Task, Task.Delay(TimeSpan.FromSeconds(30))).ConfigureAwait(false) != startedTcs.Task)
+                    Assert.Fail("The backup did not reach the processing phase within 30 seconds");
+
+                await c.AbortAsync().ConfigureAwait(false);
+
+                try
+                {
+                    await backupTask.ConfigureAwait(false);
+                    Assert.Fail("Expected the aborted backup to throw");
+                }
+                catch (OperationCanceledException)
+                {
+                    // The exception is part of the contract: DisruptionTests.StopNowAsync and the
+                    // server both rely on an abort surfacing this way.
+                }
+
+                Assert.IsNotNull(results, "OnOperationStarted never fired, so there is no result to inspect");
+                Assert.AreNotEqual(ParsedResultType.Fatal, results!.ParsedResult,
+                    "An abort the user asked for was reported as a fatal failure");
+                Assert.IsTrue(results.Interrupted,
+                    "An aborted backup was not marked as interrupted, so its partial numbers are recorded as the new truth");
+            }
+        }
+
+        /// <summary>
+        /// A stopped run did not finish, so its numbers must not be recorded as the latest
+        /// state of the backup. See Runner.UpdateMetadata, which keys off Interrupted.
+        /// </summary>
+        [Test]
+        [Category("Disruption")]
+        public async Task StoppedBackupIsMarkedInterruptedAsync()
+        {
+            var options = new Dictionary<string, string>(this.TestOptions) { ["dblock-size"] = "10mb" };
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            this.ModifySourceFiles();
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            {
+                (var backupResults, _) = await this.RunPartialBackupAsync(c).ConfigureAwait(false);
+
+                Assert.IsTrue(backupResults.Interrupted,
+                    "A stopped backup was not marked as interrupted, so its partial numbers are recorded as the new truth");
+
+                // The stop path must stay quiet: the existing partial-backup tests all assert
+                // exactly one warning, so anything added here would break them.
+                Assert.AreEqual(0, backupResults.Errors.Count());
+                Assert.AreEqual(1, backupResults.Warnings.Count());
+            }
+        }
+
+        /// <summary>
+        /// A cancellation nobody asked for is still a failure. Guards against the abort
+        /// handling swallowing real faults, which matters because HttpClient reports its own
+        /// request timeouts as a cancellation.
+        /// </summary>
+        [Test]
+        [Category("Disruption")]
+        public async Task UnrequestedCancellationIsStillFatalAsync()
+        {
+            var options = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "10mb",
+                ["number-of-retries"] = "1"
+            };
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            this.ModifySourceFiles();
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var failtarget = new DeterministicErrorBackend().ProtocolKey + "://" + this.TARGETFOLDER;
+
+            // Always cancelling, so the retries are exhausted and the cancellation reaches the
+            // controller without anyone having requested a shutdown.
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action == DeterministicErrorBackend.BackendAction.PutBefore && remotename.Contains(".dblock.", StringComparison.Ordinal))
+                    throw new OperationCanceledException();
+
+                return false;
+            };
+
+            try
+            {
+                using var c = new Controller(failtarget, options, null);
+                IBackupResults? results = null;
+                c.OnOperationStarted += r => results = (IBackupResults)r;
+
+                try
+                {
+                    await c.BackupAsync(new[] { this.DATAFOLDER }).ConfigureAwait(false);
+                    Assert.Fail("Expected the backup to fail when every upload is cancelled");
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected: the backend gave up
+                }
+
+                Assert.IsNotNull(results, "OnOperationStarted never fired, so there is no result to inspect");
+                Assert.AreEqual(ParsedResultType.Fatal, results!.ParsedResult,
+                    "A cancellation that nobody requested was not reported as a failure");
+                Assert.IsFalse(results.Interrupted,
+                    "A cancellation that nobody requested was reported as a requested interruption");
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+            }
+        }
     }
 }

--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -1439,7 +1439,7 @@ namespace Duplicati.UnitTest
             var options = new Dictionary<string, string>(this.TestOptions)
             {
                 ["dblock-size"] = "10mb",
-                ["number-of-retries"] = "1"
+                ["number-of-retries"] = "0"
             };
 
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
@@ -1450,11 +1450,13 @@ namespace Duplicati.UnitTest
             Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
             var failtarget = new DeterministicErrorBackend().ProtocolKey + "://" + this.TARGETFOLDER;
 
-            // Always cancelling, so the retries are exhausted and the cancellation reaches the
-            // controller without anyone having requested a shutdown.
+            // The filelist is the last upload of a backup, so failing it leaves nothing else in
+            // flight to fail differently once the backend manager stops. Cancelling a dblock
+            // instead is not usable here: the manager stops, and whether the cancellation or the
+            // "backend manager is stopped" error from a following upload surfaces first is a race.
             DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
             {
-                if (action == DeterministicErrorBackend.BackendAction.PutBefore && remotename.Contains(".dblock.", StringComparison.Ordinal))
+                if (action == DeterministicErrorBackend.BackendAction.PutBefore && remotename.Contains(".dlist.", StringComparison.Ordinal))
                     throw new OperationCanceledException();
 
                 return false;
@@ -1469,11 +1471,12 @@ namespace Duplicati.UnitTest
                 try
                 {
                     await c.BackupAsync(new[] { this.DATAFOLDER }).ConfigureAwait(false);
-                    Assert.Fail("Expected the backup to fail when every upload is cancelled");
+                    Assert.Fail("Expected the backup to fail when the filelist upload is cancelled");
                 }
-                catch (OperationCanceledException)
+                catch (Exception)
                 {
-                    // Expected: the backend gave up
+                    // The classification is what this test is about, not the exception type: which
+                    // exception surfaces first out of a faulted process network is not fixed.
                 }
 
                 Assert.IsNotNull(results, "OnOperationStarted never fired, so there is no result to inspect");


### PR DESCRIPTION
Aborting or stopping an operation is something the user asked for, but the two requests are classified inconsistently, and one of them is classified as a crash. I ran into this from both sides while doing #7154 and #7155, which both reported it and left it alone; this is the follow-up. Independent of those two — different file.

## The inconsistency is inside one method

`RunActionAsync` has three exits:

| exit | how it is reached | reported as |
| --- | --- | --- |
| success | the operation returns | `Interrupted = false`, unconditionally |
| `OperationAbortException` | a run-script asked to abort | `// Requested aborts are not failures.` — report-module exception cleared, `Interrupted = true`, no `Fatal` |
| `Exception` | anything else, **including `AbortAsync`** | error logged, phase `Error`, `Fatal = true`, `Interrupted` stays false |

So `AbortAsync` — the "stop now" button — cancels the progress token, the operation throws a cancellation, and it lands in the third row. Twenty lines above, the same method states that a requested abort is not a failure.

And a **stopped** operation returns normally, so it takes the first row and is marked not interrupted at all. Measured while writing #7155: a restore stopped after **1 of 40 files** returned `Interrupted: False`, zero errors, zero warnings — a complete, uninterrupted success.

## What each flag actually controls

Neither drives the CLI exit code — that comes from `PartialBackup` (50) and `ParsedResult` (2/3).

**`Interrupted`** is consumed in exactly one place that matters: `Runner.UpdateMetadataBase`, which guards `SourceFilesSize`, `SourceFilesCount`, `LastBackupStarted/Finished/Duration` and the backend statistics behind `!result.Interrupted`. So it means *"may this run's numbers be recorded as the latest state of this backup?"* A run that was stopped early is precisely the case where they may not — and today a stopped backup overwrites the recorded source size with a partial count.

**`Fatal`** makes `ParsedResult` return `Fatal`. The default `send-level` is `all`, so this does not add an email; it means the report for an operation the user stopped themselves arrives labelled **Fatal**. `ServerUtil`'s `RunBackup` also turns `Fatal` into exit code 4.

## The change

Two edits in `Controller.cs`.

**A requested abort is reported the way the run-script abort is.** A new `catch (OperationCanceledException)` between the two existing catches: clears the report-module exception, sets `Interrupted`, logs at Information instead of Error, does not set `Fatal`, and does not push the phase to `Error`.

**Clearing `Fatal` alone would not have worked.** `ReportHelper` sets the level to `Fatal` whenever it is handed an exception, ignoring the result's own classification, so the abort path passes `null` to `OperationCompleteAsync` — exactly what the run-script path already does.

**The exception is still propagated.** `DisruptionTests.StopNowAsync` asserts that `BackupAsync` throws `OperationCanceledException` after an abort, and the server relies on the same. The abort path therefore rethrows rather than returning the result.

**The guard consults the token, not the exception type.** Only `TaskControl.Terminate` cancels the progress token — `Stop` does not, and neither does `Pause` — so a cancellation nobody requested still falls through to the failure path. That distinction matters concretely: `HttpClient` reports its own request timeouts as `TaskCanceledException`, and a caller's own token would look identical.

**The success path marks a stopped run interrupted.** `Interrupted = false` becomes a check of whether a stop was requested. No warning is added and `ParsedResult` is untouched — see the constraints below.

## Constraints I found in the existing tests

These are read out of the test suite, not assumed, and each one shaped the change:

- **`DisruptionTests.StopNowAsync`** pins the abort throwing, so the new catch rethrows.
- **Six partial-backup tests** (`FilesetFilesAsync`, `KeepTimeRetentionAsync`, `KeepVersionsRetentionAsync`, `ListWithoutLocalDbAsync`, `RetentionPolicyRetentionAsync`, `StopAfterCurrentFileAsync`) assert `Warnings.Count() == 1` on a stopped backup, so the stop path must stay quiet. The new message is Information.
- **`RunScriptTests.RunScriptParsedResultAsync`** pins a case with `Interrupted == true` **and** `ParsedResult == Success`, so `ParsedResult` cannot be made to follow `Interrupted`. I had considered making a stopped run report `Warning` for symmetry with `PartialBackup`; this rules it out.
- No existing test asserts `Interrupted` on a stopped run, and `TestUtils.AssertResults` only looks at errors and warnings, so setting it is safe.

## Testing

Three new tests in `DisruptionTests`:

| test | claim | before | after |
| --- | --- | --- | --- |
| `AbortedBackupIsNotReportedAsFatalAsync` | `ParsedResult != Fatal` | **red** (`Fatal`) | green |
| | `Interrupted == true` | red | green |
| | still throws `OperationCanceledException` | green | green |
| `StoppedBackupIsMarkedInterruptedAsync` | `Interrupted == true` | **red** (`False`) | green |
| | `Warnings.Count() == 1` | green | green |
| `UnrequestedCancellationIsStillFatalAsync` | `ParsedResult == Fatal`, `Interrupted == false` | green | green |

The third one is the reason the guard is written the way it is: a cancellation nobody requested must stay `Fatal`. Nothing in the suite covered that before — the existing `TestD*UploadWithOperationCancellationAsync` tests cancel once and succeed on the retry, so the exception never reaches the controller.

**That test asserts the classification, not the exception type, and the first version of it was wrong.** I had it cancel a dblock upload and expect `BackupAsync` to surface the cancellation. It does on my machine. On CI it did not: the backend manager stops on that first failure, a following dindex or dlist upload then throws "backend manager is stopped", and *that* is what reaches the caller — so the test failed on both Linux and Windows while passing locally. Which exception comes first out of a faulted process network is not fixed, so pinning the type was the wrong assertion. The failure is now on the filelist, the last upload of a backup, so nothing else is in flight to fail differently, and the assertion is on the result being `Fatal` and not interrupted.

Worth being precise about what this buys: over-capture is close to structurally impossible, because the guard also requires the progress token to be cancelled and only `TaskControl.Terminate` ever does that. The test is there to keep it that way, not because the guard is delicately balanced.

Targeted runs, all green:

- the three new tests: **3/3**; the reworked third one **3/3** on its own after the fix
- `StopNowAsync`, the six partial-backup tests, and the three `TestD*UploadWithOperationCancellationAsync` tests: **10/10**
- `RunScriptTests`: **20/20**
- CI on the first push: **1376/1377 (Linux) and 1582/1583 (Windows)**, the single failure being the test described above; the two tests covering the actual change passed on every OS

I picked the local runs by reading what each test asserts rather than by running the whole category, since most of it does not reach this code.

## Out of scope, reported

- **A stopped restore has no `PartialBackup` equivalent.** Backup marks its fileset partial, reports `Warning` and yields CLI exit 50; restore has nothing comparable, so a partially restored set is only distinguishable through `Interrupted` and the log. Whether restore should grow such a signal — and what exit code it deserves — is a separate discussion.
- Setting `Interrupted` on a stop is a **behaviour change for backup as well as restore**: the server will no longer overwrite `SourceFilesSize` and the last-backup timestamps from a stopped run, so the UI keeps the previous complete values instead of partial ones. I believe that is the correct reading of the flag, but it is a visible change and worth a maintainer's eye.
