### PR TITLE
Let an abort interrupt the restore's file reads and writes

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -193,7 +193,11 @@ namespace Duplicati.Library.Main.Operation.Restore
                         {
                             (bytes_verified, missing_blocks, verified_blocks) = await VerifyTargetBlocksAsync(file, restoreDestination, blocks, filehasher, blockhasher, buffer, options, results, results.TaskControl.ProgressToken).ConfigureAwait(false);
                         }
-                        catch (Exception ex)
+                        // Now that the reads observe the token, a shutdown reaches this handler.
+                        // Letting it through matters twice over: continuing would carry on with
+                        // the next file after being told to stop, and it would report the
+                        // interruption as an error against the target file.
+                        catch (Exception ex) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                         {
                             Logging.Log.WriteErrorMessage(LOGTAG, "VerifyTargetBlocks", ex, "Error during checking the target file");
                             continue;
@@ -441,7 +445,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                         {
                                             // Write the block to the file
                                             sw_work_write?.Start();
-                                            await fs!.WriteAsync(datablock.Data.AsMemory(0, (int)blocks[i].BlockSize)).ConfigureAwait(false);
+                                            await fs!.WriteAsync(datablock.Data.AsMemory(0, (int)blocks[i].BlockSize), results.TaskControl.ProgressToken).ConfigureAwait(false);
                                             sw_work_write?.Stop();
                                         }
 
@@ -468,7 +472,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                         {
                                             sw_work_read?.Start();
                                             var read = await fs
-                                                .ReadAsync(buffer, 0, buffer.Length)
+                                                .ReadAsync(buffer, 0, buffer.Length, results.TaskControl.ProgressToken)
                                                 .ConfigureAwait(false);
                                             sw_work_read?.Stop();
                                             sw_work_hash?.Start();
@@ -917,7 +921,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                     using var f = await restoreDestination.OpenRead(file.TargetPath, cancellationToken).ConfigureAwait(false);
                     for (int i = 0; i < blocks.Length; i++)
                     {
-                        var read = await f.ReadAsync(buffer, 0, (int)blocks[i].BlockSize).ConfigureAwait(false);
+                        var read = await f.ReadAsync(buffer, 0, (int)blocks[i].BlockSize, cancellationToken).ConfigureAwait(false);
                         if (read == blocks[i].BlockSize)
                         {
                             // Block is present
@@ -1061,7 +1065,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                         try
                         {
                             f_original.Seek(i * options.Blocksize, SeekOrigin.Begin);
-                            read = await f_original.ReadAsync(buffer, 0, (int)blocks[j].BlockSize).ConfigureAwait(false);
+                            read = await f_original.ReadAsync(buffer, 0, (int)blocks[j].BlockSize, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                         {
@@ -1089,7 +1093,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                         {
                                             f_target.Seek(blocks[j].BlockOffset * options.Blocksize, SeekOrigin.Begin);
                                             await f_target
-                                                .WriteAsync(buffer, 0, read)
+                                                .WriteAsync(buffer, 0, read, cancellationToken)
                                                 .ConfigureAwait(false);
                                         }
                                         catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
@@ -1138,7 +1142,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                             {
                                 f_target.Seek(i * options.Blocksize, SeekOrigin.Begin);
                                 read = await f_target
-                                    .ReadAsync(buffer, 0, options.Blocksize)
+                                    .ReadAsync(buffer, 0, options.Blocksize, cancellationToken)
                                     .ConfigureAwait(false);
                             }
                             catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))

--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -233,7 +233,10 @@ namespace Duplicati.Library.Main.Operation.Restore
                                         {
                                             await CopyOldTargetBlocksToNewTargetAsync(file, new_file, restoreDestination, buffer, options.Blocksize, verified_blocks, results.TaskControl.ProgressToken).ConfigureAwait(false);
                                         }
-                                        catch (Exception ex)
+                                        // Swallowing a requested shutdown here would carry on with
+                                        // the rest of the file instead of stopping, so the filter
+                                        // lets it through to the handler that ends the process.
+                                        catch (Exception ex) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                         {
                                             Logging.Log.WriteErrorMessage(LOGTAG, "CopyOldTargetToNew", ex, "Error when trying to copy {0} to {1}", file, new_file);
                                             results.BrokenLocalFiles.Add(file.TargetPath);
@@ -505,6 +508,15 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     }
                                 }
                                 sw_work?.Stop();
+                            }
+                            // A requested shutdown stops the file wherever it happened to be, so
+                            // it did not "fail to restore" in any sense the user needs told. The
+                            // channels still have to be retired to tear the network down.
+                            catch (Exception) when (RestoreCancellation.IsShutdownRequested(results.TaskControl))
+                            {
+                                block_request.Retire();
+                                block_response.Retire();
+                                throw;
                             }
                             catch (Exception)
                             {
@@ -936,7 +948,11 @@ namespace Duplicati.Library.Main.Operation.Restore
                         }
                     }
                 }
-                catch (Exception)
+                // The file is only recorded as having failed when something actually went wrong.
+                // A stop or an abort ends the work wherever it stands, and the files that happen
+                // to be in flight at that moment are not evidence of anything: the next restore
+                // verifies them block by block and repairs whatever is short.
+                catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                 {
                     lock (results)
                     {
@@ -971,7 +987,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     using var f = await restoreDestination.OpenWrite(file.TargetPath, cancellationToken).ConfigureAwait(false);
                                     f.SetLength(file.Length);
                                 }
-                                catch (Exception)
+                                catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                 {
                                     lock (results)
                                     {
@@ -1047,7 +1063,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                             f_original.Seek(i * options.Blocksize, SeekOrigin.Begin);
                             read = await f_original.ReadAsync(buffer, 0, (int)blocks[j].BlockSize).ConfigureAwait(false);
                         }
-                        catch (Exception)
+                        catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                         {
                             lock (results)
                             {
@@ -1076,7 +1092,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                                 .WriteAsync(buffer, 0, read)
                                                 .ConfigureAwait(false);
                                         }
-                                        catch (Exception)
+                                        catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                         {
                                             lock (results)
                                             {
@@ -1125,7 +1141,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                     .ReadAsync(buffer, 0, options.Blocksize)
                                     .ConfigureAwait(false);
                             }
-                            catch (Exception)
+                            catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                             {
                                 lock (results)
                                 {
@@ -1157,7 +1173,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                                 {
                                     f_target.SetLength(file.Length);
                                 }
-                                catch (Exception)
+                                catch (Exception) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                                 {
                                     lock (results)
                                     {

--- a/Duplicati/UnitTest/RestoreHandlerTests.cs
+++ b/Duplicati/UnitTest/RestoreHandlerTests.cs
@@ -874,5 +874,139 @@ namespace Duplicati.UnitTest
                 DeterministicErrorBackend.ErrorGenerator = null;
             }
         }
+
+        /// <summary>
+        /// An abort must not record the files it was in the middle of as having failed to
+        /// restore. This runs over an existing restore target, which is what takes the file
+        /// processor through the paths that inspect the file already on disk.
+        /// </summary>
+        [Test]
+        [Category("RestoreHandler")]
+        public async Task AbortedRestoreOverExistingFilesDoesNotBlameThemAsync()
+        {
+            const int fileCount = 40;
+            const int volumesBeforeAbort = 3;
+
+            var backupOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "200kb",
+                ["blocksize"] = "4kb"
+            };
+
+            var rng = new Random(42);
+            var data = new byte[32 * 1024];
+            for (var i = 0; i < fileCount; i++)
+            {
+                rng.NextBytes(data);
+                File.WriteAllBytes(Path.Combine(this.DATAFOLDER, $"file{i}"), data);
+            }
+
+            using (var c = new Controller("file://" + this.TARGETFOLDER, backupOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+            var restoreOptions = new Dictionary<string, string>(this.TestOptions)
+            {
+                ["dblock-size"] = "200kb",
+                ["blocksize"] = "4kb",
+                ["restore-path"] = this.RESTOREFOLDER,
+                ["restore-legacy"] = "false",
+                ["restore-with-local-blocks"] = "false",
+                ["restore-volume-downloaders"] = "4",
+                ["restore-volume-decryptors"] = "1",
+                ["restore-volume-decompressors"] = "1",
+                ["restore-file-processors"] = "1"
+            };
+
+            // First restore in full, so the second one has targets on disk to inspect. Without
+            // existing targets the file processor never opens them and the paths under test are
+            // not reached at all.
+            using (var c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+                TestUtils.AssertResults(await c.RestoreAsync(new[] { "*" }));
+
+            // Corrupt every restored file so the second restore has real work to do on each of
+            // them rather than verifying them and moving on.
+            foreach (var path in Directory.GetFiles(this.RESTOREFOLDER, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                for (var i = 0; i < Math.Min(bytes.Length, 4096); i++)
+                    bytes[i] ^= 0xFF;
+                File.WriteAllBytes(path, bytes);
+            }
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var downloaded = 0;
+            var enoughDownloaded = new TaskCompletionSource();
+
+            // A hook rather than a source of errors: it always answers "no error", but delays
+            // each volume fetch and signals before the delay, so the abort lands while the
+            // restore is still working rather than wherever the machine's speed puts it.
+            DeterministicErrorBackend.ErrorGenerator = (action, remotename) =>
+            {
+                if (action != DeterministicErrorBackend.BackendAction.GetBefore
+                    || !remotename.Contains(".dblock.", StringComparison.Ordinal))
+                    return false;
+
+                if (System.Threading.Interlocked.Increment(ref downloaded) >= volumesBeforeAbort)
+                    enoughDownloaded.TrySetResult();
+
+                System.Threading.Thread.Sleep(1500);
+                return false;
+            };
+
+            try
+            {
+                var restoreErrors = new System.Collections.Concurrent.ConcurrentQueue<string>();
+                // Spelled out rather than taken from the types, which are internal to
+                // Duplicati.Library.Main
+                const string restoreNamespace = "Duplicati.Library.Main.Operation.Restore.";
+
+                Library.Main.RestoreResults? restoreResults = null;
+                using var c2 = new Controller(new DeterministicErrorBackend().ProtocolKey + "://" + this.TARGETFOLDER, restoreOptions, null);
+                c2.OnOperationStarted += r => restoreResults = (Library.Main.RestoreResults)r;
+
+                using (Library.Logging.Log.StartScope(e =>
+                {
+                    if (e.Level == Library.Logging.LogMessageType.Error
+                        && e.Tag != null && e.Tag.StartsWith(restoreNamespace, StringComparison.Ordinal))
+                        restoreErrors.Enqueue($"{e.Tag.Split('.').Last()}/{e.Id}: {e.FormattedMessage}");
+                }))
+                {
+                    var restoreTask = Task.Run(async () => await c2.RestoreAsync(new[] { "*" }));
+
+                    var trigger = await Task.WhenAny(enoughDownloaded.Task, restoreTask, Task.Delay(TimeSpan.FromMinutes(1))).ConfigureAwait(false);
+                    if (trigger == restoreTask)
+                        Assert.Ignore("The restore finished before it could be aborted; the download hook is not slowing it down enough");
+                    if (trigger != enoughDownloaded.Task)
+                        Assert.Fail($"The restore did not download {volumesBeforeAbort} volumes within a minute");
+
+                    await c2.AbortAsync().ConfigureAwait(false);
+
+                    // Bounded: an abort that does not stop the restore has to fail the test
+                    // rather than hang the run.
+                    var grace = TimeSpan.FromMinutes(2);
+                    var stopped = await Task.WhenAny(restoreTask, Task.Delay(grace)).ConfigureAwait(false) == restoreTask;
+                    Assert.IsTrue(stopped, $"The abort did not stop the restore within {grace.TotalMinutes:F0} minutes");
+
+                    try { await restoreTask.ConfigureAwait(false); }
+                    catch (Exception) { /* the abort is expected to fault the operation */ }
+                }
+
+                NUnit.Framework.Assert.Multiple(() =>
+                {
+                    Assert.AreEqual(0, restoreResults!.BrokenLocalFiles.Count(),
+                        $"An aborted restore reported files it never finished as having failed to restore: {string.Join(", ", restoreResults.BrokenLocalFiles)}");
+
+                    Assert.AreEqual(0, restoreResults.BrokenRemoteFiles.Count(),
+                        $"An aborted restore blamed the backup for {string.Join(", ", restoreResults.BrokenRemoteFiles)}");
+
+                    Assert.AreEqual(0, restoreErrors.Count,
+                        $"An aborted restore reported errors:{Environment.NewLine}{string.Join(Environment.NewLine, restoreErrors)}");
+                });
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+            }
+        }
     }
 }


### PR DESCRIPTION
> Depends on #7161 — see below. This branch is #7161 plus one commit.

`FileProcessor` opens every stream with the cancellation token and then never passes it to the reads and writes on that stream:

```csharp
using var f = await restoreDestination.OpenRead(file.TargetPath, cancellationToken)...   // passed
var read = await f.ReadAsync(buffer, 0, (int)blocks[i].BlockSize)...                     // not passed
```

`CopyOldTargetBlocksToNewTargetAsync`, in the same file, already passes the token to its `WriteAsync`. So this is a gap, not a decision.

## It does not just stop slowly — it hangs

I expected this to be a responsiveness nicety and said so while investigating. It is not. Measured on one 200 MB file whose blocks all have to be rewritten from the local original (`--restore-with-local-blocks`), so the copy loop is where the time goes:

| | before | after |
| --- | --- | --- |
| restore left alone | 28.6s | — |
| abort issued 2s in → restore stops | **still running past 2 minutes** | **0.24s** |
| restore task | never returned | `OperationCanceledException` |

A restore that finishes in 28.6s on its own does not finish within two minutes of being aborted. The loop keeps reading and writing while the rest of the process network winds down around it, and what it reaches afterwards is no longer there.

## The change

The token that is already in hand is passed to the six stream operations that were missing it — two in the main restore loop, which use `results.TaskControl.ProgressToken` like the `OpenWrite`/`OpenRead` calls beside them, and four in the verification helpers, which already receive a `cancellationToken` parameter.

`ms.WriteAsync` in the metadata path is deliberately left alone: `ms` is a `MemoryStream` and cannot block, so a token there would be noise.

**One companion change was required.** With the reads now observing the token, a shutdown reaches the handler around `VerifyTargetBlocksAsync`:

```csharp
catch (Exception ex)
{
    Logging.Log.WriteErrorMessage(LOGTAG, "VerifyTargetBlocks", ex, "Error during checking the target file");
    continue;
}
```

That `continue` would carry on with the next file after being told to stop, and would report the interruption as an error against the target. It gets the same guard #7161 gave the other handlers in this file — `when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))`.

This is not hypothetical: with the tokens in place but the guard missing, the probe reported `[Error] FileProcessor/VerifyTargetBlocks`. With the guard, that message is gone and the abort still stops the restore in 0.32s.

## Why this builds on #7161

Making the reads and writes throw is what sends cancellations into the `catch` blocks that record `BrokenLocalFiles`. Without #7161's guards on those, this change would newly blame every file that happened to be in flight.

## Testing

- the measurements above, all with a bounded wait so a restore that refuses to stop is reported rather than waited on
- `Category=RestoreHandler`: **36/36, twice**, including #7161's abort tests

**How this was measured, since the first attempts failed.** The abort has to land inside a copy loop, and I initially aborted on a fixed delay against a loop that finished in ~0.3s, so it never did. Making the loop long enough — one large file, every block rewritten from the local original — puts the abort reliably inside it. No slow-stream fake was needed: a read against an already-cancelled token throws immediately, so the loop only has to still be running.

The four sites in `VerifyLocalBlocksAsync` are the ones the measurement exercises. The two in the main restore loop are the same gap in the same shape and are changed with it, but the numbers above do not isolate them.

## Out of scope, reported

- **The CoCoL channel operations take no token either** — `block_request.WriteAsync(...)`, `block_response.ReadAsync()`, `self.Input.ReadAsync()`. Those are the back-pressure points, and threading cancellation through them changes how the network tears down, which wants its own change. It is the same family as #6461.
- `SystemIO.IO_OS.FileOpenRead` opens the original file synchronously.
