### PR TITLE
Auto configure database metadata

### DIFF
--- a/Duplicati/Library/Interface/ISourceProvider.cs
+++ b/Duplicati/Library/Interface/ISourceProvider.cs
@@ -39,6 +39,14 @@ public interface ISourceProvider : IDisposable
     string MountedPath { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this provider requires that metadata
+    /// content is stored in the database (the "store-metadata-content-in-database" option).
+    /// When a source uses a provider that returns <c>true</c>, the option is
+    /// automatically enabled if the user has not explicitly set it.
+    /// </summary>
+    bool NeedsStoredMetadata { get; }
+
+    /// <summary>
     /// Initializes the provider, if needed
     /// </summary>
     /// <param name="cancellationToken">The cancellation token</param>

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -138,6 +138,7 @@ namespace Duplicati.Library.Main
 
             CheckAutoCompactInterval();
             CheckAutoVacuumInterval();
+            SourceProviderFactory.EnableMetadataStorageIfRequiredBySources(inputsources, m_options.RawOptions);
 
             return await RunActionAsync(new BackupResults(), inputsources, inputFilter, false, static async config =>
             {

--- a/Duplicati/Library/Main/Operation/Common/SourceProviderFactory.cs
+++ b/Duplicati/Library/Main/Operation/Common/SourceProviderFactory.cs
@@ -50,6 +50,61 @@ namespace Duplicati.Library.Main.Operation.Common
         private static readonly string LOGTAG = Log.LogTagFromType(typeof(SourceProviderFactory));
 
         /// <summary>
+        /// The option that enables storing metadata content in the database
+        /// </summary>
+        public const string StoreMetadataContentInDatabaseOption = "store-metadata-content-in-database";
+
+        /// <summary>
+        /// Enables the "store-metadata-content-in-database" option if any of the sources
+        /// is provided by a source provider that requires it, and the option is not already set
+        /// </summary>
+        /// <param name="sources">The sources to check</param>
+        /// <param name="options">The options to update</param>
+        /// <returns>True if the option was enabled; false otherwise</returns>
+        public static bool EnableMetadataStorageIfRequiredBySources(IEnumerable<string>? sources, IDictionary<string, string?> options)
+        {
+            if (sources == null || options.ContainsKey(StoreMetadataContentInDatabaseOption))
+                return false;
+
+            // Find the keys of the source providers that require metadata to be stored in the database
+            var providersRequiringMetadata = SourceProviderLoader.Modules
+                .Where(x => x.NeedsStoredMetadata)
+                .Select(x => x.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            if (providersRequiringMetadata.Count == 0)
+                return false;
+
+            foreach (var source in sources)
+            {
+                // Remote sources are given on the form "@mountpoint|url"
+                var match = Regex.Match(source, @"^@(?<mountpoint>[^|]+)\|(?<url>.+)$", RegexOptions.IgnoreCase);
+                if (!match.Success)
+                    continue;
+
+                string scheme;
+                try
+                {
+                    scheme = new Duplicati.Library.Utility.RelaxedUri(match.Groups["url"].Value).Scheme;
+                }
+                catch
+                {
+                    // Invalid source urls are reported when the source provider is loaded
+                    continue;
+                }
+
+                if (providersRequiringMetadata.Contains(scheme))
+                {
+                    Log.WriteInformationMessage(LOGTAG, "AutoEnableMetadataStorage", "The source provider \"{0}\" requires metadata to be stored in the database, automatically enabling the option --{1}", scheme, StoreMetadataContentInDatabaseOption);
+                    options[StoreMetadataContentInDatabaseOption] = "true";
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets a single source provider for the given sources
         /// </summary>
         /// <param name="sources">The sources to get providers for</param>

--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -1518,6 +1518,15 @@ namespace Duplicati.Server
                 if (o.Name.StartsWith("--", StringComparison.Ordinal) && TestIfOptionApplies())
                     options[o.Name.Substring(2)] = o.Value;
 
+            // Enable metadata storage if any of the backup's sources require it,
+            // even if the current operation is not a backup
+            var sources =
+                (from n in backup.Sources
+                 let p = SpecialFolders.ExpandEnvironmentVariables(n)
+                 where !string.IsNullOrWhiteSpace(p)
+                 select p).ToArray();
+            Library.Main.Operation.Common.SourceProviderFactory.EnableMetadataStorageIfRequiredBySources(sources, options);
+
             // The server hangs if the module is enabled as there is no console attached
             DisableModule("console-password-input", options);
 

--- a/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
+++ b/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
@@ -52,6 +52,9 @@ public class BackendSourceProvider(IFolderEnabledBackend backend, string mounted
     /// <inheritdoc/>
     public IList<ICommandLineArgument> SupportedCommands => backend.SupportedCommands;
 
+    /// <inheritdoc />
+    public bool NeedsStoredMetadata => false;
+
     /// <summary>
     /// The prepared root entry, if any
     /// </summary>

--- a/Duplicati/Library/SourceProvider/Builtin/Combiner.cs
+++ b/Duplicati/Library/SourceProvider/Builtin/Combiner.cs
@@ -32,6 +32,9 @@ public class Combiner(IEnumerable<ISourceProvider> providers) : ISourceProvider
     /// <inheritdoc/>
     public string MountedPath => string.Empty;
 
+    /// <inheritdoc />
+    public bool NeedsStoredMetadata => providers.Any(x => x.NeedsStoredMetadata);
+
     /// <summary>
     /// The providers to combine
     /// </summary>

--- a/Duplicati/Library/SourceProvider/Builtin/LocalFileSource.cs
+++ b/Duplicati/Library/SourceProvider/Builtin/LocalFileSource.cs
@@ -32,6 +32,9 @@ public class LocalFileSource(ISnapshotService snapshotService) : ISourceProvider
     /// <inheritdoc/>
     public string MountedPath => string.Empty;
 
+    /// <inheritdoc />
+    public bool NeedsStoredMetadata => false;
+
     /// <inheritdoc/>
     public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/Duplicati/UnitTest/MetadataContentInDatabaseTests.cs
+++ b/Duplicati/UnitTest/MetadataContentInDatabaseTests.cs
@@ -19,8 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Duplicati.Library.Interface;
 using Duplicati.Library.Main;
 using Duplicati.Library.Main.Database;
 using Duplicati.Library.SQLiteHelper;
@@ -32,6 +38,111 @@ namespace Duplicati.UnitTest;
 [TestFixture]
 public class MetadataContentInDatabaseTests : BasicSetupHelper
 {
+    /// <summary>
+    /// A source provider entry used by <see cref="MetadataRequiringSourceProvider"/>
+    /// </summary>
+    private sealed class TestProviderEntry : ISourceProviderEntry
+    {
+        public bool IsFolder { get; set; }
+        public bool IsMetaEntry => false;
+        public bool IsRootEntry { get; set; }
+        public DateTime CreatedUtc => new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public DateTime LastModificationUtc => new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public string Path { get; set; } = string.Empty;
+        public long Size { get; set; }
+        public bool IsSymlink => false;
+        public string? SymlinkTarget => null;
+        public FileAttributes Attributes => IsFolder ? FileAttributes.Directory : FileAttributes.Normal;
+        public bool IsBlockDevice => false;
+        public bool IsCharacterDevice => false;
+        public bool IsAlternateStream => false;
+        public string? HardlinkTargetId => null;
+        public byte[]? Content { get; set; }
+        public ISourceProviderEntry? Child { get; set; }
+
+        public Task<Stream> OpenRead(CancellationToken cancellationToken)
+            => Task.FromResult<Stream>(new MemoryStream(Content ?? []));
+
+        public Task<Dictionary<string, string?>> GetMinorMetadata(CancellationToken cancellationToken)
+            => Task.FromResult(new Dictionary<string, string?>());
+
+        public Task<bool> FileExists(string filename, CancellationToken cancellationToken)
+            => Task.FromResult(false);
+
+        public async IAsyncEnumerable<ISourceProviderEntry> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            if (Child != null)
+                yield return Child;
+        }
+    }
+
+    /// <summary>
+    /// A source provider that requires the "store-metadata-content-in-database" option,
+    /// mimicking the Office365 and Google Workspace providers
+    /// </summary>
+    private sealed class MetadataRequiringSourceProvider : ISourceProviderModule
+    {
+        private readonly string _mountPoint;
+
+        /// <summary>
+        /// Constructor used by the dynamic loader for module metadata
+        /// </summary>
+        public MetadataRequiringSourceProvider()
+        {
+            _mountPoint = string.Empty;
+        }
+
+        /// <summary>
+        /// Constructor used when instantiating the provider for an operation
+        /// </summary>
+        public MetadataRequiringSourceProvider(string url, string mountPoint, Dictionary<string, string?> options)
+        {
+            _mountPoint = mountPoint;
+            if (!Library.Utility.Utility.ParseBoolOption(options, "store-metadata-content-in-database"))
+                throw new UserInformationException("The option --store-metadata-content-in-database is required for this source", "DatabaseMetadataStorageNotEnabled");
+        }
+
+        public string Key => "test-metadata-requiring";
+        public string DisplayName => "Test metadata requiring provider";
+        public string Description => "Test provider that requires metadata to be stored in the database";
+        public IList<ICommandLineArgument> SupportedCommands => [];
+        public string MountedPath => _mountPoint;
+        public bool NeedsStoredMetadata => true;
+
+        public Task InitializeAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task TestAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public async IAsyncEnumerable<ISourceProviderEntry> EnumerateAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            var content = "data"u8.ToArray();
+            yield return new TestProviderEntry
+            {
+                Path = _mountPoint,
+                IsFolder = true,
+                IsRootEntry = true,
+                Child = new TestProviderEntry
+                {
+                    Path = _mountPoint + "file.txt",
+                    IsFolder = false,
+                    Size = content.Length,
+                    Content = content
+                }
+            };
+        }
+
+        public Task<ISourceProviderEntry?> GetEntryAsync(string path, bool isFolder, CancellationToken cancellationToken)
+            => Task.FromResult<ISourceProviderEntry?>(null);
+
+        public void Dispose()
+        {
+        }
+    }
+
     private static long CountMetadatasetsWithContent(string dbPath)
     {
         using var db = SQLiteLoader.LoadConnection(dbPath);
@@ -84,5 +195,82 @@ public class MetadataContentInDatabaseTests : BasicSetupHelper
             TestUtils.AssertResults(await c.RepairAsync());
 
         Assert.That(CountMetadatasetsWithContent(options["dbpath"]), Is.GreaterThan(0));
+    }
+
+    [Test]
+    public async Task Backup_AutoEnablesMetadataStorage_WhenSourceProviderRequiresItAsync()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new MetadataRequiringSourceProvider());
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true"
+        };
+
+        // The source provider requires "store-metadata-content-in-database",
+        // which the controller should enable automatically
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.BackupAsync(["@/testremote|test-metadata-requiring://source"]));
+
+        Assert.That(CountMetadatasetsWithContent(options["dbpath"]), Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void Backup_DoesNotAutoEnableMetadataStorage_WhenOptionExplicitlyDisabled()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new MetadataRequiringSourceProvider());
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true",
+            ["store-metadata-content-in-database"] = "false"
+        };
+
+        // The user has explicitly set the option, so it is not overridden,
+        // and the source provider refuses to load
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            Assert.ThrowsAsync<UserInformationException>(async () => await c.BackupAsync(["@/testremote|test-metadata-requiring://source"]));
+    }
+
+    [Test]
+    public void EnableMetadataStorageIfRequiredBySources_SetsOption_WhenProviderRequiresIt()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new MetadataRequiringSourceProvider());
+
+        var options = new Dictionary<string, string?>();
+        var enabled = Library.Main.Operation.Common.SourceProviderFactory.EnableMetadataStorageIfRequiredBySources(
+            ["/localfolder/", "@/testremote|test-metadata-requiring://source"], options);
+
+        Assert.That(enabled, Is.True);
+        Assert.That(options["store-metadata-content-in-database"], Is.EqualTo("true"));
+    }
+
+    [Test]
+    public void EnableMetadataStorageIfRequiredBySources_DoesNotOverride_WhenOptionAlreadySet()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new MetadataRequiringSourceProvider());
+
+        var options = new Dictionary<string, string?>
+        {
+            ["store-metadata-content-in-database"] = "false"
+        };
+        var enabled = Library.Main.Operation.Common.SourceProviderFactory.EnableMetadataStorageIfRequiredBySources(
+            ["@/testremote|test-metadata-requiring://source"], options);
+
+        Assert.That(enabled, Is.False);
+        Assert.That(options["store-metadata-content-in-database"], Is.EqualTo("false"));
+    }
+
+    [Test]
+    public void EnableMetadataStorageIfRequiredBySources_IgnoresLocalAndUnknownSources()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new MetadataRequiringSourceProvider());
+
+        var options = new Dictionary<string, string?>();
+        var enabled = Library.Main.Operation.Common.SourceProviderFactory.EnableMetadataStorageIfRequiredBySources(
+            ["/localfolder/", "@/testremote|file:///somefolder", "@/testremote|unknown-scheme://source"], options);
+
+        Assert.That(enabled, Is.False);
+        Assert.That(options, Does.Not.ContainKey("store-metadata-content-in-database"));
     }
 }

--- a/proprietary/DiskImage/SourceProvider.cs
+++ b/proprietary/DiskImage/SourceProvider.cs
@@ -97,6 +97,9 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
     /// <inheritdoc />
     public IList<ICommandLineArgument> SupportedCommands => OptionsHelper.SupportedCommands;
 
+    /// <inheritdoc />
+    public bool NeedsStoredMetadata => false;
+
     /// <summary>
     /// Gets a value indicating whether to treat filesystems as unknown (force raw block-based backup).
     /// </summary>

--- a/proprietary/GoogleWorkspace/SourceProvider/SourceProvider.cs
+++ b/proprietary/GoogleWorkspace/SourceProvider/SourceProvider.cs
@@ -110,6 +110,9 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
 
     public string MountedPath => _mountPoint;
 
+    /// <inheritdoc />
+    public bool NeedsStoredMetadata => true;
+
     public void Dispose()
     {
     }

--- a/proprietary/Office365/SourceProvider/SourceProvider.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.cs
@@ -221,6 +221,9 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     public string MountedPath => _mountPoint;
 
     /// <inheritdoc />
+    public bool NeedsStoredMetadata => true;
+
+    /// <inheritdoc />
     public void Dispose()
     {
         _apiHelper?.Dispose();


### PR DESCRIPTION
If the backup is using a source provider that relies on database metadata, the user must set the option `--store-metadata-content-in-database=true`.

This PR adds automation, such that the runner will automatically detect if the setting is needed and apply it.

The automation can be opted-out by setting the option manually to the desired setting.