### PR TITLE
Ask for the AWSSDK.Core and Azure.Core the rest of the solution resolves

### DIFF
--- a/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
+++ b/Duplicati/Library/SecretProvider/Duplicati.Library.SecretProvider.csproj
@@ -13,8 +13,12 @@
     <PackageReference Include="AWSSDK.SecretsManager.Caching" Version="2.0.0" />
     <!-- Include this transitive package to ensure the latest version of AWSSDK.SecretsManager is used -->
     <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.100.3" />
+    <!-- And this one, so it asks for the AWSSDK.Core the rest of the solution already resolves -->
+    <PackageReference Include="AWSSDK.Core" Version="4.0.100.5" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
+    <!-- Neither of the two above asks for the Azure.Core the rest of the solution resolves -->
+    <PackageReference Include="Azure.Core" Version="1.55.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
     <PackageReference Include="Google.Cloud.SecretManager.V1" Version="2.6.0" />
     <PackageReference Include="SharpAESCrypt" Version="3.0.0" />


### PR DESCRIPTION
Follows [#7176](https://github.com/duplicati/duplicati/pull/7176) and [#7179](https://github.com/duplicati/duplicati/pull/7179), and waited on [#7175](https://github.com/duplicati/duplicati/pull/7175) because that one edited the same file.

**There is no demonstrated runtime harm here.** The goal is consistency, not a bug fix — the applications already resolve one version of each of these. Saying so up front so this is judged for what it is.

## What splits

Counting packages that resolve to more than one version across the 104 projects in `Duplicati.slnx`, read from `obj/project.assets.json` after a restore: **4 of 289**. Three of them come from `Duplicati.Library.SecretProvider.csproj` alone.

| package | secret provider | everyone else |
|---|---|---|
| AWSSDK.Core | 4.0.100.3 | 4.0.100.5 (29 projects) |
| Azure.Core | 1.54.0 | 1.55.0 (27 projects) |
| System.ClientModel | 1.10.0 | 1.11.0 (27 projects) |

## It is only behind when compiled on its own

The applications that ship the secret provider already resolve the higher versions, because they also reach `AWSSDK.Core` through the S3 backend and `Azure.Core` through `Azure.Storage.Blobs`:

| project | AWSSDK.Core | Azure.Core | System.ClientModel |
|---|---|---|---|
| `Duplicati.GUI.TrayIcon` | 4.0.100.5 | 1.55.0 | 1.11.0 |
| `Duplicati.Server` | 4.0.100.5 | 1.55.0 | 1.11.0 |
| `Duplicati.Library.SecretProvider` | **4.0.100.3** | **1.54.0** | **1.10.0** |

So `AWSSecretProvider.cs` and `AzureSecretProvider.cs` are compiled against three versions they never run on — the same shape as the certificate store being compiled against SharpAESCrypt 2.0.3 while 3.0.0 was what shipped (#7176).

## Why a version bump does not fix it

- `AWSSDK.SecretsManager 4.0.100.3` asks for `AWSSDK.Core` in `[4.0.100.3, 5.0.0)`. Nothing else in this project asks for more, so it lands on the floor.
- **Azure cannot be fixed by moving a direct reference.** `Azure.Identity 1.21.0` and `Azure.Security.KeyVault.Secrets 4.11.0` are both the current versions on nuget.org, and they ask for `Azure.Core` 1.53.0 and 1.54.0. Naming `Azure.Core` is the only way to reach 1.55.0.

## The change

Two lines, in the way this file and the S3 backend already name a transitive package to raise it:

```xml
<!-- this file, already there -->
<!-- Force load a newer version here -->
<PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.0" />

<!-- Duplicati.Library.Backend.S3.csproj:13, and ReleaseBuilder.csproj:12 -->
<PackageReference Include="AWSSDK.Core" Version="4.0.100.5" />
```

At **the version the applications resolve, not a newer one**, so nothing that ships moves. `System.ClientModel` needs no line of its own — `Azure.Core 1.55.0` asks for 1.11.0.

## Result

```
split packages   before  4
                 after   1
```

The one left is `System.IO.Hashing`, which splits because `Minio` is deliberately held at 6.0.0. **This leaves no unintended split in the solution.**

## Checked

- `dotnet restore Duplicati.slnx` — **no NU warnings** (no NU1605 downgrade; 4.0.100.5 and 1.55.0 are above every floor asked for)
- `TrayIcon` and `Server` resolve **exactly what they did before** — that is the evidence nothing shipped moves
- `dotnet build Duplicati.slnx -c Debug --no-incremental` — 0 errors, and the same 3 warnings as master (the existing `secrets.DBus.cs` CS0618). The build is the real check here: both providers now compile against the newer SDKs.
- `SecretProviderHelperTests` and `SecretProviderSetSecretTests` — 17 passed, 6 skipped (they need `DUPLICATI_TEST_*` or testcontainers), 0 failed

## Noticed, not changed

Both need a decision that is not mine to make, so stating them rather than acting:

- **`AWSSDK.SecretsManager.Caching 2.0.0` is not used by any `.cs` file.** Neither `SecretsManagerCache` nor the `Amazon.SecretsManager.Extensions.Caching` namespace appears anywhere in the tree. In practice its only effect is to pull `AWSSDK.SecretsManager` in, which the line below it then raises. The current version is 3.0.0, a major bump.
- **`AWSSDK.SecretsManager` is at 4.0.100.3; the current version is 4.0.100.10.** Moving it does not help here: 4.0.100.10 asks for `AWSSDK.Core >= 4.0.102`, so it would make this project the *high* one and require moving the S3 backend's pin too. That is an update-the-packages change, not an alignment one.
