### PR TITLE
Update the Microsoft.Extensions packages the last sweep left behind

### DIFF
--- a/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
+++ b/Duplicati/Library/Utility/Duplicati.Library.Utility.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Duplicati.StreamUtil" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Management" Version="10.0.0" />
   </ItemGroup>

--- a/Duplicati/PackageRef/Duplicati.PackageRef.csproj
+++ b/Duplicati/PackageRef/Duplicati.PackageRef.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.IdentityModel.Abstractions" Version="8.22.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Three `Microsoft.Extensions` references were not carried along by the last "update all packages to latest version" pass, and they sit at three different versions:

| project | package | version | current |
|---|---|---|---|
| `Duplicati.Library.Utility` | `Microsoft.Extensions.Http` | 10.0.0 | 10.0.11 |
| `Duplicati.PackageRef` | `Microsoft.Extensions.Caching.Memory` | 10.0.0 | 10.0.11 |
| `Duplicati.PackageRef` | `Microsoft.Extensions.Logging.Abstractions` | 10.0.8 | 10.0.11 |

`Logging.Abstractions` moved and the other two did not, which is what makes this look like an oversight rather than a decision.

## What being behind costs

It splits four other packages across the solution.

```
Azure.Core / System.ClientModel  ->  Configuration.Abstractions 10.0.3
Hosting.Abstractions 10.0.3      ->  Diagnostics.Abstractions 10.0.3  ->  Options 10.0.3
Configuration.Abstractions / Options  ->  Primitives 10.0.3
```

So the twenty-seven projects that reach Azure resolve `Configuration.Abstractions`, `Diagnostics.Abstractions`, `Options` and `Primitives` at 10.0.3, while the fifty-two that do not stay at 10.0.0.

## Why 10.0.11 settles it

`Microsoft.Extensions.Http` 10.0.11 requires `Configuration.Abstractions`, `Options` and `Diagnostics` at 10.0.11, and `Caching.Memory` 10.0.11 requires `Primitives` and `Options` at 10.0.11. That is above the 10.0.3 Azure asks for, so every project agrees on one version instead of two.

## Verification

Counting packages that resolve to more than one version across the 104 projects in `Duplicati.slnx`, read from `project.assets.json` after a restore:

| | packages resolving to two versions |
|---|---|
| before | 12 |
| after | **8** |

The four that go are exactly `Configuration.Abstractions`, `Diagnostics.Abstractions`, `Options` and `Primitives`. The remaining eight have nothing to do with these three references.

`dotnet build Duplicati.slnx -c Debug` is unchanged at 10 warnings and 0 errors — byte-for-byte the same warning list as master, so nothing new appears and nothing existing is masked.

## Scope

Three version numbers. No code, and no change to which packages are referenced.

These are servicing releases within 10.0.x, so I would not expect behaviour to change; I have not tried to prove that beyond the build, and the test suite here is the thing that would show it.

I should also be straight about the value: I have not found a case where the split causes a runtime fault, since the highest version wins at the app level anyway. This is consistency, not a bug fix.
