### PR TITLE
Handle queystring in win-file urls

### DIFF
--- a/Duplicati/Library/Utility/RelaxedUri.cs
+++ b/Duplicati/Library/Utility/RelaxedUri.cs
@@ -180,7 +180,21 @@ namespace Duplicati.Library.Utility
             // produces are recognized as the same Windows path and round-trip cleanly.
             if (url.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
             {
-                var candidate = UrlEncoding.UrlDecode(url.Substring("file://".Length));
+                // A query string may follow the path. Split it off before decoding,
+                // following standard query string logic: only a raw '?' delimits the
+                // query, an encoded %3F stays part of the path. A Windows path cannot
+                // contain a '?', so the split is safe.
+                var remainder = url.Substring("file://".Length);
+                string? query = null;
+                var queryIndex = remainder.IndexOf('?');
+                if (queryIndex >= 0)
+                {
+                    query = remainder.Substring(queryIndex + 1);
+                    remainder = remainder.Substring(0, queryIndex);
+                }
+
+                var candidate = UrlEncoding.UrlDecode(remainder);
+
                 // also accept the correctly-encoded file:///C:\ triple-slash form
                 if (candidate.StartsWith("/", StringComparison.Ordinal) && WINDOWS_PATH.IsMatch(candidate))
                     candidate = candidate.Substring(1);
@@ -191,7 +205,7 @@ namespace Duplicati.Library.Utility
                     this.Host = null;
                     this.Path = System.IO.Path.GetFullPath(candidate);
                     this.Port = -1;
-                    this.Query = null;
+                    this.Query = query;
                     this.Username = null;
                     this.Password = null;
                     return;

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -168,6 +168,57 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("UriUtility")]
+        public static void TestWindowsFileUrlKeepsTheQueryString()
+        {
+            // A file:// url with an encoded Windows path can still carry a query
+            // string, e.g. the file backend option "use-move-for-put". The query
+            // must be mapped to Query/QueryParameters and not swallowed into the
+            // local path.
+            var uri = new Library.Utility.RelaxedUri("file:///C%3A%5CDownloads%5C?use-move-for-put=true");
+
+            Assert.AreEqual("file", uri.Scheme);
+            Assert.IsNull(uri.Host, "Host should be null for a local path");
+            Assert.AreEqual("use-move-for-put=true", uri.Query);
+            Assert.AreEqual("true", uri.QueryParameters["use-move-for-put"]);
+            Assert.IsFalse(uri.Path.Contains("?"), "The query delimiter must not be part of the path");
+            Assert.IsFalse(uri.Path.Contains("use-move-for-put"), "The query must not be part of the path");
+
+            // The query survives being written out and parsed again
+            var roundtrip = new Library.Utility.RelaxedUri(uri.ToString());
+            Assert.AreEqual("use-move-for-put=true", roundtrip.Query);
+            Assert.AreEqual(uri.Path, roundtrip.Path);
+
+            // An encoded %3F is not a query delimiter; following standard query
+            // string logic it stays part of the path and no query is mapped
+            var encoded = new Library.Utility.RelaxedUri("file:///C%3A%5CDownloads%5%3Fuse-move-for-put%3Dtrue");
+            Assert.IsNull(encoded.Query, "An encoded %3F must not start a query string");
+            Assert.IsNull(encoded.QueryParameters["use-move-for-put"]);
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestDoubledFileSchemeDoesNotEncodeTheQueryString()
+        {
+            // A malformed url with the file:// scheme prepended twice still has a
+            // recognizable query string, and it must stay exactly as given - not
+            // percent-encoded or folded into the path.
+            var uri = new Library.Utility.RelaxedUri("file://file:///C%3A%5CDownloads%5?use-move-for-put=true");
+
+            Assert.AreEqual("use-move-for-put=true", uri.Query);
+            Assert.AreEqual("true", uri.QueryParameters["use-move-for-put"]);
+            Assert.IsFalse(uri.ToString().Contains("%3F"), "The query string must not be encoded");
+            Assert.IsFalse(uri.ToString().Contains("%3D"), "The query string must not be encoded");
+            Assert.IsFalse(uri.Query.Contains("%"), "The query string must not be encoded");
+            Assert.IsFalse(uri.Path.Contains("use-move-for-put"), "The query must not be part of the path");
+
+            // The query survives being written out and parsed again
+            var roundtrip = new Library.Utility.RelaxedUri(uri.ToString());
+            Assert.AreEqual("use-move-for-put=true", roundtrip.Query);
+            Assert.AreEqual("true", roundtrip.QueryParameters["use-move-for-put"]);
+        }
+
+        [Test]
+        [Category("UriUtility")]
         public static void TestHostKeepsItsCase()
         {
             // System.Uri lowercases the host, this parser does not. #7097 replaced the


### PR DESCRIPTION
Yet another `RelaxedUri` related bug. The RelaxedUri code would not recognize the query string, and would pass the full url, including query, to the HostAndPath property, which would then be used verbatim as the destination path.

This fix adds query-string aware file:// path parsing on Windows so it looks more like non-Windows parsing logic.