### PR TITLE
Name the two steps inside UploadNewFileset that had no timer

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
@@ -60,8 +60,15 @@ internal static class UploadRealFilelist
                 // We ignore the stop signal, but not the pause and terminate
                 await taskreader.ProgressRendevouzAsync().ConfigureAwait(false);
 
-                await db.WriteFilesetAsync(filesetvolume, filesetid, taskreader.ProgressToken).ConfigureAwait(false);
-                filesetvolume.Close();
+                // Named separately from the phase around them: a report that this phase is
+                // where a backup stops cannot say which of the five things inside it is the
+                // one that stopped, and the commit and the upload are the only two that
+                // already say so for themselves.
+                using (new Logging.Timer(LOGTAG, "WriteFileset", "Writing the fileset"))
+                    await db.WriteFilesetAsync(filesetvolume, filesetid, taskreader.ProgressToken).ConfigureAwait(false);
+
+                using (new Logging.Timer(LOGTAG, "CloseFilesetVolume", "Closing the fileset volume"))
+                    filesetvolume.Close();
 
                 // We ignore the stop signal, but not the pause and terminate
                 await taskreader.ProgressRendevouzAsync().ConfigureAwait(false);


### PR DESCRIPTION
> **Correction (and thanks to @ts678 for catching it).** The first version of this description said the reporter "cannot say more than" `UploadNewFileset`. That was wrong. The forum thread's original post identified the suspected query and where it sat in the code, and the slow query monitor later confirmed it by name. I had not read the thread carefully enough before writing that, and the sentence has been removed rather than softened.

#7127 reports that a backup stops with the status bar at "Waiting for upload to finish", and that the server profiling log puts it at `UploadNewFileset`. That timer covers five things, and two of them were never measured.

## What the phase contains, and what could be measured

`UploadRealFilelist.cs:54-80`:

| step | timed before this change |
|---|---|
| `AddControlFile` | no — but empty unless `--control-files` is set |
| **`db.WriteFilesetAsync`** | **no** |
| **`filesetvolume.Close()`** | **no** |
| `db.UpdateRemoteVolumeAsync` | no — a single UPDATE |
| `db.CommitTransactionAsync` | yes — `CommitTransaction: CommitUpdateRemoteVolume` |
| `backendManager.PutAsync` | yes — `RemoteOperationPut` |

Two timers close the gap, and then the phase divides into named parts.

## What it looks like

On a backup of 111,110 files in 11,110 folders, the profiling log now reads:

```
Starting - Uploading a new fileset
  Starting - Writing the fileset
  Writing the fileset took 0:00:00:01.602
  Starting - Closing the fileset volume
  Closing the fileset volume took 0:00:00:00.878
  CommitTransaction: CommitUpdateRemoteVolume took 0:00:00:00.000
Uploading a new fileset took 0:00:00:02.484
```

1.602 + 0.878 + 0.000 against a phase of 2.484 leaves **four milliseconds** for everything else, so the two new timers account for the phase rather than merely sitting inside it.

One thing that becomes visible and is worth knowing when reading a report about waiting for an upload: `RemoteOperationPut` for that dlist finishes **after** the phase does, because uploads are asynchronous by default. The phase named `UploadNewFileset` does not wait for the upload.

## Does the slow query monitor make this unnecessary?

@ts678 asked this directly, and for #7127 the answer is essentially yes. The monitor named `LIST_FOLDERS_AND_SYMLINKS` and timed it at ~46,767 s. Nothing here was needed to find that, and I would not want this PR credited with it.

What these two timers add is the time that is **not** in a query:

- `filesetvolume.Close()` is compression and finalisation, not SQL, so the monitor cannot see it at all
- `WriteFilesetAsync` also contains the reader loop that builds the volume. As noted in #7147, the monitor's `QueryScope` is disposed when the reader is returned, so the loop is outside it

So this is worth having for a report where the phase is slow and the monitor stays quiet, which is the case it does not currently cover. If that is too narrow to be worth two lines of diff, I am happy for this to be closed — it is a small convenience, not a fix, and the issue it was written for turned out not to need it.

## The queries are deliberately left alone

`WriteFilesetAsync` runs its two queries with `writeLog: false`, which suppresses the profiling record. Turning that on would print each query's time, but:

- `SlowQueryMonitor.StartQuery` sits **outside** that flag in `ExtensionMethods.cs`, so every query is registered with the monitor either way
- `writeLog: false` is what 123 call sites in `Library/Main` do; changing two of them would make the convention harder to read, not easier
- the record it would print is `ExecuteReader: <the whole SQL>`, which is not what makes a profiling log readable

## Scope

This is a diagnostic change. **It does not fix #7127** and is not offered as one.

## Verification

- Built clean; the warnings present are the pre-existing `GoogleCredential` and `DBusConnection` ones
- The breakdown above is from a real run, not a constructed one
- `EmptyFileTests` green
