### PR TITLE
Add partition level full disk backup

### DIFF
--- a/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
+++ b/Duplicati/Library/Main/Operation/Restore/FileProcessor.cs
@@ -66,6 +66,23 @@ namespace Duplicati.Library.Main.Operation.Restore
         public static int priority_files_remaining;
         public static object priority_files_lock = new object();
         public static TaskCompletionSource priority_files_completed = new();
+
+        /// <summary>
+        /// Faults the priority-file barrier if the given file is a priority file.
+        /// The barrier is only signaled on the success path, so a priority file that
+        /// fails terminally would otherwise leave the other processors waiting for it
+        /// forever, stalling the restore instead of failing with the real error.
+        /// </summary>
+        /// <param name="file">The file that failed.</param>
+        /// <param name="ex">The error that caused the failure.</param>
+        private static void FaultPriorityBarrierIfPriorityFile(FileRequest file, Exception ex)
+        {
+            if (!file.IsPriorityFile)
+                return;
+
+            lock (priority_files_lock)
+                priority_files_completed.TrySetException(ex);
+        }
         /// <summary>
         /// The current file processor ID. Used for debugging.
         /// </summary>
@@ -112,6 +129,10 @@ namespace Duplicati.Library.Main.Operation.Restore
                 // ID for this file processor, used for debugging.
                 var my_id = Interlocked.Increment(ref processor_id);
 
+                // The file currently being restored, tracked so a terminal failure
+                // of a priority file can fault the priority barrier
+                FileRequest? current_file = null;
+
                 try
                 {
                     using var filehasher = HashFactory.CreateHasher(options.FileHashAlgorithm);
@@ -124,6 +145,7 @@ namespace Duplicati.Library.Main.Operation.Restore
                         sw_file?.Start();
                         var file = await self.Input.ReadAsync().ConfigureAwait(false);
                         sw_file?.Stop();
+                        current_file = file;
 
                         // A stop means "finish the current file and stop", so the check sits at
                         // the top of the loop: whatever was being restored when the stop arrived
@@ -200,13 +222,16 @@ namespace Duplicati.Library.Main.Operation.Restore
                         catch (Exception ex) when (!RestoreCancellation.IsShutdownRequested(results.TaskControl))
                         {
                             Logging.Log.WriteErrorMessage(LOGTAG, "VerifyTargetBlocks", ex, "Error during checking the target file");
+                            FaultPriorityBarrierIfPriorityFile(file, ex);
                             continue;
                         }
                         long bytes_written = 0;
                         sw_work_verify_target?.Stop();
                         if (blocks.Length != missing_blocks.Count + verified_blocks.Count)
                         {
-                            Logging.Log.WriteErrorMessage(LOGTAG, "BlockCountMismatch", null, $"Block count mismatch for {file.TargetPath} - expected: {blocks.Length}, actual: {missing_blocks.Count + verified_blocks.Count}");
+                            var error = $"Block count mismatch for {file.TargetPath} - expected: {blocks.Length}, actual: {missing_blocks.Count + verified_blocks.Count}";
+                            Logging.Log.WriteErrorMessage(LOGTAG, "BlockCountMismatch", null, error);
+                            FaultPriorityBarrierIfPriorityFile(file, new InvalidOperationException(error));
                             continue;
                         }
 
@@ -608,6 +633,13 @@ namespace Duplicati.Library.Main.Operation.Restore
                 }
                 catch (Exception ex)
                 {
+                    // A priority file that fails terminally must fault the priority
+                    // barrier: it is only signaled on the success path, so without this
+                    // the other processors would wait for it forever and the restore
+                    // would stall instead of failing with the real error.
+                    if (current_file != null)
+                        FaultPriorityBarrierIfPriorityFile(current_file, ex);
+
                     Logging.Log.WriteErrorMessage(LOGTAG, "FileProcessingError", ex, "Error during file processing");
                     throw;
                 }
@@ -775,7 +807,10 @@ namespace Duplicati.Library.Main.Operation.Restore
                 }
                 finally
                 {
-                    priority_files_completed.SetResult();
+                    // TrySetResult: the barrier may already have been faulted by a
+                    // terminally failed priority file, in which case SetResult would
+                    // throw and mask the real error
+                    priority_files_completed.TrySetResult();
                 }
             }
         }        

--- a/Duplicati/UnitTest/DiskImage/IntegrationTests/ParsingTests.cs
+++ b/Duplicati/UnitTest/DiskImage/IntegrationTests/ParsingTests.cs
@@ -106,9 +106,15 @@ public class ParsingTests : DiskImageTests
             await foreach (var entry in partitionEntry.Enumerate(CancellationToken.None))
                 fsEntries.Add(entry);
 
-        // Check for filesystem entries
-        Assert.That(fsEntries.All(x => x.Path.Contains("fs_")));
-        Assert.That(fsEntries.Count, Is.GreaterThan(0), "Should have at least one filesystem entry");
+        // Check for the partition info entry, which sits in the partition folder
+        // next to the filesystem entries
+        var partitionInfoEntries = fsEntries.Where(x => x.Path.EndsWith(PartitionInfoMetadata.FileName)).ToList();
+        Assert.That(partitionInfoEntries.Count, Is.EqualTo(partitionEntries.Count), "Each partition should have a partition info entry");
+
+        // Check for filesystem entries (all non-partition-info entries)
+        var filesystemEntries = fsEntries.Where(x => !x.Path.EndsWith(PartitionInfoMetadata.FileName)).ToList();
+        Assert.That(filesystemEntries.All(x => x.Path.Contains("fs_")), Is.True, "All filesystem entries should have an fs_ path segment");
+        Assert.That(filesystemEntries.Count, Is.GreaterThan(0), "Should have at least one filesystem entry");
     }
 
     [Test]

--- a/Duplicati/UnitTest/DiskImage/UnitTests/DiskSourceEntrySubpathTests.cs
+++ b/Duplicati/UnitTest/DiskImage/UnitTests/DiskSourceEntrySubpathTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Proprietary.DiskImage;
+using Duplicati.Proprietary.DiskImage.SourceItems;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest.DiskImage.UnitTests;
+
+#nullable enable
+
+/// <summary>
+/// Tests for the partition subpath filtering in <see cref="DiskSourceEntry"/>,
+/// used when a backup source points to a single partition on a disk
+/// instead of the whole disk.
+/// </summary>
+public partial class DiskImageUnitTests : BasicSetupHelper
+{
+    [Test]
+    public async Task Test_DiskSourceEntry_NoSubpath_EmitsAllPartitions_Async()
+    {
+        var provider = new SourceProvider();
+        var entry = new DiskSourceEntry(provider, s_gptRawDisk!, string.Empty);
+
+        var entries = await EnumerateDirectChildrenAsync(entry);
+
+        var partitionEntries = GetPartitionEntries(entries);
+        Assert.AreEqual(2, partitionEntries.Count, "Whole-disk enumeration should emit both partitions.");
+        Assert.IsTrue(entries.Any(x => x.Path.EndsWith("geometry.json")), "geometry.json should be emitted.");
+    }
+
+    [Test]
+    public async Task Test_DiskSourceEntry_PartitionSubpath_EmitsOnlyMatchingPartition_Async()
+    {
+        var provider = new SourceProvider();
+        var entry = new DiskSourceEntry(provider, s_gptRawDisk!, "part_GPT_1");
+
+        var entries = await EnumerateDirectChildrenAsync(entry);
+
+        var partitionEntries = GetPartitionEntries(entries);
+        Assert.AreEqual(1, partitionEntries.Count, "Only the selected partition should be emitted.");
+        Assert.IsTrue(partitionEntries[0].Path.EndsWith($"part_GPT_1{Path.DirectorySeparatorChar}"),
+            $"The emitted partition should be part_GPT_1, but was: {partitionEntries[0].Path}");
+        Assert.IsTrue(entries.Any(x => x.Path.EndsWith("geometry.json")), "geometry.json should still be emitted.");
+    }
+
+    [Test]
+    public async Task Test_DiskSourceEntry_UnknownPartitionSubpath_EmitsNoPartitions_Async()
+    {
+        var provider = new SourceProvider();
+        var entry = new DiskSourceEntry(provider, s_gptRawDisk!, "part_GPT_99");
+
+        var entries = await EnumerateDirectChildrenAsync(entry);
+
+        var partitionEntries = GetPartitionEntries(entries);
+        Assert.AreEqual(0, partitionEntries.Count, "A subpath naming a non-existing partition should emit no partitions.");
+        Assert.IsTrue(entries.Any(x => x.Path.EndsWith("geometry.json")), "geometry.json should still be emitted.");
+    }
+
+    private static List<ISourceProviderEntry> GetPartitionEntries(List<ISourceProviderEntry> entries)
+        => entries.Where(x => x.IsFolder && x.Path.Contains($"{Path.DirectorySeparatorChar}part_")).ToList();
+
+    private static async Task<List<ISourceProviderEntry>> EnumerateDirectChildrenAsync(ISourceProviderEntry entry)
+    {
+        var entries = new List<ISourceProviderEntry>();
+        await foreach (var child in entry.Enumerate(CancellationToken.None))
+            entries.Add(child);
+        return entries;
+    }
+}

--- a/Duplicati/UnitTest/DiskImage/UnitTests/GeometryMetadataSerializationTests.cs
+++ b/Duplicati/UnitTest/DiskImage/UnitTests/GeometryMetadataSerializationTests.cs
@@ -497,4 +497,71 @@ public partial class DiskImageUnitTests : BasicSetupHelper
         Assert.IsNull(result.Filesystems, "Filesystems should be null.");
     }
 
+    /// <summary>
+    /// Tests that a fully populated PartitionInfoMetadata can be serialized to JSON
+    /// and deserialized back, preserving all field values.
+    /// </summary>
+    [Test]
+    public void Test_PartitionInfoMetadata_RoundTrip_PreservesAllFields()
+    {
+        var original = new PartitionInfoMetadata
+        {
+            Partition = new PartitionGeometry
+            {
+                Number = 2,
+                Type = PartitionType.Primary,
+                StartOffset = 512 * 2048,
+                Size = 40 * MiB,
+                Name = "Test Partition",
+                FilesystemType = FileSystemType.NTFS,
+                VolumeGuid = Guid.Parse("12345678-1234-1234-1234-123456789abc"),
+                TableType = PartitionTableType.GPT
+            },
+            Filesystem = new FilesystemGeometry
+            {
+                PartitionNumber = 2,
+                Type = FileSystemType.NTFS,
+                PartitionStartOffset = 512 * 2048,
+                BlockSize = 1024 * 1024,
+                Metadata = "{\"label\":\"NTFS_VOL\"}"
+            }
+        };
+
+        var json = original.ToJson();
+        var deserialized = PartitionInfoMetadata.FromJson(json);
+
+        Assert.IsNotNull(deserialized, "Deserialized object should not be null.");
+        Assert.AreEqual(PartitionInfoMetadata.CurrentVersion, deserialized!.Version, "Version should be the current version.");
+
+        Assert.IsNotNull(deserialized.Partition, "Partition should not be null.");
+        Assert.AreEqual(2, deserialized.Partition!.Number, "Partition number should be preserved.");
+        Assert.AreEqual(40 * MiB, deserialized.Partition.Size, "Partition size should be preserved.");
+        Assert.AreEqual(512 * 2048, deserialized.Partition.StartOffset, "Partition start offset should be preserved.");
+        Assert.AreEqual(FileSystemType.NTFS, deserialized.Partition.FilesystemType, "Partition filesystem type should be preserved.");
+        Assert.AreEqual(PartitionTableType.GPT, deserialized.Partition.TableType, "Partition table type should be preserved.");
+        Assert.AreEqual(Guid.Parse("12345678-1234-1234-1234-123456789abc"), deserialized.Partition.VolumeGuid, "Partition volume GUID should be preserved.");
+
+        Assert.IsNotNull(deserialized.Filesystem, "Filesystem should not be null.");
+        Assert.AreEqual(FileSystemType.NTFS, deserialized.Filesystem!.Type, "Filesystem type should be preserved.");
+        Assert.AreEqual(1024 * 1024, deserialized.Filesystem.BlockSize, "Filesystem block size should be preserved.");
+        Assert.AreEqual(2, deserialized.Filesystem.PartitionNumber, "Filesystem partition number should be preserved.");
+        Assert.AreEqual("{\"label\":\"NTFS_VOL\"}", deserialized.Filesystem.Metadata, "Filesystem metadata should be preserved.");
+    }
+
+    /// <summary>
+    /// Tests that deserializing an empty JSON object creates a PartitionInfoMetadata
+    /// with default property values.
+    /// </summary>
+    [Test]
+    public void Test_PartitionInfoMetadata_FromJson_EmptyObject_CreatesDefaultInstance()
+    {
+        var result = PartitionInfoMetadata.FromJson("{}");
+
+        Assert.IsNotNull(result, "Should create an instance from empty JSON object.");
+        Assert.AreEqual(PartitionInfoMetadata.CurrentVersion, result!.Version, "Version should have the default value.");
+        Assert.IsNull(result.Partition, "Partition should be null.");
+        Assert.IsNull(result.Filesystem, "Filesystem should be null.");
+    }
+
+
 }

--- a/Duplicati/UnitTest/DiskImage/UnitTests/PartitionCreatorTests.cs
+++ b/Duplicati/UnitTest/DiskImage/UnitTests/PartitionCreatorTests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Buffers.Binary;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Proprietary.DiskImage.General;
+using Duplicati.Proprietary.DiskImage.Partition;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest.DiskImage.UnitTests;
+
+#nullable enable
+
+public partial class DiskImageUnitTests : BasicSetupHelper
+{
+    [Test]
+    public void Test_PartitionCreator_FindFreeSpace_FirstFit()
+    {
+        // Two occupied ranges: [1 MiB, 11 MiB) and [21 MiB, 31 MiB)
+        var existing = new[]
+        {
+            (Start: 1 * MiB, Size: 10 * MiB),
+            (Start: 21 * MiB, Size: 10 * MiB)
+        };
+
+        // A 5 MiB partition fits in the gap starting at 11 MiB (already aligned)
+        var result = PartitionCreator.FindFreeSpace(existing, 1 * MiB, 100 * MiB, 5 * MiB, PartitionCreator.DefaultAlignment);
+        Assert.AreEqual(11 * MiB, result, "Should find the first aligned gap after the first partition.");
+    }
+
+    [Test]
+    public void Test_PartitionCreator_FindFreeSpace_PrefersSourceOffset()
+    {
+        var existing = new[]
+        {
+            (Start: 1 * MiB, Size: 10 * MiB)
+        };
+
+        // The preferred range [40 MiB, 50 MiB) is free
+        var result = PartitionCreator.FindFreeSpace(existing, 1 * MiB, 100 * MiB, 10 * MiB, PartitionCreator.DefaultAlignment, preferredStart: 40 * MiB);
+        Assert.AreEqual(40 * MiB, result, "Should honor the preferred start offset when the range is free.");
+    }
+
+    [Test]
+    public void Test_PartitionCreator_FindFreeSpace_PreferredOccupiedFallsBackToFirstFit()
+    {
+        var existing = new[]
+        {
+            (Start: 1 * MiB, Size: 10 * MiB),
+            (Start: 40 * MiB, Size: 20 * MiB)
+        };
+
+        // The preferred range overlaps the second partition
+        var result = PartitionCreator.FindFreeSpace(existing, 1 * MiB, 100 * MiB, 10 * MiB, PartitionCreator.DefaultAlignment, preferredStart: 40 * MiB);
+        Assert.AreEqual(11 * MiB, result, "Should fall back to the first fitting gap.");
+    }
+
+    [Test]
+    public void Test_PartitionCreator_FindFreeSpace_NoSpaceReturnsNull()
+    {
+        var existing = new[]
+        {
+            (Start: 1 * MiB, Size: 98 * MiB)
+        };
+
+        var result = PartitionCreator.FindFreeSpace(existing, 1 * MiB, 100 * MiB, 10 * MiB, PartitionCreator.DefaultAlignment);
+        Assert.IsNull(result, "Should return null when no gap fits the required size.");
+    }
+
+    [Test]
+    public void Test_PartitionCreator_FindFreeSpace_AlignsStart()
+    {
+        // Occupied range ends at an unaligned offset
+        var existing = new[]
+        {
+            (Start: 512L, Size: 1000L)
+        };
+
+        var result = PartitionCreator.FindFreeSpace(existing, 512, 100 * MiB, 10 * MiB, PartitionCreator.DefaultAlignment);
+        Assert.AreEqual(PartitionCreator.DefaultAlignment, result, "Should align the start offset up to the alignment boundary.");
+    }
+
+    [Test]
+    public void Test_PartitionCreator_TryWriteMbrEntry_PreservesExistingContent()
+    {
+        var sectorSize = 512;
+        var mbr = new byte[sectorSize];
+
+        // Fill boot code with a marker and add the boot signature
+        for (var i = 0; i < 446; i++)
+            mbr[i] = 0xAB;
+        mbr[510] = 0x55;
+        mbr[511] = 0xAA;
+
+        // Occupy slot 1 with an existing entry (type byte set)
+        mbr[446 + 4] = 0x0B;
+
+        var result = PartitionCreator.TryWriteMbrEntry(mbr, sectorSize, slot: 2, startOffset: 2 * MiB, size: 10 * MiB, FileSystemType.NTFS, PartitionType.Primary);
+
+        Assert.IsTrue(result, "Should write the entry into the free slot.");
+        Assert.AreEqual(0xAB, mbr[0], "Boot code must be preserved.");
+        Assert.AreEqual(0xAB, mbr[445], "Boot code must be preserved.");
+        Assert.AreEqual(0x0B, mbr[446 + 4], "The existing entry must be preserved.");
+        Assert.AreEqual(0x55, mbr[510], "Boot signature must be preserved.");
+        Assert.AreEqual(0xAA, mbr[511], "Boot signature must be preserved.");
+
+        // Verify the new entry at slot 2
+        var offset = 446 + 16;
+        Assert.AreNotEqual(0, mbr[offset + 4], "Partition type byte should be set.");
+        Assert.AreEqual((uint)(2 * MiB / sectorSize), BinaryPrimitives.ReadUInt32LittleEndian(mbr.AsSpan(offset + 8, 4)), "Start LBA should match.");
+        Assert.AreEqual((uint)(10 * MiB / sectorSize), BinaryPrimitives.ReadUInt32LittleEndian(mbr.AsSpan(offset + 12, 4)), "Size in sectors should match.");
+    }
+
+    [Test]
+    public void Test_PartitionCreator_TryWriteMbrEntry_FailsOnOccupiedSlot()
+    {
+        var mbr = new byte[512];
+        mbr[446 + 4] = 0x0B; // Slot 1 occupied
+
+        var result = PartitionCreator.TryWriteMbrEntry(mbr, 512, slot: 1, startOffset: 2 * MiB, size: 10 * MiB, FileSystemType.NTFS, PartitionType.Primary);
+
+        Assert.IsFalse(result, "Should fail when the slot is occupied.");
+    }
+
+    [Test]
+    public void Test_PartitionCreator_TryWriteMbrEntry_FailsBeyondMbrLimits()
+    {
+        var mbr = new byte[512];
+
+        // Start beyond the 32-bit LBA range
+        var result = PartitionCreator.TryWriteMbrEntry(mbr, 512, slot: 1, startOffset: 3L * 1024 * 1024 * 1024 * 1024, size: 10 * MiB, FileSystemType.NTFS, PartitionType.Primary);
+
+        Assert.IsFalse(result, "Should fail when the partition is beyond the MBR addressable range.");
+    }
+
+    [Test]
+    public async Task Test_PartitionCreator_GptEntryRoundtrip()
+    {
+        var sectorSize = 512;
+        var metadata = new GeometryMetadata
+        {
+            Disk = new DiskGeometry
+            {
+                SectorSize = sectorSize,
+                Size = 100 * MiB,
+                Sectors = (int)(100 * MiB / sectorSize)
+            },
+            PartitionTable = new PartitionTableGeometry
+            {
+                Type = PartitionTableType.GPT,
+                SectorSize = sectorSize
+            },
+            Partitions =
+            [
+                new PartitionGeometry
+                {
+                    Number = 1,
+                    Type = PartitionType.Primary,
+                    FilesystemType = FileSystemType.FAT32,
+                    StartOffset = 1 * MiB,
+                    Size = 20 * MiB,
+                    TableType = PartitionTableType.GPT
+                }
+            ]
+        };
+
+        // Synthesize a GPT table with one partition
+        var gptData = PartitionTableSynthesizer.SynthesizeGPT(metadata);
+
+        // Add a second partition entry to the entries area (starts at LBA 2)
+        var entriesOffset = 2 * sectorSize;
+        var entriesByteSize = 128 * PartitionConstants.GptPartitionEntrySize;
+        var entries = gptData[entriesOffset..(entriesOffset + entriesByteSize)];
+
+        var newStartLba = 30 * MiB / sectorSize;
+        var newEndLba = newStartLba + (10 * MiB / sectorSize) - 1;
+        var newGuid = Guid.NewGuid();
+
+        var written = PartitionCreator.TryWriteGptEntry(entries, PartitionConstants.GptPartitionEntrySize, slot: 2, startLba: newStartLba, endLba: newEndLba, PartitionType.Primary, newGuid, "Restored");
+        Assert.IsTrue(written, "Should write the entry into the free GPT slot.");
+
+        // Writing to the same slot again must fail
+        var rewritten = PartitionCreator.TryWriteGptEntry(entries, PartitionConstants.GptPartitionEntrySize, slot: 2, startLba: newStartLba, endLba: newEndLba, PartitionType.Primary, newGuid, "Restored");
+        Assert.IsFalse(rewritten, "Should fail when the GPT slot is occupied.");
+
+        // Patch the header with the updated entries CRC and a fresh header CRC
+        var headerSector = gptData[sectorSize..(2 * sectorSize)];
+        PartitionCreator.PatchGptHeader(headerSector, entries, entriesByteSize);
+
+        // Copy the patched data back into the disk image
+        entries.CopyTo(gptData, entriesOffset);
+        headerSector.CopyTo(gptData, sectorSize);
+
+        // Verify the header CRC is valid
+        var storedCrc = BinaryPrimitives.ReadUInt32LittleEndian(gptData.AsSpan(sectorSize + 16, 4));
+        var crcBuffer = gptData[sectorSize..(sectorSize + PartitionConstants.GptHeaderSize)];
+        BinaryPrimitives.WriteUInt32LittleEndian(crcBuffer.AsSpan(16, 4), 0u);
+        var computedCrc = Crc32.Calculate(crcBuffer, 0, PartitionConstants.GptHeaderSize);
+        Assert.AreEqual(computedCrc, storedCrc, "The patched GPT header CRC should be valid.");
+
+        // Verify the entries CRC is valid
+        var storedEntriesCrc = BinaryPrimitives.ReadUInt32LittleEndian(gptData.AsSpan(sectorSize + 88, 4));
+        var computedEntriesCrc = Crc32.Calculate(gptData, entriesOffset, entriesByteSize);
+        Assert.AreEqual(computedEntriesCrc, storedEntriesCrc, "The patched GPT entries CRC should be valid.");
+
+        // Parse the modified table and verify both partitions are present
+        var table = await PartitionTableFactory.CreateAsync(gptData, sectorSize, CancellationToken.None);
+        Assert.IsNotNull(table, "The modified GPT should still parse.");
+        Assert.AreEqual(PartitionTableType.GPT, table!.TableType, "The table should be detected as GPT.");
+
+        var partitions = await table.EnumeratePartitions(CancellationToken.None).ToListAsync();
+        Assert.AreEqual(2, partitions.Count, "The table should contain both partitions.");
+
+        var added = partitions.FirstOrDefault(p => p.PartitionNumber == 2);
+        Assert.IsNotNull(added, "The added partition should be present.");
+        Assert.AreEqual((long)newStartLba * sectorSize, added!.StartOffset, "The added partition start offset should match.");
+        Assert.AreEqual(10 * MiB, added.Size, "The added partition size should match.");
+        Assert.AreEqual(newGuid, added.VolumeGuid, "The added partition GUID should match.");
+        Assert.AreEqual("Restored", added.Name, "The added partition name should match.");
+    }
+}

--- a/Duplicati/UnitTest/DiskImage/UnitTests/RestoreProviderPathParsingTests.cs
+++ b/Duplicati/UnitTest/DiskImage/UnitTests/RestoreProviderPathParsingTests.cs
@@ -568,28 +568,146 @@ public partial class DiskImageUnitTests : BasicSetupHelper
     }
 
     /// <summary>
-    /// Tests that ParsePath fails for partition-level content when the target is a
-    /// whole disk, since there is no partition to write the content into.
+    /// Tests that ParsePath fails for filesystem content without a partition segment
+    /// when the target is a whole disk and no partition info has been captured, as
+    /// the partition to write the content into cannot be identified.
     /// </summary>
     [Test]
-    public void Test_RestoreProvider_ParsePath_PartitionContentOnDiskTarget_Throws()
+    public void Test_RestoreProvider_ParsePath_PartitionContentOnDiskTargetWithoutInfo_Throws()
     {
         using var provider = CreateRestoreProviderForPathParsingTests();
         var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
 
         Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
 
-        // Filesystem block without a partition segment indicates a partition backup
+        // Filesystem block without a partition segment and no captured partition
+        // info: the source partition cannot be identified
         var ex = Assert.Throws<TargetInvocationException>(() =>
             parsePathMethod!.Invoke(provider, ["fs_NTFS/0000AB"]),
-            "Should throw for filesystem content without a partition segment.");
+            "Should throw for filesystem content without a partition segment when no partition info was captured.");
         Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
+    }
 
-        // A partition info file without a partition segment likewise
-        ex = Assert.Throws<TargetInvocationException>(() =>
-            parsePathMethod!.Invoke(provider, [PartitionInfoMetadata.FileName]),
-            "Should throw for a partition info file without a partition segment.");
+    /// <summary>
+    /// Tests that ParsePath identifies a partition info file at the root (the
+    /// partition folder was stripped by the restore path mapping) as a partition
+    /// info item.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_PartitionInfoWithoutPartitionSegment_ReturnsPartitionInfoType()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        var result = parsePathMethod!.Invoke(provider, [PartitionInfoMetadata.FileName]);
+        Assert.IsNotNull(result, "Should return a tuple.");
+
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.PartitionInfo, tuple.Type, "Type should be 'PartitionInfo'.");
+        Assert.IsNull(tuple.Partition, "Partition should be null for partition info.");
+        Assert.IsNull(tuple.Filesystem, "Filesystem should be null for partition info.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePath maps filesystem content without a partition segment to
+    /// the partition identified by the captured partition info (whole-disk target).
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_PartitionContentOnDiskTargetWithInfo_ReturnsFile()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        // Partition info for source partition 2, which exists in the mock set
+        GetPartitionInfos(provider)[2] = CreateTestPartitionInfo(2, 41943040, 4096, FileSystemType.NTFS);
+
+        var result = parsePathMethod!.Invoke(provider, ["fs_NTFS/data/file.txt"]);
+        Assert.IsNotNull(result, "Should return a tuple.");
+
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.File, tuple.Type, "Type should be 'File'.");
+        Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
+        Assert.AreEqual(2, tuple.Partition!.PartitionNumber, "Should resolve to the partition identified by the captured partition info.");
+        Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
+        Assert.AreEqual(FileSystemType.NTFS, tuple.Filesystem!.Type, "Filesystem type should be NTFS.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePath fails for filesystem content without a partition segment
+    /// when partition info for multiple source partitions was captured, as the
+    /// content cannot be attributed to a single partition.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_PartitionContentOnDiskTargetMultipleInfos_Throws()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        GetPartitionInfos(provider)[1] = CreateTestPartitionInfo(1, 20971520, 4096, FileSystemType.FAT32);
+        GetPartitionInfos(provider)[2] = CreateTestPartitionInfo(2, 41943040, 4096, FileSystemType.NTFS);
+
+        var ex = Assert.Throws<TargetInvocationException>(() =>
+            parsePathMethod!.Invoke(provider, ["fs_NTFS/0000AB"]),
+            "Should throw when partition info for multiple source partitions was captured.");
         Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePath maps filesystem content without a partition segment to
+    /// the resolved target partition when restoring into a partition (subpath mode).
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_PartitionContentWithoutSegmentWithSubpath_MapsToTargetPartition()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        // Partition info describing source partition 2 was captured for target partition 1
+        GetPartitionInfos(provider)[1] = CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS);
+
+        var result = parsePathMethod!.Invoke(provider, ["fs_NTFS/data/file.txt"]);
+        Assert.IsNotNull(result, "Should return a tuple.");
+
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.File, tuple.Type, "Type should be 'File'.");
+        Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
+        Assert.AreEqual(1, tuple.Partition!.PartitionNumber, "Should resolve to the target partition number.");
+        Assert.AreSame(targetPartition, tuple.Partition, "Should return the resolved target partition.");
+        Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
+        Assert.AreEqual(FileSystemType.NTFS, tuple.Filesystem!.Type, "Filesystem type should be NTFS.");
+    }
+
+    /// <summary>
+    /// Tests that writing a partition info file at the root (the partition folder
+    /// was stripped by the restore path mapping) during a whole-disk restore
+    /// captures the metadata keyed by the source partition number.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_OpenWrite_PartitionInfoWithoutSegment_CapturedBySourceNumber()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+
+        var info = CreateTestPartitionInfo(2, 41943040, 4096, FileSystemType.NTFS);
+        var bytes = System.Text.Encoding.UTF8.GetBytes(info.ToJson());
+
+        await using (var stream = await provider.OpenWrite(PartitionInfoMetadata.FileName, CancellationToken.None))
+        {
+            await stream.WriteAsync(bytes);
+        }
+
+        var infos = GetPartitionInfos(provider);
+        Assert.IsTrue(infos.TryGetValue(2, out var captured), "Partition info should be captured under the source partition number.");
+        Assert.AreEqual(4096, captured!.Filesystem!.BlockSize, "Block size should be preserved.");
+        Assert.AreEqual(FileSystemType.NTFS, captured.Filesystem.Type, "Filesystem type should be preserved.");
     }
 
     /// <summary>

--- a/Duplicati/UnitTest/DiskImage/UnitTests/RestoreProviderPathParsingTests.cs
+++ b/Duplicati/UnitTest/DiskImage/UnitTests/RestoreProviderPathParsingTests.cs
@@ -271,21 +271,24 @@ public partial class DiskImageUnitTests : BasicSetupHelper
     }
 
     /// <summary>
-    /// Tests that ParsePartition throws InvalidOperationException for non-existent partitions.
+    /// Tests that ParsePartition throws UserInformationException for partitions that
+    /// do not exist on the target disk when the backup contains no partition
+    /// information (partitioninfo.json) to create them from.
     /// </summary>
     [Test]
-    public void Test_RestoreProvider_ParsePartition_NonExistentPartition_ThrowsInvalidOperationException()
+    public void Test_RestoreProvider_ParsePartition_NonExistentPartition_ThrowsUserInformationException()
     {
         using var provider = CreateRestoreProviderForPathParsingTests();
         var parsePartitionMethod = typeof(RestoreProvider).GetMethod("ParsePartition", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
         Assert.IsNotNull(parsePartitionMethod, "ParsePartition method should exist.");
 
-        // Test with partition number that doesn't exist
+        // Test with partition number that doesn't exist; without partition info in
+        // the backup, the partition cannot be created on the target disk
         var ex = Assert.Throws<TargetInvocationException>(() =>
             parsePartitionMethod!.Invoke(provider, ["part_GPT_99"]),
             "Should throw for non-existent partition.");
-        Assert.IsInstanceOf<InvalidOperationException>(ex!.InnerException, "Inner exception should be InvalidOperationException.");
+        Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
     }
 
     /// <summary>
@@ -723,9 +726,11 @@ public partial class DiskImageUnitTests : BasicSetupHelper
     /// <summary>
     /// Tests that ParsePartition still throws for a non-existent partition when not
     /// restoring into a partition (no subpath), even if only one partition is registered.
+    /// Without partition information in the backup, the partition cannot be created
+    /// on the target disk.
     /// </summary>
     [Test]
-    public void Test_RestoreProvider_ParsePartition_DifferentSourceNumberWithoutSubpath_ThrowsInvalidOperationException()
+    public void Test_RestoreProvider_ParsePartition_DifferentSourceNumberWithoutSubpath_ThrowsUserInformationException()
     {
         var targetPartition = CreateTargetPartition();
         using var provider = CreateRestoreProviderForPartitionTargetTests(string.Empty, targetPartition);
@@ -736,7 +741,7 @@ public partial class DiskImageUnitTests : BasicSetupHelper
         var ex = Assert.Throws<TargetInvocationException>(() =>
             parsePartitionMethod!.Invoke(provider, ["part_GPT_2"]),
             "Should throw for a non-existent partition when not in subpath mode.");
-        Assert.IsInstanceOf<InvalidOperationException>(ex!.InnerException, "Inner exception should be InvalidOperationException.");
+        Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
     }
 
     /// <summary>

--- a/Duplicati/UnitTest/DiskImage/UnitTests/RestoreProviderPathParsingTests.cs
+++ b/Duplicati/UnitTest/DiskImage/UnitTests/RestoreProviderPathParsingTests.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Duplicati.Library.Interface;
 using Duplicati.Proprietary.DiskImage;
 using Duplicati.Proprietary.DiskImage.Disk;
 using Duplicati.Proprietary.DiskImage.Filesystem;
@@ -75,9 +77,9 @@ public partial class DiskImageUnitTests : BasicSetupHelper
     /// <summary>
     /// Mock implementation of IPartitionTable for testing.
     /// </summary>
-    private class MockPartitionTable(PartitionTableType tableType) : IPartitionTable
+    private class MockPartitionTable(PartitionTableType tableType, IRawDisk? rawDisk = null) : IPartitionTable
     {
-        public IRawDisk? RawDisk => null;
+        public IRawDisk? RawDisk => rawDisk;
         public PartitionTableType TableType { get; } = tableType;
 
         public IAsyncEnumerable<IPartition> EnumeratePartitions(CancellationToken cancellationToken)
@@ -408,12 +410,12 @@ public partial class DiskImageUnitTests : BasicSetupHelper
 
         // Test with geometry file at the root of the device
         // Use the actual device path from the GPT test disk
-        var geometryPath = $"{s_gptRawDisk!.DevicePath}{Path.DirectorySeparatorChar}geometry.json";
+        var geometryPath = $"{s_gptRawDisk!.DevicePath}{Path.DirectorySeparatorChar}{GeometryMetadata.FileName}";
         var result = parsePathMethod!.Invoke(provider, [geometryPath]);
         Assert.IsNotNull(result, "Should return a tuple.");
 
-        var tuple = ((string Type, IPartition? Partition, IFilesystem? Filesystem))result!;
-        Assert.AreEqual("geometry", tuple.Type, "Type should be 'geometry'.");
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.Geometry, tuple.Type, "Type should be 'Geometry'.");
         Assert.IsNull(tuple.Partition, "Partition should be null for geometry.");
         Assert.IsNull(tuple.Filesystem, "Filesystem should be null for geometry.");
     }
@@ -433,8 +435,8 @@ public partial class DiskImageUnitTests : BasicSetupHelper
         var result = parsePathMethod!.Invoke(provider, ["/"]);
         Assert.IsNotNull(result, "Should return a tuple.");
 
-        var tuple = ((string Type, IPartition? Partition, IFilesystem? Filesystem))result!;
-        Assert.AreEqual("disk", tuple.Type, "Type should be 'disk'.");
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.Disk, tuple.Type, "Type should be 'Disk'.");
         Assert.IsNull(tuple.Partition, "Partition should be null for disk.");
         Assert.IsNull(tuple.Filesystem, "Filesystem should be null for disk.");
     }
@@ -454,8 +456,8 @@ public partial class DiskImageUnitTests : BasicSetupHelper
         var result = parsePathMethod!.Invoke(provider, ["part_GPT_1"]);
         Assert.IsNotNull(result, "Should return a tuple.");
 
-        var tuple = ((string Type, IPartition? Partition, IFilesystem? Filesystem))result!;
-        Assert.AreEqual("partition", tuple.Type, "Type should be 'partition'.");
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.Partition, tuple.Type, "Type should be 'Partition'.");
         Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
         Assert.AreEqual(1, tuple.Partition!.PartitionNumber, "Partition number should be 1.");
         Assert.IsNull(tuple.Filesystem, "Filesystem should be null for partition-only path.");
@@ -476,8 +478,8 @@ public partial class DiskImageUnitTests : BasicSetupHelper
         var result = parsePathMethod!.Invoke(provider, ["part_GPT_1/fs_FAT32/test/file.txt"]);
         Assert.IsNotNull(result, "Should return a tuple.");
 
-        var tuple = ((string Type, IPartition? Partition, IFilesystem? Filesystem))result!;
-        Assert.AreEqual("file", tuple.Type, "Type should be 'file'.");
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.File, tuple.Type, "Type should be 'File'.");
         Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
         Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
         Assert.AreEqual(1, tuple.Partition!.PartitionNumber, "Partition number should be 1.");
@@ -499,8 +501,8 @@ public partial class DiskImageUnitTests : BasicSetupHelper
         var result = parsePathMethod!.Invoke(provider, ["part_MBR_2/fs_NTFS/data/file.dat"]);
         Assert.IsNotNull(result, "Should return a tuple.");
 
-        var tuple = ((string Type, IPartition? Partition, IFilesystem? Filesystem))result!;
-        Assert.AreEqual("file", tuple.Type, "Type should be 'file'.");
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.File, tuple.Type, "Type should be 'File'.");
         Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
         Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
         Assert.AreEqual(2, tuple.Partition!.PartitionNumber, "Partition number should be 2.");
@@ -527,8 +529,8 @@ public partial class DiskImageUnitTests : BasicSetupHelper
             var result = parsePathMethod!.Invoke(provider, ["part_GPT_1\\fs_FAT32\\test\\file.txt"]);
             Assert.IsNotNull(result, "Should return a tuple.");
 
-            var tuple = ((string Type, IPartition? Partition, IFilesystem? Filesystem))result!;
-            Assert.AreEqual("file", tuple.Type, "Type should be 'file'.");
+            var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+            Assert.AreEqual(RestorePathType.File, tuple.Type, "Type should be 'File'.");
             Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
             Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
         }
@@ -560,6 +562,457 @@ public partial class DiskImageUnitTests : BasicSetupHelper
             parsePathMethod!.Invoke(provider, ["part_INVALID/fs_NTFS/file.txt"]),
             "Should throw for invalid partition segment.");
         Assert.IsInstanceOf<InvalidOperationException>(ex!.InnerException, "Inner exception should be InvalidOperationException.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePath fails for partition-level content when the target is a
+    /// whole disk, since there is no partition to write the content into.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_PartitionContentOnDiskTarget_Throws()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        // Filesystem block without a partition segment indicates a partition backup
+        var ex = Assert.Throws<TargetInvocationException>(() =>
+            parsePathMethod!.Invoke(provider, ["fs_NTFS/0000AB"]),
+            "Should throw for filesystem content without a partition segment.");
+        Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
+
+        // A partition info file without a partition segment likewise
+        ex = Assert.Throws<TargetInvocationException>(() =>
+            parsePathMethod!.Invoke(provider, [PartitionInfoMetadata.FileName]),
+            "Should throw for a partition info file without a partition segment.");
+        Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
+    }
+
+    /// <summary>
+    /// Creates a RestoreProvider that targets a single partition within a disk
+    /// (subpath mode), with only the given target partition registered.
+    /// The target partition's table is backed by the GPT test disk so that
+    /// block size validation in filesystem creation has a sector size.
+    /// </summary>
+    private static RestoreProvider CreateRestoreProviderForPartitionTargetTests(string subpath, IPartition targetPartition)
+    {
+        var provider = new RestoreProvider();
+
+        var partitionsField = typeof(RestoreProvider).GetField("_partitions", BindingFlags.NonPublic | BindingFlags.Instance);
+        var filesystemsField = typeof(RestoreProvider).GetField("_filesystems", BindingFlags.NonPublic | BindingFlags.Instance);
+        var targetDiskField = typeof(RestoreProvider).GetField("_targetDisk", BindingFlags.NonPublic | BindingFlags.Instance);
+        var subpathField = typeof(RestoreProvider).GetField("_subpath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        partitionsField?.SetValue(provider, new List<IPartition> { targetPartition });
+        filesystemsField?.SetValue(provider, new List<IFilesystem>());
+        targetDiskField?.SetValue(provider, s_gptRawDisk);
+        subpathField?.SetValue(provider, subpath);
+
+        return provider;
+    }
+
+    /// <summary>
+    /// Creates a mock target partition (number 1 on a GPT table) for partition-target tests.
+    /// </summary>
+    private static MockPartition CreateTargetPartition(long size = 20971520)
+        => new(new MockPartitionTable(PartitionTableType.GPT, s_gptRawDisk), 1, PartitionType.Primary, 1048576, size, "Target Partition", FileSystemType.NTFS);
+
+    /// <summary>
+    /// Gets the internal partition info dictionary from a RestoreProvider.
+    /// </summary>
+    private static ConcurrentDictionary<int, PartitionInfoMetadata> GetPartitionInfos(RestoreProvider provider)
+    {
+        var field = typeof(RestoreProvider).GetField("_partitionInfos", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (ConcurrentDictionary<int, PartitionInfoMetadata>)field!.GetValue(provider)!;
+    }
+
+    /// <summary>
+    /// Creates partition info metadata describing a source partition.
+    /// The block size is a multiple of common sector sizes (512 and 4096).
+    /// </summary>
+    private static PartitionInfoMetadata CreateTestPartitionInfo(int partitionNumber, long partitionSize, int blockSize, FileSystemType fsType)
+        => new()
+        {
+            Partition = new PartitionGeometry
+            {
+                Number = partitionNumber,
+                Type = PartitionType.Primary,
+                StartOffset = 1048576,
+                Size = partitionSize,
+                Name = "Source Partition",
+                FilesystemType = fsType,
+                VolumeGuid = Guid.NewGuid(),
+                TableType = PartitionTableType.GPT
+            },
+            Filesystem = new FilesystemGeometry
+            {
+                PartitionNumber = partitionNumber,
+                Type = fsType,
+                PartitionStartOffset = 1048576,
+                BlockSize = blockSize
+            }
+        };
+
+    /// <summary>
+    /// Tests that ParsePath identifies a partition info file directly inside a
+    /// partition folder as a partition info item.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_PartitionInfoFile_ReturnsPartitionInfoType()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        var result = parsePathMethod!.Invoke(provider, [$"part_GPT_1/{PartitionInfoMetadata.FileName}"]);
+        Assert.IsNotNull(result, "Should return a tuple.");
+
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.PartitionInfo, tuple.Type, "Type should be 'PartitionInfo'.");
+        Assert.IsNull(tuple.Partition, "Partition should be null for partition info.");
+        Assert.IsNull(tuple.Filesystem, "Filesystem should be null for partition info.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePath treats a file named partitioninfo.json inside a
+    /// filesystem as a regular file, not as partition info metadata.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_PartitionInfoInsideFilesystem_ReturnsFileType()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        var result = parsePathMethod!.Invoke(provider, [$"part_GPT_1/fs_FAT32/{PartitionInfoMetadata.FileName}"]);
+        Assert.IsNotNull(result, "Should return a tuple.");
+
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.File, tuple.Type, "A partitioninfo.json file inside a filesystem should be treated as a regular file.");
+        Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
+        Assert.AreEqual(1, tuple.Partition!.PartitionNumber, "Partition number should be 1.");
+        Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
+        Assert.AreEqual(FileSystemType.FAT32, tuple.Filesystem!.Type, "Filesystem type should be FAT32.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePartition maps a differing source partition number to the
+    /// resolved target partition when restoring into a partition (subpath mode).
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePartition_DifferentSourceNumberWithSubpath_MapsToTargetPartition()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+        var parsePartitionMethod = typeof(RestoreProvider).GetMethod("ParsePartition", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePartitionMethod, "ParsePartition method should exist.");
+
+        // The restore path refers to source partition 2, but the target is partition 1
+        var result = parsePartitionMethod!.Invoke(provider, ["part_GPT_2"]);
+        Assert.IsNotNull(result, "Should return a partition.");
+
+        var partition = (IPartition)result!;
+        Assert.AreEqual(1, partition.PartitionNumber, "Should map to the target partition number.");
+        Assert.AreSame(targetPartition, partition, "Should return the resolved target partition.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePartition still throws for a non-existent partition when not
+    /// restoring into a partition (no subpath), even if only one partition is registered.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePartition_DifferentSourceNumberWithoutSubpath_ThrowsInvalidOperationException()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests(string.Empty, targetPartition);
+        var parsePartitionMethod = typeof(RestoreProvider).GetMethod("ParsePartition", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePartitionMethod, "ParsePartition method should exist.");
+
+        var ex = Assert.Throws<TargetInvocationException>(() =>
+            parsePartitionMethod!.Invoke(provider, ["part_GPT_2"]),
+            "Should throw for a non-existent partition when not in subpath mode.");
+        Assert.IsInstanceOf<InvalidOperationException>(ex!.InnerException, "Inner exception should be InvalidOperationException.");
+    }
+
+    /// <summary>
+    /// Tests that ParseFilesystem creates a filesystem handler from the partition info
+    /// captured for the target partition, even when the restore path refers to a
+    /// different source partition number.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParseFilesystem_PartitionInfoForTargetPartition_CreatesFilesystem()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+        var parseFilesystemMethod = typeof(RestoreProvider).GetMethod("ParseFilesystem", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parseFilesystemMethod, "ParseFilesystem method should exist.");
+
+        // Partition info describing source partition 2 was captured for target partition 1
+        GetPartitionInfos(provider)[1] = CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS);
+
+        var result = parseFilesystemMethod!.Invoke(provider, [targetPartition, "fs_NTFS"]);
+        Assert.IsNotNull(result, "Should return a filesystem.");
+
+        var filesystem = (IFilesystem)result!;
+        Assert.AreEqual(FileSystemType.NTFS, filesystem.Type, "Filesystem type should be NTFS.");
+        Assert.AreEqual(1, filesystem.Partition.PartitionNumber, "Filesystem should reference the target partition.");
+    }
+
+    /// <summary>
+    /// Tests that ParseFilesystem throws a UserInformationException when restoring
+    /// into a partition without any captured partition info.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParseFilesystem_MissingPartitionInfo_ThrowsUserInformationException()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+        var parseFilesystemMethod = typeof(RestoreProvider).GetMethod("ParseFilesystem", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parseFilesystemMethod, "ParseFilesystem method should exist.");
+
+        var ex = Assert.Throws<TargetInvocationException>(() =>
+            parseFilesystemMethod!.Invoke(provider, [targetPartition, "fs_NTFS"]),
+            "Should throw when no partition info has been captured.");
+        Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
+    }
+
+    /// <summary>
+    /// Tests the end-to-end path parsing for restoring a backup of a source
+    /// partition into a target partition with a different partition number.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_DifferentSourceNumberWithSubpath_ReturnsTargetPartition()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        // Partition info describing source partition 2 was captured for target partition 1
+        GetPartitionInfos(provider)[1] = CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS);
+
+        var result = parsePathMethod!.Invoke(provider, ["part_GPT_2/fs_NTFS/data/file.txt"]);
+        Assert.IsNotNull(result, "Should return a tuple.");
+
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.File, tuple.Type, "Type should be 'File'.");
+        Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
+        Assert.AreEqual(1, tuple.Partition!.PartitionNumber, "Should resolve to the target partition number.");
+        Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
+        Assert.AreEqual(FileSystemType.NTFS, tuple.Filesystem!.Type, "Filesystem type should be NTFS.");
+    }
+
+    /// <summary>
+    /// Tests that writing a partition info file during a partition-target restore
+    /// captures the metadata for the target partition, regardless of the partition
+    /// number in the path.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_OpenWrite_PartitionInfo_CapturedForTargetPartition()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+
+        var info = CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS);
+        var bytes = System.Text.Encoding.UTF8.GetBytes(info.ToJson());
+
+        await using (var stream = await provider.OpenWrite($"part_GPT_2/{PartitionInfoMetadata.FileName}", CancellationToken.None))
+        {
+            await stream.WriteAsync(bytes);
+        }
+
+        var infos = GetPartitionInfos(provider);
+        Assert.IsTrue(infos.TryGetValue(1, out var captured), "Partition info should be captured under the target partition number.");
+        Assert.AreEqual(4096, captured!.Filesystem!.BlockSize, "Block size should be preserved.");
+        Assert.AreEqual(FileSystemType.NTFS, captured.Filesystem.Type, "Filesystem type should be preserved.");
+    }
+
+    /// <summary>
+    /// Tests that ParsePath fails when a geometry file is part of the restore set
+    /// and the target is a partition, since that indicates a full-disk backup.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_GeometryFileOnPartitionTarget_Throws()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        var ex = Assert.Throws<TargetInvocationException>(() =>
+            parsePathMethod!.Invoke(provider, [$"part_GPT_1/{GeometryMetadata.FileName}"]),
+            "Should throw for a geometry file when the target is a partition.");
+        Assert.IsInstanceOf<UserInformationException>(ex!.InnerException, "Inner exception should be UserInformationException.");
+    }
+
+    /// <summary>
+    /// Tests that capturing partition info for a second, different source partition
+    /// fails, as that indicates a multi-partition (disk) backup being restored into
+    /// a single partition.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_OpenWrite_ConflictingPartitionInfos_Throws()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+
+        var first = System.Text.Encoding.UTF8.GetBytes(CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS).ToJson());
+        var second = System.Text.Encoding.UTF8.GetBytes(CreateTestPartitionInfo(3, 10485760, 4096, FileSystemType.NTFS).ToJson());
+
+        await using (var stream = await provider.OpenWrite($"part_GPT_1/{PartitionInfoMetadata.FileName}", CancellationToken.None))
+            await stream.WriteAsync(first);
+
+        var stream2 = await provider.OpenWrite($"part_GPT_1/{PartitionInfoMetadata.FileName}", CancellationToken.None);
+        await stream2.WriteAsync(second);
+        Assert.Throws<UserInformationException>(() => stream2.Dispose(),
+            "Capturing info for a different source partition should throw.");
+    }
+
+    /// <summary>
+    /// Tests that reading a partition info file that was not captured (whole-disk
+    /// restore) returns an empty stream instead of throwing.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_OpenRead_PartitionInfoNotCaptured_ReturnsEmptyStream()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+
+        await using var stream = await provider.OpenRead($"part_GPT_1/{PartitionInfoMetadata.FileName}", CancellationToken.None);
+
+        Assert.AreEqual(0, stream.Length, "Whole-disk restores should return an empty stream for uncaptured partition info.");
+    }
+
+    /// <summary>
+    /// Tests that reading a captured partition info file returns its JSON content.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_OpenRead_CapturedPartitionInfo_ReturnsJson()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+
+        GetPartitionInfos(provider)[1] = CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS);
+
+        await using var stream = await provider.OpenRead($"part_GPT_2/{PartitionInfoMetadata.FileName}", CancellationToken.None);
+        Assert.Greater(stream.Length, 0, "Captured partition info should be readable.");
+
+        using var reader = new StreamReader(stream);
+        var parsed = PartitionInfoMetadata.FromJson(await reader.ReadToEndAsync());
+
+        Assert.IsNotNull(parsed, "Read content should be valid partition info JSON.");
+        Assert.AreEqual(4096, parsed!.Filesystem!.BlockSize, "Block size should be preserved.");
+    }
+
+    /// <summary>
+    /// Tests that GetFileLength returns zero for a partition info file that was
+    /// not captured (whole-disk restore) instead of throwing.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_GetFileLength_PartitionInfoNotCaptured_ReturnsZero()
+    {
+        using var provider = CreateRestoreProviderForPathParsingTests();
+
+        var length = await provider.GetFileLength($"part_GPT_1/{PartitionInfoMetadata.FileName}", CancellationToken.None);
+
+        Assert.AreEqual(0L, length, "Whole-disk restores should report zero length for uncaptured partition info.");
+    }
+
+    /// <summary>
+    /// Tests that a file named geometry.json inside a filesystem is treated as a
+    /// regular file when the restore target is a partition; only a geometry file
+    /// at the disk or partition level indicates a full-disk backup.
+    /// </summary>
+    [Test]
+    public void Test_RestoreProvider_ParsePath_GeometryFileInsideFilesystemOnPartitionTarget_ReturnsFileType()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+        var parsePathMethod = typeof(RestoreProvider).GetMethod("ParsePath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(parsePathMethod, "ParsePath method should exist.");
+
+        // Partition info describing source partition 2 was captured for target partition 1
+        GetPartitionInfos(provider)[1] = CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS);
+
+        var result = parsePathMethod!.Invoke(provider, [$"part_GPT_2/fs_NTFS/backups/{GeometryMetadata.FileName}"]);
+        Assert.IsNotNull(result, "Should return a tuple.");
+
+        var tuple = ((RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem))result!;
+        Assert.AreEqual(RestorePathType.File, tuple.Type, "A geometry.json file inside a filesystem should be treated as a regular file.");
+        Assert.IsNotNull(tuple.Partition, "Partition should not be null.");
+        Assert.AreEqual(1, tuple.Partition!.PartitionNumber, "Should resolve to the target partition number.");
+        Assert.IsNotNull(tuple.Filesystem, "Filesystem should not be null.");
+    }
+
+    /// <summary>
+    /// Tests that a partition info file without a source partition number is not
+    /// captured, since multi-partition conflicts cannot be detected without it.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_OpenWrite_IncompletePartitionInfo_NotCaptured()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+
+        var incomplete = new PartitionInfoMetadata
+        {
+            Filesystem = new FilesystemGeometry
+            {
+                PartitionNumber = 2,
+                Type = FileSystemType.NTFS,
+                PartitionStartOffset = 1048576,
+                BlockSize = 4096
+            }
+        };
+        var bytes = System.Text.Encoding.UTF8.GetBytes(incomplete.ToJson());
+
+        await using (var stream = await provider.OpenWrite($"part_GPT_2/{PartitionInfoMetadata.FileName}", CancellationToken.None))
+            await stream.WriteAsync(bytes);
+
+        Assert.IsEmpty(GetPartitionInfos(provider), "Partition info without a source partition number should not be captured.");
+    }
+
+    /// <summary>
+    /// Tests that a partition info file without a source partition number does not
+    /// overwrite a previously captured, complete partition info.
+    /// </summary>
+    [Test]
+    public async Task Test_RestoreProvider_OpenWrite_IncompletePartitionInfo_DoesNotOverwriteCaptured()
+    {
+        var targetPartition = CreateTargetPartition();
+        using var provider = CreateRestoreProviderForPartitionTargetTests("part_GPT_1", targetPartition);
+
+        var complete = System.Text.Encoding.UTF8.GetBytes(CreateTestPartitionInfo(2, 10485760, 4096, FileSystemType.NTFS).ToJson());
+        var incomplete = System.Text.Encoding.UTF8.GetBytes(new PartitionInfoMetadata
+        {
+            Filesystem = new FilesystemGeometry
+            {
+                PartitionNumber = 2,
+                Type = FileSystemType.NTFS,
+                PartitionStartOffset = 1048576,
+                BlockSize = 8192
+            }
+        }.ToJson());
+
+        await using (var stream = await provider.OpenWrite($"part_GPT_2/{PartitionInfoMetadata.FileName}", CancellationToken.None))
+            await stream.WriteAsync(complete);
+
+        await using (var stream = await provider.OpenWrite($"part_GPT_2/{PartitionInfoMetadata.FileName}", CancellationToken.None))
+            await stream.WriteAsync(incomplete);
+
+        var infos = GetPartitionInfos(provider);
+        Assert.IsTrue(infos.TryGetValue(1, out var captured), "Partition info should be captured under the target partition number.");
+        Assert.AreEqual(2, captured!.Partition!.Number, "The captured partition info should be unchanged.");
+        Assert.AreEqual(4096, captured.Filesystem!.BlockSize, "The captured block size should be unchanged.");
     }
 
 }

--- a/proprietary/DiskImage/General/GeometryMetadata.cs
+++ b/proprietary/DiskImage/General/GeometryMetadata.cs
@@ -15,6 +15,11 @@ namespace Duplicati.Proprietary.DiskImage.General;
 public class GeometryMetadata
 {
     /// <summary>
+    /// The file name used for the geometry metadata file at the disk level.
+    /// </summary>
+    public const string FileName = "geometry.json";
+
+    /// <summary>
     /// The version of the metadata format.
     /// </summary>
     public int Version { get; set; } = 1;
@@ -181,32 +186,85 @@ public class PartitionGeometry
 }
 
 /// <summary>
-/// Filesystem-level geometry information.
+/// Geometry information for a filesystem, used for reconstruction after restore.
 /// </summary>
 public class FilesystemGeometry
 {
-    /// <summary>
-    /// The partition number this filesystem resides on.
-    /// </summary>
-    public int PartitionNumber { get; set; }
-
     /// <summary>
     /// The type of filesystem.
     /// </summary>
     public FileSystemType Type { get; set; }
 
     /// <summary>
-    /// The starting offset of the partition in bytes.
+    /// The partition number containing this filesystem.
+    /// </summary>
+    public int PartitionNumber { get; set; }
+
+    /// <summary>
+    /// The starting offset of the partition containing this filesystem.
     /// </summary>
     public long PartitionStartOffset { get; set; }
 
     /// <summary>
-    /// The block size used by the filesystem.
+    /// Block size used for reading/writing.
     /// </summary>
     public int BlockSize { get; set; }
 
     /// <summary>
-    /// Filesystem-specific metadata as a JSON string.
+    /// Filesystem-specific metadata as JSON.
     /// </summary>
     public string? Metadata { get; set; }
+}
+
+/// <summary>
+/// Consolidated info for a single partition, stored as partitioninfo.json inside
+/// the partition folder. Unlike geometry.json (which sits at the disk level),
+/// this file is included when a restore selection contains only the partition,
+/// providing the partition size and filesystem block size without geometry metadata.
+/// </summary>
+public sealed record PartitionInfoMetadata
+{
+    /// <summary>
+    /// The file name used for the partition info file within a partition folder.
+    /// </summary>
+    public const string FileName = "partitioninfo.json";
+
+    /// <summary>
+    /// The current version of the partition info format.
+    /// </summary>
+    public const int CurrentVersion = 1;
+
+    /// <summary>
+    /// The version of the partition info format.
+    /// </summary>
+    public int Version { get; init; } = CurrentVersion;
+
+    /// <summary>
+    /// Geometry information for the partition.
+    /// </summary>
+    public PartitionGeometry? Partition { get; init; }
+
+    /// <summary>
+    /// Geometry information for the filesystem on the partition, including the block size.
+    /// </summary>
+    public FilesystemGeometry? Filesystem { get; init; }
+
+    /// <summary>
+    /// JSON serializer options with string enum conversion.
+    /// </summary>
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    /// <summary>
+    /// Serializes this metadata to JSON.
+    /// </summary>
+    public string ToJson() => JsonSerializer.Serialize(this, JsonOptions);
+
+    /// <summary>
+    /// Deserializes partition info from JSON.
+    /// </summary>
+    public static PartitionInfoMetadata? FromJson(string json) => JsonSerializer.Deserialize<PartitionInfoMetadata>(json, JsonOptions);
 }

--- a/proprietary/DiskImage/Partition/PartitionCreator.cs
+++ b/proprietary/DiskImage/Partition/PartitionCreator.cs
@@ -1,0 +1,513 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Logging;
+using Duplicati.Proprietary.DiskImage.Disk;
+using Duplicati.Proprietary.DiskImage.General;
+
+namespace Duplicati.Proprietary.DiskImage.Partition;
+
+/// <summary>
+/// Creates new partitions on a target disk that already has a partition table
+/// (or initializes a new table on a blank disk). Used when restoring partition
+/// backups to a whole-disk target, where the partition referenced by the backup
+/// does not exist on the target disk and must be created in free space.
+/// </summary>
+internal static class PartitionCreator
+{
+    private static readonly string LOGTAG = Log.LogTagFromType(typeof(PartitionCreator));
+
+    /// <summary>
+    /// The alignment used when placing new partitions (1 MiB).
+    /// </summary>
+    public const long DefaultAlignment = 1024 * 1024;
+
+    /// <summary>
+    /// Describes a partition that has been allocated (placement decided) but not
+    /// yet written to the target disk's partition table.
+    /// </summary>
+    /// <param name="TableType">The partition table type of the target disk the allocation was made for.</param>
+    /// <param name="Slot">The reserved 1-based slot in the partition table.</param>
+    /// <param name="StartOffset">The starting offset of the partition in bytes.</param>
+    /// <param name="Size">The size of the partition in bytes.</param>
+    /// <param name="Type">The partition type.</param>
+    /// <param name="FilesystemType">The filesystem type of the partition content.</param>
+    /// <param name="Name">The partition name (GPT only).</param>
+    /// <param name="VolumeGuid">The unique partition GUID (GPT only).</param>
+    public sealed record AllocatedPartition(
+        PartitionTableType TableType,
+        int Slot,
+        long StartOffset,
+        long Size,
+        PartitionType Type,
+        FileSystemType FilesystemType,
+        string? Name,
+        Guid? VolumeGuid);
+
+    /// <summary>
+    /// Finds free space for a new partition within the usable range of a disk.
+    /// Prefers <paramref name="preferredStart"/> when that range is free, otherwise
+    /// returns the first gap that fits the required size with the given alignment.
+    /// </summary>
+    /// <param name="existing">The occupied ranges on the disk (start offset and size in bytes).</param>
+    /// <param name="usableStart">The first usable byte offset (inclusive).</param>
+    /// <param name="usableEnd">The last usable byte offset (exclusive).</param>
+    /// <param name="requiredSize">The required size in bytes.</param>
+    /// <param name="alignment">The alignment for the start offset in bytes.</param>
+    /// <param name="preferredStart">An optional preferred start offset (e.g. the source partition's original offset).</param>
+    /// <returns>The start offset for the new partition, or null if no suitable free space exists.</returns>
+    public static long? FindFreeSpace(
+        IEnumerable<(long Start, long Size)> existing,
+        long usableStart,
+        long usableEnd,
+        long requiredSize,
+        long alignment,
+        long? preferredStart = null)
+    {
+        if (requiredSize <= 0 || usableEnd <= usableStart)
+            return null;
+
+        var sorted = existing
+            .Where(e => e.Size > 0 && e.Start + e.Size > usableStart && e.Start < usableEnd)
+            .OrderBy(e => e.Start)
+            .ToList();
+
+        // Honor the preferred start (e.g. the source partition's original offset)
+        // when that exact range is free.
+        if (preferredStart.HasValue
+            && preferredStart.Value >= usableStart
+            && preferredStart.Value + requiredSize <= usableEnd
+            && !sorted.Any(e => preferredStart.Value < e.Start + e.Size && e.Start < preferredStart.Value + requiredSize))
+            return preferredStart.Value;
+
+        var candidate = AlignUp(usableStart, alignment);
+        foreach (var e in sorted)
+        {
+            if (candidate < e.Start && candidate + requiredSize <= e.Start)
+                return candidate;
+
+            candidate = Math.Max(candidate, AlignUp(e.Start + e.Size, alignment));
+        }
+
+        return candidate + requiredSize <= usableEnd ? candidate : null;
+    }
+
+    /// <summary>
+    /// Allocates space for a new partition on the target disk by examining the
+    /// disk's partition table and finding free space. Disks without a recognizable
+    /// partition table are treated as blank and will get a new GPT table.
+    /// </summary>
+    /// <param name="disk">The target disk.</param>
+    /// <param name="requiredSize">The required partition size in bytes (rounded up to sector size).</param>
+    /// <param name="preferredStart">An optional preferred start offset (the source partition's original offset).</param>
+    /// <param name="type">The partition type.</param>
+    /// <param name="filesystemType">The filesystem type of the partition content.</param>
+    /// <param name="name">The partition name (GPT only).</param>
+    /// <param name="volumeGuid">The unique partition GUID (GPT only); a new GUID is generated when null, so the primary and secondary tables stay consistent.</param>
+    /// <param name="pending">Previously allocated partitions that are not yet written to the disk.</param>
+    /// <param name="cancel">Cancellation token.</param>
+    /// <returns>The allocation describing where the partition will be created.</returns>
+    /// <exception cref="UserInformationException">Thrown if the disk has no suitable free space or no free partition table slot.</exception>
+    public static async Task<AllocatedPartition> AllocateAsync(
+        IRawDisk disk,
+        long requiredSize,
+        long? preferredStart,
+        PartitionType type,
+        FileSystemType filesystemType,
+        string? name,
+        Guid? volumeGuid,
+        IReadOnlyList<AllocatedPartition> pending,
+        CancellationToken cancel)
+    {
+        var sectorSize = disk.SectorSize;
+        using var table = await PartitionTableFactory.CreateAsync(disk, cancel).ConfigureAwait(false);
+        var tableType = table?.TableType ?? PartitionTableType.Unknown;
+
+        // Round the required size up to a sector multiple
+        requiredSize = AlignUp(requiredSize, sectorSize);
+
+        var existing = new List<(long Start, long Size)>();
+        var usedSlots = new HashSet<int>();
+        long usableStart;
+        long usableEnd;
+        int maxSlots;
+
+        if (tableType == PartitionTableType.GPT && table is GPT gpt)
+        {
+            usableStart = gpt.FirstUsableLba * sectorSize;
+            usableEnd = (gpt.LastUsableLba + 1) * sectorSize;
+            maxSlots = (int)gpt.NumPartitionEntries;
+        }
+        else if (tableType == PartitionTableType.MBR)
+        {
+            usableStart = sectorSize;
+            // MBR uses 32-bit LBA fields, limiting the addressable range
+            usableEnd = Math.Min(disk.Size, ((long)uint.MaxValue + 1) * sectorSize);
+            maxSlots = PartitionConstants.MaxMbrPartitionEntries;
+        }
+        else
+        {
+            // No recognizable partition table: treat the disk as blank and
+            // reserve space for a new GPT table (primary and secondary)
+            tableType = PartitionTableType.GPT;
+            var entriesSectors = (PartitionConstants.GptNumPartitionEntries * PartitionConstants.GptPartitionEntrySize + sectorSize - 1) / sectorSize;
+            usableStart = (2 + entriesSectors) * (long)sectorSize;
+            usableEnd = disk.Size - (entriesSectors + 1) * (long)sectorSize;
+            maxSlots = PartitionConstants.GptNumPartitionEntries;
+        }
+
+        if (table != null && table.TableType is PartitionTableType.GPT or PartitionTableType.MBR)
+        {
+            await foreach (var p in table.EnumeratePartitions(cancel).ConfigureAwait(false))
+            {
+                existing.Add((p.StartOffset, p.Size));
+                usedSlots.Add(p.PartitionNumber);
+            }
+        }
+
+        // Exclude previously allocated (but not yet written) partitions
+        foreach (var a in pending)
+        {
+            existing.Add((a.StartOffset, a.Size));
+            usedSlots.Add(a.Slot);
+        }
+
+        var slot = Enumerable.Range(1, maxSlots).FirstOrDefault(s => !usedSlots.Contains(s));
+        if (slot == 0)
+            throw new UserInformationException($"Cannot create a partition on '{disk.DevicePath}': the {tableType} partition table has no free entries.", "DiskRestoreNoFreePartitionSlot");
+
+        var start = FindFreeSpace(existing, usableStart, usableEnd, requiredSize, DefaultAlignment, preferredStart);
+        if (start == null)
+            throw new UserInformationException($"Cannot create a partition on '{disk.DevicePath}': the disk has no contiguous free space of {requiredSize} bytes.", "DiskRestoreNoFreeSpace");
+
+        // MBR: the partition must fit in the 32-bit LBA fields
+        if (tableType == PartitionTableType.MBR
+            && (start / sectorSize > uint.MaxValue || requiredSize / sectorSize > uint.MaxValue))
+            throw new UserInformationException($"Cannot create a partition on '{disk.DevicePath}': the partition does not fit within the MBR addressable range.", "DiskRestoreNoFreeSpace");
+
+        Log.WriteInformationMessage(LOGTAG, "PartitionAllocated",
+            $"Allocated {requiredSize} bytes at offset {start} for a new partition (slot {slot}, {tableType}) on {disk.DevicePath}");
+
+        // Resolve the partition GUID once, so the primary and secondary GPT
+        // entries written later carry the same unique partition GUID
+        volumeGuid ??= Guid.NewGuid();
+
+        return new AllocatedPartition(tableType, slot, start.Value, requiredSize, type, filesystemType, name, volumeGuid);
+    }
+
+    /// <summary>
+    /// Writes previously allocated partitions into the target disk's partition table.
+    /// When the disk has no recognizable partition table, a new GPT table containing
+    /// the partitions is synthesized instead.
+    /// </summary>
+    /// <param name="disk">The target disk.</param>
+    /// <param name="partitions">The partitions to write.</param>
+    /// <param name="cancel">Cancellation token.</param>
+    /// <returns>An awaitable task.</returns>
+    public static async Task WritePartitionsAsync(IRawDisk disk, IReadOnlyList<AllocatedPartition> partitions, CancellationToken cancel)
+    {
+        if (partitions.Count == 0)
+            return;
+
+        using var table = await PartitionTableFactory.CreateAsync(disk, cancel).ConfigureAwait(false);
+        var tableType = table?.TableType ?? PartitionTableType.Unknown;
+
+        if (tableType == PartitionTableType.Unknown)
+        {
+            // Blank disk: synthesize a new GPT table containing all partitions
+            await SynthesizeNewTableAsync(disk, partitions, cancel).ConfigureAwait(false);
+            return;
+        }
+
+        foreach (var partition in partitions.OrderBy(p => p.Slot))
+        {
+            if (partition.TableType != tableType)
+                throw new InvalidOperationException($"The partition was allocated for a {partition.TableType} table, but the disk '{disk.DevicePath}' has a {tableType} table.");
+
+            if (tableType == PartitionTableType.MBR)
+                await WriteMbrEntryAsync(disk, partition, cancel).ConfigureAwait(false);
+            else if (tableType == PartitionTableType.GPT)
+                await WriteGptEntryAsync(disk, partition, cancel).ConfigureAwait(false);
+            else
+                throw new NotSupportedException($"Cannot add a partition to a {tableType} partition table.");
+
+            Log.WriteInformationMessage(LOGTAG, "PartitionCreated",
+                $"Created partition in slot {partition.Slot} ({tableType}) on {disk.DevicePath}, offset: {partition.StartOffset}, size: {partition.Size} bytes");
+        }
+    }
+
+    /// <summary>
+    /// Writes an MBR partition entry into an MBR sector buffer, preserving all
+    /// existing content (boot code, disk signature, other entries).
+    /// </summary>
+    /// <param name="mbrSector">The buffer containing the MBR sector; must be at least 512 bytes.</param>
+    /// <param name="sectorSize">The disk's sector size in bytes.</param>
+    /// <param name="slot">The 1-based slot (1-4) to write the entry into; must be empty.</param>
+    /// <param name="startOffset">The partition start offset in bytes.</param>
+    /// <param name="size">The partition size in bytes.</param>
+    /// <param name="filesystemType">The filesystem type of the partition content.</param>
+    /// <param name="type">The partition type.</param>
+    /// <returns><c>true</c> if the entry was written; <c>false</c> if the slot is occupied, invalid, or the values exceed the 32-bit LBA fields.</returns>
+    public static bool TryWriteMbrEntry(byte[] mbrSector, int sectorSize, int slot, long startOffset, long size, FileSystemType filesystemType, PartitionType type)
+    {
+        if (mbrSector.Length < PartitionConstants.MbrSize)
+            throw new ArgumentException($"The buffer must be at least {PartitionConstants.MbrSize} bytes.", nameof(mbrSector));
+
+        if (slot < 1 || slot > PartitionConstants.MaxMbrPartitionEntries)
+            return false;
+
+        var startLba = startOffset / sectorSize;
+        var sizeInSectors = size / sectorSize;
+        if (startLba > uint.MaxValue || sizeInSectors > uint.MaxValue || sizeInSectors == 0)
+            return false;
+
+        var offset = 446 + (slot - 1) * PartitionConstants.MbrPartitionEntrySize;
+
+        // The slot must be empty (type byte 0)
+        if (mbrSector[offset + 4] != 0)
+            return false;
+
+        // Status byte (not bootable)
+        mbrSector[offset] = 0x00;
+
+        // CHS start/end: set to 0xFF (invalid), modern systems use LBA
+        mbrSector[offset + 1] = 0xFF;
+        mbrSector[offset + 2] = 0xFF;
+        mbrSector[offset + 3] = 0xFF;
+        mbrSector[offset + 5] = 0xFF;
+        mbrSector[offset + 6] = 0xFF;
+        mbrSector[offset + 7] = 0xFF;
+
+        // Partition type byte
+        mbrSector[offset + 4] = MbrPartitionTypes.ToTypeByte(filesystemType, type);
+
+        // Start LBA and size in sectors
+        BinaryPrimitives.WriteUInt32LittleEndian(mbrSector.AsSpan(offset + 8, 4), (uint)startLba);
+        BinaryPrimitives.WriteUInt32LittleEndian(mbrSector.AsSpan(offset + 12, 4), (uint)sizeInSectors);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Writes a GPT partition entry into a partition entries buffer.
+    /// </summary>
+    /// <param name="entriesBuffer">The buffer containing the GPT partition entries.</param>
+    /// <param name="entrySize">The size of each partition entry in bytes (typically 128).</param>
+    /// <param name="slot">The 1-based slot to write the entry into; must be empty.</param>
+    /// <param name="startLba">The starting LBA of the partition.</param>
+    /// <param name="endLba">The ending LBA of the partition (inclusive).</param>
+    /// <param name="type">The partition type.</param>
+    /// <param name="volumeGuid">The unique partition GUID, or null to generate a new one.</param>
+    /// <param name="name">The partition name (max 36 UTF-16 characters).</param>
+    /// <returns><c>true</c> if the entry was written; <c>false</c> if the slot is occupied or out of range.</returns>
+    public static bool TryWriteGptEntry(Span<byte> entriesBuffer, int entrySize, int slot, long startLba, long endLba, PartitionType type, Guid? volumeGuid, string? name)
+    {
+        if (slot < 1 || (long)slot * entrySize > entriesBuffer.Length)
+            return false;
+
+        var offset = (slot - 1) * entrySize;
+        var entry = entriesBuffer.Slice(offset, entrySize);
+
+        // The slot must be empty (partition type GUID all zeros)
+        if (entry.Slice(0, 16).IndexOfAnyExcept((byte)0) != -1)
+            return false;
+
+        // Partition type GUID (16 bytes)
+        GptPartitionTypeGuids.ToGuid(type).ToByteArray().CopyTo(entry);
+
+        // Unique partition GUID (16 bytes)
+        (volumeGuid ?? Guid.NewGuid()).ToByteArray().CopyTo(entry.Slice(16));
+
+        // Starting and ending LBA
+        BinaryPrimitives.WriteInt64LittleEndian(entry.Slice(32, 8), startLba);
+        BinaryPrimitives.WriteInt64LittleEndian(entry.Slice(40, 8), endLba);
+
+        // Attributes (8 bytes) - default to 0
+        BinaryPrimitives.WriteInt64LittleEndian(entry.Slice(48, 8), 0);
+
+        // Partition name (72 bytes, UTF-16LE)
+        var nameBytes = Encoding.Unicode.GetBytes(name ?? "");
+        nameBytes.AsSpan(0, Math.Min(nameBytes.Length, 72)).CopyTo(entry.Slice(56));
+
+        return true;
+    }
+
+    /// <summary>
+    /// Updates the partition entries CRC32 in a GPT header and recomputes the
+    /// header CRC32. Must be called after modifying the partition entries.
+    /// </summary>
+    /// <param name="headerSector">The sector containing the GPT header (first 92 bytes are used).</param>
+    /// <param name="entriesBuffer">The partition entries buffer the CRC is computed over.</param>
+    /// <param name="entriesByteSize">The exact size of the partition entries array in bytes (number of entries times entry size).</param>
+    public static void PatchGptHeader(Span<byte> headerSector, byte[] entriesBuffer, int entriesByteSize)
+    {
+        // CRC32 of partition entries (offset 88)
+        var entriesCrc = Crc32.Calculate(entriesBuffer, 0, entriesByteSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(headerSector.Slice(88, 4), entriesCrc);
+
+        // Recompute header CRC32 (offset 16, calculated with the field zeroed)
+        BinaryPrimitives.WriteUInt32LittleEndian(headerSector.Slice(16, 4), 0u);
+        var headerCrc = Crc32.Calculate(headerSector.ToArray(), 0, PartitionConstants.GptHeaderSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(headerSector.Slice(16, 4), headerCrc);
+    }
+
+    /// <summary>
+    /// Adds a partition entry to an existing MBR partition table, preserving the
+    /// boot code and other entries.
+    /// </summary>
+    private static async Task WriteMbrEntryAsync(IRawDisk disk, AllocatedPartition partition, CancellationToken cancel)
+    {
+        var sectorSize = disk.SectorSize;
+
+        // Read the full first sector (MBR), patch it, write it back
+        var mbrSector = new byte[sectorSize];
+        using (var stream = await disk.ReadBytesAsync(0, sectorSize, cancel).ConfigureAwait(false))
+            await stream.ReadAtLeastAsync(mbrSector, sectorSize, cancellationToken: cancel).ConfigureAwait(false);
+
+        var bootSignature = BinaryPrimitives.ReadUInt16LittleEndian(mbrSector.AsSpan(510, 2));
+        if (bootSignature != PartitionConstants.MbrBootSignature)
+            throw new InvalidOperationException($"The disk '{disk.DevicePath}' does not have a valid MBR boot signature.");
+
+        if (!TryWriteMbrEntry(mbrSector, sectorSize, partition.Slot, partition.StartOffset, partition.Size, partition.FilesystemType, partition.Type))
+            throw new InvalidOperationException($"Failed to add the partition to slot {partition.Slot} of the MBR on '{disk.DevicePath}': the slot is occupied or the partition exceeds the MBR limits. The disk may have been modified since the restore started.");
+
+        await disk.WriteBytesAsync(0, mbrSector, cancel).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Adds a partition entry to an existing GPT partition table, updating both the
+    /// primary and secondary headers and entries along with their CRC32 checksums.
+    /// The disk GUID and all other entries are preserved.
+    /// </summary>
+    private static async Task WriteGptEntryAsync(IRawDisk disk, AllocatedPartition partition, CancellationToken cancel)
+    {
+        var sectorSize = disk.SectorSize;
+
+        // Read the primary GPT header sector (LBA 1)
+        var headerSector = new byte[sectorSize];
+        using (var stream = await disk.ReadBytesAsync(sectorSize, sectorSize, cancel).ConfigureAwait(false))
+            await stream.ReadAtLeastAsync(headerSector, sectorSize, cancellationToken: cancel).ConfigureAwait(false);
+
+        if (BinaryPrimitives.ReadInt64LittleEndian(headerSector.AsSpan(0, 8)) != PartitionConstants.GptSignature)
+            throw new InvalidOperationException($"The disk '{disk.DevicePath}' does not have a valid GPT header.");
+
+        var backupLba = BinaryPrimitives.ReadInt64LittleEndian(headerSector.AsSpan(32, 8));
+        var entriesLba = BinaryPrimitives.ReadInt64LittleEndian(headerSector.AsSpan(72, 8));
+        var numEntries = BinaryPrimitives.ReadUInt32LittleEndian(headerSector.AsSpan(80, 4));
+        var entrySize = (int)BinaryPrimitives.ReadUInt32LittleEndian(headerSector.AsSpan(84, 4));
+
+        // The header is re-read from disk here (not taken from the parsed table),
+        // so validate the entry parameters before sizing buffers from them
+        if (entrySize < PartitionConstants.GptPartitionEntrySize || numEntries == 0 || (long)numEntries * entrySize > int.MaxValue)
+            throw new InvalidOperationException($"The GPT header on '{disk.DevicePath}' has invalid partition entry parameters (entries: {numEntries}, entry size: {entrySize}).");
+
+        var entriesByteSize = (int)(numEntries * entrySize);
+        var entriesSectors = (entriesByteSize + sectorSize - 1) / sectorSize;
+        var entriesBufferSize = entriesSectors * sectorSize;
+
+        var startLba = partition.StartOffset / sectorSize;
+        var endLba = startLba + (partition.Size / sectorSize) - 1;
+
+        // Patch the primary partition entries
+        var primaryEntries = new byte[entriesBufferSize];
+        using (var stream = await disk.ReadBytesAsync(entriesLba * sectorSize, entriesBufferSize, cancel).ConfigureAwait(false))
+            await stream.ReadAtLeastAsync(primaryEntries, entriesBufferSize, cancellationToken: cancel).ConfigureAwait(false);
+
+        if (!TryWriteGptEntry(primaryEntries, entrySize, partition.Slot, startLba, endLba, partition.Type, partition.VolumeGuid, partition.Name))
+            throw new InvalidOperationException($"Failed to add the partition to slot {partition.Slot} of the GPT on '{disk.DevicePath}': the slot is occupied. The disk may have been modified since the restore started.");
+
+        await disk.WriteBytesAsync(entriesLba * sectorSize, primaryEntries, cancel).ConfigureAwait(false);
+
+        // Patch the primary header (entries CRC + header CRC)
+        PatchGptHeader(headerSector, primaryEntries, entriesByteSize);
+        await disk.WriteBytesAsync(sectorSize, headerSector, cancel).ConfigureAwait(false);
+
+        // Read the secondary GPT header to locate the secondary entries
+        var secondaryHeader = new byte[sectorSize];
+        using (var stream = await disk.ReadBytesAsync(backupLba * sectorSize, sectorSize, cancel).ConfigureAwait(false))
+            await stream.ReadAtLeastAsync(secondaryHeader, sectorSize, cancellationToken: cancel).ConfigureAwait(false);
+
+        if (BinaryPrimitives.ReadInt64LittleEndian(secondaryHeader.AsSpan(0, 8)) != PartitionConstants.GptSignature)
+        {
+            Log.WriteWarningMessage(LOGTAG, "SecondaryGptInvalid", null,
+                $"The secondary GPT header on '{disk.DevicePath}' is invalid; only the primary partition table was updated.");
+            return;
+        }
+
+        var secondaryEntriesLba = BinaryPrimitives.ReadInt64LittleEndian(secondaryHeader.AsSpan(72, 8));
+
+        // Patch the secondary partition entries
+        var secondaryEntries = new byte[entriesBufferSize];
+        using (var stream = await disk.ReadBytesAsync(secondaryEntriesLba * sectorSize, entriesBufferSize, cancel).ConfigureAwait(false))
+            await stream.ReadAtLeastAsync(secondaryEntries, entriesBufferSize, cancellationToken: cancel).ConfigureAwait(false);
+
+        TryWriteGptEntry(secondaryEntries, entrySize, partition.Slot, startLba, endLba, partition.Type, partition.VolumeGuid, partition.Name);
+        await disk.WriteBytesAsync(secondaryEntriesLba * sectorSize, secondaryEntries, cancel).ConfigureAwait(false);
+
+        // Patch the secondary header (entries CRC + header CRC)
+        PatchGptHeader(secondaryHeader, secondaryEntries, entriesByteSize);
+        await disk.WriteBytesAsync(backupLba * sectorSize, secondaryHeader, cancel).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Synthesizes a new GPT partition table containing the given partitions and
+    /// writes it to a blank disk (primary and secondary).
+    /// </summary>
+    private static async Task SynthesizeNewTableAsync(IRawDisk disk, IReadOnlyList<AllocatedPartition> partitions, CancellationToken cancel)
+    {
+        var metadata = new GeometryMetadata
+        {
+            Disk = new DiskGeometry
+            {
+                DevicePath = disk.DevicePath,
+                Size = disk.Size,
+                SectorSize = disk.SectorSize,
+                Sectors = disk.Sectors,
+                TableType = PartitionTableType.GPT
+            },
+            PartitionTable = new PartitionTableGeometry
+            {
+                Type = PartitionTableType.GPT,
+                SectorSize = disk.SectorSize,
+                HasProtectiveMbr = true,
+                HeaderSize = PartitionConstants.GptHeaderSize
+            },
+            Partitions = partitions
+                .OrderBy(p => p.Slot)
+                .Select(p => new PartitionGeometry
+                {
+                    Number = p.Slot,
+                    Type = p.Type,
+                    StartOffset = p.StartOffset,
+                    Size = p.Size,
+                    Name = p.Name,
+                    FilesystemType = p.FilesystemType,
+                    VolumeGuid = p.VolumeGuid,
+                    TableType = PartitionTableType.GPT
+                })
+                .ToList()
+        };
+
+        var tableData = PartitionTableSynthesizer.SynthesizePartitionTable(metadata)
+            ?? throw new InvalidOperationException("Failed to synthesize a GPT partition table for the blank disk.");
+
+        await disk.WriteBytesAsync(0, tableData, cancel).ConfigureAwait(false);
+        await PartitionTableSynthesizer.WriteSecondaryGPTAsync(disk, metadata, tableData, cancel).ConfigureAwait(false);
+
+        Log.WriteInformationMessage(LOGTAG, "PartitionTableCreated",
+            $"Wrote a new GPT partition table with {partitions.Count} partition(s) to blank disk {disk.DevicePath}");
+    }
+
+    /// <summary>
+    /// Rounds the given value up to the next multiple of the alignment.
+    /// </summary>
+    private static long AlignUp(long value, long alignment)
+        => alignment <= 1 ? value : ((value + alignment - 1) / alignment) * alignment;
+}

--- a/proprietary/DiskImage/Partition/ReconstructedPartitionTable.cs
+++ b/proprietary/DiskImage/Partition/ReconstructedPartitionTable.cs
@@ -18,7 +18,7 @@ namespace Duplicati.Proprietary.DiskImage.Partition;
 internal class ReconstructedPartitionTable : IPartitionTable
 {
     private readonly IRawDisk _rawDisk;
-    private readonly GeometryMetadata _geometry;
+    private readonly GeometryMetadata? _geometry;
     private bool _disposed = false;
 
     /// <summary>
@@ -31,6 +31,18 @@ internal class ReconstructedPartitionTable : IPartitionTable
     {
         _rawDisk = rawDisk;
         _geometry = geometry;
+        TableType = tableType;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReconstructedPartitionTable"/> class
+    /// without geometry metadata, for partitions created on the target disk during restore.
+    /// </summary>
+    /// <param name="rawDisk">The raw disk.</param>
+    /// <param name="tableType">The partition table type (GPT or MBR).</param>
+    public ReconstructedPartitionTable(IRawDisk rawDisk, PartitionTableType tableType)
+    {
+        _rawDisk = rawDisk;
         TableType = tableType;
     }
 

--- a/proprietary/DiskImage/RestoreProvider.cs
+++ b/proprietary/DiskImage/RestoreProvider.cs
@@ -440,6 +440,55 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     }
 
     /// <summary>
+    /// Resolves the partition for partition-level content whose restore path has no
+    /// partition segment. This shape results from a restore selection that lies
+    /// entirely within a single source partition, where the restore path mapping
+    /// stripped the partition folder as part of the common prefix. When the restore
+    /// target is a partition, the content maps to it. For a whole-disk target, the
+    /// partition info captured from the backup (a priority file, restored before any
+    /// partition content) identifies the source partition: an existing partition
+    /// with that number is used when present, otherwise a new partition is created
+    /// on the target disk.
+    /// </summary>
+    /// <returns>The partition the content maps to.</returns>
+    /// <exception cref="UserInformationException">Thrown if the backup has no partition information, or contains information for multiple partitions, which cannot be told apart without partition segments in the paths.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the target partition has not been resolved (partition target only).</exception>
+    private IPartition ResolveImplicitTargetPartition()
+    {
+        // When restoring into a target partition, all partition content maps to
+        // that partition
+        if (!string.IsNullOrEmpty(_subpath))
+            return _partitions.FirstOrDefault()
+                ?? throw new InvalidOperationException("The target partition has not been resolved.");
+
+        int sourceNumber;
+        lock (_creationLock)
+        {
+            if (_partitionInfos.IsEmpty)
+                throw new UserInformationException($"The backup does not contain partition information ({PartitionInfoMetadata.FileName}) for the partition being restored. Restoring partition data to a whole-disk target requires a backup that includes partition information; alternatively, restore to an existing partition on the target disk (e.g. '{_restorePath}{Path.DirectorySeparatorChar}part_GPT_1').", "DiskRestorePartitionInfoMissing");
+
+            // Whole-disk restores key the info by source partition number; more
+            // than one entry means the restore set spans multiple source partitions
+            // and the stripped paths cannot be attributed to a single partition.
+            if (_partitionInfos.Count > 1)
+                throw new UserInformationException($"The restore data contains partition-level data for multiple partitions, but the restore paths do not identify the partition. Restore the partitions including their partition folders, or restore each partition to a partition on the target disk instead (e.g. '{_restorePath}{Path.DirectorySeparatorChar}part_GPT_1').", "DiskRestoreAmbiguousPartitionContent");
+
+            sourceNumber = _partitionInfos.Keys.First();
+
+            // The lookup is done under the creation lock because CreateTargetPartition
+            // (triggered by concurrent writes) adds to the list.
+            var partition = _partitions.FirstOrDefault(p => p.PartitionNumber == sourceNumber);
+            if (partition != null)
+                return partition;
+        }
+
+        // The restore set contains partition data but no geometry metadata
+        // (e.g. a partition backup), so the partition does not exist in the
+        // reconstructed structures. Create the partition on the target disk.
+        return CreateTargetPartition(sourceNumber);
+    }
+
+    /// <summary>
     /// Parses a filesystem segment from the path and returns the corresponding filesystem.
     /// The segment is expected to be in the format "fs_{FileSystemType}", e.g. "fs_NTFS".
     /// </summary>
@@ -508,6 +557,10 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     /// Parses the given path to determine if it refers to a disk-level item, partition, partition info file, or file, and returns the corresponding objects.
     /// The path is expected to be in the format:
     /// root/part_{PartitionTableType}_{PartitionNumber}/fs_{FileSystemType}/path/to/file
+    /// When the restore selection lies entirely within a single source partition, the
+    /// restore path mapping strips the partition folder as part of the common prefix;
+    /// such paths carry no part_ segment and are resolved through the captured
+    /// partition info (see <see cref="ResolveImplicitTargetPartition"/>).
     /// </summary>
     /// <param name="path">The path to parse.</param>
     /// <returns>A tuple containing the item type, partition, and filesystem.</returns>
@@ -573,13 +626,28 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
             return (RestorePathType.Partition, partition, null);
         }
 
-        // No partition segment in the path. Partition-level content (filesystem blocks
-        // or a partition info file) only has this shape when a partition backup is
-        // restored to a whole-disk target; there is no partition to write the blocks
-        // into, so fail instead of silently dropping the data.
-        if (segments.Any(s => s.StartsWith("fs_", StringComparison.OrdinalIgnoreCase))
-            || (segments.Length > 0 && segments[^1].Equals(PartitionInfoMetadata.FileName, StringComparison.OrdinalIgnoreCase)))
-            throw new UserInformationException($"The restore data contains partition-level data, but the restore target '{_restorePath}' is a whole disk. Restore to a partition on the target disk instead (e.g. '{_restorePath}{Path.DirectorySeparatorChar}part_GPT_1').", "DiskRestorePartitionContentToDiskTarget");
+        // No partition segment in the path. Partition-level content has this shape
+        // when the restore selection is entirely within a single source partition:
+        // the restore path mapping strips the common prefix, which then includes
+        // the partition folder. The content belongs to that single source partition.
+        var implicitFilesystemSegment = segments.FirstOrDefault(s => s.StartsWith("fs_", StringComparison.OrdinalIgnoreCase));
+
+        // A partition info file sits directly in the partition folder, so with the
+        // partition folder stripped it appears at the root. It is not resolved to a
+        // partition here, as it is restored during the priority-file phase where the
+        // geometry-based reconstruction may not have run yet. A file of the same
+        // name inside a filesystem (fs_ segment present) is regular file content.
+        if (implicitFilesystemSegment == null
+            && segments.Length > 0
+            && segments[^1].Equals(PartitionInfoMetadata.FileName, StringComparison.OrdinalIgnoreCase))
+            return (RestorePathType.PartitionInfo, null, null);
+
+        if (implicitFilesystemSegment != null)
+        {
+            var partition = ResolveImplicitTargetPartition();
+            var filesystem = ParseFilesystem(partition, implicitFilesystemSegment);
+            return (RestorePathType.File, partition, filesystem);
+        }
 
         return (RestorePathType.Disk, null, null);
     }
@@ -827,10 +895,11 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
             return Task.FromResult<Stream>(new MemoryStream(data));
         }
 
-        // Partition info is only captured when the restore target is a specific
-        // partition. Whole-disk restores intentionally do not store it (there may
-        // be multiple such files and geometry.json provides the metadata), so
-        // return an empty stream instead of failing.
+        // Partition info is only readable when the restore target is a specific
+        // partition, where it is keyed by the target partition number. Whole-disk
+        // restores store infos keyed by source partition number, which the path
+        // does not identify (there may be several, and geometry.json provides the
+        // metadata), so return an empty stream instead of failing.
         Log.WriteVerboseMessage(LOGTAG, "PartitionInfoNotAvailable", $"Partition info metadata for '{path}' was not captured; returning an empty stream.");
         return Task.FromResult<Stream>(new MemoryStream());
     }
@@ -1050,7 +1119,7 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         if (_targetDisk == null)
             throw new InvalidOperationException("Provider not initialized.");
 
-        var totalItems = _pendingWrites.Count;
+        var totalItems = _pendingWrites.Count + _pendingPartitionCreations.Count;
         if (totalItems == 0)
         {
             Log.WriteInformationMessage(LOGTAG, "RestoreNoItems", "No items to restore.");

--- a/proprietary/DiskImage/RestoreProvider.cs
+++ b/proprietary/DiskImage/RestoreProvider.cs
@@ -80,13 +80,31 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     private GeometryMetadata? _geometryMetadata;
 
     /// <summary>
-    /// Stores partition info metadata parsed from restored partitioninfo.json files,
-    /// keyed by the source partition number found in the restored path. Provides the
-    /// partition size and filesystem block size when geometry.json is not part of the
-    /// restore selection (e.g. when only a single partition is restored). Only
-    /// populated when the restore target is a specific partition.
+    /// Stores partition info metadata parsed from restored partitioninfo.json files.
+    /// When the restore target is a specific partition, this is keyed by the target
+    /// partition number and provides the partition size and filesystem block size
+    /// when geometry.json is not part of the restore selection. When the restore
+    /// target is a whole disk, this is keyed by the source partition number and is
+    /// used to create target partitions for partition backups.
     /// </summary>
     private readonly ConcurrentDictionary<int, PartitionInfoMetadata> _partitionInfos = new();
+
+    /// <summary>
+    /// Maps source partition numbers to partitions created on the target disk
+    /// during this restore (whole-disk target without geometry metadata).
+    /// </summary>
+    private readonly Dictionary<int, IPartition> _createdPartitions = [];
+
+    /// <summary>
+    /// The allocations for partitions created during this restore, whose partition
+    /// table entries are written to the target disk during Finalize.
+    /// </summary>
+    private readonly List<PartitionCreator.AllocatedPartition> _pendingPartitionCreations = [];
+
+    /// <summary>
+    /// Serializes partition creation, which can be triggered from concurrent writes.
+    /// </summary>
+    private readonly Lock _creationLock = new();
 
     private List<IPartition> _partitions = [];
     private List<IFilesystem> _filesystems = [];
@@ -337,15 +355,88 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
             return _partitions.FirstOrDefault()
                 ?? throw new InvalidOperationException("The target partition has not been resolved.");
 
-        // Full-disk restore: match the source partition from the path
-        var partition = _partitions.FirstOrDefault(p =>
-            p.PartitionNumber == pn &&
-            p.PartitionTable.TableType == ptType);
+        // Full-disk restore: match the source partition from the path. The lookup
+        // is done under the creation lock because CreateTargetPartition (triggered
+        // by concurrent writes) adds to the list.
+        IPartition? partition;
+        lock (_creationLock)
+        {
+            partition = _partitions.FirstOrDefault(p =>
+                p.PartitionNumber == pn &&
+                p.PartitionTable.TableType == ptType);
+        }
 
         if (partition == null)
-            throw new InvalidOperationException($"Partition not found for segment: {segment}. Partition number {pn} with table type {ptType} not in reconstructed partitions.");
+        {
+            // The restore set contains partition data but no geometry metadata
+            // (e.g. a partition backup), so the partition does not exist in the
+            // reconstructed structures. Create the partition on the target disk.
+            partition = CreateTargetPartition(pn);
+        }
 
         return partition;
+    }
+
+    /// <summary>
+    /// Creates a new partition on the target disk for a partition backup being
+    /// restored to a whole-disk target. The partition is allocated in free space
+    /// (preferring the source partition's original offset) and registered so that
+    /// restored content maps to it; the partition table entry is written during
+    /// Finalize. Requires partition information (partitioninfo.json) from the backup.
+    /// </summary>
+    /// <param name="sourceNumber">The source partition number.</param>
+    /// <returns>The created partition.</returns>
+    /// <exception cref="UserInformationException">Thrown if the backup has no partition information, the partition table is skipped, or the disk has no suitable free space.</exception>
+    private IPartition CreateTargetPartition(int sourceNumber)
+    {
+        lock (_creationLock)
+        {
+            if (_createdPartitions.TryGetValue(sourceNumber, out var existing))
+                return existing;
+
+            if (!_partitionInfos.TryGetValue(sourceNumber, out var info) || info.Partition == null)
+                throw new UserInformationException($"The backup does not contain partition information ({PartitionInfoMetadata.FileName}) for partition {sourceNumber}. Restoring partition data to a whole-disk target requires a backup that includes partition information.", "DiskRestorePartitionInfoMissing");
+
+            if (_skipPartitionTable)
+                throw new UserInformationException($"Cannot create a partition on the target disk '{_devicePath}' because the partition table is excluded from the restore ({OptionsHelper.DISK_RESTORE_SKIP_PARTITION_TABLE_OPTION} is set). Restore to an existing partition on the target disk instead, or unset the option.", "DiskRestorePartitionCreationSkipped");
+
+            var source = info.Partition;
+            var allocated = PartitionCreator.AllocateAsync(
+                _targetDisk!,
+                source.Size,
+                source.StartOffset,
+                source.Type,
+                source.FilesystemType,
+                source.Name,
+                source.VolumeGuid,
+                _pendingPartitionCreations,
+                CancellationToken.None).Await();
+
+            var partition = new BasePartition
+            {
+                PartitionNumber = sourceNumber,
+                Type = source.Type,
+                PartitionTable = new ReconstructedPartitionTable(_targetDisk!, allocated.TableType),
+                StartOffset = allocated.StartOffset,
+                Size = allocated.Size,
+                Name = source.Name,
+                FilesystemType = source.FilesystemType,
+                VolumeGuid = source.VolumeGuid,
+                RawDisk = _targetDisk,
+                StartingLba = allocated.StartOffset / _targetDisk!.SectorSize,
+                EndingLba = (allocated.StartOffset + allocated.Size) / _targetDisk!.SectorSize - 1,
+                Attributes = 0
+            };
+
+            _partitions.Add(partition);
+            _createdPartitions[sourceNumber] = partition;
+            _pendingPartitionCreations.Add(allocated);
+
+            Log.WriteInformationMessage(LOGTAG, "RestoreTargetPartitionCreated",
+                $"Creating partition for source partition {sourceNumber} on {_devicePath}, offset: {allocated.StartOffset}, size: {allocated.Size} bytes; the partition table entry is written when the restore completes");
+
+            return partition;
+        }
     }
 
     /// <summary>
@@ -371,13 +462,21 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         // Find the filesystem in our reconstructed list
         var fs = _filesystems.FirstOrDefault(f => f.Partition.PartitionNumber == partition.PartitionNumber && f.Type == fsType);
 
-        if (fs == null && !string.IsNullOrEmpty(_subpath))
+        // Read under the creation lock, as CreateTargetPartition (triggered by
+        // concurrent writes) adds to the dictionary
+        bool isCreatedPartition;
+        lock (_creationLock)
+            isCreatedPartition = _createdPartitions.ContainsKey(partition.PartitionNumber);
+
+        if (fs == null && (!string.IsNullOrEmpty(_subpath) || isCreatedPartition))
         {
-            // When restoring into a target partition, geometry.json is not part of
-            // the restore selection. The partition info file (restored as a priority
-            // file before any partition content) provides the block size and source
-            // partition size, and is required for the restore. The info is keyed by
-            // the target partition number; all content maps to the target partition.
+            // When restoring into a target partition, or into a partition created
+            // on the target disk, geometry.json is not part of the restore selection.
+            // The partition info file (restored as a priority file before any
+            // partition content) provides the block size and source partition size,
+            // and is required for the restore. For a partition target the info is
+            // keyed by the target partition number; for created partitions by the
+            // source partition number (which the created partition carries).
             if (!_partitionInfos.TryGetValue(partition.PartitionNumber, out var info))
                 throw new UserInformationException($"The backup does not contain partition information ({PartitionInfoMetadata.FileName}) for the partition being restored. Restoring directly into a partition requires a backup that includes partition information.", "DiskRestorePartitionInfoMissing");
 
@@ -503,8 +602,10 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
     /// <summary>
     /// Opens a stream for writing partition info metadata (captured when disposed).
-    /// Only used when restoring into a partition; ignored for whole-disk restores,
-    /// where geometry.json provides the metadata.
+    /// When restoring into a partition, the info is keyed by the target partition;
+    /// for whole-disk restores it is keyed by the source partition number and is
+    /// used to create partitions on the target disk when the backup has no
+    /// geometry metadata.
     /// </summary>
     private Task<Stream> OpenWritePartitionInfo(string path, CancellationToken cancel)
         => Task.FromResult<Stream>(new CaptureStream(new MemoryStream(), data => CapturePartitionInfo(path, data)));
@@ -533,14 +634,6 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     /// <exception cref="UserInformationException">Thrown if the restore set contains info for multiple source partitions, which cannot be restored into a single partition.</exception>
     private void CapturePartitionInfo(string path, ReadOnlyMemory<byte> data)
     {
-        if (string.IsNullOrEmpty(_subpath))
-        {
-            // Whole-disk restore: geometry.json provides the metadata, and there
-            // may be multiple partition info files, so they are not stored
-            Log.WriteVerboseMessage(LOGTAG, "PartitionInfoIgnored", $"Ignoring partition info from '{path}' because the restore target is a whole disk.");
-            return;
-        }
-
         PartitionInfoMetadata? info;
         try
         {
@@ -574,6 +667,18 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
             return;
         }
 
+        if (string.IsNullOrEmpty(_subpath))
+        {
+            // Whole-disk restore: geometry.json normally provides the metadata.
+            // The info is stored keyed by the source partition number so that
+            // partition backups (which have no geometry.json) can be restored by
+            // creating the partition on the target disk.
+            _partitionInfos[newNumber] = info;
+            Log.WriteInformationMessage(LOGTAG, "PartitionInfoParsed",
+                $"Parsed partition info for source partition {newNumber}: filesystem {info.Filesystem?.Type}, block size {info.Filesystem?.BlockSize}, source size {info.Partition?.Size} bytes");
+            return;
+        }
+
         // The info describes the source partition, but is keyed by the target
         // partition: when a target partition has been set, all restored content
         // maps to it regardless of the partition numbers in the paths
@@ -600,12 +705,17 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
     /// <summary>
     /// Gets the partition info captured for the target partition, if any.
+    /// Only applies when the restore target is a specific partition; whole-disk
+    /// restores store infos keyed by source partition number.
     /// </summary>
     /// <param name="info">The captured partition info, or <c>null</c> if none was captured.</param>
     /// <returns><c>true</c> if partition info was captured for the target partition; otherwise, <c>false</c>.</returns>
     private bool TryGetTargetPartitionInfo(out PartitionInfoMetadata? info)
     {
         info = null;
+        if (string.IsNullOrEmpty(_subpath))
+            return false;
+
         var target = _partitions.FirstOrDefault();
         return target != null && _partitionInfos.TryGetValue(target.PartitionNumber, out info);
     }
@@ -1000,6 +1110,37 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
             }
             processedCount += diskItems.Count;
             progressCallback?.Invoke(processedCount / (double)totalItems);
+        }
+
+        // Write partition table entries for partitions created during this restore
+        // (partition backups restored to a whole-disk target). The partition content
+        // has already been written to the allocated space; adding the table entries
+        // last ensures an interrupted restore leaves no entries pointing at
+        // incomplete data.
+        if (_pendingPartitionCreations.Count > 0)
+        {
+            if (_skipPartitionTable)
+            {
+                // Unreachable: partition creation is refused when the partition
+                // table is skipped. Guarded here for safety.
+                Log.WriteWarningMessage(LOGTAG, "PartitionCreationSkipped", null,
+                    "Skipping creation of partition table entries because the partition table is excluded from the restore.");
+            }
+            else
+            {
+                try
+                {
+                    await PartitionCreator.WritePartitionsAsync(_targetDisk, _pendingPartitionCreations, cancel).ConfigureAwait(false);
+                    Log.WriteInformationMessage(LOGTAG, "PartitionEntriesWritten",
+                        $"Successfully wrote {_pendingPartitionCreations.Count} partition table entrie(s) to {_devicePath}.");
+                }
+                catch (Exception ex)
+                {
+                    Log.WriteErrorMessage(LOGTAG, "PartitionCreationFailed", ex,
+                        $"Failed to create the partition on the target disk: {ex.Message}");
+                    throw;
+                }
+            }
         }
 
         // Restore partition-level items

--- a/proprietary/DiskImage/RestoreProvider.cs
+++ b/proprietary/DiskImage/RestoreProvider.cs
@@ -20,7 +20,31 @@ using Duplicati.Proprietary.DiskImage.Partition;
 namespace Duplicati.Proprietary.DiskImage;
 
 /// <summary>
+/// The type of item a restore path refers to within the disk image hierarchy.
+/// </summary>
+internal enum RestorePathType
+{
+    /// <summary>The path refers to the disk-level geometry metadata file (geometry.json).</summary>
+    Geometry,
+
+    /// <summary>The path refers to a partition-level info file (partitioninfo.json).</summary>
+    PartitionInfo,
+
+    /// <summary>The path refers to disk-level data (e.g. the partition table).</summary>
+    Disk,
+
+    /// <summary>The path refers to partition-level data.</summary>
+    Partition,
+
+    /// <summary>The path refers to a file within a filesystem on a partition.</summary>
+    File
+}
+
+/// <summary>
 /// Restore provider for disk images. Allows restoring disk images back to physical disks.
+/// When the target URL points to a partition within a disk (e.g. part_GPT_1), the data
+/// is restored into that partition instead, which also supports backups of a single
+/// partition that have no geometry metadata.
 /// </summary>
 public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDisposable
 {
@@ -28,6 +52,14 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
     private readonly string _devicePath;
     private readonly string _restorePath;
+
+    /// <summary>
+    /// The subpath within the disk hierarchy that the target URL points to
+    /// (the part after the device name, e.g. a partition segment such as
+    /// "part_GPT_1"), or empty if the URL targets the whole disk.
+    /// </summary>
+    private readonly string _subpath;
+
     private readonly bool _autoUnmount;
     private readonly bool _skipPartitionTable;
     private readonly bool _validateSize;
@@ -46,6 +78,15 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     /// Used to reconstruct disk, partition, and filesystem structures.
     /// </summary>
     private GeometryMetadata? _geometryMetadata;
+
+    /// <summary>
+    /// Stores partition info metadata parsed from restored partitioninfo.json files,
+    /// keyed by the source partition number found in the restored path. Provides the
+    /// partition size and filesystem block size when geometry.json is not part of the
+    /// restore selection (e.g. when only a single partition is restored). Only
+    /// populated when the restore target is a specific partition.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, PartitionInfoMetadata> _partitionInfos = new();
 
     private List<IPartition> _partitions = [];
     private List<IFilesystem> _filesystems = [];
@@ -99,6 +140,7 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     {
         _devicePath = null!;
         _restorePath = null!;
+        _subpath = string.Empty;
         _skipPartitionTable = false;
         _validateSize = true;
         _hasSetOverwriteOption = false;
@@ -113,7 +155,12 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     {
         var uri = new Library.Utility.RelaxedUri(url);
         _restorePath = uri.HostAndPath;
-        _devicePath = uri.HostAndPath;
+
+        // Split the target into the disk device path and an optional subpath
+        // within the disk hierarchy (e.g. a partition). When a subpath is present,
+        // the restore writes into that partition instead of rewriting the whole disk,
+        // which also allows restoring partition backups that have no geometry.json.
+        (_devicePath, _subpath) = SourceProvider.SplitDeviceAndSubpath(uri.HostAndPath);
 
         _skipPartitionTable = Utility.ParseBoolOption(options, OptionsHelper.DISK_RESTORE_SKIP_PARTITION_TABLE_OPTION);
         _validateSize = Utility.ParseBoolOption(options, OptionsHelper.DISK_RESTORE_VALIDATE_SIZE_OPTION);
@@ -159,12 +206,57 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         if (!string.IsNullOrWhiteSpace(msg))
             throw new UserInformationException(string.Format(Strings.RestoreDeviceNotWriteable, _devicePath, msg), "DiskInitializeFailed");
 
+        // When the target URL points to a partition within the disk, resolve the
+        // target partition from the disk's partition table. This allows restoring
+        // backups of a single partition (which have no geometry.json) directly
+        // into that partition.
+        if (!string.IsNullOrEmpty(_subpath))
+            await ResolveTargetPartitionAsync(cancel).ConfigureAwait(false);
+
         // Validate target size if requested
         if (_validateSize)
         {
             // Size validation will be done during Finalize when we have source metadata
             Log.WriteInformationMessage(LOGTAG, "RestoreSizeValidationEnabled", "Target size validation is enabled.");
         }
+    }
+
+    /// <summary>
+    /// Resolves the target partition identified by <see cref="_subpath"/> from the
+    /// target disk's partition table and registers it, so that restore paths
+    /// referencing the partition can be mapped without geometry metadata.
+    /// </summary>
+    /// <param name="cancel">Cancellation token.</param>
+    /// <returns>An awaitable task.</returns>
+    /// <exception cref="UserInformationException">Thrown if the subpath does not identify a partition, or the partition cannot be found on the target disk.</exception>
+    private async Task ResolveTargetPartitionAsync(CancellationToken cancel)
+    {
+        var segment = _subpath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (string.IsNullOrEmpty(segment))
+            throw new UserInformationException(string.Format(Strings.RestoreInvalidPath, _restorePath), "DiskRestoreInvalidPath");
+
+        // The segment is expected in the format "part_{PartitionTableType}_{PartitionNumber}", e.g. "part_GPT_1"
+        var parts = segment.Split('_');
+        if (parts.Length < 3
+            || !parts[0].Equals("part", StringComparison.OrdinalIgnoreCase)
+            || !Enum.TryParse<PartitionTableType>(parts[1], true, out var ptType)
+            || !int.TryParse(parts[2], out var partitionNumber))
+            throw new UserInformationException($"The restore target '{_restorePath}' does not point to a partition. Expected format: part_{{PartitionTableType}}_{{PartitionNumber}}", "DiskRestoreInvalidPartitionPath");
+
+        var table = await PartitionTableFactory.CreateAsync(_targetDisk!, cancel).ConfigureAwait(false);
+        if (table == null || table.TableType == PartitionTableType.Unknown)
+            throw new UserInformationException($"The target disk '{_devicePath}' does not have a recognizable partition table, so the target partition '{segment}' cannot be resolved.", "DiskRestoreNoPartitionTable");
+
+        if (table.TableType != ptType)
+            throw new UserInformationException($"The target disk '{_devicePath}' uses a {table.TableType} partition table, which does not match the requested {ptType} partition '{segment}'.", "DiskRestorePartitionTableMismatch");
+
+        var partition = await table.GetPartitionAsync(partitionNumber, cancel).ConfigureAwait(false)
+            ?? throw new UserInformationException(string.Format(Strings.RestoreTargetNotFound, $"{_devicePath}/{segment}"), "DiskRestorePartitionNotFound");
+
+        _partitions.Add(partition);
+
+        Log.WriteInformationMessage(LOGTAG, "RestoreTargetPartitionResolved",
+            $"Restoring into partition {partitionNumber} ({ptType}) on {_devicePath}, offset: {partition.StartOffset}, size: {partition.Size} bytes");
     }
 
     /// <inheritdoc />
@@ -217,6 +309,9 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     /// <summary>
     /// Parses a partition segment from the path and returns the corresponding partition.
     /// The segment is expected to be in the format "part_{PartitionTableType}_{PartitionNumber}", e.g. "part_GPT_1".
+    /// When a target partition has been set, it is always returned, as the partition number
+    /// in the path refers to the source partition. Only for full-disk restores is the
+    /// segment matched against the source partitions.
     /// </summary>
     /// <param name="segment">The partition segment string.</param>
     /// <returns>The corresponding partition.</returns>
@@ -236,7 +331,13 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         if (!int.TryParse(parts[2], out var pn))
             throw new InvalidOperationException($"Unable to parse partition number from segment: {segment}. Tried {parts[2]}");
 
-        // Find the partition in our reconstructed list
+        // When restoring into a target partition, all partition content maps to that
+        // partition; the number in the path is the source partition's and is not matched
+        if (!string.IsNullOrEmpty(_subpath))
+            return _partitions.FirstOrDefault()
+                ?? throw new InvalidOperationException("The target partition has not been resolved.");
+
+        // Full-disk restore: match the source partition from the path
         var partition = _partitions.FirstOrDefault(p =>
             p.PartitionNumber == pn &&
             p.PartitionTable.TableType == ptType);
@@ -269,6 +370,35 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
         // Find the filesystem in our reconstructed list
         var fs = _filesystems.FirstOrDefault(f => f.Partition.PartitionNumber == partition.PartitionNumber && f.Type == fsType);
+
+        if (fs == null && !string.IsNullOrEmpty(_subpath))
+        {
+            // When restoring into a target partition, geometry.json is not part of
+            // the restore selection. The partition info file (restored as a priority
+            // file before any partition content) provides the block size and source
+            // partition size, and is required for the restore. The info is keyed by
+            // the target partition number; all content maps to the target partition.
+            if (!_partitionInfos.TryGetValue(partition.PartitionNumber, out var info))
+                throw new UserInformationException($"The backup does not contain partition information ({PartitionInfoMetadata.FileName}) for the partition being restored. Restoring directly into a partition requires a backup that includes partition information.", "DiskRestorePartitionInfoMissing");
+
+            if (info.Filesystem != null && info.Filesystem.Type != fsType)
+                throw new InvalidOperationException($"The backup describes the filesystem on the restored partition as {info.Filesystem.Type}, but the restore path refers to it as {fsType}.");
+
+            if (_validateSize && info.Partition != null && info.Partition.Size > partition.Size)
+                throw new UserInformationException(
+                    string.Format(Strings.RestoreTargetTooSmall, partition.Size, info.Partition.Size),
+                    "RestoreTargetTooSmall");
+
+            var blockSize = info.Filesystem is { BlockSize: > 0 } fsGeom
+                ? fsGeom.BlockSize
+                : throw new UserInformationException($"The partition information ({PartitionInfoMetadata.FileName}) in the backup does not provide a valid block size.", "DiskRestoreBlockSizeMissing");
+
+            fs = new UnknownFilesystem(partition, blockSize, fsType);
+            _filesystems.Add(fs);
+            Log.WriteInformationMessage(LOGTAG, "FilesystemHandlerCreated",
+                $"Created block-level filesystem handler (reported as {fsType}) for target partition {partition.PartitionNumber} with block size {blockSize}; content is restored as raw blocks");
+        }
+
         if (fs == null)
             throw new InvalidOperationException($"No matching filesystem found for segment: {segment} with type {fsType}");
 
@@ -276,14 +406,14 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     }
 
     /// <summary>
-    /// Parses the given path to determine if it refers to a disk-level item, partition, or file, and returns the corresponding objects.
+    /// Parses the given path to determine if it refers to a disk-level item, partition, partition info file, or file, and returns the corresponding objects.
     /// The path is expected to be in the format:
     /// root/part_{PartitionTableType}_{PartitionNumber}/fs_{FileSystemType}/path/to/file
     /// </summary>
     /// <param name="path">The path to parse.</param>
     /// <returns>A tuple containing the item type, partition, and filesystem.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the path cannot be parsed.</exception>
-    internal (string, IPartition?, IFilesystem?) ParsePath(string path)
+    internal (RestorePathType Type, IPartition? Partition, IFilesystem? Filesystem) ParsePath(string path)
     {
         // For disk image restore, the path is expected to be in the format:
         // root/part_{PartitionTableType}_{PartitionNumber}/fs_{FileSystemType}/path/to/file
@@ -296,25 +426,63 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         var separators = OperatingSystem.IsWindows() ? new[] { '/', '\\' } : new[] { '/' };
 
         if (IsGeometryFile(path))
-            return ("geometry", null, null);
+        {
+            // The path matches the target disk's own geometry file. With a partition
+            // target this still means the restore set contains a full-disk backup
+            if (!string.IsNullOrEmpty(_subpath))
+                throw DiskContentToPartitionTarget();
+            return (RestorePathType.Geometry, null, null);
+        }
 
         var segments = path.Split(separators, StringSplitOptions.RemoveEmptyEntries) ??
             throw new InvalidOperationException($"Unable to parse path: {path}");
 
+        // When the restore target is a single partition, a geometry file in the
+        // restore set indicates a full-disk backup, which cannot be restored into
+        // a partition (its partition table and other partitions would have nowhere
+        // to go). Fail here, before any partition content is written. The geometry
+        // file sits at the disk or partition level, so a file named geometry.json
+        // inside a filesystem (fs_ segment present) is regular file content and is
+        // restored like any other file.
+        if (!string.IsNullOrEmpty(_subpath)
+            && segments.Length > 0
+            && segments[^1].Equals(GeometryMetadata.FileName, StringComparison.OrdinalIgnoreCase)
+            && !segments.Any(s => s.StartsWith("fs_", StringComparison.OrdinalIgnoreCase)))
+            throw DiskContentToPartitionTarget();
+
+        static UserInformationException DiskContentToPartitionTarget()
+            => new($"The backup contains a full disk image (including '{GeometryMetadata.FileName}'), which cannot be restored into a single partition. Restore to a whole-disk target instead.", "DiskRestoreDiskContentToPartitionTarget");
 
         string? partitionSegment = segments.FirstOrDefault(s => s.StartsWith("part_", StringComparison.OrdinalIgnoreCase));
         if (!string.IsNullOrEmpty(partitionSegment))
         {
-            var partition = ParsePartition(partitionSegment);
             string? filesystemSegment = segments.FirstOrDefault(s => s.StartsWith("fs_", StringComparison.OrdinalIgnoreCase));
+
+            // A partition info file sits directly in the partition folder and
+            // travels with the partition content. It is not resolved to a
+            // partition here, as it is restored during the priority-file phase
+            // where the geometry-based reconstruction may not have run yet.
+            if (filesystemSegment == null && segments[^1].Equals(PartitionInfoMetadata.FileName, StringComparison.OrdinalIgnoreCase))
+                return (RestorePathType.PartitionInfo, null, null);
+
+            var partition = ParsePartition(partitionSegment);
             if (!string.IsNullOrEmpty(filesystemSegment))
             {
                 var filesystem = ParseFilesystem(partition, filesystemSegment);
-                return ("file", partition, filesystem);
+                return (RestorePathType.File, partition, filesystem);
             }
-            return ("partition", partition, null);
+            return (RestorePathType.Partition, partition, null);
         }
-        return ("disk", null, null);
+
+        // No partition segment in the path. Partition-level content (filesystem blocks
+        // or a partition info file) only has this shape when a partition backup is
+        // restored to a whole-disk target; there is no partition to write the blocks
+        // into, so fail instead of silently dropping the data.
+        if (segments.Any(s => s.StartsWith("fs_", StringComparison.OrdinalIgnoreCase))
+            || (segments.Length > 0 && segments[^1].Equals(PartitionInfoMetadata.FileName, StringComparison.OrdinalIgnoreCase)))
+            throw new UserInformationException($"The restore data contains partition-level data, but the restore target '{_restorePath}' is a whole disk. Restore to a partition on the target disk instead (e.g. '{_restorePath}{Path.DirectorySeparatorChar}part_GPT_1').", "DiskRestorePartitionContentToDiskTarget");
+
+        return (RestorePathType.Disk, null, null);
     }
 
     /// <inheritdoc />
@@ -324,12 +492,122 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
         return typeStr switch
         {
-            "geometry" => OpenWriteGeometry(cancel),
-            "disk" => OpenWriteDisk(path, cancel),
-            "partition" => OpenWritePartition(path, partition!, cancel),
-            "file" => filesystem!.OpenWriteStreamAsync(path, cancel),
+            RestorePathType.Geometry => OpenWriteGeometry(cancel),
+            RestorePathType.PartitionInfo => OpenWritePartitionInfo(path, cancel),
+            RestorePathType.Disk => OpenWriteDisk(path, cancel),
+            RestorePathType.Partition => OpenWritePartition(path, partition!, cancel),
+            RestorePathType.File => filesystem!.OpenWriteStreamAsync(path, cancel),
             _ => throw new NotSupportedException($"Unsupported item type: {typeStr}")
         };
+    }
+
+    /// <summary>
+    /// Opens a stream for writing partition info metadata (captured when disposed).
+    /// Only used when restoring into a partition; ignored for whole-disk restores,
+    /// where geometry.json provides the metadata.
+    /// </summary>
+    private Task<Stream> OpenWritePartitionInfo(string path, CancellationToken cancel)
+        => Task.FromResult<Stream>(new CaptureStream(new MemoryStream(), data => CapturePartitionInfo(path, data)));
+
+    /// <summary>
+    /// Opens a stream for read-write access to partition info metadata.
+    /// </summary>
+    private async Task<Stream> OpenReadWritePartitionInfo(string path, CancellationToken cancel)
+    {
+        var stream = new MemoryStream();
+        if (TryGetTargetPartitionInfo(out var existing))
+        {
+            var current = System.Text.Encoding.UTF8.GetBytes(existing!.ToJson());
+            await stream.WriteAsync(current, cancel);
+            stream.Position = 0;
+        }
+
+        return new CaptureStream(stream, data => CapturePartitionInfo(path, data));
+    }
+
+    /// <summary>
+    /// Captures and parses partition info metadata written during restore.
+    /// </summary>
+    /// <param name="path">The path of the partition info file.</param>
+    /// <param name="data">The written data.</param>
+    /// <exception cref="UserInformationException">Thrown if the restore set contains info for multiple source partitions, which cannot be restored into a single partition.</exception>
+    private void CapturePartitionInfo(string path, ReadOnlyMemory<byte> data)
+    {
+        if (string.IsNullOrEmpty(_subpath))
+        {
+            // Whole-disk restore: geometry.json provides the metadata, and there
+            // may be multiple partition info files, so they are not stored
+            Log.WriteVerboseMessage(LOGTAG, "PartitionInfoIgnored", $"Ignoring partition info from '{path}' because the restore target is a whole disk.");
+            return;
+        }
+
+        PartitionInfoMetadata? info;
+        try
+        {
+            var json = System.Text.Encoding.UTF8.GetString(data.Span);
+            info = PartitionInfoMetadata.FromJson(json);
+        }
+        catch (Exception ex)
+        {
+            Log.WriteWarningMessage(LOGTAG, "PartitionInfoParseFailed", ex, $"Failed to parse partition info from '{path}'.");
+            return;
+        }
+
+        if (info == null)
+        {
+            Log.WriteWarningMessage(LOGTAG, "PartitionInfoParseFailed", null, $"Failed to parse partition info from '{path}': parsed object was null.");
+            return;
+        }
+
+        if (info.Version > PartitionInfoMetadata.CurrentVersion)
+            Log.WriteWarningMessage(LOGTAG, "PartitionInfoVersionNewer", null,
+                $"The partition info from '{path}' has version {info.Version}, which is newer than the supported version {PartitionInfoMetadata.CurrentVersion}. Some fields may be ignored.");
+
+        // Without the source partition number, multi-partition conflicts cannot be
+        // detected and the size validation in ParseFilesystem has no source size.
+        // Refuse to store incomplete info so a previously captured, complete info
+        // is not silently overwritten by a lesser one.
+        if (info.Partition?.Number is not int newNumber)
+        {
+            Log.WriteWarningMessage(LOGTAG, "PartitionInfoIncomplete", null,
+                $"Ignoring partition info from '{path}' because it does not identify the source partition.");
+            return;
+        }
+
+        // The info describes the source partition, but is keyed by the target
+        // partition: when a target partition has been set, all restored content
+        // maps to it regardless of the partition numbers in the paths
+        var target = _partitions.FirstOrDefault();
+        if (target == null)
+        {
+            Log.WriteWarningMessage(LOGTAG, "PartitionInfoParseFailed", null, $"Failed to capture partition info from '{path}': the target partition has not been resolved.");
+            return;
+        }
+
+        // A second partition info describing a different source partition means the
+        // restore set contains multiple partitions (e.g. a disk backup without the
+        // geometry file), which cannot be mapped into the single target partition.
+        // Since incomplete infos are rejected above, any existing entry always has
+        // a source partition number to compare against.
+        if (_partitionInfos.TryGetValue(target.PartitionNumber, out var existing)
+            && existing.Partition!.Number != newNumber)
+            throw new UserInformationException($"The backup contains data for multiple partitions (at least partitions {existing.Partition.Number} and {newNumber}), which cannot be restored into a single partition. Restore to a whole-disk target instead.", "DiskRestoreDiskContentToPartitionTarget");
+
+        _partitionInfos[target.PartitionNumber] = info;
+        Log.WriteInformationMessage(LOGTAG, "PartitionInfoParsed",
+            $"Parsed partition info for target partition {target.PartitionNumber}: filesystem {info.Filesystem?.Type}, block size {info.Filesystem?.BlockSize}, source size {info.Partition?.Size} bytes");
+    }
+
+    /// <summary>
+    /// Gets the partition info captured for the target partition, if any.
+    /// </summary>
+    /// <param name="info">The captured partition info, or <c>null</c> if none was captured.</param>
+    /// <returns><c>true</c> if partition info was captured for the target partition; otherwise, <c>false</c>.</returns>
+    private bool TryGetTargetPartitionInfo(out PartitionInfoMetadata? info)
+    {
+        info = null;
+        var target = _partitions.FirstOrDefault();
+        return target != null && _partitionInfos.TryGetValue(target.PartitionNumber, out info);
     }
 
     /// <summary>
@@ -406,10 +684,11 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
         return typeStr switch
         {
-            "disk" => OpenReadDisk(path, cancel),
-            "partition" => OpenReadPartition(path, partition!, cancel),
-            "geometry" => OpenReadGeometry(cancel),
-            "file" => filesystem!.OpenReadStreamAsync(path, cancel),
+            RestorePathType.Disk => OpenReadDisk(path, cancel),
+            RestorePathType.Partition => OpenReadPartition(path, partition!, cancel),
+            RestorePathType.Geometry => OpenReadGeometry(cancel),
+            RestorePathType.PartitionInfo => OpenReadPartitionInfo(path, cancel),
+            RestorePathType.File => filesystem!.OpenReadStreamAsync(path, cancel),
             _ => throw new NotSupportedException($"Unsupported item type: {typeStr}")
         };
     }
@@ -425,6 +704,25 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         var json = _geometryMetadata.ToJson();
         var data = System.Text.Encoding.UTF8.GetBytes(json);
         return Task.FromResult<Stream>(new MemoryStream(data));
+    }
+
+    /// <summary>
+    /// Opens a stream for reading partition info metadata.
+    /// </summary>
+    private Task<Stream> OpenReadPartitionInfo(string path, CancellationToken cancel)
+    {
+        if (TryGetTargetPartitionInfo(out var info))
+        {
+            var data = System.Text.Encoding.UTF8.GetBytes(info!.ToJson());
+            return Task.FromResult<Stream>(new MemoryStream(data));
+        }
+
+        // Partition info is only captured when the restore target is a specific
+        // partition. Whole-disk restores intentionally do not store it (there may
+        // be multiple such files and geometry.json provides the metadata), so
+        // return an empty stream instead of failing.
+        Log.WriteVerboseMessage(LOGTAG, "PartitionInfoNotAvailable", $"Partition info metadata for '{path}' was not captured; returning an empty stream.");
+        return Task.FromResult<Stream>(new MemoryStream());
     }
 
     /// <summary>
@@ -456,10 +754,11 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
         return typeStr switch
         {
-            "disk" => OpenWriteDisk(path, cancel), // For disk-level, we treat read-write as write since we only capture the data to be written during Finalize
-            "partition" => Task.FromResult((Stream)new MemoryStream()),
-            "geometry" => OpenReadWriteGeometry(cancel),
-            "file" => filesystem!.OpenReadWriteStreamAsync(path, cancel),
+            RestorePathType.Disk => OpenWriteDisk(path, cancel), // For disk-level, we treat read-write as write since we only capture the data to be written during Finalize
+            RestorePathType.Partition => Task.FromResult((Stream)new MemoryStream()),
+            RestorePathType.Geometry => OpenReadWriteGeometry(cancel),
+            RestorePathType.PartitionInfo => OpenReadWritePartitionInfo(path, cancel),
+            RestorePathType.File => filesystem!.OpenReadWriteStreamAsync(path, cancel),
             _ => throw new NotSupportedException($"Unsupported item type: {typeStr}")
         };
     }
@@ -497,6 +796,15 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
                 {
                     _geometryMetadata = newGeometry;
 
+                    if (!string.IsNullOrEmpty(_subpath))
+                    {
+                        // The restore target is a single partition, so disk-level
+                        // geometry must not be applied to the target disk.
+                        Log.WriteInformationMessage(LOGTAG, "GeometryMetadataIgnored",
+                            "Geometry metadata was restored, but the restore target is a partition; the partition table and disk structures of the target disk will not be modified.");
+                        return;
+                    }
+
                     // Clear existing reconstructed objects
                     foreach (var part in _partitions)
                         part.Dispose();
@@ -528,6 +836,14 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     }
 
     /// <summary>
+    /// Returns the number of bytes needed to encode the JSON string as UTF-8.
+    /// </summary>
+    /// <param name="json">The JSON string; can be <c>null</c></param>
+    /// <returns>The length in bytes, or 0 if the string is null or empty</returns>
+    private static long GetJsonUtf8Length(string? json)
+        => string.IsNullOrWhiteSpace(json) ? 0L : System.Text.Encoding.UTF8.GetByteCount(json);
+
+    /// <summary>
     /// Gets the length of a file at the specified path.
     /// </summary>
     /// <param name="path">The path to the file.</param>
@@ -539,10 +855,11 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
         return typeStr switch
         {
-            "disk" => Task.FromResult(0L),
-            "partition" => Task.FromResult(0L),
-            "geometry" => Task.FromResult((long)_geometryMetadata!.ToJson().Count()),
-            "file" => filesystem!.GetFileLengthAsync(path, cancel),
+            RestorePathType.Disk => Task.FromResult(0L),
+            RestorePathType.Partition => Task.FromResult(0L),
+            RestorePathType.Geometry => Task.FromResult(GetJsonUtf8Length(_geometryMetadata?.ToJson())),
+            RestorePathType.PartitionInfo => Task.FromResult(TryGetTargetPartitionInfo(out var info) ? GetJsonUtf8Length(info?.ToJson()) : 0L),
+            RestorePathType.File => filesystem!.GetFileLengthAsync(path, cancel),
             _ => throw new NotSupportedException($"Unsupported item type: {typeStr}")
         };
     }
@@ -560,6 +877,28 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     {
         // TODO properly handle metadata
 
+        // When the entry describes a source partition, validate that the target
+        // partition is large enough to hold the source partition's data.
+        if (_validateSize
+            && metadata.TryGetValue("diskimage:Type", out var entryType)
+            && string.Equals(entryType, "partition", StringComparison.OrdinalIgnoreCase)
+            && metadata.TryGetValue("partition:Number", out var numberStr)
+            && int.TryParse(numberStr, out var partitionNumber)
+            && metadata.TryGetValue("partition:Size", out var sizeStr)
+            && long.TryParse(sizeStr, out var sourceSize))
+        {
+            // When a target partition has been set, it is always the target of the
+            // restore; otherwise match the source partition number (full-disk restore).
+            var target = !string.IsNullOrEmpty(_subpath)
+                ? _partitions.FirstOrDefault()
+                : _partitions.FirstOrDefault(p => p.PartitionNumber == partitionNumber);
+
+            if (target != null && sourceSize > target.Size)
+                throw new UserInformationException(
+                    string.Format(Strings.RestoreTargetTooSmall, target.Size, sourceSize),
+                    "RestoreTargetTooSmall");
+        }
+
         return Task.FromResult(true);
     }
 
@@ -574,7 +913,7 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
     /// <inheritdoc />
     public IList<string> GetPriorityFiles()
     {
-        return ["geometry.json"];
+        return [GeometryMetadata.FileName, PartitionInfoMetadata.FileName];
     }
 
     /// <summary>
@@ -590,7 +929,7 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
 
         string geometryDevicePath = NormalizePath(_targetDisk.DevicePath);
 
-        string expectedGeometryPath = $"{geometryDevicePath}{Path.DirectorySeparatorChar}geometry.json";
+        string expectedGeometryPath = $"{geometryDevicePath}{Path.DirectorySeparatorChar}{GeometryMetadata.FileName}";
 
         return string.Equals(path, expectedGeometryPath, StringComparison.OrdinalIgnoreCase);
     }
@@ -619,7 +958,14 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         // Restore disk-level items (partition table)
         if (!_skipPartitionTable && diskItems.Count > 0)
         {
-            if (_geometryMetadata?.PartitionTable != null)
+            if (!string.IsNullOrEmpty(_subpath))
+            {
+                // The restore target is a single partition, so the partition table
+                // of the target disk must not be modified.
+                Log.WriteWarningMessage(LOGTAG, "PartitionTableRestoreSkipped", null,
+                    "Skipping partition table restore because the restore target is a partition, not a whole disk.");
+            }
+            else if (_geometryMetadata?.PartitionTable != null)
             {
                 try
                 {

--- a/proprietary/DiskImage/SourceItems/DiskSourceEntry.cs
+++ b/proprietary/DiskImage/SourceItems/DiskSourceEntry.cs
@@ -141,17 +141,19 @@ internal class DiskSourceEntry(SourceProvider provider, IRawDisk disk, string su
             // Now yield the consolidated geometry metadata file with all geometry collected
             yield return new GeometrySourceEntry(this.Path, geometryMetadata);
 
-            // If the source pointed to a specific partition, only emit that one now
-            var subpathmarker = string.IsNullOrWhiteSpace(subpath) || subpath.StartsWith(System.IO.Path.DirectorySeparatorChar)
-                ? subpath
-                : System.IO.Path.DirectorySeparatorChar + subpath;
-
+            // If the source pointed to a specific partition, only emit that one now.
+            // The subpath has no leading or trailing separator (e.g. "part_GPT_1"),
+            // while the partition entry paths end with a separator, so the paths
+            // are normalized before comparing.
+            var subpathmarker = string.IsNullOrWhiteSpace(subpath)
+                ? string.Empty
+                : System.IO.Path.DirectorySeparatorChar + subpath.Trim(System.IO.Path.DirectorySeparatorChar);
 
             // Then yield the actual partition and filesystem entries
             foreach (var partition in partitions)
             {
                 var pse = new PartitionSourceEntry(this.Path, partition, provider.TreatFilesystemAsUnknown);
-                if (string.IsNullOrWhiteSpace(subpathmarker) || pse.Path.EndsWith(subpathmarker))
+                if (string.IsNullOrEmpty(subpathmarker) || IsPartitionPathMatch(pse.Path, subpathmarker))
                     yield return pse;
             }
         }
@@ -160,6 +162,25 @@ internal class DiskSourceEntry(SourceProvider provider, IRawDisk disk, string su
             // No partition table found, still yield the disk geometry
             yield return new GeometrySourceEntry(this.Path, geometryMetadata);
         }
+    }
+
+    /// <summary>
+    /// Checks whether a partition entry path matches the requested subpath marker.
+    /// </summary>
+    /// <param name="partitionPath">The partition entry path, which ends with a directory separator.</param>
+    /// <param name="subpathmarker">The subpath marker, prefixed with a directory separator and without a trailing one (e.g. "\part_GPT_1").</param>
+    /// <returns>True if the subpath targets this partition or an entry inside it; false otherwise.</returns>
+    private static bool IsPartitionPathMatch(string partitionPath, string subpathmarker)
+    {
+        var trimmedPath = partitionPath.TrimEnd(System.IO.Path.DirectorySeparatorChar);
+
+        // The subpath targets this partition
+        if (trimmedPath.EndsWith(subpathmarker, Library.Utility.Utility.ClientFilenameStringComparison))
+            return true;
+
+        // The subpath targets an entry inside this partition (e.g. a folder in its filesystem)
+        var partitionFolder = trimmedPath.Substring(trimmedPath.LastIndexOf(System.IO.Path.DirectorySeparatorChar));
+        return subpathmarker.StartsWith(partitionFolder + System.IO.Path.DirectorySeparatorChar, Library.Utility.Utility.ClientFilenameStringComparison);
     }
 
     /// <inheritdoc />

--- a/proprietary/DiskImage/SourceItems/GeometrySourceEntry.cs
+++ b/proprietary/DiskImage/SourceItems/GeometrySourceEntry.cs
@@ -21,7 +21,7 @@ internal class GeometrySourceEntry : DiskImageEntryBase
     private readonly GeometryMetadata _metadata;
 
     public GeometrySourceEntry(string parentPath, GeometryMetadata metadata)
-        : base(System.IO.Path.Combine(parentPath, "geometry.json"))
+        : base(System.IO.Path.Combine(parentPath, GeometryMetadata.FileName))
     {
         _metadata = metadata;
     }

--- a/proprietary/DiskImage/SourceItems/PartitionInfoSourceEntry.cs
+++ b/proprietary/DiskImage/SourceItems/PartitionInfoSourceEntry.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Proprietary.DiskImage.General;
+
+namespace Duplicati.Proprietary.DiskImage.SourceItems;
+
+/// <summary>
+/// Represents a partition info metadata file as a source entry.
+/// The file lives inside the partition folder so that a restore selection
+/// containing only this partition still carries the partition size and the
+/// filesystem block size (geometry.json sits at the disk level and is not
+/// part of such a selection). The restore provider treats it as a priority file.
+/// </summary>
+internal class PartitionInfoSourceEntry : DiskImageEntryBase
+{
+    private readonly PartitionInfoMetadata _metadata;
+
+    public PartitionInfoSourceEntry(string parentPath, PartitionInfoMetadata metadata)
+        : base(System.IO.Path.Combine(parentPath, PartitionInfoMetadata.FileName))
+    {
+        _metadata = metadata;
+    }
+
+    /// <inheritdoc />
+    public override bool IsFolder => false;
+    /// <inheritdoc />
+    public override bool IsMetaEntry => false;
+    /// <inheritdoc />
+    public override long Size => Encoding.UTF8.GetByteCount(_metadata.ToJson());
+    /// <summary>
+    /// Gets the last modification time. Always the current time, so partition info
+    /// is always backed up, as block sizes and partition sizes may change.
+    /// </summary>
+    /// <inheritdoc />
+    public override DateTime LastModificationUtc => DateTime.UtcNow;
+
+    public PartitionInfoMetadata Metadata => _metadata;
+
+    public override Task<Stream> OpenRead(CancellationToken cancellationToken)
+    {
+        var json = _metadata.ToJson();
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return Task.FromResult<Stream>(new MemoryStream(bytes));
+    }
+
+    public override async IAsyncEnumerable<ISourceProviderEntry> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // Partition info entries are leaf nodes - no children
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    public override async Task<Dictionary<string, string?>> GetMinorMetadata(CancellationToken cancellationToken)
+    {
+        var metadata = await base.GetMinorMetadata(cancellationToken);
+
+        // Add partition info specific metadata
+        metadata["diskimage:Type"] = "partitioninfo";
+        metadata["partitioninfo:Version"] = _metadata.Version.ToString();
+
+        if (_metadata.Filesystem != null)
+        {
+            metadata["filesystem:Type"] = _metadata.Filesystem.Type.ToString();
+            metadata["filesystem:BlockSize"] = _metadata.Filesystem.BlockSize.ToString();
+        }
+
+        return metadata;
+    }
+}

--- a/proprietary/DiskImage/SourceItems/PartitionSourceEntry.cs
+++ b/proprietary/DiskImage/SourceItems/PartitionSourceEntry.cs
@@ -42,6 +42,8 @@ internal class PartitionSourceEntry(string parentPath, IPartition partition, boo
     /// <inheritdoc />
     public override async IAsyncEnumerable<ISourceProviderEntry> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // Create a filesystem parser based on the detected filesystem type
+        // If the filesystem is unknown, fall back to raw block-level access
         IFilesystem fs = TreatFilesystemAsUnknown || partition.FilesystemType == FileSystemType.Unknown
             ? new UnknownFilesystem(partition)
             : partition.FilesystemType switch
@@ -50,7 +52,31 @@ internal class PartitionSourceEntry(string parentPath, IPartition partition, boo
                 FileSystemType.NTFS => new NtfsFilesystem(partition),
                 _ => new UnknownFilesystem(partition)
             };
-        yield return new FilesystemSourceEntry(this.Path, fs);
+
+        var filesystemEntry = new FilesystemSourceEntry(this.Path, fs);
+
+        // Emit the partition info file first, so that a restore selection containing
+        // only this partition still carries the partition size and filesystem block
+        // size (geometry.json sits at the disk level and is not part of such a selection)
+        var info = new PartitionInfoMetadata
+        {
+            Partition = new PartitionGeometry
+            {
+                Number = partition.PartitionNumber,
+                Type = partition.Type,
+                StartOffset = partition.StartOffset,
+                Size = partition.Size,
+                Name = partition.Name,
+                FilesystemType = partition.FilesystemType,
+                VolumeGuid = partition.VolumeGuid,
+                TableType = partition.PartitionTable.TableType
+            },
+            Filesystem = await filesystemEntry.GetFilesystemGeometry(cancellationToken)
+        };
+        yield return new PartitionInfoSourceEntry(this.Path, info);
+
+        // Yield filesystem-specific entries
+        yield return filesystemEntry;
     }
 
     /// <inheritdoc />

--- a/proprietary/DiskImage/SourceProvider.cs
+++ b/proprietary/DiskImage/SourceProvider.cs
@@ -124,10 +124,8 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
 
     private async Task<object> GetDiskAsync(string path, CancellationToken cancellationToken)
     {
-        var prefix = GetDevicePrefix();
-        List<string> parts = [.. path[prefix.Length..].Split(Path.DirectorySeparatorChar, 2)];
-        var physicalDrivePath = prefix + parts.First();
-        _subpath = parts.Count > 1 ? parts[1] : string.Empty;
+        var (physicalDrivePath, subpath) = SplitDeviceAndSubpath(path);
+        _subpath = subpath;
 
         if (OperatingSystem.IsWindows())
         {
@@ -269,6 +267,32 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
             return Linux.Prefix;
         else
             throw new PlatformNotSupportedException(Strings.PlatformNotSupported);
+    }
+
+    /// <summary>
+    /// Splits a host-and-path value (e.g. from a device URL) into the disk device
+    /// path and an optional subpath within the disk hierarchy (e.g. a partition
+    /// segment such as "part_GPT_1").
+    /// </summary>
+    /// <param name="hostAndPath">The host and path value to split.</param>
+    /// <returns>
+    /// A tuple with the disk device path and the subpath. The subpath is empty when
+    /// the value targets the whole disk.
+    /// </returns>
+    public static (string DevicePath, string Subpath) SplitDeviceAndSubpath(string hostAndPath)
+    {
+        var prefix = GetDevicePrefix();
+        if (!hostAndPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return (hostAndPath, string.Empty);
+
+        var remainder = hostAndPath[prefix.Length..];
+        var separatorIndex = remainder.IndexOf(Path.DirectorySeparatorChar);
+        if (separatorIndex < 0)
+            return (hostAndPath, string.Empty);
+
+        var devicePath = prefix + remainder[..separatorIndex];
+        var subpath = remainder[(separatorIndex + 1)..].Trim(Path.DirectorySeparatorChar);
+        return (devicePath, subpath);
     }
 
     /// <inheritdoc />

--- a/proprietary/DiskImage/SourceProvider.cs
+++ b/proprietary/DiskImage/SourceProvider.cs
@@ -104,7 +104,7 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
     public IList<ICommandLineArgument> SupportedCommands => OptionsHelper.SupportedCommands;
 
     /// <inheritdoc />
-    public bool NeedsStoredMetadata => false;
+    public bool NeedsStoredMetadata => true;
 
     /// <summary>
     /// Gets a value indicating whether to treat filesystems as unknown (force raw block-based backup).

--- a/proprietary/DiskImage/WebModule.cs
+++ b/proprietary/DiskImage/WebModule.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,10 +54,7 @@ public class WebModule : IWebModule
             return res;
         }
 
-        var prefix = SourceProvider.GetDevicePrefix();
-        List<string> parts = [.. path[prefix.Length..].Split(Path.DirectorySeparatorChar, 2)];
-        var physicalDrivePath = prefix + parts.First();
-        var subpath = parts.Last();
+        var (physicalDrivePath, subpath) = SourceProvider.SplitDeviceAndSubpath(path);
 
         using var client = new SourceProvider("diskimage://" + physicalDrivePath, "", new Dictionary<string, string?>(options));
         await client.InitializeAsync(cancellationToken);
@@ -75,7 +71,9 @@ public class WebModule : IWebModule
         var result = new Dictionary<string, string>();
         await foreach (var entry in targetEntry.Enumerate(cancellationToken))
         {
-            if (entry.Path.EndsWith("geometry.json", StringComparison.OrdinalIgnoreCase))
+            if (entry.Path.EndsWith(GeometryMetadata.FileName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (entry.Path.EndsWith(PartitionInfoMetadata.FileName, StringComparison.OrdinalIgnoreCase))
                 continue;
             var metadata = await entry.GetMinorMetadata(cancellationToken);
             if (metadata.ContainsKey("partition:Number"))


### PR DESCRIPTION
This PR adds the option to choose a single disk partition as the backup source. This is functionally the same as selecting the full disk and filtering the unwanted partition, but choosing the specific partition is a bit more intuitive in some cases.

Additionally, this also adds support for restoring a partition to a partition. This can be used in cases where the disk contains multiple partitions and only a single partition should be restored.

After this PR it is possible to do disk-to-disk restores as before, but also partion-to-partition restores. Even if the source is a full disk, it is possible to pick a single partition and target that at another partition for restoring.

This also fixes a bug where failing to restore a priority file would leave the restore stuck until the user cancelled it.