### PR TITLE
Ask for one version of SharpAESCrypt rather than two

### DIFF
--- a/Duplicati/Library/Certificates/Duplicati.Library.Certificates.csproj
+++ b/Duplicati/Library/Certificates/Duplicati.Library.Certificates.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpAESCrypt" Version="2.0.3" />
+    <PackageReference Include="SharpAESCrypt" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
+++ b/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Google.Cloud.SecretManager.V1" Version="2.6.0" />
-    <PackageReference Include="SharpAESCrypt" Version="2.0.3" />
+    <PackageReference Include="SharpAESCrypt" Version="3.0.0" />
     <PackageReference Include="VaultSharp" Version="1.17.5.1" />
     <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.4" />
     <!-- Important! Avalonia also depends on this package, so make sure the versions are in sync -->


### PR DESCRIPTION
Three projects name `SharpAESCrypt` and they do not agree:

| version | project |
|---|---|
| **3.0.0** | `Duplicati.Library.Encryption` |
| **2.0.3** | `Duplicati.Library.Certificates`, `Duplicati.Library.SecretProvider` |

All three end up in the same application, so one assembly ships. I checked which: **3.0.0.0**, in both `Duplicati.CommandLine` and the test host. Two of the three projects are therefore compiled against a version they never run on.

## Why nothing is broken today

Comparing the public surface of the two assemblies, the entire difference is one property:

```
only in 2.0.3:   (nothing)
only in 3.0.0:   EncryptionOptions.KdfIterations
```

Nothing was removed, so code written against 2.0.3 compiles and runs against 3.0.0. `KdfIterations` is the key derivation iteration count, and `AESEncryption` reads it — which looks like why the encryption library moved and the other two did not follow.

## Why it is still worth fixing

The two projects left behind cannot see anything added since 2.0.3. That is not hypothetical here: the same secret provider resolved `Google.Apis.Auth` **1.69.0** through a transitive dependency, a version old enough to predate both `CredentialFactory` and the deprecation of the loaders it was still using, so nothing warned about it until the version was named explicitly (#7175).

The failure mode is quiet in both cases — no error, no warning, just an older view of the library.

## Scope

Two lines, both `PackageReference` versions. Nothing else changes; 3.0.0 is already what runs.

## Verification

- Full solution build: no errors and no new warnings. That the code written against 2.0.3 compiles unchanged against 3.0.0 is the compatibility check, and it follows from nothing having been removed
- `CertificateTests` — 22 tests, green. Those exercise the encrypt and decrypt path in `CertificateStorageHelper`
- Asking `dotnet list package --include-transitive` across the solution before and after: `SharpAESCrypt` no longer resolves at two versions

## Note

This touches `Duplicati.Library.SecretProvider.csproj`, which #7175 also touches — a different line in the same file. They are independent; whichever lands second may want a trivial rebase.
