### PR TITLE
Subscribe to the notification signal through the supported overload

### DIFF
--- a/Duplicati/GUI/Duplicati.GUI.TrayIcon/LinuxDBusNotifier.cs
+++ b/Duplicati/GUI/Duplicati.GUI.TrayIcon/LinuxDBusNotifier.cs
@@ -23,12 +23,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Logging;
 using Tmds.DBus.Protocol;
+
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
 
 namespace Duplicati.GUI.TrayIcon;
 
@@ -164,20 +167,31 @@ public sealed class LinuxDBusNotifier : INativeNotifier
                     var reader = m.GetBodyReader();
                     return (id: reader.ReadUInt32(), key: reader.ReadString());
                 },
-                (Exception? ex, (uint id, string key) arg, object? _, object? _2) =>
-                {
-                    if (ex != null)
-                        Log.WriteWarningMessage(LOGTAG, "SignalError", ex, "Error in ActionInvoked signal");
-                    else if (arg.key == "default")
-                        NotificationClicked?.Invoke();
-                },
-                null, null, false, ObserverFlags.None
+                (Action<Notification<(uint id, string key)>>)(n =>
+                    HandleActionInvoked(n.Exception, n.HasValue ? n.Value : default, NotificationClicked)),
+                false, ObserverFlags.None, null
             ).AsTask().GetAwaiter().GetResult();
         }
         catch (Exception ex)
         {
             Log.WriteWarningMessage(LOGTAG, "SignalSubscribeFailed", ex, "Failed to subscribe to ActionInvoked");
         }
+    }
+
+    /// <summary>
+    /// Decides what an <c>ActionInvoked</c> signal means. Kept separate from the
+    /// subscription so it can be exercised without a session bus, which the notifier
+    /// itself requires to exist.
+    /// </summary>
+    /// <param name="exception">The error the subscription reported, if any.</param>
+    /// <param name="action">The signal payload: the notification id and the action key.</param>
+    /// <param name="notificationClicked">The callback to raise when the body of the notification was clicked.</param>
+    internal static void HandleActionInvoked(Exception? exception, (uint id, string key) action, Action? notificationClicked)
+    {
+        if (exception != null)
+            Log.WriteWarningMessage(LOGTAG, "SignalError", exception, "Error in ActionInvoked signal");
+        else if (action.key == "default")
+            notificationClicked?.Invoke();
     }
 
     private Task<uint> CallNotifyAsync(

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -47,6 +47,7 @@
     <ProjectReference Include="..\..\proprietary\DiskImage\Duplicati.Proprietary.DiskImage.csproj" />
     <ProjectReference Include="..\WebserverCore\Duplicati.WebserverCore.csproj" />
     <ProjectReference Include="..\Library\Certificates\Duplicati.Library.Certificates.csproj" />
+    <ProjectReference Include="..\GUI\Duplicati.GUI.TrayIcon\Duplicati.GUI.TrayIcon.csproj" />
   </ItemGroup>
 
   <!-- Copy in WindowsModules for easier debug, or if we are targeting Windows -->

--- a/Duplicati/UnitTest/NativeNotifierTests.cs
+++ b/Duplicati/UnitTest/NativeNotifierTests.cs
@@ -22,6 +22,7 @@
 #nullable enable
 
 using System;
+using Duplicati.GUI.TrayIcon;
 using Duplicati.Library.Snapshots.Windows;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
@@ -55,5 +56,37 @@ namespace Duplicati.UnitTest
             Assert.IsTrue(clicked, "The stored callback must be invocable");
         }
 
+        /// <summary>
+        /// The Linux notifier decides what an ActionInvoked signal means. The decision is
+        /// reachable without a session bus; the notifier itself is not, because its
+        /// constructor takes the session bus connection.
+        /// </summary>
+        [Test]
+        public void ActionInvokedRaisesTheClickOnlyForTheDefaultAction()
+        {
+            var clicked = 0;
+            void OnClicked() => clicked++;
+
+            // The body of the notification was clicked.
+            LinuxDBusNotifier.HandleActionInvoked(null, (1u, "default"), OnClicked);
+            Assert.AreEqual(1, clicked, "Clicking the notification body should raise the callback");
+
+            // One of the notification's own action buttons was used instead.
+            LinuxDBusNotifier.HandleActionInvoked(null, (1u, "open-log"), OnClicked);
+            Assert.AreEqual(1, clicked, "Another action must not be reported as a click on the notification");
+
+            // The subscription itself failed; there is no action to report.
+            LinuxDBusNotifier.HandleActionInvoked(new InvalidOperationException("bus went away"), default, OnClicked);
+            Assert.AreEqual(1, clicked, "A failed subscription must not be reported as a click");
+        }
+
+        /// <summary>
+        /// A notifier that was never given a callback must not throw when a signal arrives.
+        /// </summary>
+        [Test]
+        public void ActionInvokedWithoutACallbackIsHarmless()
+        {
+            Assert.DoesNotThrow(() => LinuxDBusNotifier.HandleActionInvoked(null, (1u, "default"), null));
+        }
     }
 }

--- a/Duplicati/UnitTest/NativeNotifierTests.cs
+++ b/Duplicati/UnitTest/NativeNotifierTests.cs
@@ -64,6 +64,12 @@ namespace Duplicati.UnitTest
         [Test]
         public void ActionInvokedRaisesTheClickOnlyForTheDefaultAction()
         {
+            if (!OperatingSystem.IsLinux())
+            {
+                Assert.Ignore("The D-Bus notifier is only supported on Linux");
+                return;
+            }
+
             var clicked = 0;
             void OnClicked() => clicked++;
 
@@ -86,7 +92,15 @@ namespace Duplicati.UnitTest
         [Test]
         public void ActionInvokedWithoutACallbackIsHarmless()
         {
-            Assert.DoesNotThrow(() => LinuxDBusNotifier.HandleActionInvoked(null, (1u, "default"), null));
+            if (!OperatingSystem.IsLinux())
+            {
+                Assert.Ignore("The D-Bus notifier is only supported on Linux");
+                return;
+            }
+
+            // Called directly rather than through Assert.DoesNotThrow: the platform guard
+            // above does not reach inside a lambda, and the test fails on a throw either way.
+            LinuxDBusNotifier.HandleActionInvoked(null, (1u, "default"), null);
         }
     }
 }


### PR DESCRIPTION
A non-incremental build of the solution reports 10 warnings, all `CS0618`. This clears one of them.

```
warning CS0618: 'DBusConnection.AddMatchAsync<T>(MatchRule, MessageValueReader<T>,
  Action<Exception?, T, object?, object?>, object?, object?, bool, ObserverFlags)' is obsolete
  ('Use the overload that accepts Action<Notification<T>> instead.')
```

`Tmds.DBus.Protocol` 0.94.1 — the version already referenced — has

```
AddMatchAsync<T>(MatchRule, MessageValueReader<T>, Action<Notification<T>>, bool, ObserverFlags, object)
```

The two carry the same information: the error and the value arrive as one `Notification<T>` instead of as separate arguments. The message reader is untouched; only the handler shape changed.

## What the signal means now lives in its own method

The notifier cannot be constructed without a session bus — its constructor takes `DBusConnection.Session` — so nothing inside it was reachable from a test. Moving the decision out of the lambda is what makes it reachable:

```csharp
internal static void HandleActionInvoked(Exception? exception, (uint id, string key) action, Action? notificationClicked)
```

It takes plain arguments rather than a `Notification<T>`, which keeps the test free of D-Bus types — `Notification<T>` has no public constructor, so a test could not have produced one.

## Testing

`Duplicati.GUI.TrayIcon` had no tests, so this adds the first: a project reference from `Duplicati.UnitTest`, and the `InternalsVisibleTo("Duplicati.UnitTest")` that the backend assemblies already use. The tests live beside the existing Windows notifier test, which covers the same kind of thing.

| claim | why |
| --- | --- |
| `"default"` raises the callback | clicking the notification body reaches `NotificationClicked` |
| another action key does not | an action button is not a click on the body |
| a reported exception does not | a failed subscription is not a click |
| a missing callback does not throw | a notifier that was never given one still survives a signal |

- **3/3 green.** Inverting the `"default"` comparison turns the first one red, so the assertions are doing work. That check was run before the platform guard below was added, while the tests still executed on Windows.
- The two D-Bus tests are guarded to Linux and skip elsewhere, so they run on the Linux job.
- Build: **0 errors, no new warnings.** The `LinuxDBusNotifier.cs` warning is gone; the remaining nine are untouched (six in the Google credential paths, three in the generated `secrets.DBus.cs`).

The guard needed more than the `Assert.Ignore` the Windows test beside it uses. Measured, since each step still left warnings behind:

| guard | remaining CA1416 |
| --- | --- |
| `Assert.Ignore` alone | 4 |
| plus an explicit `return` | 1 |
| plus calling directly instead of through `Assert.DoesNotThrow` | **0** |

The analyser does not treat `Assert.Ignore` as ending the flow, and it does not follow the guard into a lambda. The last call is therefore made directly; the test still fails if it throws.

**What is not verified.** Whether a notification is actually displayed, and whether the signal arrives over a real session bus, are not exercised — that needs a Linux session with a notification service. The existing Windows test draws the line in the same place: it checks the shim loads and the callback is invocable, not that a notification appears.

## The other nine warnings, and why they are not here

- **`secrets.DBus.cs` (3)** is generated — its header records `dotnet dbus codegen --protocol-api --service org.freedesktop.secrets`. Hand-editing it would be undone by the next regeneration. The current generator (`Tmds.DBus.Tool` 0.94.2) already emits the supported overload — I checked by generating from a minimal introspection XML — so the committed copy is simply older than the package it builds against. Regenerating is the fix, but the repository records no way to do it: there is no tool manifest, script, or build target, only that comment. Worth its own change.
- **Google credentials (6)** are deprecated for a stated security reason, with `CredentialFactory` plus `.ToGoogleCredential()` as the replacement. That path validates externally-sourced credential configurations, so it can reject configurations that work today — which for a backup tool means someone's GCS job stops authenticating. That deserves a deliberate decision rather than a warning cleanup.
