### PR TITLE
Recreate a database from a first backup that never finished

### DIFF
--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -231,14 +231,30 @@ namespace Duplicati.Library.Main.Operation
                 orderby n.Time descending
                 select n;
 
+            // A filelist is only written once a backup finishes, so a first backup that was
+            // interrupted leaves blocks and index files behind and no filelist at all. Refusing
+            // to recreate from that made such a backup unrecoverable: the backup asked for a
+            // repair, and the repair had nothing it would accept to repair from.
+            //
+            // The blocks are still described by the index files, so the recreate has everything
+            // it needs to register them and let the next backup carry on from where it stopped.
+            // Asking for a particular filelist is a different matter: that was asked for
+            // explicitly, and not finding it is not something to carry on past.
             if (!filelists.Any())
-                throw new UserInformationException("No filelists found on the remote destination", "EmptyRemoteLocation");
+            {
+                if (filelistfilter != null)
+                    throw new UserInformationException("No filelists found on the remote destination", "EmptyRemoteLocation");
+
+                Logging.Log.WriteWarningMessage(LOGTAG, "EmptyRemoteLocation", null, "No filelists found on the remote destination. This is expected if a first backup was interrupted before it finished, and the recreated database will let it resume. If this destination did hold filelists, they have been lost, and the backup can no longer be restored from.");
+            }
 
             if (filelistfilter != null)
+            {
                 filelists = filelistfilter(filelists).Select(x => x.Value).ToArray();
 
-            if (!filelists.Any())
-                throw new UserInformationException("No filelists", "NoMatchingRemoteFilelists");
+                if (!filelists.Any())
+                    throw new UserInformationException("No filelists", "NoMatchingRemoteFilelists");
+            }
 
             // If we are updating, all files should be accounted for
             foreach (var fl in remotefiles)
@@ -254,9 +270,10 @@ namespace Duplicati.Library.Main.Operation
             var filelistWork = (from n in filelists orderby n.Time select new RemoteVolume(n.File) as IRemoteVolume).ToList();
             Logging.Log.WriteInformationMessage(LOGTAG, "RebuildStarted", "Rebuild database started, downloading {0} filelists", filelistWork.Count);
 
-            // The newest filelist is the authority for version labels,
-            // even if it does not contain a labels.json file
-            var newestFilelistName = filelists.First().File.Name;
+            // The newest filelist is the authority for version labels, even if it does not
+            // contain a labels.json file. A first backup that was interrupted has no filelist
+            // at all, and then there is no name to match and no labels to apply either.
+            var newestFilelistName = filelists.FirstOrDefault()?.File.Name;
             IReadOnlyDictionary<DateTime, string> remoteLabels = null;
 
             var progress = 0;

--- a/Duplicati/UnitTest/RecreateWithoutFilelistTests.cs
+++ b/Duplicati/UnitTest/RecreateWithoutFilelistTests.cs
@@ -1,0 +1,125 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// A filelist is only written once the first backup finishes, so interrupting it leaves a
+    /// destination holding blocks and index files and nothing else. Recreating a database from
+    /// that used to be refused, which left the backup unrecoverable: the backup asked for a
+    /// repair and the repair said there was nothing to repair from. Reported as issue #3546.
+    /// </summary>
+    public class RecreateWithoutFilelistTests : BasicSetupHelper
+    {
+        private string Target => "file://" + TARGETFOLDER;
+
+        /// <summary>
+        /// The part of the warning that says the destination held no filelists.
+        /// </summary>
+        private const string MissingFilelistWarning = "No filelists found on the remote destination";
+
+        private int CountRemote(string kind)
+            => Directory.GetFiles(TARGETFOLDER).Count(x => Path.GetFileName(x).Contains(kind));
+
+        /// <summary>
+        /// Leaves the destination in the state an interrupted first backup leaves it in: the
+        /// blocks and index files are there, and the filelist that is written last is not.
+        /// Done by removing the filelist rather than by killing a backup, so the state is the
+        /// same every run.
+        /// </summary>
+        private async Task BackupThenRemoveTheFilelistAsync()
+        {
+            Directory.CreateDirectory(Path.Combine(DATAFOLDER, "folder"));
+            for (var i = 0; i < 5; i++)
+                File.WriteAllText(Path.Combine(DATAFOLDER, "folder", $"file-{i}.txt"), $"contents {i}");
+
+            using (var c = new Controller(Target, TestOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+            foreach (var f in Directory.GetFiles(TARGETFOLDER).Where(x => Path.GetFileName(x).Contains("dlist")))
+                File.Delete(f);
+
+            File.Delete(DBFILE);
+
+            Assert.That(CountRemote("dblock"), Is.GreaterThan(0), "The backup left no blocks to recover");
+            Assert.That(CountRemote("dlist"), Is.EqualTo(0), "The filelist was not removed");
+        }
+
+        /// <summary>
+        /// The repair that the backup tells the user to run has to work, and has to say that the
+        /// filelists were missing: a destination that did once hold them has lost something.
+        /// </summary>
+        [Test]
+        [Category("RepairHandler")]
+        public async Task ARepairSucceedsWithoutAnyFilelistAsync()
+        {
+            await BackupThenRemoveTheFilelistAsync();
+
+            using var c = new Controller(Target, TestOptions, null);
+            var results = await c.RepairAsync();
+            TestUtils.AssertResults(results, [MissingFilelistWarning]);
+
+            Assert.That(results.Warnings.Any(x => x.Contains(MissingFilelistWarning)), Is.True,
+                "The repair recreated the database without saying the filelists were missing");
+        }
+
+        /// <summary>
+        /// And it has to leave the blocks that were already uploaded usable, rather than starting
+        /// the upload over. This fails if the recreate discards what it could not describe.
+        /// </summary>
+        [Test]
+        [Category("RepairHandler")]
+        public async Task TheRecoveredBackupReusesWhatWasAlreadyUploadedAsync()
+        {
+            await BackupThenRemoveTheFilelistAsync();
+            var blocksBefore = CountRemote("dblock");
+
+            using (var c = new Controller(Target, TestOptions, null))
+                TestUtils.AssertResults(await c.RepairAsync(), [MissingFilelistWarning]);
+
+            using (var c = new Controller(Target, TestOptions, null))
+                TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+            Assert.That(CountRemote("dblock"), Is.EqualTo(blocksBefore),
+                "The backup uploaded the data again instead of reusing the blocks that were already there");
+            Assert.That(CountRemote("dlist"), Is.GreaterThan(0), "The recovered backup wrote no filelist");
+        }
+
+        /// <summary>
+        /// A destination with nothing in it at all is still an error. Without this, removing the
+        /// refusal altogether would pass the tests above.
+        /// </summary>
+        [Test]
+        [Category("RepairHandler")]
+        public void ARepairOfAnEmptyDestinationStillFails()
+        {
+            using var c = new Controller(Target, TestOptions, null);
+            Assert.ThrowsAsync<UserInformationException>(async () => await c.RepairAsync());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3546, reported in 2018 and hit again by two other people in 2019.

Interrupting a first backup leaves the destination holding blocks and index files and **no filelist**, because the filelist is written last. From there the backup is unrecoverable:

```
repair -> No filelists found on the remote destination   (EmptyRemoteLocation)
backup -> Found 58 remote files that are not recorded in local storage ...
          you can use repair to delete the unknown files
```

The backup asks for a repair, and the repair has nothing it will accept to repair from. Whatever was already uploaded cannot be reached, and the only way out is to throw the destination away and start over.

## Nothing was actually missing

The blocks are described by the index files, so the recreate has everything it needs to register them and let the next backup carry on from where it stopped.

Measured on a 116 MB source, interrupted after 29 blocks had been uploaded:

| | before | after |
|---|---|---|
| `repair` | `No filelists found on the remote destination` | succeeds, with a warning |
| `backup` after it | refuses, points at `repair` | completes, 400 files |
| blocks at the destination | — | **still 29** |
| destination size | — | **115 MB** against a 116 MB source |

So the blocks are reused rather than uploaded again, which is the point of recovering rather than starting over.

## Two refusals, not one

`RecreateDatabaseHandler` rejects this twice — `EmptyRemoteLocation` and then `NoMatchingRemoteFilelists` — and stopping at the first leaves the second in the way. I only found that by taking the first one out and watching it stop again at the next line.

Asking for a *particular* filelist still fails. That is asked for explicitly, by `--version` or a restore of one version, and not finding it is a different matter from a backup that never wrote one.

## The warning

A destination that did once hold filelists and no longer does has lost something, so the recreate says so rather than passing over it in silence. This is what @Pectojin proposed on the issue in 2018:

> the resolution is to make repair accept there being no dlist files available so it's possible to recreate the DB and resume an initial upload. It should still throw a warning about no dlist being available since this is an issue if there used to be dlist files.

## Verified

- `RecreateWithoutFilelistTests`, 3 cases. Two are red before this change (`No filelists found on the remote destination`); the third — that an entirely empty destination still fails — passes both before and after, so removing the refusal rather than narrowing it does not pass
- The test reproduces the state by deleting the filelist after a completed backup rather than by killing one part way, because killing it is a race: at 8 seconds it sometimes wrote the filelist and sometimes did not
- `RepairHandlerTests` and `RepairWithMissingRemoteFiles` — 53 cases green, since this touches the recreate path they both use
- The command line was run through the same recovery by hand, giving the numbers in the table above
- Build clean, warning list byte-for-byte identical to master


## Rebased on 2026-08-29, and one more line was needed

Version labels landed while this sat, and `RecreateDatabaseHandler` now opens with

```csharp
var newestFilelistName = filelists.First().File.Name;
```

That is unreachable on master, because the refusal this PR removes stands in front of it. With the refusal gone it is reachable with nothing in the list, and the two new tests failed on all three platforms with `Sequence contains no elements`.

The name is only used to recognise the newest filelist while iterating the filelists, so with none of them the loop does not run, `remoteLabels` stays null, and `ApplyLabelsFromFilelistAsync` returns at its first line. Nothing downstream wanted a name; only taking it was eager. `FirstOrDefault()?.File.Name` is the whole fix.

Re-verified after the rebase: `RecreateWithoutFilelistTests` 3/3, `RepairHandlerTests` + `RepairWithMissingRemoteFiles` + `RepairFilesetTimestampTests` 53/53, solution builds with 0 errors and the same 3 warnings as master.
