### PR TITLE
Say which versions are there when a disruption test counts the wrong number

### DIFF
--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -920,7 +920,12 @@ namespace Duplicati.UnitTest
             {
                 var backupResults = await c.BackupAsync(new string[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
-                Assert.AreEqual(expectedFilesets, (await c.ListAsync()).Filesets.Count());
+                var listResults = await c.ListAsync();
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"The last backup reported {backupResults.AddedFiles} added and "
+                    + $"{backupResults.ModifiedFiles} modified file(s), "
+                    + $"{backupResults.AddedFolders} added and {backupResults.ModifiedFolders} modified folder(s). "
+                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}");
             }
 
             // Test that we can recreate
@@ -938,7 +943,8 @@ namespace Duplicati.UnitTest
             {
                 var listResults = await c.ListAsync();
                 TestUtils.AssertResults(listResults);
-                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count());
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"Versions present after the recreate: {DescribeFilesets(listResults.Filesets)}");
             }
         }
 
@@ -1009,7 +1015,12 @@ namespace Duplicati.UnitTest
             {
                 var backupResults = await c.BackupAsync(new string[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
-                Assert.AreEqual(expectedFilesets, (await c.ListAsync()).Filesets.Count());
+                var listResults = await c.ListAsync();
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"The last backup reported {backupResults.AddedFiles} added and "
+                    + $"{backupResults.ModifiedFiles} modified file(s), "
+                    + $"{backupResults.AddedFolders} added and {backupResults.ModifiedFolders} modified folder(s). "
+                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}");
             }
 
             // Verify that all is in order
@@ -1031,7 +1042,8 @@ namespace Duplicati.UnitTest
             {
                 var listResults = await c.ListAsync();
                 TestUtils.AssertResults(listResults);
-                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count());
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"Versions present after the recreate: {DescribeFilesets(listResults.Filesets)}");
             }
         }
 
@@ -1172,7 +1184,12 @@ namespace Duplicati.UnitTest
             {
                 var backupResults = await c.BackupAsync(new string[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
-                Assert.AreEqual(expectedFilesets, (await c.ListAsync()).Filesets.Count());
+                var listResults = await c.ListAsync();
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"The last backup reported {backupResults.AddedFiles} added and "
+                    + $"{backupResults.ModifiedFiles} modified file(s), "
+                    + $"{backupResults.AddedFolders} added and {backupResults.ModifiedFolders} modified folder(s). "
+                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}");
             }
 
             // Verify that all is in order
@@ -1194,9 +1211,25 @@ namespace Duplicati.UnitTest
             {
                 var listResults = await c.ListAsync();
                 TestUtils.AssertResults(listResults);
-                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count());
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"Versions present after the recreate: {DescribeFilesets(listResults.Filesets)}");
             }
         }
+
+        /// <summary>
+        /// Names the versions a disruption test ended up with, for the message of the assertion
+        /// that counts them.
+        ///
+        /// These three tests interrupt a backup and then assert how many versions are left, and
+        /// the count is the only thing the failure says. Which versions they are, when they were
+        /// made and whether any of them is partial is the difference between a report that can be
+        /// acted on and two numbers.
+        /// </summary>
+        private static string DescribeFilesets(IEnumerable<IListResultFileset> filesets)
+            => string.Join(", ", filesets
+                .OrderBy(x => x.Version)
+                .Select(x => $"#{x.Version} {(x.IsFullBackup == 1 ? "full" : "partial")}"
+                    + $" at {x.Time.ToUniversalTime():HH:mm:ss}Z with {x.FileCount} file(s)"));
 
         private class LogSink : IMessageSink
         {


### PR DESCRIPTION
`TestMultiExceptionOnDlistAsync` fails on macOS occasionally — twice in the last thirty runs of `tests.yml`, once on `feature/bump-ngclient-231`, a branch whose only changes are two Angular package files. When it does, the entire report is this:

```
Expected: 1
But was:  2
```

That is not enough to tell a product fault from a test expecting the wrong thing, and it is why finding out anything at all took a probe branch and several hundred runs on a fork.

## What the versions say

Everything needed is already in scope where the assertion is made:

- **whether an extra version is partial** — a partial one is a synthetic filelist, uploaded because the previous run looked interrupted, which is a different story from an ordinary version that survived
- **the timestamps** — they say which of the interrupted runs left it behind
- **the added and modified counts**, where the assertion follows a backup — they say whether that backup thought anything had changed at all

Before:

```
Expected: 1
But was:  2
```

After, from a run with the expectation deliberately broken so the message could be read:

```
The last backup reported 0 added and 3 modified file(s), 0 added and 0 modified folder(s).
Versions present: #0 full at 09:22:22Z with 3 file(s), #1 partial at 09:22:07Z with 3 file(s)
```

## Scope

Three tests in `DisruptionTests` assert a version count the same way, twice each — after the final backup and again after a recreate. All six get the message; the three that follow a backup also report its counters. One helper, `DescribeFilesets`, formats the list.

Nothing else changes. A passing run is identical.

## This does not fix the flake

It is worth being plain about that. The failure is rare and comes and goes — a probe branch caught it eight times in 663 runs, and not once in the last 312 — so what is missing is not analysis but evidence, and evidence only arrives when it fails. After this, every occurrence in an ordinary run carries what a probe branch would have had to be built to collect.

## Verification

- The three affected tests, 16 cases, green
- The message above is from a real run with the expected count deliberately changed, not composed by hand
- Build clean, no new warnings
