### PR TITLE
Rebuild the query statistics when they no longer describe the database

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -1376,6 +1376,45 @@ namespace Duplicati.Library.Main.Database.Local
         }
 
         /// <summary>
+        /// The number of rows ANALYZE samples per index. SQLite recommends 400 as a value that
+        /// keeps the cost bounded while still producing usable estimates.
+        /// </summary>
+        private const long StatisticsAnalysisLimit = 400;
+
+        /// <summary>
+        /// Rebuilds the query statistics if the ones recorded no longer describe the database.
+        ///
+        /// A backup that starts from an almost empty database leaves "sqlite_stat1" saying the
+        /// tables hold a row or two, and then fills them with tens of thousands. The planner keeps
+        /// believing the recorded numbers, and picks join orders for the fileset and consistency
+        /// queries that do not finish in any reasonable time.
+        ///
+        /// The mask matters. 0x10000 is what makes SQLite look at every table rather than only
+        /// the ones this connection has touched, and without it the pragma does nothing at all
+        /// while a transaction is open -- which one always is here. 0x0002 is the ANALYZE step.
+        /// SQLite recommends exactly this combination for long-lived connections.
+        /// </summary>
+        /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes when the statistics have been refreshed, if they needed it.</returns>
+        public async Task RefreshQueryStatisticsAsync(CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            using (new Logging.Timer(LOGTAG, "RefreshQueryStatistics", "Refreshing the query statistics"))
+            {
+                await cmd.ExecuteNonQueryAsync($"PRAGMA analysis_limit={StatisticsAnalysisLimit}", token)
+                    .ConfigureAwait(false);
+
+                // SQLite decides for itself which tables have moved far enough to be worth
+                // re-analyzing, so there is nothing to gain from guessing at that here. On a
+                // database whose statistics already fit, this costs about four milliseconds.
+                await cmd.ExecuteNonQueryAsync("PRAGMA optimize=0x10002", token)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
         /// Performs a VACUUM operation on the database to reclaim unused space.
         /// This operation can help optimize the database performance by defragmenting it.
         /// Note: This operation can take a significant amount of time depending on the size of the database.

--- a/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
@@ -385,6 +385,15 @@ namespace Duplicati.Library.Main.Operation.Backup
             );
         }
 
+        public Task RefreshQueryStatisticsAsync(CancellationToken cancellationToken)
+        {
+            return RunOnMainAsync(async () =>
+                await m_database
+                    .RefreshQueryStatisticsAsync(cancellationToken)
+                    .ConfigureAwait(false)
+            );
+        }
+
         public Task RemoveRemoteVolumeAsync(string remoteFilename, CancellationToken cancellationToken)
         {
             return RunOnMainAsync(async () =>

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -215,6 +215,15 @@ namespace Duplicati.Library.Main.Operation
 
                     result.Dryrun = options.Dryrun;
 
+                    // A backup that was killed before it could close leaves the query statistics
+                    // describing the database as it was when that run started, which is enough to
+                    // make the planner choose join orders that never finish. Everything below
+                    // reads tables that are affected, starting with the longest-path probe, so
+                    // this has to come before any of it.
+                    await database
+                        .RefreshQueryStatisticsAsync(result.TaskControl.ProgressToken)
+                        .ConfigureAwait(false);
+
                     // Check the database integrity
                     await Utility.UpdateOptionsFromDbAsync(database, options, result.TaskControl.ProgressToken)
                         .ConfigureAwait(false);
@@ -733,6 +742,14 @@ namespace Duplicati.Library.Main.Operation
 
                     // Add the fileset file to the dlist file
                     filesetvolume.CreateFilesetFile(!m_result.PartialBackup);
+
+                    // The tables have just grown by everything this backup added, which can be
+                    // several orders of magnitude when the previous run was small. Rebuild the
+                    // statistics before the fileset is written, because that query joins six
+                    // tables and the planner needs to know how big they actually are.
+                    await db
+                        .RefreshQueryStatisticsAsync(m_taskReader.ProgressToken)
+                        .ConfigureAwait(false);
 
                     // Ensure the database is in a sane state after adding data
                     using (new Logging.Timer(LOGTAG, "VerifyConsistency", "VerifyConsistency"))

--- a/Duplicati/UnitTest/QueryStatisticsTests.cs
+++ b/Duplicati/UnitTest/QueryStatisticsTests.cs
@@ -1,0 +1,178 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Main;
+using Duplicati.Library.Main.Database;
+using Duplicati.Library.Main.Database.Local;
+using Duplicati.Library.SQLiteHelper;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A backup that starts from an almost empty database leaves "sqlite_stat1" saying the tables
+/// hold a row or two, and then fills them with tens of thousands. The planner keeps believing
+/// the recorded numbers and picks join orders for the fileset queries that never finish.
+/// Reported as issue #7127.
+/// </summary>
+public class QueryStatisticsTests : BasicSetupHelper
+{
+    /// <summary>
+    /// Rewrites every recorded row count as one, which is the state a first backup of a single
+    /// file leaves behind.
+    /// </summary>
+    private async Task MakeStatisticsDescribeOneRowAsync()
+    {
+        await using var con = await SQLiteLoader.LoadConnectionAsync(DBFILE);
+        await using var cmd = con.CreateCommand();
+
+        var rewritten = new List<(string Table, string Index, string Stat)>();
+        cmd.SetCommandAndParameters(@"SELECT ""tbl"", ""idx"", ""stat"" FROM ""sqlite_stat1""");
+        await using (var rd = await cmd.ExecuteReaderAsync())
+            while (await rd.ReadAsync())
+            {
+                // Only the leading number is the row count; the rest describes the columns and
+                // has to keep its shape for SQLite to read the row back.
+                var stat = rd.ConvertValueToString(2) ?? "1";
+                var space = stat.IndexOf(' ');
+                rewritten.Add((rd.ConvertValueToString(0)!, rd.ConvertValueToString(1)!,
+                    space < 0 ? "1" : "1" + stat.Substring(space)));
+            }
+
+        Assert.That(rewritten, Is.Not.Empty, "The backup left no statistics to work with");
+
+        foreach (var row in rewritten)
+        {
+            cmd.SetCommandAndParameters(@"UPDATE ""sqlite_stat1"" SET ""stat"" = @Stat WHERE ""tbl"" = @Table AND ""idx"" IS @Index");
+            cmd.SetParameterValue("@Stat", row.Stat);
+            cmd.SetParameterValue("@Table", row.Table);
+            cmd.SetParameterValue("@Index", row.Index);
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    /// <summary>
+    /// Reads what the statistics claim a table holds, and what it actually holds.
+    /// </summary>
+    private async Task<(long Recorded, long Actual)> ReadStatisticsForAsync(string table)
+    {
+        await using var con = await SQLiteLoader.LoadConnectionAsync(DBFILE);
+        await using var cmd = con.CreateCommand();
+
+        cmd.SetCommandAndParameters(@"SELECT CAST(""stat"" AS INTEGER) FROM ""sqlite_stat1"" WHERE ""tbl"" = @Table LIMIT 1");
+        cmd.SetParameterValue("@Table", table);
+        var recorded = await cmd.ExecuteScalarInt64Async(-1, CancellationToken.None);
+
+        var actual = await cmd.ExecuteScalarInt64Async($@"SELECT COUNT(*) FROM ""{table}""", 0, CancellationToken.None);
+        return (recorded, actual);
+    }
+
+    private async Task BackupManyFilesAsync()
+    {
+        var testopts = TestOptions.Expand(new { no_encryption = true });
+
+        // Enough files that the recorded row count and the real one are far apart once the
+        // statistics are reset, which is what the refresh has to notice.
+        for (var i = 0; i < 40; i++)
+        {
+            var dir = Path.Combine(DATAFOLDER, $"folder-{i}");
+            Directory.CreateDirectory(dir);
+            for (var j = 0; j < 10; j++)
+                File.WriteAllText(Path.Combine(dir, $"file-{j}.txt"), $"contents {i} {j}");
+        }
+
+        using var c = new Controller("file://" + TARGETFOLDER, testopts, null);
+        TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+    }
+
+    /// <summary>
+    /// The refresh has to run against the transaction the database keeps open, because a backup
+    /// never leaves one. A bare "PRAGMA optimize" is silently a no-op there -- only the 0x10000
+    /// bit makes it look past the tables this connection has touched -- so this fails if the mask
+    /// is ever dropped, which is a change that looks harmless in a diff.
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task StaleStatisticsAreRebuiltWhileATransactionIsOpenAsync()
+    {
+        await BackupManyFilesAsync();
+        await MakeStatisticsDescribeOneRowAsync();
+
+        var before = await ReadStatisticsForAsync("FileLookup");
+        Assert.That(before.Recorded, Is.EqualTo(1), "The statistics were not reset");
+        Assert.That(before.Actual, Is.GreaterThan(100), "Too few rows for the statistics to be meaningfully stale");
+
+        await using (var db = await LocalDatabase.CreateLocalDatabaseAsync(DBFILE, "test", true, null, CancellationToken.None))
+        {
+            await db.RefreshQueryStatisticsAsync(CancellationToken.None);
+            await db.Transaction.CommitAsync(CancellationToken.None);
+        }
+
+        var after = await ReadStatisticsForAsync("FileLookup");
+        Assert.That(after.Recorded, Is.EqualTo(after.Actual),
+            $"The statistics still describe {after.Recorded} row(s) where there are {after.Actual}");
+    }
+
+    /// <summary>
+    /// Statistics that already describe the database are left alone, so an ordinary backup does
+    /// not pay for an ANALYZE it does not need.
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task CurrentStatisticsAreLeftAloneAsync()
+    {
+        await BackupManyFilesAsync();
+
+        // Give the statistics a recognisable shape that a rebuild would replace.
+        await using (var con = await SQLiteLoader.LoadConnectionAsync(DBFILE))
+        await using (var cmd = con.CreateCommand())
+        {
+            var (recorded, actual) = await ReadStatisticsForAsync("FileLookup");
+            Assert.That(recorded, Is.GreaterThan(0), "The backup left no statistics to work with");
+            Assert.That(recorded * 10, Is.GreaterThan(actual), "The statistics are already stale, so nothing is being tested");
+
+            cmd.SetCommandAndParameters(@"UPDATE ""sqlite_stat1"" SET ""stat"" = ""stat"" || ' 1' WHERE ""tbl"" = 'FileLookup'");
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        string marked;
+        await using (var con = await SQLiteLoader.LoadConnectionAsync(DBFILE))
+        await using (var cmd = con.CreateCommand())
+            marked = (await cmd.ExecuteScalarAsync(@"SELECT ""stat"" FROM ""sqlite_stat1"" WHERE ""tbl"" = 'FileLookup' LIMIT 1", CancellationToken.None))?.ToString() ?? "";
+
+        await using (var db = await LocalDatabase.CreateLocalDatabaseAsync(DBFILE, "test", true, null, CancellationToken.None))
+        {
+            await db.RefreshQueryStatisticsAsync(CancellationToken.None);
+            await db.Transaction.CommitAsync(CancellationToken.None);
+        }
+
+        await using (var con = await SQLiteLoader.LoadConnectionAsync(DBFILE))
+        await using (var cmd = con.CreateCommand())
+        {
+            var now = (await cmd.ExecuteScalarAsync(@"SELECT ""stat"" FROM ""sqlite_stat1"" WHERE ""tbl"" = 'FileLookup' LIMIT 1", CancellationToken.None))?.ToString() ?? "";
+            Assert.That(now, Is.EqualTo(marked), "The statistics were rebuilt even though they described the database");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7127.

A first backup small enough to leave the tables holding a handful of rows — a file or three, given as **file paths rather than a folder**, which would add its own row — has that written into `sqlite_stat1` by `PRAGMA optimize` at connection close. The second backup fills those tables with tens of thousands of rows, and nothing refreshes the numbers along the way: the pragma runs only when the connection closes, which the stuck backup never reaches.

Reproduction and the original measurements are in [the issue](https://github.com/duplicati/duplicati/issues/7127#issuecomment-5307802039).

## How small the first backup has to be

Forcing every recorded row count to a given value and running `LIST_FOLDERS_AND_SYMLINKS` against real data:

| recorded row count | 12,103 files | 52,069 files |
|---|---|---|
| 1 | **did not finish in 45 s** | **did not finish in 45 s** |
| 2 | **did not finish in 45 s** | **did not finish in 45 s** |
| 3 | **did not finish in 45 s** | 0.3244 s |
| 10 | 0.0950 s | 0.1933 s |
| accurate | 0.0434 s | 0.2181 s |

So it is not only the one-file case the issue was reported from — two or three files do it as well, and where it stops depends on the database.

Worth noting that the plan shape is not the tell: at 52,069 files a recorded count of 2 produces **no `SCAN` at all** and still does not finish. It is the join order that goes wrong, so counting `SCAN` lines is a misleading way to check this.

Nor is it one query. In the run below the one that would not finish was the length check inside `VerifyConsistency`, not the fileset query the issue was reported against — which is the argument for fixing the statistics rather than any particular statement.

## The mask is the part that matters

`0x10000` is what makes SQLite look at every table rather than only the ones this connection has touched. Without it the pragma **does nothing at all while a transaction is open**, and one always is here — `ReusableTransaction` opens a new one as soon as it commits.

```
inside a transaction:  PRAGMA optimize          0.0003 s   statistics unchanged
                       PRAGMA optimize=0x10002  0.3655 s   statistics updated
```

There is a test for the mask, because dropping it looks harmless in a diff and quietly disables all of this.

## Why setting it at connection open is not enough

@ts678 [suggested](https://github.com/duplicati/duplicati/pull/7181#issuecomment-5308786408) `CUSTOMSQLITEOPTIONS_DUPLICATI=optimize=0x10002`, which needs no code at all, and it does fix a backup that follows a killed one. It cannot fix the case the issue was reported from: when the connection opens, the tables still hold the handful of rows the statistics describe, so there is correctly nothing to do, and the growth happens afterwards.

Measured on master with that variable set — one file, then 20,000:

| | |
|---|---|
| completion | **none in 25 minutes** |
| slow query warnings | 16 |
| longest single query | still running after **975.9 s** |

## Where it is called

Twice: once when the database is opened, before anything reads a large table, and again after the main operation, when the tables have just grown by everything the backup added.

The first placement matters more than it looks. I originally put it just before the consistency check and measured six slow-query warnings anyway — the longest-path probe in `PreBackupVerify` reads the `File` view, and on a killed database **that query alone ran for over seven minutes**.

The second is what covers the reported case. `PRAGMA optimize` sees the rows the open transaction has added but not yet committed — measured by adding 52,069 rows inside a transaction and watching the recorded count go to 104,138 — so it describes the database as it stands.

## Cost

`PRAGMA analysis_limit=400` bounds the sampling, and SQLite decides for itself which tables have moved far enough to be worth re-analyzing, so there is no guard around the call:

| | |
|---|---|
| database whose statistics already fit | **0.0040 s** |
| database needing the rebuild, 58,115 rows | 0.0538 s |

## Verification

The same scenario that would not finish in 25 minutes on master:

| | slow query warnings | duration |
|---|---|---|
| master, `optimize=0x10002` at open | **16** | **did not finish in 25m** |
| this change | **0** | **5m52s** |

with the fileset upload taking 0.870 s and the consistency check 0.148 s, and the statistics ending accurate (`FileLookup` 40,002 rows, recorded as 40,002).

- `QueryStatisticsTests`, 2 cases. Red before the change, and red again if the mask is dropped (`The statistics still describe 1 row(s) where there are 441`)
- `SymLinkTests`, `EmptyFileTests`, `EmptyMetadataTests` — 14 cases green
- Build clean, warning list byte-for-byte identical to master

## Credit

@ts678 — the `sqlite_stat1` dump is what made the size of the first backup findable, the correction that the original case involved no kill is what stopped me reproducing the wrong thing, and the pragma mask replaced a worse implementation of mine: I had been running `ANALYZE` behind a hand-written staleness check, which cost 0.0523 s on a database that needed nothing done to it.
