### PR TITLE
Cover the libsecret secret provider

### DIFF
--- a/.github/workflows/secretprovidertests.yml
+++ b/.github/workflows/secretprovidertests.yml
@@ -269,3 +269,58 @@ jobs:
         run: |
           mkdir -p "$GITHUB_WORKSPACE/TestResults/secretprovider/hcvault-testcontainers"
           dotnet test --no-build --filter="FullyQualifiedName~SecretProviderSetSecretTests.HcVaultProvider_SetSecret_Works_WithTestcontainers" --collect:"XPlat Code Coverage" --results-directory "$GITHUB_WORKSPACE/TestResults/secretprovider/hcvault-testcontainers" --logger:"console;verbosity=detailed" Duplicati.slnx
+
+  test_libsecret:
+    name: libsecret Secret Provider SetSecret Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.x
+      - name: Checkout source
+        uses: actions/checkout@v7
+      - name: Restore NuGet dependencies
+        run: >-
+          dotnet restore
+          Duplicati.slnx
+      - name: Build project
+        run: >-
+          dotnet build --no-restore
+          Duplicati.slnx
+      - name: Install a secret service
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gnome-keyring dbus xvfb
+      - name: Run libsecret Secret Provider SetSecret tests
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/TestResults/secretprovider/libsecret"
+          cat > "$RUNNER_TEMP/libsecret-test.sh" <<'SCRIPT'
+          #!/bin/bash
+          set -euo pipefail
+
+          # Unlike the other providers here, this one cannot be pointed at a service running
+          # somewhere else: the secret service has to be on the same session bus as the process
+          # using it, so it is started inside this session and waited for.
+          echo -n "duplicati-test" | gnome-keyring-daemon --unlock --components=secrets &
+
+          for _ in $(seq 1 30); do
+            if dbus-send --session --dest=org.freedesktop.DBus --print-reply \
+                 /org/freedesktop/DBus org.freedesktop.DBus.ListNames 2>/dev/null \
+                 | grep -q org.freedesktop.secrets; then
+              break
+            fi
+            sleep 1
+          done
+
+          # Fail rather than let the test report itself skipped for want of a service, which
+          # would leave the job green without having run anything.
+          dbus-send --session --dest=org.freedesktop.DBus --print-reply \
+            /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep -q org.freedesktop.secrets
+
+          # xvfb-run so that DISPLAY names an X server that is really there: the provider
+          # reports itself unsupported without one, on the grounds that the secret service
+          # asks its questions through prompts that need a session able to show them.
+          xvfb-run -a dotnet test --no-build --filter="FullyQualifiedName~SecretProviderSetSecretTests.LibSecretProvider_SetSecret_Works_Async" --collect:"XPlat Code Coverage" --results-directory "$GITHUB_WORKSPACE/TestResults/secretprovider/libsecret" --logger:"console;verbosity=detailed" Duplicati.slnx
+          SCRIPT
+          dbus-run-session -- bash "$RUNNER_TEMP/libsecret-test.sh"

--- a/Duplicati/UnitTest/SecretProviderSetSecretTests.cs
+++ b/Duplicati/UnitTest/SecretProviderSetSecretTests.cs
@@ -713,4 +713,81 @@ public class SecretProviderSetSecretTests
             }
         }
     }
+
+    /// <summary>
+    /// Exercises the libsecret provider against whatever Secret Service is on the session
+    /// bus. Unlike the other providers here there is no way to point it at a container: the
+    /// service has to be on the same bus as this process, so the test runs where one exists
+    /// and skips where it does not.
+    /// </summary>
+    [Test]
+    [Category("SecretProviders.Remote")]
+    public async Task LibSecretProvider_SetSecret_Works_Async()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            Assert.Ignore("The libsecret provider is only supported on Linux");
+            return;
+        }
+
+        var provider = new LibSecretLinuxProvider();
+        if (!await provider.IsSupported(CancellationToken.None).ConfigureAwait(false))
+        {
+            Assert.Ignore("No Secret Service is available on the session bus");
+            return;
+        }
+
+        // The default collection, not one of the test's own making: creating a collection
+        // asks the secret service for a new keyring, which it answers with a prompt for the
+        // keyring password, and a prompt needs a prompter to display it. Where there is none
+        // the service hands back "/" for both the collection and the prompt, so a test that
+        // created its own collection could only ever run in front of a desktop session.
+        //
+        // The keys below are named for this test and carry a fresh guid, so nothing that is
+        // already in the default collection is read, written or replaced.
+        await provider.InitializeAsync(new Uri("libsecret://"), CancellationToken.None).ConfigureAwait(false);
+        Assert.IsTrue(await provider.DoesCollectionExist(CancellationToken.None).ConfigureAwait(false),
+            "The default collection should be resolvable");
+
+        var key = $"duplicati-test-key-{Guid.NewGuid():N}";
+
+        await provider.SetSecretAsync(key, "value1", overwrite: false, CancellationToken.None).ConfigureAwait(false);
+        var resolved = await provider.ResolveSecretsAsync(new[] { key }, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual("value1", resolved[key], "The stored secret should come back unchanged");
+
+        // Writing the same key again without overwrite must not silently replace it.
+        // Caught by hand rather than with Assert.ThrowsAsync: the platform guard above does
+        // not reach inside a lambda, which CA1416 reports.
+        var refused = false;
+        try
+        {
+            await provider.SetSecretAsync(key, "value2", overwrite: false, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            refused = true;
+        }
+        Assert.IsTrue(refused, "Storing over an existing key without overwrite should be refused");
+
+        var unchanged = await provider.ResolveSecretsAsync(new[] { key }, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual("value1", unchanged[key], "The refused write must leave the original value in place");
+
+        await provider.SetSecretAsync(key, "value2", overwrite: true, CancellationToken.None).ConfigureAwait(false);
+        var overwritten = await provider.ResolveSecretsAsync(new[] { key }, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual("value2", overwritten[key], "Overwriting should replace the stored value");
+
+        // A key that was never stored must not come back as a value.
+        var missingKey = $"duplicati-test-missing-{Guid.NewGuid():N}";
+        var reportedMissing = false;
+        try
+        {
+            var absent = await provider.ResolveSecretsAsync(new[] { missingKey }, CancellationToken.None).ConfigureAwait(false);
+            reportedMissing = !absent.ContainsKey(missingKey);
+        }
+        catch (Exception)
+        {
+            reportedMissing = true;
+        }
+        Assert.IsTrue(reportedMissing, "Resolving a key that does not exist must not yield a value");
+    }
 }


### PR DESCRIPTION
The libsecret secret provider has no tests. This adds one, and a CI job that actually runs it.

## What the test covers

| Assertion | Why |
|---|---|
| A stored secret comes back unchanged | The store and read paths agree |
| A second write to the same key without `overwrite` is refused | `SetSecretAsync` honours the flag |
| The refused write left the first value in place | The refusal is not a partial write |
| Writing with `overwrite: true` replaces the value | The other side of the flag |
| A key that was never stored yields no value | A miss is a miss, not an empty string |

## What it does not cover

The prompt path and locked collections. Both need a prompter, which a CI runner has no way to provide — see below.

## Making it run

`SecretProviderSetSecretTests` is excluded from the unit test job, so the test lives in `secretprovidertests.yml`. Unlike every other provider there, this one cannot be pointed at a service somewhere else: the secret service has to be on the same session bus as the process using it. So the job starts gnome-keyring on its own session bus and waits for `org.freedesktop.secrets` to appear.

If the name never appears the job **fails** rather than proceeding. Otherwise the test would report itself skipped and the job would go green without having run anything, which is worse than having no test at all.

Two environment details are worth explaining:

- **`xvfb-run`.** `SecretCollection.IsSupported` treats a missing `DISPLAY` as "no secret service", on the grounds that the service's prompts need a session able to show them. Running under Xvfb means `DISPLAY` names an X server that is really there, rather than being set to one that is not.
- **The default collection.** The test first made a collection of its own, so as not to touch the login keyring. That cannot work headlessly: creating a collection asks the service for a new keyring, which it answers with a prompt for the keyring password, and with no prompter the service hands back `/` for both the collection and the prompt. So the test uses the default collection, with keys named `duplicati-test-key-<guid>` — nothing already in the collection is read, written or replaced.

## Verification

Run in a `mcr.microsoft.com/dotnet/sdk:10.0` container with gnome-keyring on a `dbus-run-session` bus:

```
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 813 ms
```

The same run first reproduced the two ways this can go wrong — skipped without `DISPLAY`, and `The secret service returned an invalid collection path` when creating a collection — so the guards above are there for observed reasons rather than anticipated ones.

Build is clean; the warnings that remain in the projects touched are the pre-existing `GoogleCredential` ones.

## Why now

`Duplicati/Library/SecretProvider/LibSecret/secrets.DBus.cs` is generated, and its committed copy predates the current generator, which is where three of the `CS0618` build warnings come from. Regenerating it is the fix, but it rewrites most of the file, and reviewing that with no test coverage at all underneath is not a reasonable thing to ask. This is the coverage. The regeneration is a separate change.
