### PR TITLE
Stop reporting a time the backend statistics never had

### DIFF
--- a/Duplicati/Library/ResultSerialization/JsonFormatSerializer.cs
+++ b/Duplicati/Library/ResultSerialization/JsonFormatSerializer.cs
@@ -40,6 +40,19 @@ namespace Duplicati.Library.ResultSerialization
         private class DynamicContractResolver : DefaultContractResolver
         {
             /// <summary>
+            /// The properties the backend statistics inherit from the result base class without
+            /// ever assigning them, so they serialize as a zero DateTime and an empty duration.
+            /// The text output leaves them out for the same reason; see BasicResults.ToString.
+            /// </summary>
+            private static readonly HashSet<string> UnsetOnBackendStatistics = new HashSet<string>(StringComparer.Ordinal)
+            {
+                "MainOperation",
+                "BeginTime",
+                "EndTime",
+                "Duration"
+            };
+
+            /// <summary>
             /// List of names to exclude
             /// </summary>
             private readonly HashSet<string> m_excludes;
@@ -61,10 +74,13 @@ namespace Duplicati.Library.ResultSerialization
             /// <param name="memberSerialization">Member serialization parameter.</param>
             protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
             {
+                var isBackendStatistics = typeof(IBackendStatstics).IsAssignableFrom(type);
+
                 return base
                     .CreateProperties(type, memberSerialization)
                     .Where(x => !m_excludes.Contains(x.PropertyName))
                     .Where(x => !typeof(Task).IsAssignableFrom(x.PropertyType))
+                    .Where(x => !(isBackendStatistics && UnsetOnBackendStatistics.Contains(x.PropertyName)))
                     .ToList();
             }
         }

--- a/Duplicati/UnitTest/ResultSerializationTests.cs
+++ b/Duplicati/UnitTest/ResultSerializationTests.cs
@@ -1,0 +1,98 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Duplicati.Library.Main;
+using Duplicati.Library.Main.Database;
+using Duplicati.Library.SQLiteHelper;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The result written to the operation log is serialized by JsonFormatSerializer, and the
+    /// backend statistics nested inside it inherit the operation-level timestamps from the result
+    /// base class without ever setting them. Reported as issue #3853.
+    /// </summary>
+    [TestFixture]
+    public class ResultSerializationTests : BasicSetupHelper
+    {
+        /// <summary>
+        /// The value a DateTime that was never assigned serializes to.
+        /// </summary>
+        private const string UnsetTimestamp = "0001-01-01T00:00:00";
+
+        /// <summary>
+        /// Runs a backup and returns what was written to the operation log as the result.
+        /// </summary>
+        private async Task<List<string>> BackupAndReadResultLogAsync()
+        {
+            var testopts = TestOptions.Expand(new { no_encryption = true });
+
+            Directory.CreateDirectory(Path.Combine(DATAFOLDER, "folder"));
+            File.WriteAllText(Path.Combine(DATAFOLDER, "folder", "file.txt"), "some data");
+
+            using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+                TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+            var results = new List<string>();
+            await using (var con = await SQLiteLoader.LoadConnectionAsync(DBFILE))
+            await using (var cmd = con.CreateCommand())
+            {
+                cmd.SetCommandAndParameters(@"SELECT ""Message"" FROM ""LogData"" WHERE ""Type"" = 'Result'");
+                await using (var rd = await cmd.ExecuteReaderAsync())
+                    while (await rd.ReadAsync())
+                        results.Add(rd.ConvertValueToString(0) ?? "");
+            }
+
+            Assert.That(results, Is.Not.Empty, "The backup wrote no result to the operation log");
+            return results;
+        }
+
+        /// <summary>
+        /// The timestamps on the backend statistics are never assigned, so serializing them puts a
+        /// zero DateTime in the log where a reader expects a time.
+        /// </summary>
+        [Test]
+        [Category("Serialization")]
+        public async Task TheResultLogHasNoUnsetTimestampsAsync()
+        {
+            foreach (var result in await BackupAndReadResultLogAsync())
+                Assert.That(result, Does.Not.Contain(UnsetTimestamp),
+                    $"The result written to the operation log contains an unassigned timestamp:{System.Environment.NewLine}{result}");
+        }
+
+        /// <summary>
+        /// Dropping the whole BackendStatistics object would also remove the unset timestamps, and
+        /// would take the numbers worth reading with them. This fails if that is how it is fixed.
+        /// </summary>
+        [Test]
+        [Category("Serialization")]
+        public async Task TheResultLogStillReportsWhatTheBackendDidAsync()
+        {
+            foreach (var result in await BackupAndReadResultLogAsync())
+                Assert.That(result, Does.Contain("BytesUploaded"),
+                    $"The result written to the operation log no longer says what the backend did:{System.Environment.NewLine}{result}");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3853, reported in 2019 and confirmed still reproducing by @ts678 in 2024.

The result written to the operation log carries a timestamp that was never set. Captured from a real restore on master with `--run-script-result-output-format=Json`:

```
Data                  MainOperation=Restore  BeginTime=2026-08-17T11:14:55Z  EndTime=2026-08-17T11:14:57Z
  BackendStatistics   MainOperation=Restore  BeginTime=2026-08-17T11:14:55Z  EndTime=0001-01-01T00:00:00
```

`BackendWriter` derives from `BasicResults`, so it inherits `MainOperation`, `BeginTime`, `EndTime` and `Duration`, and nothing ever assigns them. `Duration` is computed from `EndTime`, so it reads `00:00:00` for the same reason.

## The correct behaviour is already in the code

The text output leaves all four out, and has done for years — `BasicResults.ToString` filters them by `item is BackendWriter`:

```csharp
!(prop.Name == "MainOperation" && item is BackendWriter) &&
!(prop.Name == "EndTime"       && item is BackendWriter) &&
!(prop.Name == "Duration"      && item is BackendWriter) &&
!(prop.Name == "BeginTime"     && item is BackendWriter),
```

So this is not a judgement call about what those fields ought to say. The JSON path simply never got the same treatment: `DynamicContractResolver` excludes property *names* globally, and `EndTime` cannot be excluded that way without taking the real one on the result itself.

`CreateProperties` already receives the type it is building properties for, so the resolver now drops those four when that type is backend statistics.

## What this covers

Both callers share the resolver, so both are fixed at once:

| path | caller |
|---|---|
| the operation log in the local database — what the UI shows as the complete log | `LocalDatabase.WriteResultsAndCommitAsync` → `SerializeResults` |
| notification modules asked for `Json` | `ReportHelper` → `Serialize` |

The default `Duplicati` format goes through `ToString` and was never affected.

## Not dropping the object instead

Removing `BackendStatistics` wholesale would also remove the unset timestamps, and would take `BytesUploaded`, `FilesUploaded` and the rest with them. The second test fails if it is ever fixed that way.

## Verified

- On a real restore, `0001-01-01` went from appearing in the captured JSON to appearing **not at all**, with `BackendStatistics` and `BytesUploaded` still present
- `ResultSerializationTests`, 2 cases. The first is red before this change (`The result written to the operation log contains an unassigned timestamp`)
- `ResultFormatSerializerProviderTest`, `TemplateSerializerTests`, `EmptyFileTests` — 22 cases green
- Build clean, warning list byte-for-byte identical to master

Only two implementations of `IBackendStatstics` exist — `BackendWriter` and `BackendStatisticsWrapper` — and the second has no timestamp properties at all, so the check is a no-op there. Nothing in the tree reads `BackendStatistics.MainOperation`, `.BeginTime`, `.EndTime` or `.Duration`.

## One thing found and deliberately left alone

The exclusion list in `SerializeResults` contains `nameof(IBackendStatstics)`. That evaluates to the *type* name, while the property is `IBasicResults.BackendStatistics`, so it has never matched anything and has no effect.

Correcting it to `nameof(IBasicResults.BackendStatistics)` would make the first test here pass — by removing the backend numbers from the log entirely, which is a regression rather than a fix, and is why it is not what this PR does. Flagging it rather than changing it, since which way it should go is a call for the maintainers.
