### PR TITLE
Index the verification tables on the columns they are compared on

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalTestDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalTestDatabase.cs
@@ -395,9 +395,10 @@ namespace Duplicati.Library.Main.Database.Local
             /// <param name="tablePrefix">The prefix for the temporary table name.</param>
             /// <param name="tableFormat">The SQL format for creating the temporary table.</param>
             /// <param name="insertCommand">The SQL command for inserting data into the temporary table.</param>
+            /// <param name="indexColumns">The columns the comparison joins on, quoted and comma separated.</param>
             /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
             /// <returns>A task that represents the asynchronous operation. The task result contains the initialized <see cref="Basiclist"/> instance.</returns>
-            protected static async Task<Basiclist> CreateAsync(Basiclist bl, LocalDatabase db, string volumename, string tablePrefix, string tableFormat, string insertCommand, CancellationToken token)
+            protected static async Task<Basiclist> CreateAsync(Basiclist bl, LocalDatabase db, string volumename, string tablePrefix, string tableFormat, string insertCommand, string indexColumns, CancellationToken token)
             {
                 bl.m_db = db;
                 bl.m_volumename = volumename;
@@ -411,6 +412,9 @@ namespace Duplicati.Library.Main.Database.Local
                     ", token)
                         .ConfigureAwait(false);
 
+                    await CreateComparisonIndexAsync(cmd, tablename, indexColumns, token)
+                        .ConfigureAwait(false);
+
                     bl.m_tablename = tablename;
                 }
 
@@ -422,6 +426,26 @@ namespace Duplicati.Library.Main.Database.Local
 
                 return bl;
             }
+
+            /// <summary>
+            /// Indexes a comparison table on the columns the comparison joins and filters on.
+            ///
+            /// Without one, SQLite builds a transient index for the join and leaves the two
+            /// NOT IN subqueries to a scan behind a Bloom filter. One explicit index serves
+            /// all three, which measures at rather more than twice the speed on a hundred
+            /// thousand rows and pays for itself against the cost of building it.
+            /// </summary>
+            /// <param name="cmd">The command to create the index with.</param>
+            /// <param name="tablename">The table to index.</param>
+            /// <param name="indexColumns">The columns, quoted and comma separated.</param>
+            /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+            /// <returns>A task that completes when the index has been created.</returns>
+            protected static async Task CreateComparisonIndexAsync(SqliteCommand cmd, string tablename, string indexColumns, CancellationToken token)
+                => await cmd.ExecuteNonQueryAsync($@"
+                    CREATE INDEX ""idx-{tablename}""
+                    ON ""{tablename}"" ({indexColumns})
+                ", token)
+                    .ConfigureAwait(false);
 
             public void Dispose()
             {
@@ -517,6 +541,11 @@ namespace Duplicati.Library.Main.Database.Local
             ";
 
             /// <summary>
+            /// The column the comparison joins and filters on.
+            /// </summary>
+            private const string INDEX_COLUMNS = @"""Path""";
+
+            /// <summary>
             /// Calling this constructor will throw an exception. Use the CreateAsync method instead.
             /// </summary>
             [Obsolete("Calling this constructor will throw an exception. Use the CreateAsync method instead.")]
@@ -542,7 +571,7 @@ namespace Duplicati.Library.Main.Database.Local
             {
                 var bl = new Filelist();
                 return (Filelist)
-                    await CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, token)
+                    await CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, INDEX_COLUMNS, token)
                         .ConfigureAwait(false);
             }
 
@@ -649,6 +678,9 @@ namespace Duplicati.Library.Main.Database.Local
                         .ExecuteNonQueryAsync(true, token)
                         .ConfigureAwait(false);
 
+                    await CreateComparisonIndexAsync(cmd, cmpName, INDEX_COLUMNS, token)
+                        .ConfigureAwait(false);
+
                     cmd
                         .SetCommandAndParameters($"{extra} UNION {missing} UNION {modified}")
                         .SetParameterValue("@TypeExtra", (int)Interface.TestEntryStatus.Extra)
@@ -738,6 +770,11 @@ namespace Duplicati.Library.Main.Database.Local
             ";
 
             /// <summary>
+            /// The column the comparison joins and filters on.
+            /// </summary>
+            private const string INDEX_COLUMNS = @"""Name""";
+
+            /// <summary>
             /// Calling this constructor will throw an exception. Use the CreateAsync method instead.
             /// </summary>
             [Obsolete("Calling this constructor will throw an exception. Use the CreateAsync method instead.")]
@@ -763,7 +800,7 @@ namespace Duplicati.Library.Main.Database.Local
             {
                 var bl = new Indexlist();
                 return (Indexlist)
-                    await CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, token)
+                    await CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, INDEX_COLUMNS, token)
                         .ConfigureAwait(false);
             }
 
@@ -845,6 +882,9 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetCommandAndParameters(create)
                         .SetParameterValue("@Name", m_volumename)
                         .ExecuteNonQueryAsync(true, token)
+                        .ConfigureAwait(false);
+
+                    await CreateComparisonIndexAsync(cmd, cmpName, INDEX_COLUMNS, token)
                         .ConfigureAwait(false);
 
                     cmd
@@ -946,6 +986,11 @@ namespace Duplicati.Library.Main.Database.Local
             )";
 
             /// <summary>
+            /// The column the comparison joins and filters on.
+            /// </summary>
+            private const string INDEX_COLUMNS = @"""Hash""";
+
+            /// <summary>
             /// Calling this constructor will throw an exception. Use the CreateAsync method instead.
             /// </summary>
             [Obsolete("Calling this constructor will throw an exception. Use the CreateAsync method instead.")]
@@ -969,7 +1014,7 @@ namespace Duplicati.Library.Main.Database.Local
             {
                 var bl = new Blocklist();
                 return (Blocklist)
-                    await Basiclist.CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, token)
+                    await Basiclist.CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, INDEX_COLUMNS, token)
                         .ConfigureAwait(false);
             }
 
@@ -1086,6 +1131,9 @@ namespace Duplicati.Library.Main.Database.Local
                         .ExecuteNonQueryAsync(true, token)
                         .ConfigureAwait(false);
 
+                    await CreateComparisonIndexAsync(cmd, cmpName, INDEX_COLUMNS, token)
+                        .ConfigureAwait(false);
+
                     cmd
                         .SetCommandAndParameters($@"
                                 {extra}
@@ -1146,6 +1194,12 @@ namespace Duplicati.Library.Main.Database.Local
             )";
 
             /// <summary>
+            /// The columns the comparison joins on: both sides match on the hash and the size
+            /// together, so an index on the hash alone leaves the second half to a scan.
+            /// </summary>
+            private const string INDEX_COLUMNS = @"""Hash"", ""Size""";
+
+            /// <summary>
             /// Calling this constructor will throw an exception. Use the CreateAsync method instead.
             /// </summary>
             [Obsolete("Calling this constructor will throw an exception. Use the CreateAsync method instead.")]
@@ -1170,7 +1224,7 @@ namespace Duplicati.Library.Main.Database.Local
             {
                 var bl = new BlocklistHashList();
                 return (BlocklistHashList)
-                    await Basiclist.CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, token)
+                    await Basiclist.CreateAsync(bl, db, volumename, TABLE_PREFIX, TABLE_FORMAT, INSERT_COMMAND, INDEX_COLUMNS, token)
                         .ConfigureAwait(false);
             }
 
@@ -1304,6 +1358,9 @@ namespace Duplicati.Library.Main.Database.Local
                         .SetCommandAndParameters(create)
                         .SetParameterValue("@Name", m_volumename)
                         .ExecuteNonQueryAsync(true, token)
+                        .ConfigureAwait(false);
+
+                    await CreateComparisonIndexAsync(cmd, cmpName, INDEX_COLUMNS, token)
                         .ConfigureAwait(false);
 
                     // Compare against actual values inserted into temp table

--- a/Duplicati/UnitTest/AutomaticIndexTests.cs
+++ b/Duplicati/UnitTest/AutomaticIndexTests.cs
@@ -63,17 +63,7 @@ namespace Duplicati.UnitTest
             //   LocalDatabase.VerifyConsistencyInnerAsync, the grouped blocklist hash counts
             "G(BlocksetID)",
             //   LocalDeleteDatabase.GetWastedSpaceReportAsync, the grouped scan times
-            "B(VolumeID)",
-
-            // Temporary tables that are created, read by a single statement and dropped again.
-            // An explicit index on those costs the same as the transient one it would replace,
-            // so it is left to SQLite. All of these are in LocalTestDatabase.
-            "Blocklist(Hash)",
-            "BlocklistHashList(Hash)",
-            "CmpTable(Hash)",
-            "CmpTable(Name)",
-            "CmpTable(Path)",
-            "CmpTable(Size)"
+            "B(VolumeID)"
         };
 
         [Test]


### PR DESCRIPTION
Testing a remote volume builds two temporary tables in `LocalTestDatabase` and compares them three ways — rows on one side and not the other, twice, and rows on both sides that differ. Neither table carried an index.

## Where this came from

While looking into #7127 I ran a backup of 111,110 files. Across every run of that investigation, the slow query monitor raised exactly one warning, and this was it:

```
Query still running after 1.7s in ExecuteReaderAsync:
  ... FROM "Filelist-..." WHERE "Path" NOT IN (SELECT "Path" FROM "CmpTable-...")
  UNION ... FROM "CmpTable-..." WHERE "Path" NOT IN (SELECT "Path" FROM "Filelist-...")
  UNION ... FROM "Filelist-..." "E", "CmpTable-..." "D" WHERE "D"."Path" = "E"."Path" ...
```

There is no `CREATE INDEX` anywhere in that file.

## What the index buys

SQLite builds a transient index for the join on its own, but only for the join. The two `NOT IN` subqueries are left to a scan behind a bloom filter. One explicit index serves all three, which is the difference the plan shows:

| | without an index | with one |
|---|---|---|
| `NOT IN` (extra) | `SCAN C` + `CREATE BLOOM FILTER` | `SCAN L USING COVERING INDEX idx_L`, `USING INDEX idx_C FOR IN-OPERATOR` |
| `NOT IN` (missing) | `SCAN L` + `CREATE BLOOM FILTER` | `SCAN C USING COVERING INDEX idx_C`, `USING INDEX idx_L FOR IN-OPERATOR` |
| join (modified) | `SEARCH D USING AUTOMATIC COVERING INDEX (Path=?)` | `SEARCH D USING INDEX idx_C (Path=?)` |

Measured on SQLite 3.53.4, the version shipped in `e_sqlite3`:

| paths | without | with | building the index |
|---|---|---|---|
| 10,000 | 0.020s | 0.009s | 0.006s |
| 50,000 | 0.113s | 0.054s | 0.034s |
| 122,222 | 0.280s | 0.130s | 0.078s |

It pays for itself on the first read.

The blocklist hash list is the one that mattered most. Its comparison matches on the hash **and** the size together, and without an index SQLite builds four transient ones for a single statement. At eight thousand rows:

| | time |
|---|---|
| no index | 5.215s |
| `("Hash", "Size")` | **0.019s** |
| `("Size", "Hash")` | 4.900s |

So the column order matters there, and the pair is what the comparison needs.

## About the entries removed from `AutomaticIndexTests`

That test recorded these tables as ones an index could not help:

```
// Temporary tables that are created, read by a single statement and dropped again.
// An explicit index on those costs the same as the transient one it would replace,
// so it is left to SQLite.
```

That is true of the join and not of the statement: the transient index never covered the two `NOT IN` subqueries. Those six entries are removed, and **that is what verifies this change**. The test fails if SQLite still has to build an index of its own, so the sequence was:

1. Remove the entries with no other change — the test **fails**, naming five automatic indexes with the call site of each
2. Add the indexes — the test **passes**

Without step 1 there would be no way to tell "the index removed it" from "it was never there".

`B(BlocksetID)`, `G(BlocksetID)` and `B(VolumeID)` stay: those are aliases of subqueries rather than tables, so no index on the underlying tables reaches them.

## Honest about the limits

`Filelist(Path)` and `Indexlist(Name)` never appeared as automatic indexes, so for those two tables the test proves nothing and the case rests on the timings above. They are indexed anyway, because the three-way comparison is the same shape in all four classes and leaving two of them out would be harder to explain than to justify.

## Verification

- `AutomaticIndexTests` red without the indexes, green with them
- `EmptyFileTests` (4 tests, exercises the verification path) green
- Build clean, no new warnings
