### PR TITLE
Stop deduplicating twice in the fileset consistency check

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -2142,13 +2142,15 @@ namespace Duplicati.Library.Main.Database.Local
                     ");
                     await foreach (var filesetid in cmd.ExecuteReaderEnumerableAsync(token).Select(x => x.ConvertValueToInt64(0, -1)).ConfigureAwait(false))
                     {
+                        // UNION already removes duplicates from the combined result,
+                        // so a DISTINCT on each side only pays for a pass that is redone.
                         var expandedlist = await cmd2.SetCommandAndParameters($@"
                             SELECT COUNT(*)
                             FROM (
-                                SELECT DISTINCT ""Path""
+                                SELECT ""Path""
                                 FROM ({LIST_FILESETS})
                                 UNION
-                                SELECT DISTINCT ""Path""
+                                SELECT ""Path""
                                 FROM ({LIST_FOLDERS_AND_SYMLINKS})
                             )
                         ")


### PR DESCRIPTION
`VerifyConsistency` counts the paths a fileset expands to, and asks for it like this:

```sql
SELECT COUNT(*)
FROM (
    SELECT DISTINCT "Path" FROM (LIST_FILESETS)
    UNION
    SELECT DISTINCT "Path" FROM (LIST_FOLDERS_AND_SYMLINKS)
)
```

`UNION`, unlike `UNION ALL`, already removes duplicates from the combined result. Neither `DISTINCT` can change what comes out — each one only buys a deduplication pass that `UNION` then does again.

This is not an inference from measurement; it follows from what `UNION` is defined to do. The measurement is only there to say whether it costs anything.

## It costs something

Fastest of five runs, iterating every fileset, on three databases I had from other work:

| `FilesetEntry` rows | before | after | speedup | count |
|---|---|---|---|---|
| 21,005 | 0.1577 s | 0.0893 s | 1.77x | equal |
| 12,104 | 0.0860 s | 0.0436 s | 1.97x | equal |
| 12,227 | 0.0775 s | 0.0313 s | 2.48x | equal |

`EXPLAIN QUERY PLAN` goes from four `USE TEMP B-TREE` lines to two, which is the two discarded passes showing up directly.

## Where it is paid

`BackupHandler` calls this with `!options.DisableFilelistConsistencyChecks`, so it runs by default, and the loop covers **every fileset** — the cost is paid again for each version kept.

## Scope, honestly

This is tens to hundreds of milliseconds per backup at these sizes. It is worth having and it is not worth overselling, and it is not a fix for #7127 — I found it while measuring that query for other reasons.

The same shape appears four more times, in `LocalDeleteDatabase` (three) and `LocalPurgeDatabase` (one), inside `NOT IN (...)` where duplicates matter even less. Those sit on delete and purge paths and I have not measured them, so I have left them alone rather than change code I cannot show a number for.

## Verification

- `SymLinkTests` — 6 cases green. Symlinks and folders are exactly the two `BlocksetID` values the second branch selects, so this reaches the change
- `EmptyFileTests` and `EmptyMetadataTests` — 6 cases green
- The count is identical on all three databases above, which is what would break if the reasoning were wrong: a wrong count makes `VerifyConsistency` throw `Unexpected difference in fileset`
- Build clean, warning list byte-for-byte the same as master
