### PR TITLE
Keep a "+" in the path of a WebDAV destination

### DIFF
--- a/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
+++ b/Duplicati/Library/Backend/WEBDAV/WEBDAV.cs
@@ -26,6 +26,8 @@ using Duplicati.Library.Utility.Options;
 using System.Net;
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend
 {
     public class WEBDAV : IStreamingBackend, IRenameEnabledBackend
@@ -157,6 +159,25 @@ namespace Duplicati.Library.Backend
             m_propfindPathPrefixes = null!;
         }
 
+        /// <summary>
+        /// Turns the path from the destination url into the one used against the server: rooted,
+        /// ending in a separator, and decoded.
+        /// </summary>
+        /// <remarks>
+        /// The decoding has to leave a "+" alone. Only a query string spells a space that way, so
+        /// reading it as one renames a folder called "My+Folder" to "My Folder" and nothing found
+        /// at the destination matches afterwards. Reported as issue #4880.
+        /// </remarks>
+        /// <param name="path">The path from the url</param>
+        /// <returns>The path to use against the server</returns>
+        internal static string NormalizePath(string path)
+        {
+            if (!path.StartsWith("/", StringComparison.Ordinal))
+                path = "/" + path;
+
+            return Utility.UrlEncoding.UrlPathDecode(Util.AppendDirSeparator(path, "/"));
+        }
+
         public WEBDAV(string url, Dictionary<string, string?> options)
         {
             var u = new Utility.RelaxedUri(url);
@@ -185,12 +206,7 @@ namespace Duplicati.Library.Backend
             m_url = u.SetScheme(m_certificateOptions.UseSSL ? "https" : "http").SetCredentials(null, null).SetQuery(null).ToString();
             m_url = Util.AppendDirSeparator(m_url, "/");
 
-            m_path = u.Path;
-            if (!m_path.StartsWith("/", StringComparison.Ordinal))
-                m_path = "/" + m_path;
-            m_path = Util.AppendDirSeparator(m_path, "/");
-
-            m_path = Utility.UrlEncoding.UrlDecode(m_path);
+            m_path = NormalizePath(u.Path);
             m_rawurl = new Utility.RelaxedUri(m_certificateOptions.UseSSL ? "https" : "http", u.Host, m_path).ToString();
 
             int port = u.Port;
@@ -238,7 +254,7 @@ namespace Duplicati.Library.Backend
             if (path == null)
                 return;
 
-            var normalized = Utility.UrlEncoding.UrlDecode(path.Replace("+", "%2B"));
+            var normalized = Utility.UrlEncoding.UrlPathDecode(path);
 
             if (!normalized.StartsWith("/", StringComparison.Ordinal))
                 normalized = "/" + normalized;
@@ -264,17 +280,17 @@ namespace Duplicati.Library.Backend
                 }
                 else
                 {
-                    var decodedValue = Utility.UrlEncoding.UrlDecode(trimmed.Replace("+", "%2B"));
+                    var decodedValue = Utility.UrlEncoding.UrlPathDecode(trimmed);
                     return ExtractRelativeFromDecodedPath(decodedValue);
                 }
             }
 
-            var decodedPath = Utility.UrlEncoding.UrlDecode(hrefUri.AbsolutePath.Replace("+", "%2B"));
+            var decodedPath = Utility.UrlEncoding.UrlPathDecode(hrefUri.AbsolutePath);
             var name = ExtractRelativeFromDecodedPath(decodedPath);
             if (!string.IsNullOrEmpty(name))
                 return name;
 
-            var decodedHref = Utility.UrlEncoding.UrlDecode(trimmed.Replace("+", "%2B"));
+            var decodedHref = Utility.UrlEncoding.UrlPathDecode(trimmed);
             return ExtractRelativeFromDecodedPath(decodedHref);
         }
 
@@ -329,7 +345,7 @@ namespace Duplicati.Library.Backend
             if (string.IsNullOrWhiteSpace(hrefValue))
                 return null;
 
-            string name = Utility.UrlEncoding.UrlDecode(hrefValue.Replace("+", "%2B"));
+            string name = Utility.UrlEncoding.UrlPathDecode(hrefValue);
 
             string cmp_path;
 

--- a/Duplicati/Library/Utility/UrlEncoding.cs
+++ b/Duplicati/Library/Utility/UrlEncoding.cs
@@ -100,12 +100,29 @@ namespace Duplicati.Library.Utility
         private static readonly System.Text.RegularExpressions.Regex RE_NUMBER = new System.Text.RegularExpressions.Regex(@"(\%(?<number>([0-9]|[a-f]|[A-F]){2}))|(\+)|(\%u(?<unicode>([0-9]|[a-f]|[A-F]){4}))", System.Text.RegularExpressions.RegexOptions.Compiled);
 
         /// <summary>
+        /// Decodes the path part of a URL, where a "+" is the character itself rather than a
+        /// space. Only a query string spells a space that way, so decoding a path with
+        /// <see cref="UrlDecode"/> turns a folder named "a+b" into one named "a b".
+        /// </summary>
+        /// <returns>The decoded path</returns>
+        /// <param name="value">The path to decode</param>
+        /// <param name="encoding">The encoding to use</param>
+        public static string UrlPathDecode(string value, System.Text.Encoding? encoding = null)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            return UrlDecode(value, encoding, plusIsSpace: false);
+        }
+
+        /// <summary>
         /// Decodes a URL, like System.Web.HttpUtility.UrlDecode
         /// </summary>
         /// <returns>The decoded URL</returns>
         /// <param name="value">The URL fragment to decode</param>
         /// <param name="encoding">The encoding to use</param>
-        public static string UrlDecode(string value, System.Text.Encoding? encoding = null)
+        /// <param name="plusIsSpace">True to read "+" as a space, as a query string spells it</param>
+        public static string UrlDecode(string value, System.Text.Encoding? encoding = null, bool plusIsSpace = true)
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
@@ -119,7 +136,7 @@ namespace Duplicati.Library.Utility
             return RE_NUMBER.Replace(value, (m) =>
             {
                 if (m.Value == "+")
-                    return " ";
+                    return plusIsSpace ? " " : "+";
 
                 try
                 {

--- a/Duplicati/UnitTest/UrlEncodingTests.cs
+++ b/Duplicati/UnitTest/UrlEncodingTests.cs
@@ -54,6 +54,27 @@ namespace Duplicati.UnitTest
 
         [Test]
         [Category("Utility")]
+        public static void PlusIsACharacterInAPath()
+        {
+            // Only a query string spells a space as a plus, so a folder named "a+b" keeps its
+            // name. Decoding a path with UrlDecode instead renames it to "a b", which is what
+            // issue #4880 was about.
+            Assert.AreEqual("a+b", Library.Utility.UrlEncoding.UrlPathDecode("a+b"));
+            Assert.AreEqual("a b", Library.Utility.UrlEncoding.UrlPathDecode("a%20b"));
+            Assert.AreEqual("a+b", Library.Utility.UrlEncoding.UrlPathDecode("a%2Bb"));
+
+            // The rest of the decoding is unchanged
+            Assert.AreEqual("Mäppe", Library.Utility.UrlEncoding.UrlPathDecode("M%C3%A4ppe"));
+            Assert.AreEqual("æ", Library.Utility.UrlEncoding.UrlPathDecode("%u00e6"));
+
+            // And what the five call sites in the WebDAV backend spell by hand is the same thing
+            Assert.AreEqual(
+                Library.Utility.UrlEncoding.UrlDecode("a+b%20c".Replace("+", "%2B")),
+                Library.Utility.UrlEncoding.UrlPathDecode("a+b%20c"));
+        }
+
+        [Test]
+        [Category("Utility")]
         public static void MultiByteSequencesAreDecoded()
         {
             // Every %XX is matched on its own, so decoding a character that takes

--- a/Duplicati/UnitTest/WebDavUrlTests.cs
+++ b/Duplicati/UnitTest/WebDavUrlTests.cs
@@ -1,0 +1,50 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Duplicati.Library.Backend;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The path names the folder at the destination, so what it decodes to has to be the folder
+    /// the user asked for. Reported as issue #4880, where a "+" in the path was read as a space.
+    /// </summary>
+    [TestFixture]
+    public class WebDavUrlTests
+    {
+        // A plus is a character here. Only a query string spells a space that way.
+        [TestCase("My+Folder", "/My+Folder/")]
+        [TestCase("a+b/c+d", "/a+b/c+d/")]
+        // An encoded plus is the same character
+        [TestCase("My%2BFolder", "/My+Folder/")]
+        // A space is spelled the way a path spells one
+        [TestCase("My%20Folder", "/My Folder/")]
+        // The rest of the decoding is unchanged
+        [TestCase("M%C3%A4ppe", "/Mäppe/")]
+        [TestCase("Backup/Sub", "/Backup/Sub/")]
+        // Already rooted and already ending in a separator
+        [TestCase("/Backup/", "/Backup/")]
+        public void ThePathKeepsWhatTheUserAskedFor(string path, string expected)
+            => Assert.AreEqual(expected, WEBDAV.NormalizePath(path), path);
+    }
+}


### PR DESCRIPTION
Fixes #4880.

## The report

A WebDAV destination whose path contains a `+` reports missing data files on every backup, although every file was uploaded. The reporter worked around it by taking the `+` out of the path.

## Cause

`UrlEncoding.UrlDecode` reads a `+` as a space:

https://github.com/duplicati/duplicati/blob/6eac8af8fca6dd28a4c4de84b71b40ba0a12ffa1/Duplicati/Library/Utility/UrlEncoding.cs#L121-L122

That is the `application/x-www-form-urlencoded` rule. It applies to a query string, not to a path. The WebDAV backend applied it to the destination path, so `/My+Folder/` became `/My Folder/` and nothing listed at the destination matched it afterwards.

## The expected behaviour was already in the file

Five other places in `WEBDAV.cs` already guard against exactly this, on the response side:

```csharp
Utility.UrlEncoding.UrlDecode(path.Replace("+", "%2B"))
```

So this is not a judgement call about what a `+` in a path should mean — the file already answers it. The response side was fixed and the entry point was left out.

Those five lines are hand-writing a function that does not exist. The encode side has the pair:

| | |
|---|---|
| `UrlEncode(value, encoding, spacevalue = "+")` | choose what a space becomes |
| `UrlPathEncode(value, encoding)` | thin wrapper passing `"%20"` |
| `UrlDecode(value, encoding)` | `+` → space, fixed. **no counterpart** |

## The change

- `UrlDecode` takes an optional `plusIsSpace`, in the same shape as `UrlEncode`'s `spacevalue`. **The default is unchanged**, and a test now holds it in place — `UrlDecode` has many callers and this must not move under them.
- `UrlPathDecode` is the thin wrapper over it, mirroring how `UrlPathEncode` wraps `UrlEncode`.
- WebDAV's constructor uses it — **this is the reported bug**.
- The five `.Replace("+", "%2B")` sites use it too. That is the same operation said by name; a test asserts the two spellings are equal before the replacement was made.
- The constructor's path handling moved into an `internal static NormalizePath` so a test can reach it, following the existing `SSHv2.ParseSshUrl`.

## Tests

`WebDavUrlTests` is new and drives `NormalizePath`. Before the change:

```
失敗 ThePathKeepsWhatTheUserAskedFor("My+Folder","/My+Folder/")
  Expected: "/My+Folder/"
  But was:  "/My Folder/"
```

which is the reported symptom. `%20` still decodes to a space, `%2B` to a `+`, and `M%C3%A4ppe` to `Mäppe` — the existing decoding is untouched.

`UrlEncodingTests` gains `PlusIsACharacterInAPath`, next to the existing `PlusDecodesToSpace` that fixes the default.

Because `UrlDecode` is used widely, the URL-parsing tests were run together: `UrlEncodingTests`, `UriUtilityTests`, `SshUrlTests`, `FtpUrlTests`, `SmbUrlTests`, `TahoeUrlTests`, `PCloudUrlTests`, `S3BackendEndpointParsingTests`, `WebDavUrlTests` — **263 passed, 0 failed**. A full `--no-incremental` build adds no warning.

## Reported, not changed

Two other backends decode a path with the same call:

- [`Dropbox.cs:51`](https://github.com/duplicati/duplicati/blob/6eac8af8fca6dd28a4c4de84b71b40ba0a12ffa1/Duplicati/Library/Backend/Dropbox/Dropbox.cs#L51) — `UrlDecode(uri.HostAndPath)`
- [`MicrosoftGraphBackend.cs:683`](https://github.com/duplicati/duplicati/blob/6eac8af8fca6dd28a4c4de84b71b40ba0a12ffa1/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs#L683) — `UrlDecode(uri.HostAndPath)`

They should have the same problem, but I cannot verify that against the real services, and the report is about WebDAV. Stating it rather than changing it — `UrlPathDecode` is now there if a maintainer wants to.

`SSHv2Backend.cs:638` also calls `UrlDecode`, but on inline key data rather than a path, so it is not affected.
