### PR TITLE
Read Google credentials as service accounts, which is what they are documented to be

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -105,15 +105,19 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
             m_storage_class = options.GetValueOrDefault(STORAGECLASS_OPTION);
 
             m_retention_policy_mode = Utility.Utility.ParseEnumOption(options, RETENTION_POLICY_MODE_OPTION, DEFAULT_RETENTION_POLICY_MODE);
+            // Read as a service account and nothing else. Both options are documented as taking
+            // the JSON key of a service account, and the loader that takes any kind of credential
+            // would read whatever arrived -- including an external account configuration, which
+            // names the endpoint it fetches tokens from.
             if (!string.IsNullOrWhiteSpace(serviceAccountJson))
             {
-                m_oauth = new ServiceAccountHttpClient(GoogleCredential.FromJson(serviceAccountJson).CreateScoped(CREDENTIAL_SCOPE));
-                m_create_oauth_fullcontrol = () => new ServiceAccountHttpClient(GoogleCredential.FromJson(serviceAccountJson).CreateScoped(CREDENTIAL_SCOPE_FULL_CONTROL));
+                m_oauth = new ServiceAccountHttpClient(CredentialFactory.FromJson<ServiceAccountCredential>(serviceAccountJson).ToGoogleCredential().CreateScoped(CREDENTIAL_SCOPE));
+                m_create_oauth_fullcontrol = () => new ServiceAccountHttpClient(CredentialFactory.FromJson<ServiceAccountCredential>(serviceAccountJson).ToGoogleCredential().CreateScoped(CREDENTIAL_SCOPE_FULL_CONTROL));
             }
             else if (!string.IsNullOrWhiteSpace(serviceAccountFile))
             {
-                m_oauth = new ServiceAccountHttpClient(GoogleCredential.FromFile(serviceAccountFile).CreateScoped(CREDENTIAL_SCOPE));
-                m_create_oauth_fullcontrol = () => new ServiceAccountHttpClient(GoogleCredential.FromFile(serviceAccountFile).CreateScoped(CREDENTIAL_SCOPE_FULL_CONTROL));
+                m_oauth = new ServiceAccountHttpClient(CredentialFactory.FromFile<ServiceAccountCredential>(serviceAccountFile).ToGoogleCredential().CreateScoped(CREDENTIAL_SCOPE));
+                m_create_oauth_fullcontrol = () => new ServiceAccountHttpClient(CredentialFactory.FromFile<ServiceAccountCredential>(serviceAccountFile).ToGoogleCredential().CreateScoped(CREDENTIAL_SCOPE_FULL_CONTROL));
             }
             else
             {

--- a/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
+++ b/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.100.3" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
     <PackageReference Include="Google.Cloud.SecretManager.V1" Version="2.6.0" />
     <PackageReference Include="SharpAESCrypt" Version="3.0.0" />
     <PackageReference Include="VaultSharp" Version="1.17.5.1" />

--- a/Duplicati/Library/SecretProvider/GCSSecretProvider.cs
+++ b/Duplicati/Library/SecretProvider/GCSSecretProvider.cs
@@ -138,10 +138,14 @@ public class GCSSecretProvider : ISecretProvider
             };
 
         GoogleCredential credential;
+        // Read as a service account and nothing else. Both options are documented as taking the
+        // JSON key of a service account, and the loader that takes any kind of credential would
+        // read whatever arrived -- including an external account configuration, which names the
+        // endpoint it fetches tokens from.
         if (!string.IsNullOrWhiteSpace(cfg.ServiceAccountJson))
-            credential = GoogleCredential.FromJson(cfg.ServiceAccountJson);
+            credential = CredentialFactory.FromJson<ServiceAccountCredential>(cfg.ServiceAccountJson).ToGoogleCredential();
         else if (!string.IsNullOrWhiteSpace(cfg.ServiceAccountFile))
-            credential = GoogleCredential.FromFile(cfg.ServiceAccountFile);
+            credential = CredentialFactory.FromFile<ServiceAccountCredential>(cfg.ServiceAccountFile).ToGoogleCredential();
         else if (!string.IsNullOrWhiteSpace(cfg.AccessToken))
             credential = GoogleCredential.FromAccessToken(cfg.AccessToken);
         else

--- a/Duplicati/UnitTest/GoogleCredentialTests.cs
+++ b/Duplicati/UnitTest/GoogleCredentialTests.cs
@@ -1,0 +1,123 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The Google Cloud Storage options are documented as taking the JSON key of a service
+    /// account, and nothing else. These pin that: a service account is accepted, and a
+    /// credential of another kind is not.
+    ///
+    /// Nothing here talks to Google. Reading a credential parses the JSON and the key and
+    /// stops there, and the http client the backend builds from it only asks for a token when
+    /// it sends a request, so a key that was generated here and registered nowhere is enough.
+    /// </summary>
+    [TestFixture]
+    public class GoogleCredentialTests
+    {
+        private const string URL = "googlecloudstorage://a-bucket/a-prefix";
+        private const string JSON_OPTION = "gcs-service-account-json";
+        private const string FILE_OPTION = "gcs-service-account-file";
+
+        /// <summary>
+        /// A service account key in the shape Google hands out, with a key made here. It is
+        /// structurally a real key and registered with nobody, which is all that reading it
+        /// requires.
+        /// </summary>
+        private static string ServiceAccountJson()
+        {
+            using var rsa = RSA.Create(2048);
+            return JsonSerializer.Serialize(new Dictionary<string, string>
+            {
+                ["type"] = "service_account",
+                ["project_id"] = "duplicati-unit-test",
+                ["private_key_id"] = "0000000000000000000000000000000000000000",
+                ["private_key"] = rsa.ExportPkcs8PrivateKeyPem() + "\n",
+                ["client_email"] = "unit-test@duplicati-unit-test.iam.gserviceaccount.com",
+                ["client_id"] = "000000000000000000000",
+                ["token_uri"] = "https://oauth2.googleapis.com/token"
+            });
+        }
+
+        /// <summary>
+        /// The other kind the old loader accepted: a user credential as the Cloud SDK stores
+        /// it. The options have never been documented as taking one.
+        /// </summary>
+        private static string UserCredentialJson()
+            => JsonSerializer.Serialize(new Dictionary<string, string>
+            {
+                ["type"] = "authorized_user",
+                ["client_id"] = "000000000000-duplicati.apps.googleusercontent.com",
+                ["client_secret"] = "not-a-real-secret",
+                ["refresh_token"] = "not-a-real-token"
+            });
+
+        [Test]
+        [Category("GoogleCredentials")]
+        public void AServiceAccountKeyIsAccepted()
+        {
+            var options = new Dictionary<string, string?> { [JSON_OPTION] = ServiceAccountJson() };
+            Assert.DoesNotThrow(
+                () => new Library.Backend.GoogleCloudStorage.GoogleCloudStorage(URL, options),
+                "A service account key is what these options are documented to take");
+        }
+
+        [Test]
+        [Category("GoogleCredentials")]
+        public void AServiceAccountKeyInAFileIsAccepted()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"duplicati-gcs-{Guid.NewGuid():N}.json");
+            File.WriteAllText(path, ServiceAccountJson());
+            try
+            {
+                var options = new Dictionary<string, string?> { [FILE_OPTION] = path };
+                Assert.DoesNotThrow(
+                    () => new Library.Backend.GoogleCloudStorage.GoogleCloudStorage(URL, options),
+                    "The file option has to accept exactly what the inline option accepts");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        [Category("GoogleCredentials")]
+        public void AUserCredentialIsRejected()
+        {
+            var options = new Dictionary<string, string?> { [JSON_OPTION] = UserCredentialJson() };
+            Assert.Catch(
+                () => new Library.Backend.GoogleCloudStorage.GoogleCloudStorage(URL, options),
+                "A credential that is not a service account has to be refused rather than used: "
+                + "the option is documented as taking a service account, and accepting whatever "
+                + "arrives is how an unvalidated credential configuration gets through");
+        }
+    }
+}

--- a/Duplicati/UnitTest/SecretProviderSetSecretTests.cs
+++ b/Duplicati/UnitTest/SecretProviderSetSecretTests.cs
@@ -289,7 +289,7 @@ public class SecretProviderSetSecretTests
         try
         {
             var builder = new SecretManagerServiceClientBuilder();
-            builder.Credential = GoogleCredential.FromJson(serviceAccountJson);
+            builder.Credential = CredentialFactory.FromJson<ServiceAccountCredential>(serviceAccountJson).ToGoogleCredential();
             cleanupClient = builder.Build();
 
             var provider = new GCSSecretProvider();

--- a/proprietary/GoogleWorkspace/APIHelper.cs
+++ b/proprietary/GoogleWorkspace/APIHelper.cs
@@ -47,7 +47,11 @@ public class APIHelper
         var backoffInitializer = new BackOffInitializer();
         if (!string.IsNullOrEmpty(_serviceAccountJson))
         {
-            var credential = GoogleCredential.FromJson(_serviceAccountJson)
+            // Read as a service account and nothing else: the impersonation below is domain-wide
+            // delegation, which no other kind of credential can do, and the loader that takes any
+            // kind would read whatever arrived.
+            var credential = CredentialFactory.FromJson<ServiceAccountCredential>(_serviceAccountJson)
+                .ToGoogleCredential()
                 .CreateScoped(scopes.ToArray());
 
             var userToImpersonate = userId ?? _adminEmail;


### PR DESCRIPTION
This removes the remaining `CS0618` warnings from the Google credential loaders, but the warning is not the point — the loaders accept more than the options are documented to take, and the deprecation is why.

## The deprecation

`Google.Apis.Auth` marks `GoogleCredential.FromJson` and `FromFile` obsolete, and its own documentation says why:

> **Important**: If you accept a credential configuration (credential JSON/File/Stream) from an external source for authentication to Google Cloud, you must validate it before providing it to any Google API or library. Providing an unvalidated credential configuration to Google APIs can compromise the security of your systems and data.

Those loaders read whatever the JSON says it is — a service account key, a stored user credential, or an **external account** configuration, which carries the URL it fetches tokens from. `CredentialFactory.FromJson<T>` requires the caller to say what it expects.

## What Duplicati says these options are

| where | text |
|---|---|
| `--gcs-service-account-json` | "String with JSON credentials for **a Google Cloud service account**" |
| `--gcs-service-account-file` | "Path to a file with JSON credentials for **a Google Cloud service account**" |
| [manual, GCS destination](https://github.com/duplicati/documentation/blob/main/backup-destinations/provider-specific-destinations/google-cloud-storage-destination.md) | "recommended that you use a Google **Service Account** … provide it with `--gcs-service-account-file=` or `--gcs-service-account-json=`" |
| [manual, secret provider](https://github.com/duplicati/documentation/blob/main/detailed-descriptions/security-and-secrets/using-the-secret-provider/cloud-providers.md) | "Service account → Keys → Add key → Create new key → JSON" |

Nowhere is any other kind of credential offered. The code was simply more permissive than everything that describes it, so this brings the code to the documentation rather than the other way round.

## This changes behaviour, and that is the change

A configuration that passes a **stored user credential** or an **external account** JSON to these options works today and will stop working. That is intended — but it is a real change and worth calling out, in case anyone has been relying on the loader's breadth.

## The secret provider had the same call and no warning

`GCSSecretProvider` makes the identical call and raised nothing, because `Google.Cloud.SecretManager.V1` resolves `Google.Apis.Auth` **1.69.0** for that project — a version that predates both `CredentialFactory` and the deprecation. Leaving it would have fixed the warnings while leaving the behaviour in place, so it names 1.75.0 explicitly, which is the version the GoogleServices backend and the Workspace helper already use.

## Test

`GoogleCredentialTests` builds a service account key around a fresh `RSA.Create(2048)` and drives the real entry point, `new GoogleCloudStorage(url, options)`:

| assertion | before | after |
|---|---|---|
| a service account key is accepted | pass | pass |
| the same key by file is accepted | pass | pass |
| **a stored user credential is refused** | **fail** | **pass** |

The third one passing on the old code is what there was to fix, and it was run against the old code first for exactly that reason — otherwise there is no way to tell a test that guards something from a test that guards nothing.

**No Google account or cloud resources are involved.** Reading a credential parses the JSON and the key and stops; `ServiceAccountHttpClient`'s constructor only stores the credential, and the token is fetched in `CreateRequestAsync`. So a key registered with nobody exercises all of the changed code.

What that does not cover: an actual round trip to Google Cloud Storage. The credential type reaching the API is unchanged — a `ServiceAccountCredential` inside a `GoogleCredential`, as before — but I have not run it against a live bucket.

## Verification

- Full solution build, no errors, and the Google `CS0618` warnings go from 6 to 0 with no new warnings of any kind. What remains is `secrets.DBus.cs` (generated) and `LinuxDBusNotifier.cs` (#7170)
- `SecretProviderSetSecretTests` builds; it cannot run without credentials and is skipped on forks
