### PR TITLE
Improve Linux build experience

### DIFF
--- a/Duplicati/WebserverCore/Middlewares/StaticFilesMiddleware.Debug.cs
+++ b/Duplicati/WebserverCore/Middlewares/StaticFilesMiddleware.Debug.cs
@@ -39,18 +39,13 @@ internal static class NpmSpaHelper
 
     public static SpaConfig? InstallNpmPackage(string packageUrl, string targetPath)
     {
-        var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-        // Handle move not working across drive boundaries on Windows
-        if (OperatingSystem.IsWindows() && Path.GetPathRoot(tempPath) != Path.GetPathRoot(targetPath))
-        {
-            tempPath = Path.GetFullPath(targetPath);
-            if (targetPath.EndsWith(Path.DirectorySeparatorChar))
-                tempPath = tempPath[..-1];
-            tempPath += "-tmp";
-            if (Directory.Exists(tempPath))
-                Directory.Delete(tempPath, true);
-        }
+        // Make a temp folder next to the target path
+        var tempPath = Path.GetFullPath(targetPath);
+        if (tempPath.EndsWith(Path.DirectorySeparatorChar))
+            tempPath = tempPath[..-1];
+        tempPath += "-ins-tmp";
+        if (Directory.Exists(tempPath))
+            Directory.Delete(tempPath, true);
 
         try
         {


### PR DESCRIPTION
When running in Debug mode, we automatially extracts the ngclient from the latest package and place the files in the build tree, such that starting Duplicati in Debug mode will automatically have a UI.

This PR fixes a bug with that approach, which is triggered if the TEMP folder is on a different disk/filesystem than where Duplicati is running from.

Previously, we had a fix for this on Windows, where we avoided the TEMP folder if it was not on the same disk. This PR extends this fix so it applies the same to all operating systems regardless of the disk.

Specifically for Linux developers, this fixes the issue as `/tmp` is often a special filesystem, which would cause the setup to fail.

There is no change to production code, the install code is only included in Debug builds.