### PR TITLE
Corrupt the byte the repair test means to corrupt

### DIFF
--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -920,7 +920,12 @@ namespace Duplicati.UnitTest
             {
                 var backupResults = await c.BackupAsync(new string[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
-                Assert.AreEqual(expectedFilesets, (await c.ListAsync()).Filesets.Count());
+                var listResults = await c.ListAsync();
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"The last backup reported {backupResults.AddedFiles} added and "
+                    + $"{backupResults.ModifiedFiles} modified file(s), "
+                    + $"{backupResults.AddedFolders} added and {backupResults.ModifiedFolders} modified folder(s). "
+                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}");
             }
 
             // Test that we can recreate
@@ -938,7 +943,8 @@ namespace Duplicati.UnitTest
             {
                 var listResults = await c.ListAsync();
                 TestUtils.AssertResults(listResults);
-                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count());
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"Versions present after the recreate: {DescribeFilesets(listResults.Filesets)}");
             }
         }
 
@@ -1009,7 +1015,12 @@ namespace Duplicati.UnitTest
             {
                 var backupResults = await c.BackupAsync(new string[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
-                Assert.AreEqual(expectedFilesets, (await c.ListAsync()).Filesets.Count());
+                var listResults = await c.ListAsync();
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"The last backup reported {backupResults.AddedFiles} added and "
+                    + $"{backupResults.ModifiedFiles} modified file(s), "
+                    + $"{backupResults.AddedFolders} added and {backupResults.ModifiedFolders} modified folder(s). "
+                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}");
             }
 
             // Verify that all is in order
@@ -1031,7 +1042,8 @@ namespace Duplicati.UnitTest
             {
                 var listResults = await c.ListAsync();
                 TestUtils.AssertResults(listResults);
-                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count());
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"Versions present after the recreate: {DescribeFilesets(listResults.Filesets)}");
             }
         }
 
@@ -1172,7 +1184,12 @@ namespace Duplicati.UnitTest
             {
                 var backupResults = await c.BackupAsync(new string[] { DATAFOLDER });
                 TestUtils.AssertResults(backupResults);
-                Assert.AreEqual(expectedFilesets, (await c.ListAsync()).Filesets.Count());
+                var listResults = await c.ListAsync();
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"The last backup reported {backupResults.AddedFiles} added and "
+                    + $"{backupResults.ModifiedFiles} modified file(s), "
+                    + $"{backupResults.AddedFolders} added and {backupResults.ModifiedFolders} modified folder(s). "
+                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}");
             }
 
             // Verify that all is in order
@@ -1194,9 +1211,25 @@ namespace Duplicati.UnitTest
             {
                 var listResults = await c.ListAsync();
                 TestUtils.AssertResults(listResults);
-                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count());
+                Assert.AreEqual(expectedFilesets, listResults.Filesets.Count(),
+                    $"Versions present after the recreate: {DescribeFilesets(listResults.Filesets)}");
             }
         }
+
+        /// <summary>
+        /// Names the versions a disruption test ended up with, for the message of the assertion
+        /// that counts them.
+        ///
+        /// These three tests interrupt a backup and then assert how many versions are left, and
+        /// the count is the only thing the failure says. Which versions they are, when they were
+        /// made and whether any of them is partial is the difference between a report that can be
+        /// acted on and two numbers.
+        /// </summary>
+        private static string DescribeFilesets(IEnumerable<IListResultFileset> filesets)
+            => string.Join(", ", filesets
+                .OrderBy(x => x.Version)
+                .Select(x => $"#{x.Version} {(x.IsFullBackup == 1 ? "full" : "partial")}"
+                    + $" at {x.Time.ToUniversalTime():HH:mm:ss}Z with {x.FileCount} file(s)"));
 
         private class LogSink : IMessageSink
         {

--- a/Duplicati/UnitTest/RepairWithMissingRemoteFiles.cs
+++ b/Duplicati/UnitTest/RepairWithMissingRemoteFiles.cs
@@ -523,9 +523,13 @@ namespace Duplicati.UnitTest
             var corruptBothFiles = corruptLargeFile && corruptSmallFile;
             var destroyMetadata = scenario == 3;
 
-            // Destroy some source data (keep metadata)
+            // Destroy some source data (keep metadata).
+            // Flipped rather than assigned: the data is random, so one run in 256 already holds
+            // whatever constant is written here, and then nothing is destroyed at all. The repair
+            // recovers every block, no warning is raised, and the assertion below fails without
+            // anything being wrong.
             var prev = data[1];
-            data[1] = 1;
+            data[1] = (byte)~prev;
             if (corruptLargeFile)
             {
                 var timestamp = File.GetLastWriteTime(Path.Combine(DATAFOLDER, "a"));


### PR DESCRIPTION
`TestPartialRepairPossibleWithPartialDataAsync(2)` fails about once in every few hundred runs, and this is why.

## The bug

The test fills its data randomly and then destroys one byte of it by assigning a constant:

```csharp
var data = new byte[1024 * 32 * 3 + 1028];
Random.Shared.NextBytes(data);
...
var prev = data[1];
data[1] = 1;
```

**One run in 256, `data[1]` is already `1`.** Then the "corruption" changes nothing: the file written back is byte-for-byte what was backed up, so the repair recovers every block from it. `RepairHandler` only warns when blocks are still missing:

```csharp
else if (recoveredBlocks > 0)
{
    if (missingBlocks > 0)
        Logging.Log.WriteWarningMessage(..., "... purge-broken-files ...");
}
```

With `missingBlocks == 0` there is no warning, and:

```csharp
Assert.IsTrue(res.Warnings.Count(x => x.Contains("purge-broken-files")) == 1,
    "Repair should warn about missing block data.");
```

fails, reporting `Expected: True But was: False` when nothing is wrong with the product.

Flipping the byte instead of assigning to it always changes it.

## That this is the failure being seen

Across the last forty runs of `tests.yml`, this test failed on its own — that is, as the only failing test in the job — twice:

| run | branch | os | case |
|---|---|---|---|
| 31614260303 | `dependabot/nuget/…/SSHv2` | windows | **(2)** |
| 31872949274 | a logging change | macos | **(2)** |

Neither branch goes near repair, and both are scenario 2 — the only scenario that destroys data and then expects the warning. Scenarios 0 and 1 corrupt one file each and take the other branch of the assertion; scenario 3 changes timestamps rather than content.

(The same test also fails on `feature/improve-missing-metadata-handling` alongside nine to twelve others on all three platforms. That is a different matter and not this.)

## Reproduced, then not

Forcing the case by adding `data[1] = 1;` right after `NextBytes`:

| | before this change | after |
|---|---|---|
| forced `data[1] == 1` | **fails**, `(2)` only, exactly as CI reported | **passes**, 4 of 4 |

And three ordinary runs of the four cases pass.
