### PR TITLE
Stop telling a restore that the destination is full

### DIFF
--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -549,10 +549,26 @@ namespace Duplicati.Library.Main.Operation
             };
         }
 
+        /// <summary>
+        /// The operations that only read from the destination. Running out of room there cannot
+        /// stop them and they cannot cause it, so the quota is recorded for them without being
+        /// reported on. A destination that is full or mounted read-only reports no free space,
+        /// and a restore from one of those succeeds; see issue #3672.
+        /// </summary>
+        /// <remarks>
+        /// Listed the way round that leaves an operation added later reporting as it does now,
+        /// because missing a destination that has genuinely filled up is worse than saying so
+        /// where it does not matter.
+        /// </remarks>
+        private static bool OnlyReadsFromBackend(OperationMode operation)
+            => operation is OperationMode.Restore or OperationMode.ListBrokenFiles;
+
         private static async Task CheckQuotaAsync(IBackendManager backendManager, Options options, IBackendWriter log, long knownFileSize)
         {
             if (options.QuotaDisable)
                 return;
+
+            var reportShortage = !OnlyReadsFromBackend(log.MainOperation);
 
             var quota = await backendManager.GetQuotaInfoAsync(CancellationToken.None).ConfigureAwait(false);
             if (quota != null)
@@ -565,12 +581,12 @@ namespace Duplicati.Library.Main.Operation
                 // (both at the start and end, for example), the log keeps track of
                 // whether a quota error or warning has been sent already.
                 // Note that an error can still be sent later even if a warning was sent earlier.
-                if (!log.ReportedQuotaError && quota.FreeQuotaSpace == 0)
+                if (reportShortage && !log.ReportedQuotaError && quota.FreeQuotaSpace == 0)
                 {
                     log.ReportedQuotaError = true;
                     Logging.Log.WriteErrorMessage(LOGTAG, "BackendQuotaExceeded", null, "Backend quota has been exceeded: Using {0} of {1} ({2} available)", Library.Utility.Utility.FormatSizeString(knownFileSize), Library.Utility.Utility.FormatSizeString(quota.TotalQuotaSpace), Library.Utility.Utility.FormatSizeString(quota.FreeQuotaSpace));
                 }
-                else if (!log.ReportedQuotaWarning && !log.ReportedQuotaError && quota.FreeQuotaSpace >= 0) // Negative value means the backend didn't return the quota info
+                else if (reportShortage && !log.ReportedQuotaWarning && !log.ReportedQuotaError && quota.FreeQuotaSpace >= 0) // Negative value means the backend didn't return the quota info
                 {
                     // Warnings are sent if the available free space is less than the given percentage of the total backup size.
                     double warningThreshold = options.QuotaWarningThreshold / (double)100;
@@ -586,12 +602,12 @@ namespace Duplicati.Library.Main.Operation
             if (log.AssignedQuotaSpace != -1)
             {
                 // Check assigned quota
-                if (!log.ReportedQuotaError && knownFileSize > log.AssignedQuotaSpace)
+                if (reportShortage && !log.ReportedQuotaError && knownFileSize > log.AssignedQuotaSpace)
                 {
                     log.ReportedQuotaError = true;
                     Logging.Log.WriteErrorMessage(LOGTAG, "AssignedQuotaExceeded", null, "Assigned quota has been exceeded: Using {0} of {1}", Library.Utility.Utility.FormatSizeString(knownFileSize), Library.Utility.Utility.FormatSizeString(log.AssignedQuotaSpace));
                 }
-                else if (!log.ReportedQuotaWarning && !log.ReportedQuotaError)
+                else if (reportShortage && !log.ReportedQuotaWarning && !log.ReportedQuotaError)
                 {
                     // Warnings are sent if the available free space is less than the given percentage of the total backup size.
                     double warningThreshold = options.QuotaWarningThreshold / (double)100;

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -39,6 +39,12 @@ namespace Duplicati.Library.Main
         bool ReportedQuotaWarning { get; set; }
 
         /// <summary>
+        /// The operation the backend is working for, which decides whether running out of room
+        /// at the destination is something it can suffer from.
+        /// </summary>
+        OperationMode MainOperation { get; }
+
+        /// <summary>
         /// The backend sends this event when performing an action
         /// </summary>
         /// <param name="action">The action performed</param>

--- a/Duplicati/UnitTest/NoFreeSpaceBackend.cs
+++ b/Duplicati/UnitTest/NoFreeSpaceBackend.cs
@@ -1,0 +1,119 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Common.IO;
+using Duplicati.Library.Interface;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Stores files in a local folder, and reports that the destination has no room left.
+    ///
+    /// A read-only mount does exactly this: macOS mounting an NTFS volume reports zero bytes
+    /// available while the volume is perfectly readable, which is what issue #3672 was about.
+    /// </summary>
+    public class NoFreeSpaceBackend : IBackend, IQuotaEnabledBackend
+    {
+        /// <summary>
+        /// What the destination claims its capacity is.
+        /// </summary>
+        private const long TotalSpace = 4_000_000_000_000;
+
+        /// <summary>
+        /// Where the files actually go. Set by the test, so the url does not have to carry a
+        /// path and this does not have to parse one.
+        /// </summary>
+        public static string Folder { get; set; } = "";
+
+        private readonly string m_folder = Folder;
+
+        public NoFreeSpaceBackend()
+        {
+        }
+
+        public NoFreeSpaceBackend(string url, Dictionary<string, string> options)
+        {
+            if (!string.IsNullOrEmpty(m_folder) && !Directory.Exists(m_folder))
+                Directory.CreateDirectory(m_folder);
+        }
+
+        public Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
+            => Task.FromResult<IQuotaInfo?>(new QuotaInfo(TotalSpace, 0));
+
+        public Task TestAsync(bool alsoWrite, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task CreateFolderAsync(CancellationToken cancellationToken)
+        {
+            Directory.CreateDirectory(m_folder);
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<IFileEntry> ListAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+            foreach (var path in Directory.EnumerateFiles(m_folder))
+            {
+                var info = new FileInfo(path);
+                yield return new FileEntry(info.Name, info.Length, info.LastAccessTimeUtc, info.LastWriteTimeUtc);
+            }
+        }
+
+        public async Task PutAsync(string remotename, string filename, CancellationToken cancellationToken)
+        {
+            await using var src = File.OpenRead(filename);
+            await using var dst = File.Create(Path.Combine(m_folder, remotename));
+            await src.CopyToAsync(dst, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task GetAsync(string remotename, string filename, CancellationToken cancellationToken)
+        {
+            await using var src = File.OpenRead(Path.Combine(m_folder, remotename));
+            await using var dst = File.Create(filename);
+            await src.CopyToAsync(dst, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+        {
+            File.Delete(Path.Combine(m_folder, remotename));
+            return Task.CompletedTask;
+        }
+
+        public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken)
+            => Task.FromResult(Array.Empty<string>());
+
+        public string DisplayName => "No Free Space Backend";
+        public string ProtocolKey => "nofreespace";
+        public string Description => "A testing backend that stores files locally but reports no free space";
+        public IList<ICommandLineArgument> SupportedCommands => new List<ICommandLineArgument>();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Duplicati/UnitTest/QuotaReportingTests.cs
+++ b/Duplicati/UnitTest/QuotaReportingTests.cs
@@ -1,0 +1,105 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.DynamicLoader;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// A destination with no room left stops a backup, but says nothing about whether a restore
+    /// can be read out of it. Reported as issue #3672, where restoring from a read-only mount
+    /// finished correctly and reported an error anyway.
+    /// </summary>
+    [TestFixture]
+    public class QuotaReportingTests : BasicSetupHelper
+    {
+        /// <summary>
+        /// The destination the fake backend keeps its files in.
+        /// </summary>
+        private const string FullTarget = "nofreespace://destination";
+
+        [SetUp]
+        public void RegisterBackend()
+        {
+            NoFreeSpaceBackend.Folder = TARGETFOLDER;
+            BackendLoader.AddBackend(new NoFreeSpaceBackend());
+        }
+
+        private void CreateSourceData()
+        {
+            Directory.CreateDirectory(Path.Combine(DATAFOLDER, "folder"));
+            File.WriteAllText(Path.Combine(DATAFOLDER, "folder", "file.txt"), "some data");
+        }
+
+        /// <summary>
+        /// A restore reads and never writes, so the destination being full cannot affect it.
+        /// </summary>
+        [Test]
+        [Category("Quota")]
+        public async Task ARestoreFromAFullDestinationReportsNoQuotaErrorAsync()
+        {
+            var testopts = TestOptions.Expand(new { no_encryption = true, quota_warning_threshold = 0 });
+            CreateSourceData();
+
+            using (var c = new Controller(FullTarget, testopts, null))
+                await c.BackupAsync([DATAFOLDER]);
+
+            var restoreFolder = Path.Combine(BASEFOLDER, "restored");
+            Directory.CreateDirectory(restoreFolder);
+
+            var restoreopts = TestOptions.Expand(new { no_encryption = true, quota_warning_threshold = 0, restore_path = restoreFolder });
+            using (var c = new Controller(FullTarget, restoreopts, null))
+            {
+                var results = await c.RestoreAsync(null);
+                var quotaErrors = results.Errors.Where(x => x.Contains("quota")).ToList();
+
+                Assert.That(quotaErrors, Is.Empty,
+                    "A restore reported a quota error for a destination it only reads from: "
+                        + string.Join(System.Environment.NewLine, quotaErrors));
+            }
+        }
+
+        /// <summary>
+        /// The same destination has to keep stopping a backup, which does write to it. This fails
+        /// if the fix removes the quota check rather than confining it to what can be affected.
+        /// </summary>
+        [Test]
+        [Category("Quota")]
+        public async Task ABackupToAFullDestinationStillReportsAQuotaErrorAsync()
+        {
+            var testopts = TestOptions.Expand(new { no_encryption = true });
+            CreateSourceData();
+
+            using (var c = new Controller(FullTarget, testopts, null))
+            {
+                var results = await c.BackupAsync([DATAFOLDER]);
+
+                Assert.That(results.Errors.Any(x => x.Contains("quota")), Is.True,
+                    "A backup to a destination with no room left reported no quota error");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3672, reported in 2019.

Restoring from a destination with no room left reports this, and then restores everything correctly anyway:

```
Error: Backend quota has been exceeded: Using 199.63 GB of 3.64 TB (0 bytes available)
```

## The backend is not lying, and the check is not misreading it

macOS mounts NTFS volumes read-only, and a read-only mount reports **zero bytes available** while being perfectly readable. That is what the reporter was restoring from, so `0` is the honest answer to the question that was asked.

Nor is `== 0` a misreading of the convention. `IQuotaInfo` documents `-1` as "not supported", so an unknown quota does not trigger this, and the warning beside it already guards on exactly that:

```csharp
else if (... && quota.FreeQuotaSpace >= 0) // Negative value means the backend didn't return the quota info
```

**The problem is that a restore is asked at all.** It reaches the check through `RestoreHandler.cs:857` → `VerifyRemoteListAsync` → `RemoteListAnalysisAsync` → `CheckQuotaAsync`, writes nothing, and would finish whether or not there is room. Reporting it as an **Error** makes an operation that succeeded look like it failed, which is what the reporter saw — the files were fine.

## What changes

The shortage is reported only for operations that can suffer from it. The numbers themselves — `TotalQuotaSpace`, `FreeQuotaSpace`, `AssignedQuotaSpace` — are still recorded for everything, since the log and the UI read them. The same applies to `--quota-size`, which a restore can do just as little about.

`Restore` and `ListBrokenFiles` are named, rather than listing the operations that do write. An operation added later then keeps reporting as it does now, because staying quiet about a destination that has genuinely filled up is worse than mentioning it where it does not matter.

## Why not `VerifyMode`

Deriving this from `verifyMode` would work today — `VerifyOnly` happens to be used by exactly those two operations and by nothing that writes. But that enum means "do not repair partials", not "does not write", and the day the two drift apart the quota errors would disappear with nothing failing to say so.

So `MainOperation` is added to `IBackendWriter` instead. `BackendWriter` already has the property, delegating to its parent, so only the interface declaration changes.

## Verified

- `QuotaReportingTests`, 2 cases, against a fake backend that stores files locally and reports no free space
  - the restore case is red before this change: `A restore reported a quota error for a destination it only reads from: ... Backend quota has been exceeded: Using 2.67 KiB of 3.64 TiB (0 available)`
  - the backup case passes both before and after — it is there so that removing the check rather than confining it fails
- `EmptyFileTests`, `ResultSerializationTests` — 8 cases green
- Build clean, warning list byte-for-byte identical to master
