### PR TITLE
Stop blaming the local files a shutdown interrupted

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -233,7 +233,10 @@ namespace Duplicati.Library.Main.Operation.Restore
                                         {
                                             await CopyOldTargetBlocksToNewTargetAsync(file, new_file, restoreDestination, buffer, options.Blocksize, verified_blocks, results.TaskControl.ProgressToken).ConfigureAwait(false);
                                         }
-                                        catch (Exception ex)
+                                        // Swallowing a requested shutdown here would carry on with
+                                        // the rest of the file instead of stopping, so the filter
+                                        // lets it through to the handler that ends the process.
+                                        catch (Exception ex) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                         {
                                             Logging.Log.WriteErrorMessage(LOGTAG, "CopyOldTargetToNew", ex, "Error when trying to copy {0} to {1}", file, new_file);
                                             results.BrokenLocalFiles.Add(file.TargetPath);
@@ -505,6 +508,15 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     }
                                 }
                                 sw_work?.Stop();
+                            }
+                            // A requested shutdown stops the file wherever it happened to be, so
+                            // it did not "fail to restore" in any sense the user needs told. The
+                            // channels still have to be retired to tear the network down.
+                            catch (Exception) when (RestoreCancellation.IsShutdownRequested(results.TaskControl))
+                            {
+                                block_request.Retire();
+                                block_response.Retire();
+                                throw;
                             }
                             catch (Exception)
                             {
@@ -936,7 +948,11 @@ namespace Duplicati.Library.Main.Operation.Restore
                         }
                     }
                 }
-                catch (Exception)
+                // The file is only recorded as having failed when something actually went wrong.
+                // A stop or an abort ends the work wherever it stands, and the files that happen
+                // to be in flight at that moment are not evidence of anything: the next restore
+                // verifies them block by block and repairs whatever is short.
+                catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                 {
                     lock (results)
                     {
@@ -971,7 +987,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     using var f = await restoreDestination.OpenWrite(file.TargetPath, cancellationToken).ConfigureAwait(false);
                                     f.SetLength(file.Length);
                                 }
-                                catch (Exception)
+                                catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                 {
                                     lock (results)
                                     {
@@ -1047,7 +1063,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                             f_original.Seek(i * options.Blocksize, SeekOrigin.Begin);
                             read = await f_original.ReadAsync(buffer, 0, (int)blocks[j].BlockSize).ConfigureAwait(false);
                         }
-                        catch (Exception)
+                        catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                         {
                             lock (results)
                             {
@@ -1076,7 +1092,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                                 .WriteAsync(buffer, 0, read)
                                                 .ConfigureAwait(false);
                                         }
-                                        catch (Exception)
+                                        catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                         {
                                             lock (results)
                                             {
@@ -1125,7 +1141,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     .ReadAsync(buffer, 0, options.Blocksize)
                                     .ConfigureAwait(false);
                             }
-                            catch (Exception)
+                            catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                             {
                                 lock (results)
                                 {
@@ -1157,7 +1173,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                 {
                                     f_target.SetLength(file.Length);
                                 }
-                                catch (Exception)
+                                catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                 {
                                     lock (results)
                                     {

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -874,5 +874,139 @@ namespace Duplicati.UnitTest
                 DeterministicErrorBackend.ErrorGenerator = null;
             }
         }
+
+        /// <summary>
+        /// An abort must not record the files it was in the middle of as having failed to
+        /// restore. This runs over an existing restore target, which is what takes the file
+        /// processor through the paths that inspect the file already on disk.
+        /// </summary>
+        [Test]
+        [Category("RestoreHandler")]
+        public async Task AbortedRestoreOverExistingFilesDoesNotBlameThemAsync()
+        {
+            const int fileCount = 40;
+            const int volumesBeforeAbort = 3;
+
+            var backupOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "200kb",
+                ["blocksize"] = "4kb"
+            };
+
+            var rng = new Random(42);
+            var data = new byte[32 * 1024];
+            for (var i = 0; i < fileCount; i++)
+            {
+                rng.NextBytes(data);
+                File.WriteAllBytes(Path.Combine(this.DATAFOLDER, $"file{i}"), data);
+            }
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            var restoreOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "200kb",
+                ["blocksize"] = "4kb",
+                ["restore-path"] = this.RESTOREFOLDER,
+                ["restore-legacy"] = "false",
+                ["restore-with-local-blocks"] = "false",
+                ["restore-volume-downloaders"] = "4",
+                ["restore-volume-decryptors"] = "1",
+                ["restore-volume-decompressors"] = "1",
+                ["restore-file-processors"] = "1"
+            };
+
+            // First restore in full, so the second one has targets on disk to inspect. Without
+            // existing targets the file processor never opens them and the paths under test are
+            // not reached at all.
+            using (var c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+                TestUtils.AssertResults(await c.RestoreAsync(new[] { "*" }));
+
+            // Corrupt every restored file so the second restore has real work to do on each of
+            // them rather than verifying them and moving on.
+            foreach (var path in Directory.GetFiles(this.RESTOREFOLDER, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                for (var i = 0; i < Math.Min(bytes.Length, 4096); i++)
+                    bytes[i] ^= 0xFF;
+                File.WriteAllBytes(path, bytes);
+            }
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var downloaded = 0;
+            var enoughDownloaded = new TaskCompletionSource();
+
+            // A hook rather than a source of errors: it always answers "no error", but delays
+            // each volume fetch and signals before the delay, so the abort lands while the
+            // restore is still working rather than wherever the machine's speed puts it.
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action != DeterministicErrorBackend.BackendAction.GetBefore
+                    || !remotename.Contains(".dblock.", StringComparison.Ordinal))
+                    return false;
+
+                if (System.Threading.Interlocked.Increment(ref downloaded) >= volumesBeforeAbort)
+                    enoughDownloaded.TrySetResult();
+
+                System.Threading.Thread.Sleep(1500);
+                return false;
+            };
+
+            try
+            {
+                var restoreErrors = new System.Collections.Concurrent.ConcurrentQueue<string>();
+                // Spelled out rather than taken from the types, which are internal to
+                // Duplicati.Library.Main
+                const string restoreNamespace = "Duplicati.Library.Main.Operation.Restore.";
+
+                Library.Main.RestoreResults? restoreResults = null;
+                using var c2 = new Controller(new DeterministicErrorBackend().ProtocolKey + "://" + this.TARGETFOLDER, restoreOptions, null);
+                c2.OnOperationStarted += r => restoreResults = (Library.Main.RestoreResults)r;
+
+                using (Library.Logging.Log.StartScope(e =>
+                {
+                    if (e.Level == Library.Logging.LogMessageType.Error
+                        && e.Tag != null && e.Tag.StartsWith(restoreNamespace, StringComparison.Ordinal))
+                        restoreErrors.Enqueue($"{e.Tag.Split('.').Last()}/{e.Id}: {e.FormattedMessage}");
+                }))
+                {
+                    var restoreTask = Task.Run(async () => await c2.RestoreAsync(new[] { "*" }));
+
+                    var trigger = await Task.WhenAny(enoughDownloaded.Task, restoreTask, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false);
+                    if (trigger == restoreTask)
+                        Assert.Ignore("The restore finished before it could be aborted; the download hook is not slowing it down enough");
+                    if (trigger != enoughDownloaded.Task)
+                        Assert.Fail($"The restore did not download {volumesBeforeAbort} volumes within a minute");
+
+                    await c2.AbortAsync().ConfigureAwait(false);
+
+                    // Bounded: an abort that does not stop the restore has to fail the test
+                    // rather than hang the run.
+                    var grace = TimeSpan.FromMinutes(2);
+                    var stopped = await Task.WhenAny(restoreTask, Task.Delay(grace)).ConfigureAwait(false) == restoreTask;
+                    Assert.IsTrue(stopped, $"The abort did not stop the restore within {grace.TotalMinutes:F0} minutes");
+
+                    try { await restoreTask.ConfigureAwait(false); }
+                    catch (Exception) { /* the abort is expected to fault the operation */ }
+                }
+
+                NUnit.Framework.Assert.Multiple(() =>
+                {
+                    Assert.AreEqual(0, restoreResults!.BrokenLocalFiles.Count(),
+                        $"An aborted restore reported files it never finished as having failed to restore: {string.Join(", ", restoreResults.BrokenLocalFiles)}");
+
+                    Assert.AreEqual(0, restoreResults.BrokenRemoteFiles.Count(),
+                        $"An aborted restore blamed the backup for {string.Join(", ", restoreResults.BrokenRemoteFiles)}");
+
+                    Assert.AreEqual(0, restoreErrors.Count,
+                        $"An aborted restore reported errors:{Environment.NewLine}{string.Join(Environment.NewLine, restoreErrors)}");
+                });
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+            }
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #7154. That PR fixed the download side — an aborted transfer being recorded in `BrokenRemoteFiles` as a defect in the backup — and reported the same shape in `FileProcessor` without fixing it, because I thought the argument was different: a local file that was half-written when the abort landed genuinely *is* suspect. Having looked at it properly, that reasoning does not hold up.

## What happens today

`FileProcessor` adds to `results.BrokenLocalFiles` from eight `catch` blocks, none of which asks why the operation failed. Aborting a restore therefore lists whatever files the workers happened to be holding at that instant.

Measured on a restore running over existing targets — abort after three volumes have been fetched:

| | before | after |
| --- | --- | --- |
| `BrokenLocalFiles` | **1 entry**, a file the restore simply never finished | 0 |
| `BrokenRemoteFiles` | 0 (fixed in #7154) | 0 |
| error-level logs from the restore namespace | 0 (fixed in #7154) | 0 |

`BrokenLocalFiles` means "failed to restore" — `RestoreHandler` renders it as `Failed to restore {N} local files.` at error level — so a requested stop does not belong in it.

## Why record nothing rather than record the half-written ones

Two reasons, and they are what changed my mind since #7154:

**The next restore repairs them by itself.** `VerifyTargetBlocksAsync` walks the existing target block by block and re-fetches whatever does not match. A file left short by an abort is exactly the case that path is built for. Listing it adds nothing the user has to act on.

**The list is an arbitrary subset either way.** It is not the files that were not restored, and it is not the files that were damaged — it is the files a worker was inside when the token was cancelled. Reporting that as "failed to restore" says something the data does not support.

## The change

Seven of the eight sites get an exception filter, so the record is skipped when — and only when — a shutdown was requested:

```csharp
catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
```

The exception still propagates; only the bookkeeping is dropped. `IsShutdownRequested` is the predicate #7154 introduced and #7155 widened; it consults the task reader's tokens rather than the exception type, so a real backend timeout — which `HttpClient` reports as a `TaskCanceledException` — is still recorded as a failure.

Two sites needed more than the filter:

- **The one that retires the block channels** gets its own preceding catch, so retirement still happens on the shutdown path. That is cleanup, not reporting. Same treatment `VolumeDownloader` got in #7154.
- **The one that swallowed its exception** (`CopyOldTargetToNew`) now lets a shutdown through instead. Keeping the swallow while dropping only the record would have carried on with the rest of the file after being told to stop — and it also stops that path logging an error for a requested abort.

**The hash-mismatch site is deliberately untouched.** It is not an exception handler but a genuine verification result — the file was restored and its hash does not match — and a cancellation cannot produce it, since the cancellation throws before the check. Same reasoning that left `NotRetired` alone in #7154.

## Testing

New test `RestoreHandlerTests.AbortedRestoreOverExistingFilesDoesNotBlameThemAsync`, reusing #7154's scaffolding (`DeterministicErrorBackend` as a hook that answers "no error" but delays each `dblock` fetch and signals before the delay, so the abort lands at the same point on every machine).

It restores once in full and then corrupts the targets before the run under test. That matters: without existing targets the file processor never opens them, `VerifyTargetBlocksAsync` returns early, and the paths under test are not reached at all — which is why #7154's abort test did not catch this.

- new test: **red before** (1 entry), **green 3/3 after**
- `Category=RestoreHandler`: **36/36, twice**
- the wait after the abort is bounded, so an abort that fails to stop the restore fails the test instead of hanging the run

**Honest about coverage.** Only the sites in `VerifyTargetBlocksAsync` and the per-file handler are exercised: their `try` blocks wrap `OpenRead`/`OpenWrite` calls that take the cancellation token. The four sites in `VerifyLocalBlocksAsync` are **not** covered — that method needs `--restore-with-local-blocks`, which defaults to false, and the operations its `catch` blocks wrap (`ReadAsync`, `WriteAsync`, `SetLength`) take no token. They are changed for consistency, since they are the same construct with the same problem, but I have not demonstrated them firing.

## Out of scope

`RestoreHandler`'s `RestoreFailures` summary is never reached on an abort — the process network faults and `DoRunNewAsync` throws before it — so this changes the result object rather than that message. How a stopped or aborted operation is classified overall is #7157.
