### PR TITLE
Point the CI test filters at the tests they meant to run

### DIFF
--- a/.github/workflows/backendtests.yml
+++ b/.github/workflows/backendtests.yml
@@ -628,7 +628,7 @@ jobs:
           LiveTests/Duplicati.Backend.Tests/Duplicati.Backend.Tests.slnx
       - name: Run CIFS tests
         run: >-
-          dotnet test --no-build --filter="ClassName~CIFSTests"
+          dotnet test --no-build --filter="ClassName~SMBTests"
           --logger:"console;verbosity=detailed"
           LiveTests/Duplicati.Backend.Tests/Duplicati.Backend.Tests.slnx
   test_b2:

--- a/.github/workflows/secretprovidertests.yml
+++ b/.github/workflows/secretprovidertests.yml
@@ -245,7 +245,7 @@ jobs:
           DUPLICATI_TEST_HCV_URL: "${{ secrets.DUPLICATI_TEST_HCV_URL }}"
         run: |
           mkdir -p "$GITHUB_WORKSPACE/TestResults/secretprovider/hcvault"
-          dotnet test --no-build --filter="FullyQualifiedName~SecretProviderSetSecretTests.HcVaultProvider_SetSecret_Works" --collect:"XPlat Code Coverage" --results-directory "$GITHUB_WORKSPACE/TestResults/secretprovider/hcvault" --logger:"console;verbosity=detailed" Duplicati.slnx
+          dotnet test --no-build --filter="FullyQualifiedName~SecretProviderSetSecretTests.HcVaultProvider_SetSecret_Works_Async" --collect:"XPlat Code Coverage" --results-directory "$GITHUB_WORKSPACE/TestResults/secretprovider/hcvault" --logger:"console;verbosity=detailed" Duplicati.slnx
 
   test_hcvault_testcontainers:
     name: HashiCorp Vault Secret Provider SetSecret Tests (Testcontainers)


### PR DESCRIPTION
Two `--filter` expressions in the workflows do not select the tests they name. I went looking after noticing a permanently skipped check on #7157 and comparing every filter in both workflows against the test sources.

## The CIFS job has been green while running no tests

`backendtests.yml` filters the CIFS job on `ClassName~CIFSTests`. **There is no such class.** The tests are in `SMBTests` (`Duplicati.Backend.Tests.SMB`), which lives under the `CIFS/` directory — the filter appears to have been named after the directory.

`dotnet test` returns success when a filter matches nothing, so the job goes green. Any run that reached it says so in the log — for example the CIFS job on #7159:

```
No test matches the given testcase filter `ClassName~CIFSTests` in .../Duplicati.Backend.Tests.dll
```

and the job concluded **success**. Reproduced locally, same result: exit code 0, zero tests. This is worse than a skipped check, because a skip is at least visible.

## The HashiCorp Vault job's filter is broader than its name

`--filter` matches substrings, so `FullyQualifiedName~SecretProviderSetSecretTests.HcVaultProvider_SetSecret_Works` selects both

- `HcVaultProvider_SetSecret_Works_Async` — the one it means, which talks to a real Vault
- `HcVaultProvider_SetSecret_Works_WithTestcontainers_Async` — which has its own job

That job runs a three-OS matrix, so it would pull the container-based test onto the Windows and macOS runners, where there is no Docker and it can only ignore itself. Measured on the current tree:

| filter | tests selected |
| --- | --- |
| `…HcVaultProvider_SetSecret_Works` | **2** |
| `…HcVaultProvider_SetSecret_Works_Async` | 1 |

It has never actually run — `DUPLICATI_TEST_HCV_URL` is not configured, so the job has skipped on every recent run. A job that has never run is also a job whose correctness nobody has ever checked, which is how this went unnoticed.

## Everything else checks out

I compared every filter in both workflows against the sources rather than fixing only what I tripped over:

| | result |
| --- | --- |
| `secretprovidertests.yml`, 5 `FullyQualifiedName~` filters | the other 4 (File, Aws, Azure, Gcs) each select exactly 1 test |
| `backendtests.yml`, 17 `ClassName~` filters | the other 16 each select exactly 1 class |

The namespace-qualified ones were checked against the real namespaces too — `Box.BoxTests` does not collide with `DropBoxTests` precisely because it is qualified. `SMBTests` is unique among the 20 test classes, so the bare form matches the style of its unqualified siblings (`FtpTests`, `S3Tests`, …).

## Verification

The fix is two lines, so the verification is about proving the filters now select what they name.

| filter | before | after |
| --- | --- | --- |
| CIFS | `No test matches`, **exit 0** | `TestSmb` discovered, 1 test |
| HCV | 2 tests selected | 1 test selected |

**What I could not verify: whether the CIFS test itself passes.** It has never run in CI, and I cannot run it here — `SMBTests` binds host ports 139 and 445, and on Windows both are held by the OS (PID 4), so the job is `ubuntu-latest` for a reason. I did start Docker and try: the Samba container did not become ready inside the wait strategy's timeout. That tells us nothing about the Linux runner, so I am not presenting it as evidence either way. I checked the one hypothesis I could rule out cheaply — the generated `entrypoint.sh` picking up CRLF from the source file — and it does not apply, since `SMBTests.cs` is LF-only.

**So this PR may well turn the CIFS job red.** That is the point of it, but it is worth saying plainly rather than having it arrive as a surprise: the job is currently green on zero coverage, and after this it will report whatever the SMB tests actually do.

Neither job runs on a fork PR — both are gated on secrets (`TC_CLOUD_TOKEN`, `DUPLICATI_TEST_HCV_URL`) — so CI on this PR cannot exercise either of them.

## Out of scope, reported

- **The CIFS job is gated on `TC_CLOUD_TOKEN`**, but the test's own comment says "This test has no requirement of environment variables" — it needs Docker, not a Testcontainers Cloud token, and GitHub's ubuntu runners have Docker. Removing that gate would let it run on fork PRs, at the cost of runner time. That is a maintainer's call, so I left it alone.
- **`DUPLICATI_TEST_HCV_URL` is not configured**, so the Vault job will keep skipping. This PR makes it correct for the day it is configured; it does not stop the skip.
