### PR TITLE
Add labels to backup versions

### DIFF
--- a/Duplicati/CommandLine/CLI/Commands.cs
+++ b/Duplicati/CommandLine/CLI/Commands.cs
@@ -389,10 +389,11 @@ namespace Duplicati.CommandLine
                 outwriter.WriteLine("Listing filesets:");
                 foreach (var e in res.Filesets)
                 {
+                    var label = string.IsNullOrWhiteSpace(e.Label) ? "" : $" [{e.Label}]";
                     if (e.FileCount != null && e.FileSizes != null && e.IsFullBackup != null)
-                        outwriter.WriteLine($"{e.Version}\t: {e.Time} ({e.FileCount.Value} files, {Library.Utility.Utility.FormatSizeString(e.FileSizes.Value)}){(e.IsFullBackup.Value ? "" : ", partial")}");
+                        outwriter.WriteLine($"{e.Version}\t: {e.Time}{label} ({e.FileCount.Value} files, {Library.Utility.Utility.FormatSizeString(e.FileSizes.Value)}){(e.IsFullBackup.Value ? "" : ", partial")}");
                     else
-                        outwriter.WriteLine($"{e.Version}\t: {e.Time}");
+                        outwriter.WriteLine($"{e.Version}\t: {e.Time}{label}");
                 }
             }
 
@@ -581,10 +582,11 @@ namespace Duplicati.CommandLine
 
                     foreach (var e in res.Filesets)
                     {
+                        var label = string.IsNullOrWhiteSpace(e.Label) ? "" : $" [{e.Label}]";
                         if (e.FileCount >= 0)
-                            outwriter.WriteLine("{0}\t: {1} ({2} files, {3})", e.Version, e.Time, e.FileCount, Library.Utility.Utility.FormatSizeString(e.FileSizes));
+                            outwriter.WriteLine("{0}\t: {1}{2} ({3} files, {4})", e.Version, e.Time, label, e.FileCount, Library.Utility.Utility.FormatSizeString(e.FileSizes));
                         else
-                            outwriter.WriteLine("{0}\t: {1}", e.Version, e.Time);
+                            outwriter.WriteLine("{0}\t: {1}{2}", e.Version, e.Time, label);
                     }
                 }
                 else if (isRequestForFiles)
@@ -1330,6 +1332,50 @@ namespace Duplicati.CommandLine
                 setup(i);
                 foreach (var l in i.SendMailAsync().Await().Lines)
                     outwriter.WriteLine(l);
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Updates the label of a backup version.
+        /// The version and label are given as arguments;
+        /// an empty label clears the label.
+        /// </summary>
+        public static int SetVersionLabel(
+            TextWriter outwriter,
+            Action<Duplicati.Library.Main.Controller> setup,
+            List<string> args,
+            Dictionary<string, string> options,
+            Library.Utility.IFilter filter)
+        {
+            if (args.Count != 3)
+                return PrintWrongNumberOfArguments(outwriter, args, 3);
+
+            if (!long.TryParse(args[1], out var version))
+            {
+                outwriter.WriteLine("The version must be a number, got: \"{0}\"", args[1]);
+                return 200;
+            }
+
+            options["version"] = version.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            options["version-name"] = args[2];
+
+            using (var console = new ConsoleOutput(outwriter, options))
+            using (var controller = new Library.Main.Controller(args[0], options, console))
+            {
+                setup(controller);
+                var res = controller.SetVersionLabelAsync().Await();
+
+                if (console.FullResults)
+                {
+                    Library.Utility.Utility.PrintSerializeObject(res, outwriter);
+                    outwriter.WriteLine();
+                }
+                else
+                {
+                    outwriter.WriteLine("Updated label for version {0} ({1}) to \"{2}\"", res.BackupVersion, res.Time, res.Label);
+                }
             }
 
             return 0;

--- a/Duplicati/CommandLine/CLI/Program.cs
+++ b/Duplicati/CommandLine/CLI/Program.cs
@@ -103,6 +103,8 @@ namespace Duplicati.CommandLine
                         ["vacuum"] = Commands.Vacuum,
                         ["set-locks"] = Commands.SetLocks,
                         ["setlocks"] = Commands.SetLocks,
+                        ["set-version-label"] = Commands.SetVersionLabel,
+                        ["setversionlabel"] = Commands.SetVersionLabel,
                         ["read-lock-info"] = Commands.ReadLockInfo,
                         ["readlockinfo"] = Commands.ReadLockInfo,
                         ["system-info"] = Commands.SystemInfo,

--- a/Duplicati/CommandLine/CLI/help.txt
+++ b/Duplicati/CommandLine/CLI/help.txt
@@ -16,6 +16,7 @@ See %CLI_EXE% help <topic> for more information.
   Searching: list-filesets, list-folder-contents, list-file-versions, search-files
   Repair: repair, affected, list-broken-files, purge-broken-files
   Locking: set-locks, read-lock-info
+  Versions: set-version-label
   Debug: debug, logging, create-report, test-filters, system-info, send-mail
   Targets: %BACKENDS%
   Modules: %ENCRYPTIONMODULES%, %COMPRESSIONMODULES%, %GENERICMODULES%
@@ -396,6 +397,21 @@ Usage: %CLI_EXE% set-locks <storage-URL> [<options>]
   --remote-file-lock-duration=<time>
     Sets how long the remote volumes should be protected (for example, 30D).
     The lock expiration is computed as: now + file-lock-duration.
+
+# =============================================================================
+> duplicati.commandline.exe help set-version-label
+> duplicati.commandline.exe help setversionlabel
+
+Usage: %CLI_EXE% set-version-label <storage-URL> <version> <label> [<options>]
+
+  Updates the label of a backup version.
+  This operation requires a local database (set --dbpath if it is not found automatically).
+
+  The version is the number reported by the list-filesets command.
+  Use an empty label ("") to clear the label.
+
+  The label is stored in the local database and included in the fileset
+  of the next backup. Labels could be lost if no new backup is made.
 
 # =============================================================================
 > duplicati.commandline.exe help read-lock-info

--- a/Duplicati/CommandLine/DatabaseTool/Scripts/Local/20. Remove label from fileset.sql
+++ b/Duplicati/CommandLine/DatabaseTool/Scripts/Local/20. Remove label from fileset.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "Fileset_Temp" (
+    "ID" INTEGER PRIMARY KEY,
+    "OperationID" INTEGER NOT NULL,
+    "VolumeID" INTEGER NOT NULL,
+    "IsFullBackup" INTEGER NOT NULL,
+    "Timestamp" INTEGER NOT NULL
+);
+
+INSERT INTO "Fileset_Temp" (
+    "ID", "OperationID", "VolumeID", "IsFullBackup", "Timestamp"
+)
+SELECT
+    "ID", "OperationID", "VolumeID", "IsFullBackup", "Timestamp"
+FROM "Fileset";
+
+DROP TABLE "Fileset";
+ALTER TABLE "Fileset_Temp" RENAME TO "Fileset";

--- a/Duplicati/Library/Interface/ResultInterfaces.cs
+++ b/Duplicati/Library/Interface/ResultInterfaces.cs
@@ -106,6 +106,10 @@ namespace Duplicati.Library.Interface
         DateTime Time { get; }
         long FileCount { get; }
         long FileSizes { get; }
+        /// <summary>
+        /// The label assigned to the version, or null if no label is set
+        /// </summary>
+        string Label { get; }
     }
 
     public interface IListResults : IBasicResults
@@ -140,6 +144,29 @@ namespace Duplicati.Library.Interface
         /// The size of the files in the fileset; not set if listing remote
         /// </summary>
         long? FileSizes { get; }
+        /// <summary>
+        /// The label assigned to the version; not set if listing remote or no label is set
+        /// </summary>
+        string Label { get; }
+    }
+
+    /// <summary>
+    /// The result of a set version label operation
+    /// </summary>
+    public interface ISetVersionLabelResults : IBasicResults
+    {
+        /// <summary>
+        /// The backup version that was updated
+        /// </summary>
+        long BackupVersion { get; }
+        /// <summary>
+        /// The timestamp of the version that was updated
+        /// </summary>
+        DateTime Time { get; }
+        /// <summary>
+        /// The label that was assigned, or null if the label was cleared
+        /// </summary>
+        string Label { get; }
     }
 
     /// <summary>

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -229,6 +229,12 @@ namespace Duplicati.Library.Main
             ).ConfigureAwait(false);
 
         /// <inheritdoc />
+        public async Task<ISetVersionLabelResults> SetVersionLabelAsync()
+            => await RunActionAsync(new SetVersionLabelResults(), null, null, false, static config =>
+                Operation.SetVersionLabelHandler.RunAsync(config.Options, config.Result)
+            ).ConfigureAwait(false);
+
+        /// <inheritdoc />
         public async Task<IListFolderResults> ListFolderAsync(string[] folders, long offset, long limit, bool extendedData)
             => await RunActionAsync(new ListFolderResults(), folders, null, new { offset, limit, extendedData }, static config =>
                 Operation.ListFolderHandler.RunAsync(config.Options, config.Result, config.Paths, config.Context.offset, config.Context.limit, config.Context.extendedData)

--- a/Duplicati/Library/Main/Database/Local/Database schema/20. Add label to fileset table.sql
+++ b/Duplicati/Library/Main/Database/Local/Database schema/20. Add label to fileset table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Fileset" ADD COLUMN "Label" TEXT NULL;

--- a/Duplicati/Library/Main/Database/Local/Database schema/Schema.sql
+++ b/Duplicati/Library/Main/Database/Local/Database schema/Schema.sql
@@ -64,7 +64,8 @@ CREATE TABLE "Fileset" (
 	"OperationID" INTEGER NOT NULL,
 	"VolumeID" INTEGER NOT NULL,
 	"IsFullBackup" INTEGER NOT NULL,
-	"Timestamp" INTEGER NOT NULL
+	"Timestamp" INTEGER NOT NULL,
+	"Label" TEXT NULL
 );
 
 /*
@@ -297,4 +298,4 @@ CREATE TABLE "ChangeJournalData" (
     "ConfigHash" TEXT NOT NULL  
 );
 
-INSERT INTO "Version" ("Version") VALUES (19);
+INSERT INTO "Version" ("Version") VALUES (20);

--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -3102,6 +3102,53 @@ namespace Duplicati.Library.Main.Database.Local
         }
 
         /// <summary>
+        /// Updates the label of a fileset.
+        /// </summary>
+        /// <param name="filesetId">The fileset to update.</param>
+        /// <param name="label">The label to set, or null to clear the label.</param>
+        /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes when the update is finished.</returns>
+        public async Task UpdateFilesetLabelAsync(long filesetId, string? label, CancellationToken token)
+        {
+            await using var cmd = await m_connection.CreateCommandAsync(@"
+                UPDATE ""Fileset""
+                SET ""Label"" = @Label
+                WHERE ""ID"" = @FilesetId
+            ", token)
+                .ConfigureAwait(false);
+
+            await cmd.SetTransaction(m_rtr)
+                .SetParameterValue("@FilesetId", filesetId)
+                .SetParameterValue("@Label", string.IsNullOrWhiteSpace(label) ? null : label)
+                .ExecuteNonQueryAsync(true, token)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the timestamp and label of all filesets that have a non-null label.
+        /// </summary>
+        /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
+        /// <returns>An asynchronous enumerable of key-value pairs, where each pair contains the fileset timestamp (UTC) and its label.</returns>
+        public async IAsyncEnumerable<KeyValuePair<DateTime, string>> GetFilesetLabelsAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            await using var cmd = await m_connection.CreateCommandAsync(@"
+                SELECT
+                    ""Timestamp"",
+                    ""Label""
+                FROM ""Fileset""
+                WHERE ""Label"" IS NOT NULL
+            ", token)
+                .ConfigureAwait(false);
+
+            await using var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false);
+            while (await rd.ReadAsync(token).ConfigureAwait(false))
+                yield return new KeyValuePair<DateTime, string>(
+                    ParseFromEpochSeconds(rd.ConvertValueToInt64(0)),
+                    rd.ConvertValueToString(1) ?? ""
+                );
+        }
+
+        /// <summary>
         /// Removes all entries in the fileset entry table for a given fileset ID.
         /// </summary>
         /// <param name="filesetId">The fileset ID to clear.</param>

--- a/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
@@ -310,7 +310,8 @@ namespace Duplicati.Library.Main.Database.Local
             cmd.SetCommandAndParameters(@"
                     SELECT
                         ""IsFullBackup"",
-                        ""Timestamp""
+                        ""Timestamp"",
+                        ""Label""
                     FROM ""Fileset""
                     ORDER BY ""Timestamp"" DESC
                 ");
@@ -324,7 +325,8 @@ namespace Duplicati.Library.Main.Database.Local
                     reader.GetInt32(0),
                     ParseFromEpochSeconds(reader.ConvertValueToInt64(1)).ToLocalTime(),
                     -1L,
-                    -1L
+                    -1L,
+                    reader.ConvertValueToString(2)
                 );
             }
         }

--- a/Duplicati/Library/Main/Database/Local/LocalListAffectedDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListAffectedDatabase.cs
@@ -80,6 +80,10 @@ namespace Duplicati.Library.Main.Database.Local
             /// Gets or sets the total size of files in the fileset.
             /// </summary>
             public long FileSizes { get; set; }
+            /// <summary>
+            /// Gets or sets the label assigned to the fileset, if any.
+            /// </summary>
+            public string? Label { get; set; }
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListDatabase.cs
@@ -117,6 +117,10 @@ namespace Duplicati.Library.Main.Database.Local
             /// Gets the total sizes of files in the fileset.
             /// </summary>
             long FileSizes { get; }
+            /// <summary>
+            /// Gets the label assigned to the fileset, or null if no label is set.
+            /// </summary>
+            string? Label { get; }
         }
 
         /// <summary>
@@ -226,7 +230,8 @@ namespace Duplicati.Library.Main.Database.Local
                         SELECT DISTINCT
                             ""ID"" AS ""FilesetID"",
                             ""IsFullBackup"" AS ""IsFullBackup"",
-                            ""Timestamp"" AS ""Timestamp""
+                            ""Timestamp"" AS ""Timestamp"",
+                            ""Label"" AS ""Label""
                         FROM ""Fileset"" {Query}
                     ", Values, token)
                         .ConfigureAwait(false);
@@ -269,6 +274,10 @@ namespace Duplicati.Library.Main.Database.Local
                 /// The total sizes of files in this fileset.
                 /// </summary>
                 public long FileSizes { get; private set; }
+                /// <summary>
+                /// The label assigned to this fileset, if any.
+                /// </summary>
+                public string? Label { get; private set; }
 
                 /// <summary>
                 /// Initializes a new instance of the <see cref="Fileset"/> class.
@@ -278,13 +287,15 @@ namespace Duplicati.Library.Main.Database.Local
                 /// <param name="time">The timestamp of the fileset, indicating when it was created.</param>
                 /// <param name="filecount">The count of files in this fileset.</param>
                 /// <param name="filesizes">The total sizes of files in this fileset.</param>
-                public Fileset(long version, int isFullBackup, DateTime time, long filecount, long filesizes)
+                /// <param name="label">The label assigned to the fileset, if any.</param>
+                public Fileset(long version, int isFullBackup, DateTime time, long filecount, long filesizes, string? label)
                 {
                     Version = version;
                     IsFullBackup = isFullBackup;
                     Time = time;
                     FileCount = filecount;
                     FileSizes = filesizes;
+                    Label = label;
                 }
             }
 
@@ -796,7 +807,8 @@ namespace Duplicati.Library.Main.Database.Local
                 await using var rd = await cmd.ExecuteReaderAsync(@"
                     SELECT DISTINCT
                         ""ID"",
-                        ""IsFullBackup""
+                        ""IsFullBackup"",
+                        ""Label""
                     FROM ""Fileset""
                     ORDER BY ""Timestamp"" DESC
                 ", token)
@@ -805,6 +817,7 @@ namespace Duplicati.Library.Main.Database.Local
                 {
                     var id = rd.ConvertValueToInt64(0);
                     var backupType = rd.GetInt32(1);
+                    var label = rd.ConvertValueToString(2);
                     var e = dict[id];
 
                     yield return new Fileset(
@@ -812,7 +825,8 @@ namespace Duplicati.Library.Main.Database.Local
                         backupType,
                         m_filesets[e].Value,
                         -1L,
-                        -1L
+                        -1L,
+                        label
                     );
                 }
             }
@@ -848,7 +862,8 @@ namespace Duplicati.Library.Main.Database.Local
                         ""A"".""FilesetID"",
                         ""A"".""IsFullBackup"",
                         ""B"".""FileCount"",
-                        ""B"".""FileSizes""
+                        ""B"".""FileSizes"",
+                        ""A"".""Label""
                     FROM ""{m_tablename}"" ""A""
                     LEFT OUTER JOIN ( {summation} ) ""B""
                         ON ""A"".""FilesetID"" = ""B"".""FilesetID""
@@ -863,13 +878,15 @@ namespace Duplicati.Library.Main.Database.Local
                     var e = dict[id];
                     var filecount = rd.ConvertValueToInt64(2, -1L);
                     var filesizes = rd.ConvertValueToInt64(3, -1L);
+                    var label = rd.ConvertValueToString(4);
 
                     yield return new Fileset(
                         e,
                         isFullBackup,
                         m_filesets[e].Value,
                         filecount,
-                        filesizes
+                        filesizes,
+                        label
                     );
                 }
             }
@@ -917,7 +934,8 @@ namespace Duplicati.Library.Main.Database.Local
         /// <param name="Time">The timestamp of the fileset.</param>
         /// <param name="FileCount">The number of files in the fileset.</param>
         /// <param name="FileSizes">>The total size of files in the fileset.</param>
-        private sealed record FilesetEntry(long Version, long ID, bool? IsFullBackup, DateTime Time, long? FileCount, long? FileSizes) : IListFilesetResultFileset;
+        /// <param name="Label">The label assigned to the fileset, if any.</param>
+        private sealed record FilesetEntry(long Version, long ID, bool? IsFullBackup, DateTime Time, long? FileCount, long? FileSizes, string? Label) : IListFilesetResultFileset;
 
         /// <summary>
         /// Lists all filesets with summary data.
@@ -932,7 +950,8 @@ namespace Duplicati.Library.Main.Database.Local
                     ""f"".""Timestamp"",
                     ""f"".""IsFullBackup"",
                     COUNT(""fe"".""FileID"") AS ""NumberOfFiles"",
-                    COALESCE(SUM(""b"".""Length""), 0) AS ""TotalFileSize""
+                    COALESCE(SUM(""b"".""Length""), 0) AS ""TotalFileSize"",
+                    ""f"".""Label""
                 FROM ""Fileset"" ""f""
                 LEFT JOIN ""FilesetEntry"" ""fe""
                     ON ""f"".""ID"" = ""fe"".""FilesetID""
@@ -953,13 +972,15 @@ namespace Duplicati.Library.Main.Database.Local
                 var isFullBackup = rd.GetInt32(2) == BackupType.FULL_BACKUP;
                 var filecount = rd.ConvertValueToInt64(3, -1L);
                 var filesizes = rd.ConvertValueToInt64(4, -1L);
+                var label = rd.ConvertValueToString(5);
 
                 yield return new FilesetEntry(
                     version++, id,
                     isFullBackup,
                     time,
                     filecount,
-                    filesizes
+                    filesizes,
+                    label
                 );
             }
         }

--- a/Duplicati/Library/Main/Enums.cs
+++ b/Duplicati/Library/Main/Enums.cs
@@ -76,7 +76,8 @@ namespace Duplicati.Library.Main
         SearchFiles,
         SetLock,
         ReadLockInfo,
-        RemoteSynchronization
+        RemoteSynchronization,
+        SetVersionLabel
     }
 
     /// <summary>

--- a/Duplicati/Library/Main/IController.cs
+++ b/Duplicati/Library/Main/IController.cs
@@ -251,6 +251,14 @@ public interface IController : IDisposable
     Task<ISetLockResults> SetLocksAsync();
 
     /// <summary>
+    /// Updates the label of a backup version.
+    /// The version is selected with the --version option and the label
+    /// with the --version-name option; an empty label clears the label.
+    /// </summary>
+    /// <returns>The set version label results</returns>
+    Task<ISetVersionLabelResults> SetVersionLabelAsync();
+
+    /// <summary>
     /// Sets the secret provider to use for all operations
     /// </summary>
     /// <param name="secretProvider">The secret provider to use</param>

--- a/Duplicati/Library/Main/IPC/ControllerRpcProxy.cs
+++ b/Duplicati/Library/Main/IPC/ControllerRpcProxy.cs
@@ -427,6 +427,10 @@ public class ControllerRpcProxy : IController, IDisposable, IControllerRpcCallba
         => await Rpc.InvokeAsync<ISetLockResults>(nameof(IController.SetLocksAsync)).ConfigureAwait(false);
 
     /// <inheritdoc />
+    public async Task<ISetVersionLabelResults> SetVersionLabelAsync()
+        => await Rpc.InvokeAsync<ISetVersionLabelResults>(nameof(IController.SetVersionLabelAsync)).ConfigureAwait(false);
+
+    /// <inheritdoc />
     public async Task<IReadLockInfoResults> ReadLockInfoAsync()
         => await Rpc.InvokeAsync<IReadLockInfoResults>(nameof(IController.ReadLockInfoAsync)).ConfigureAwait(false);
 

--- a/Duplicati/Library/Main/IPC/ControllerRpcServer.cs
+++ b/Duplicati/Library/Main/IPC/ControllerRpcServer.cs
@@ -101,6 +101,8 @@ public class ControllerRpcServer : IController, IDisposable
                         operation = OperationMode.ListRemote;
                     else if (results is ISetLockResults)
                         operation = OperationMode.SetLock;
+                    else if (results is ISetVersionLabelResults)
+                        operation = OperationMode.SetVersionLabel;
                     else if (results is IReadLockInfoResults)
                         operation = OperationMode.ReadLockInfo;
 
@@ -199,6 +201,10 @@ public class ControllerRpcServer : IController, IDisposable
     /// <inheritdoc />
     public Task<ISetLockResults> SetLocksAsync()
         => Controller.SetLocksAsync();
+
+    /// <inheritdoc />
+    public Task<ISetVersionLabelResults> SetVersionLabelAsync()
+        => Controller.SetVersionLabelAsync();
 
     /// <inheritdoc />
     public Task<IReadLockInfoResults> ReadLockInfoAsync()

--- a/Duplicati/Library/Main/IPC/Dto/ResultsDto.cs
+++ b/Duplicati/Library/Main/IPC/Dto/ResultsDto.cs
@@ -414,6 +414,36 @@ public class SetLockResultsDto : BasicResultsDto
 }
 
 /// <summary>
+/// DTO for set version label results
+/// </summary>
+[Serializable]
+public class SetVersionLabelResultsDto : BasicResultsDto
+{
+    public long BackupVersion { get; set; }
+    public DateTime Time { get; set; }
+    public string Label { get; set; }
+
+    public static SetVersionLabelResultsDto FromResults(ISetVersionLabelResults results)
+    {
+        if (results == null) return null;
+        return new SetVersionLabelResultsDto
+        {
+            BeginTime = results.BeginTime,
+            EndTime = results.EndTime,
+            Duration = results.Duration,
+            Errors = results.Errors?.ToList() ?? new List<string>(),
+            Warnings = results.Warnings?.ToList() ?? new List<string>(),
+            Messages = results.Messages?.ToList() ?? new List<string>(),
+            ParsedResult = results.ParsedResult,
+            Interrupted = results.Interrupted,
+            BackupVersion = results.BackupVersion,
+            Time = results.Time,
+            Label = results.Label
+        };
+    }
+}
+
+/// <summary>
 /// DTO for remote synchronization results
 /// </summary>
 [Serializable]
@@ -539,6 +569,7 @@ public class ListResultFilesetDto
     public DateTime Time { get; set; }
     public long FileCount { get; set; }
     public long FileSizes { get; set; }
+    public string Label { get; set; }
 
     public static ListResultFilesetDto FromResult(IListResultFileset result)
     {
@@ -549,7 +580,8 @@ public class ListResultFilesetDto
             IsFullBackup = result.IsFullBackup,
             Time = result.Time,
             FileCount = result.FileCount,
-            FileSizes = result.FileSizes
+            FileSizes = result.FileSizes,
+            Label = result.Label
         };
     }
 }
@@ -613,6 +645,7 @@ public class ListFilesetResultFilesetDto
     public DateTime Time { get; set; }
     public long? FileCount { get; set; }
     public long? FileSizes { get; set; }
+    public string Label { get; set; }
 
     public static ListFilesetResultFilesetDto FromResult(IListFilesetResultFileset result)
     {
@@ -623,7 +656,8 @@ public class ListFilesetResultFilesetDto
             IsFullBackup = result.IsFullBackup,
             Time = result.Time,
             FileCount = result.FileCount,
-            FileSizes = result.FileSizes
+            FileSizes = result.FileSizes,
+            Label = result.Label
         };
     }
 }

--- a/Duplicati/Library/Main/IPC/ResultWrappers.cs
+++ b/Duplicati/Library/Main/IPC/ResultWrappers.cs
@@ -229,6 +229,20 @@ public class SetLockResultsWrapper : BasicResultsWrapper, ISetLockResults
 }
 
 /// <summary>
+/// Wrapper for set version label results
+/// </summary>
+public class SetVersionLabelResultsWrapper : BasicResultsWrapper, ISetVersionLabelResults
+{
+    public SetVersionLabelResultsWrapper(SetVersionLabelResultsDto dto) : base(dto) { }
+
+    protected new SetVersionLabelResultsDto _dto => (SetVersionLabelResultsDto)base._dto;
+
+    public long BackupVersion => _dto.BackupVersion;
+    public DateTime Time => _dto.Time;
+    public string Label => _dto.Label;
+}
+
+/// <summary>
 /// Wrapper for remote synchronization results
 /// </summary>
 public class RemoteSynchronizationResultsWrapper : BasicResultsWrapper, IRemoteSynchronizationResults
@@ -302,6 +316,7 @@ public class ListResultFilesetWrapper : IListResultFileset
     public DateTime Time => _dto.Time;
     public long FileCount => _dto.FileCount;
     public long FileSizes => _dto.FileSizes;
+    public string Label => _dto.Label;
 }
 
 /// <summary>
@@ -350,6 +365,7 @@ public class ListFilesetResultFilesetWrapper : IListFilesetResultFileset
     public DateTime Time => _dto.Time;
     public long? FileCount => _dto.FileCount;
     public long? FileSizes => _dto.FileSizes;
+    public string Label => _dto.Label;
 }
 
 /// <summary>

--- a/Duplicati/Library/Main/IPC/RpcJsonOptions.cs
+++ b/Duplicati/Library/Main/IPC/RpcJsonOptions.cs
@@ -119,6 +119,7 @@ public class ResultsDtoConverterFactory : JsonConverterFactory
         [typeof(ICreateLogDatabaseResults)] = (typeof(CreateLogDatabaseResultsDto), typeof(CreateLogDatabaseResultsWrapper)),
         [typeof(IListRemoteResults)] = (typeof(ListRemoteResultsDto), typeof(ListRemoteResultsWrapper)),
         [typeof(ISetLockResults)] = (typeof(SetLockResultsDto), typeof(SetLockResultsWrapper)),
+        [typeof(ISetVersionLabelResults)] = (typeof(SetVersionLabelResultsDto), typeof(SetVersionLabelResultsWrapper)),
         [typeof(IReadLockInfoResults)] = (typeof(ReadLockInfoResultsDto), typeof(ReadLockInfoResultsWrapper)),
         [typeof(IRecreateDatabaseResults)] = (typeof(RecreateDatabaseResultsDto), typeof(RecreateDatabaseResultsWrapper)),
         [typeof(IPurgeFilesResults)] = (typeof(PurgeFilesResultsDto), typeof(PurgeFilesResultsWrapper)),

--- a/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
+++ b/Duplicati/Library/Main/Operation/Backup/BackupDatabase.cs
@@ -362,6 +362,25 @@ namespace Duplicati.Library.Main.Operation.Backup
             );
         }
 
+        public Task UpdateFilesetLabelAsync(long filesetid, string label, CancellationToken cancellationToken)
+        {
+            return RunOnMainAsync(async () =>
+                await m_database
+                    .UpdateFilesetLabelAsync(filesetid, label, cancellationToken)
+                    .ConfigureAwait(false)
+            );
+        }
+
+        public Task<KeyValuePair<DateTime, string>[]> GetFilesetLabelsAsync(CancellationToken cancellationToken)
+        {
+            return RunOnMainAsync(async () =>
+                await m_database
+                    .GetFilesetLabelsAsync(cancellationToken)
+                    .ToArrayAsync(cancellationToken: cancellationToken)
+                    .ConfigureAwait(false)
+            );
+        }
+
         public Task<IAsyncEnumerable<string>> GetMissingIndexFilesAsync(CancellationToken cancellationToken)
         {
             return RunOnMainAsync(() => m_database.GetMissingIndexFilesAsync(cancellationToken));

--- a/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadRealFilelist.cs
@@ -61,6 +61,13 @@ internal static class UploadRealFilelist
                 await taskreader.ProgressRendevouzAsync().ConfigureAwait(false);
 
                 await db.WriteFilesetAsync(filesetvolume, filesetid, taskreader.ProgressToken).ConfigureAwait(false);
+
+                // Best effort: store the current set of labels with the backup,
+                // so they can be recovered if the local database is recreated
+                var labels = await db.GetFilesetLabelsAsync(taskreader.ProgressToken).ConfigureAwait(false);
+                if (labels.Length > 0)
+                    filesetvolume.AddLabelsFile(labels);
+
                 filesetvolume.Close();
 
                 // We ignore the stop signal, but not the pause and terminate

--- a/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
+++ b/Duplicati/Library/Main/Operation/Backup/UploadSyntheticFilelist.cs
@@ -106,6 +106,13 @@ namespace Duplicati.Library.Main.Operation.Backup
                 await database.AppendFilesFromPreviousSetAsync(null, newFilesetID, prevId, fileTime, taskreader.ProgressToken).ConfigureAwait(false);
 
                 await database.WriteFilesetAsync(fsw, newFilesetID, taskreader.ProgressToken).ConfigureAwait(false);
+
+                // Best effort: store the current set of labels with the backup,
+                // so they can be recovered if the local database is recreated
+                var labels = await database.GetFilesetLabelsAsync(taskreader.ProgressToken).ConfigureAwait(false);
+                if (labels.Length > 0)
+                    fsw.AddLabelsFile(labels);
+
                 fsw.Close();
 
                 if (!await taskreader.ProgressRendevouzAsync().ConfigureAwait(false))

--- a/Duplicati/Library/Main/Operation/BackupHandler.cs
+++ b/Duplicati/Library/Main/Operation/BackupHandler.cs
@@ -699,6 +699,12 @@ namespace Duplicati.Library.Main.Operation
                                 .CreateFilesetAsync(filesetvolumeid, VolumeBase.ParseFilename(filesetvolume.RemoteFilename).Time, m_taskReader.ProgressToken)
                                 .ConfigureAwait(false);
 
+                            // Record the version label, if one is set
+                            if (!string.IsNullOrWhiteSpace(m_options.VersionName))
+                                await db
+                                    .UpdateFilesetLabelAsync(filesetid, m_options.VersionName, m_taskReader.ProgressToken)
+                                    .ConfigureAwait(false);
+
                             var journalService = GetJournalService(source, filter, lastfilesetid);
 
                             // Start parallel scan, or use the database

--- a/Duplicati/Library/Main/Operation/ListFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListFilesHandler.cs
@@ -92,7 +92,7 @@ namespace Duplicati.Library.Main.Operation
                         m_result.SetResult(
                             await filesets
                                 .QuickSetsAsync(m_result.TaskControl.ProgressToken)
-                                .Select(x => new ListResultFileset(x.Version, x.IsFullBackup, x.Time, x.FileCount, x.FileSizes))
+                                .Select(x => new ListResultFileset(x.Version, x.IsFullBackup, x.Time, x.FileCount, x.FileSizes, x.Label))
                                 .ToArrayAsync(cancellationToken: m_result.TaskControl.ProgressToken)
                                 .ConfigureAwait(false),
                             null
@@ -103,7 +103,7 @@ namespace Duplicati.Library.Main.Operation
                         m_result.SetResult(
                             await filesets
                                 .SetsAsync(m_result.TaskControl.ProgressToken)
-                                .Select(x => new ListResultFileset(x.Version, x.IsFullBackup, x.Time, x.FileCount, x.FileSizes))
+                                .Select(x => new ListResultFileset(x.Version, x.IsFullBackup, x.Time, x.FileCount, x.FileSizes, x.Label))
                                 .ToArrayAsync(cancellationToken: m_result.TaskControl.ProgressToken)
                                 .ConfigureAwait(false),
                             files == null

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -254,6 +254,11 @@ namespace Duplicati.Library.Main.Operation
             var filelistWork = (from n in filelists orderby n.Time select new RemoteVolume(n.File) as IRemoteVolume).ToList();
             Logging.Log.WriteInformationMessage(LOGTAG, "RebuildStarted", "Rebuild database started, downloading {0} filelists", filelistWork.Count);
 
+            // The newest filelist is the authority for version labels,
+            // even if it does not contain a labels.json file
+            var newestFilelistName = filelists.First().File.Name;
+            IReadOnlyDictionary<DateTime, string> remoteLabels = null;
+
             var progress = 0;
 
             // Register the files we are working with, if not already updated
@@ -330,6 +335,11 @@ namespace Duplicati.Library.Main.Operation
 
                         await RecreateFilesetFromRemoteListAsync(restoredb, compressor, filesetid, m_options, filter, m_result.TaskControl.ProgressToken)
                             .ConfigureAwait(false);
+
+                        // Grab the labels from the newest filelist volume;
+                        // they are applied as the final step of the recreate
+                        if (string.Equals(name, newestFilelistName, StringComparison.Ordinal))
+                            remoteLabels = VolumeReaderBase.GetLabelsData(compressor);
                     }
                 }
                 catch (Exception ex)
@@ -685,6 +695,10 @@ namespace Duplicati.Library.Main.Operation
 
             await restoredb.CleanupMissingVolumesAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false);
 
+            // Apply the labels from the newest filelist as the final step of the recreate
+            await ApplyLabelsFromFilelistAsync(restoredb, remoteLabels, m_result.TaskControl.ProgressToken)
+                .ConfigureAwait(false);
+
             if (!m_options.RepairOnlyPaths && m_options.StoreMetadataContentInDatabase)
             {
                 await RestoreMetadataContentAsync(backendManager, restoredb, m_result.TaskControl.ProgressToken)
@@ -744,6 +758,68 @@ namespace Duplicati.Library.Main.Operation
             }
 
             m_result.EndTime = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// The maximum time a fileset timestamp may be newer than the label timestamp
+        /// and still be considered a match. Filelist timestamps can drift slightly
+        /// when the remote filename is probed or recreated, so an exact match is
+        /// not guaranteed.
+        /// </summary>
+        private static readonly TimeSpan MAX_LABEL_TIMESTAMP_DRIFT = TimeSpan.FromSeconds(15);
+
+        /// <summary>
+        /// Applies the labels found in the newest filelist volume to the recreated database.
+        /// The labels are matched to filesets by timestamp; as filelist timestamps can
+        /// drift slightly, the nearest fileset with a timestamp that is the same or newer
+        /// than the label timestamp, within <see cref="MAX_LABEL_TIMESTAMP_DRIFT"/>, is used.
+        /// </summary>
+        /// <param name="restoredb">The database being recreated.</param>
+        /// <param name="labels">The labels read from the newest filelist volume, or null if the newest filelist was not processed.</param>
+        /// <param name="token">Cancellation token to monitor for cancellation requests.</param>
+        /// <returns>A task that completes when the labels have been applied.</returns>
+        private static async Task ApplyLabelsFromFilelistAsync(LocalRecreateDatabase restoredb, IReadOnlyDictionary<DateTime, string> labels, CancellationToken token)
+        {
+            if (labels == null || labels.Count == 0)
+                return;
+
+            var filesets = await restoredb
+                .FilesetTimesAsync(token)
+                .ToArrayAsync(cancellationToken: token)
+                .ConfigureAwait(false);
+
+            var updated = 0;
+            foreach (var (labeltime, label) in labels)
+            {
+                var labeltimeUtc = labeltime.ToUniversalTime();
+
+                // Find the fileset with the nearest timestamp that is the same or
+                // newer than the label timestamp, within the allowed drift
+                var best = filesets
+                    .Select(x => new { FilesetId = x.Key, Drift = x.Value.ToUniversalTime() - labeltimeUtc })
+                    .Where(x => x.Drift >= TimeSpan.Zero && x.Drift <= MAX_LABEL_TIMESTAMP_DRIFT)
+                    .OrderBy(x => x.Drift)
+                    .FirstOrDefault();
+
+                if (best == null)
+                {
+                    Logging.Log.WriteWarningMessage(LOGTAG, "LabelWithoutMatchingFileset", null, "No fileset found matching the label \"{0}\" with timestamp {1:u}", label, labeltimeUtc);
+                    continue;
+                }
+
+                await restoredb
+                    .UpdateFilesetLabelAsync(best.FilesetId, label, token)
+                    .ConfigureAwait(false);
+                updated++;
+            }
+
+            if (updated > 0)
+            {
+                Logging.Log.WriteInformationMessage(LOGTAG, "LabelsRestoredFromFilelist", "Restored {0} version labels from the filelist volume", updated);
+                await restoredb.Transaction
+                    .CommitAsync(token)
+                    .ConfigureAwait(false);
+            }
         }
 
         private sealed record MetadataBlockRef(long MetadataId, long BlockIndex, string BlockHash, long BlockSize);

--- a/Duplicati/Library/Main/Operation/SetVersionLabelHandler.cs
+++ b/Duplicati/Library/Main/Operation/SetVersionLabelHandler.cs
@@ -1,0 +1,90 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Logging;
+using Duplicati.Library.Main.Database.Local;
+
+namespace Duplicati.Library.Main.Operation
+{
+    /// <summary>
+    /// Handler for updating the label of a backup version.
+    /// The label is stored in the local database and will be included
+    /// in the labels.json file of the next backup; no new filelist volume
+    /// is written just to update a label.
+    /// </summary>
+    internal static class SetVersionLabelHandler
+    {
+        /// <summary>
+        /// The tag used for logging
+        /// </summary>
+        private static readonly string LOGTAG = Log.LogTagFromType(typeof(SetVersionLabelHandler));
+
+        /// <summary>
+        /// Updates the label of a backup version in the local database.
+        /// </summary>
+        /// <param name="options">The options to use</param>
+        /// <param name="result">The result class</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        public static async Task RunAsync(Options options, SetVersionLabelResults result)
+        {
+            var token = result.TaskControl.ProgressToken;
+
+            if (options.Version == null || options.Version.Length != 1)
+                throw new UserInformationException("You must specify exactly one version to update the label for", "NoVersionSpecifiedForLabelUpdate");
+
+            if (string.IsNullOrWhiteSpace(options.Dbpath) || !File.Exists(options.Dbpath))
+                throw new UserInformationException("The local database does not exist, the label can only be updated when a local database is present", "LocalDatabaseMissing");
+
+            var version = options.Version[0];
+            var label = options.VersionName;
+
+            await using var db = await LocalListDatabase.CreateAsync(options.Dbpath, null, token)
+                .ConfigureAwait(false);
+
+            var filesets = await db
+                .FilesetTimesAsync(token)
+                .ToArrayAsync(cancellationToken: token)
+                .ConfigureAwait(false);
+
+            if (version < 0 || version >= filesets.Length)
+                throw new UserInformationException($"No such version: {version}", "VersionNotFoundForLabelUpdate");
+
+            var fileset = filesets[version];
+
+            Log.WriteInformationMessage(LOGTAG, "UpdatingVersionLabel", "Setting label for version {0} ({1:u}) to \"{2}\"", version, fileset.Value.ToUniversalTime(), label);
+
+            await db.UpdateFilesetLabelAsync(fileset.Key, label, token).ConfigureAwait(false);
+            await db.Transaction.CommitAsync(token).ConfigureAwait(false);
+
+            result.BackupVersion = version;
+            result.Time = fileset.Value;
+            result.Label = label;
+            result.EndTime = DateTime.UtcNow;
+        }
+    }
+}

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -416,6 +416,7 @@ namespace Duplicati.Library.Main
             new CommandLineArgument("restore-path", CommandLineArgument.ArgumentType.String, Strings.Options.RestorepathShort, Strings.Options.RestorepathLong),
             new CommandLineArgument("time", CommandLineArgument.ArgumentType.DateTime, Strings.Options.TimeShort, Strings.Options.TimeLong, "now"),
             new CommandLineArgument("version", CommandLineArgument.ArgumentType.String, Strings.Options.VersionShort, Strings.Options.VersionLong, ""),
+            new CommandLineArgument("version-name", CommandLineArgument.ArgumentType.String, Strings.Options.VersionnameShort, Strings.Options.VersionnameLong, ""),
             new CommandLineArgument("all-versions", CommandLineArgument.ArgumentType.Boolean, Strings.Options.AllversionsShort, Strings.Options.AllversionsLong, "false"),
             new CommandLineArgument("list-prefix-only", CommandLineArgument.ArgumentType.Boolean, Strings.Options.ListprefixonlyShort, Strings.Options.ListprefixonlyLong, "false"),
             new CommandLineArgument("soft-delete-prefix", CommandLineArgument.ArgumentType.String, Strings.Options.SoftdeleteprefixShort, Strings.Options.SoftdeleteprefixLong),
@@ -741,6 +742,11 @@ namespace Duplicati.Library.Main
         /// A value indicating if all versions are listed
         /// </summary>
         public bool AllVersions => GetBool("all-versions");
+
+        /// <summary>
+        /// Gets the label to assign to the backup version, or null if no label is set
+        /// </summary>
+        public string? VersionName => GetString("version-name", null);
 
         /// <summary>
         /// A value indicating if only the largest common prefix is returned

--- a/Duplicati/Library/Main/ResultClasses.cs
+++ b/Duplicati/Library/Main/ResultClasses.cs
@@ -617,17 +617,27 @@ namespace Duplicati.Library.Main
         public DateTime Time { get; private set; }
         public long FileCount { get; private set; }
         public long FileSizes { get; private set; }
-        public ListResultFileset(long version, int isFullBackup, DateTime time, long fileCount, long fileSizes)
+        public string Label { get; private set; }
+        public ListResultFileset(long version, int isFullBackup, DateTime time, long fileCount, long fileSizes, string label = null)
         {
             this.Version = version;
             this.IsFullBackup = isFullBackup;
             this.Time = time;
             this.FileCount = fileCount;
             this.FileSizes = fileSizes;
+            this.Label = label;
         }
     }
 
-    internal sealed record ListFilesetResultFileset(long Version, DateTime Time, bool? IsFullBackup, long? FileCount, long? FileSizes) : IListFilesetResultFileset;
+    internal sealed record ListFilesetResultFileset(long Version, DateTime Time, bool? IsFullBackup, long? FileCount, long? FileSizes, string Label = null) : IListFilesetResultFileset;
+
+    internal class SetVersionLabelResults : BasicResults, ISetVersionLabelResults
+    {
+        public override OperationMode MainOperation => OperationMode.SetVersionLabel;
+        public long BackupVersion { get; set; }
+        public DateTime Time { get; set; }
+        public string Label { get; set; }
+    }
 
 
     internal class ListFilesetResults : BasicResults, IListFilesetResults

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -79,6 +79,8 @@ namespace Duplicati.Library.Main.Strings
         public static string TimeShort { get { return LC.L(@"The time to list/restore files"); } }
         public static string VersionLong { get { return LC.L(@"By default, Duplicati will list and restore files from the most recent backup. Use this option to select another item. You may enter multiple values separated with comma, and ranges using -, e.g. ""0,2-4,7"" ."); } }
         public static string VersionShort { get { return LC.L(@"The version to list/restore files"); } }
+        public static string VersionnameLong { get { return LC.L(@"Use this option to assign a human-readable label to a backup version. When running a backup, the label is recorded in the local database and stored with the backup. When updating a version label, the label is stored in the local database and included in the next backup."); } }
+        public static string VersionnameShort { get { return LC.L(@"A label to assign to the backup version"); } }
         public static string AllversionsLong { get { return LC.L(@"When searching for files, only the most recent backup is searched. Use this option to show all previous versions too."); } }
         public static string AllversionsShort { get { return LC.L(@"Show all versions"); } }
         public static string ListprefixonlyLong { get { return LC.L(@"When searching for files, all matching files are returned. Use this option to return only the largest common prefix path."); } }

--- a/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
+++ b/Duplicati/Library/Main/Volumes/FilesetVolumeWriter.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main.Database.Local;
@@ -220,6 +221,22 @@ namespace Duplicati.Library.Main.Volumes
             using (var sr = new StreamWriter(this.m_compression.CreateFile(FILESET_FILENAME, CompressionHint.Compressible, DateTime.UtcNow), ENCODING))
             {
                 sr.Write(FilesetData.GetFilesetInstance(isFullBackup));
+            }
+        }
+
+        /// <summary>
+        /// Adds the labels.json file to the volume, containing the labels of all backup versions.
+        /// </summary>
+        /// <param name="labels">The labels to write, where the key is the backup timestamp and the value is the label.</param>
+        public void AddLabelsFile(IEnumerable<KeyValuePair<DateTime, string>> labels)
+        {
+            var data = labels.ToDictionary(
+                x => Library.Utility.Utility.SerializeDateTime(x.Key.ToUniversalTime()),
+                x => x.Value);
+
+            using (var sr = new StreamWriter(this.m_compression.CreateFile(LABELS_FILENAME, CompressionHint.Compressible, DateTime.UtcNow), ENCODING))
+            {
+                sr.Write(JsonConvert.SerializeObject(data));
             }
         }
 

--- a/Duplicati/Library/Main/Volumes/VolumeBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeBase.cs
@@ -227,6 +227,7 @@ namespace Duplicati.Library.Main.Volumes
         protected const string FILESET_FILENAME = "fileset";
         protected const string MANIFEST_FILENAME = "manifest";
         protected const string FILELIST = "filelist.json";
+        protected const string LABELS_FILENAME = "labels.json";
 
         protected const string INDEX_VOLUME_FOLDER = "vol/";
         protected const string INDEX_BLOCKLIST_FOLDER = "list/";

--- a/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
+++ b/Duplicati/Library/Main/Volumes/VolumeReaderBase.cs
@@ -29,6 +29,11 @@ namespace Duplicati.Library.Main.Volumes
 {
     public abstract class VolumeReaderBase : VolumeBase, IDisposable
     {
+        /// <summary>
+        /// The tag used for log messages
+        /// </summary>
+        private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(VolumeReaderBase));
+
         public bool IsFullBackup { get; set; }
 
         protected readonly bool m_disposeCompression = false;
@@ -131,6 +136,56 @@ namespace Duplicati.Library.Main.Volumes
                 using (var fs = new StreamReader(s, ENCODING))
                 {
                     return JsonConvert.DeserializeObject<FilesetData>(fs.ReadToEnd());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads the labels.json file from a fileset volume, if present.
+        /// </summary>
+        /// <param name="compressor">The compressor to use</param>
+        /// <returns>A dictionary mapping backup timestamps (UTC) to labels; empty if the volume has no labels file or the file cannot be parsed</returns>
+        public static IReadOnlyDictionary<DateTime, string> GetLabelsData(ICompression compressor)
+        {
+            using (var s = compressor.OpenRead(LABELS_FILENAME))
+            {
+                if (s == null)
+                    return new Dictionary<DateTime, string>();
+
+                using (var fs = new StreamReader(s, ENCODING))
+                {
+                    Dictionary<string, string> data;
+                    try
+                    {
+                        data = JsonConvert.DeserializeObject<Dictionary<string, string>>(fs.ReadToEnd());
+                    }
+                    catch (Exception ex)
+                    {
+                        // A corrupt labels file should not fail the operation using the volume
+                        Logging.Log.WriteWarningMessage(LOGTAG, "InvalidLabelsFile", ex, "Failed to parse the {0} file in the volume, ignoring it", LABELS_FILENAME);
+                        return new Dictionary<DateTime, string>();
+                    }
+
+                    if (data == null)
+                        return new Dictionary<DateTime, string>();
+
+                    var res = new Dictionary<DateTime, string>();
+                    foreach (var kv in data)
+                    {
+                        if (string.IsNullOrWhiteSpace(kv.Value))
+                            continue;
+
+                        try
+                        {
+                            res[Library.Utility.Utility.DeserializeDateTime(kv.Key).ToUniversalTime()] = kv.Value;
+                        }
+                        catch
+                        {
+                            // Ignore entries with unparseable timestamps
+                        }
+                    }
+
+                    return res;
                 }
             }
         }

--- a/Duplicati/Library/RestAPI/Runner.cs
+++ b/Duplicati/Library/RestAPI/Runner.cs
@@ -314,6 +314,27 @@ namespace Duplicati.Server
                 extraOptions ?? new Dictionary<string, string?>());
         }
 
+        /// <summary>
+        /// Creates a task that updates the label of a backup version.
+        /// </summary>
+        /// <param name="backup">The backup to update the version label for</param>
+        /// <param name="version">The version to update</param>
+        /// <param name="label">The label to set, or null to clear the label</param>
+        /// <returns>The runner task</returns>
+        public static IRunnerData CreateSetVersionLabelTask(IBackup backup, long version, string? label)
+        {
+            var dict = new Dictionary<string, string?>
+            {
+                ["version"] = version.ToString(CultureInfo.InvariantCulture),
+                ["version-name"] = label ?? ""
+            };
+
+            return CreateTask(
+                DuplicatiOperation.SetVersionLabel,
+                backup,
+                dict);
+        }
+
         public static IRunnerData CreateListFolderContents(IBackup backup, string[]? folders, DateTime time, int pageSize, int pageOffset, bool returnExtended)
         {
             var dict = new Dictionary<string, string?>();
@@ -1006,6 +1027,12 @@ namespace Duplicati.Server
                         case DuplicatiOperation.ListFilesets:
                             {
                                 var r = await controller.ListFilesetsAsync().ConfigureAwait(false);
+                                UpdateMetadataBase(databaseConnection, eventPollNotify, notificationUpdateService, backup, r);
+                                return r;
+                            }
+                        case DuplicatiOperation.SetVersionLabel:
+                            {
+                                var r = await controller.SetVersionLabelAsync().ConfigureAwait(false);
                                 UpdateMetadataBase(databaseConnection, eventPollNotify, notificationUpdateService, backup, r);
                                 return r;
                             }

--- a/Duplicati/Server/Duplicati.Server.Serialization/Enums.cs
+++ b/Duplicati/Server/Duplicati.Server.Serialization/Enums.cs
@@ -52,6 +52,7 @@ namespace Duplicati.Server.Serialization
         DeleteVersions,
         ListBrokenFiles,
         PurgeBrokenFiles,
+        SetVersionLabel,
     }
 
     public enum SuggestedStatusIcon

--- a/Duplicati/UnitTest/DatabaseUpgraderTests.cs
+++ b/Duplicati/UnitTest/DatabaseUpgraderTests.cs
@@ -50,14 +50,14 @@ namespace Duplicati.UnitTest
         /// last line of <c>Duplicati/Library/Main/Database/Local/Database schema/Schema.sql</c>
         /// and must be kept in sync if the schema is bumped.
         /// </summary>
-        private const int EXPECTED_LATEST_SCHEMA_VERSION = 19;
+        private const int EXPECTED_LATEST_SCHEMA_VERSION = 20;
 
         /// <summary>
         /// The most recent numbered upgrade script in the LocalDatabase schema
-        /// resources, e.g. <c>19. Add metadata content column.sql</c>. This is the
+        /// resources, e.g. <c>20. Add label to fileset table.sql</c>. This is the
         /// last upgrade the upgrader should be able to discover and apply.
         /// </summary>
-        private const int EXPECTED_HIGHEST_UPGRADE_SCRIPT = 19;
+        private const int EXPECTED_HIGHEST_UPGRADE_SCRIPT = 20;
 
         /// <summary>
         /// Calling <c>UpgradeDatabase</c> on a fresh (empty) database should load the
@@ -108,14 +108,14 @@ namespace Duplicati.UnitTest
                 // version: drop the column the most recent upgrade script introduces.
                 DatabaseUpgrader.UpgradeDatabase(db, dbfile, typeof(DatabaseSchemaMarker));
 
-                // The final upgrade script ("19. Add metadata content column.sql") does:
-                //   ALTER TABLE "Metadataset" ADD COLUMN "Content" TEXT NULL;
-                // Remove that column to simulate the pre-upgrade (version 18) state so the
+                // The final upgrade script ("20. Add label to fileset table.sql") does:
+                //   ALTER TABLE "Fileset" ADD COLUMN "Label" TEXT NULL;
+                // Remove that column to simulate the pre-upgrade (version 19) state so the
                 // upgrader has an outstanding upgrade to apply. ALTER TABLE DROP COLUMN
                 // requires SQLite >= 3.35.0, which the bundled Microsoft.Data.Sqlite
                 // runtime ships (3.46.x). If older SQLite versions ever need supporting,
                 // fall back to recreating the table without the column.
-                cmd.CommandText = @"ALTER TABLE ""Metadataset"" DROP COLUMN ""Content""";
+                cmd.CommandText = @"ALTER TABLE ""Fileset"" DROP COLUMN ""Label""";
                 await cmd.ExecuteNonQueryAsync();
 
                 // Pin the recorded version one below the latest so the upgrader has work to do.
@@ -136,8 +136,8 @@ namespace Duplicati.UnitTest
 
                 // The column added by the final upgrade script must now exist again,
                 // proving the upgrade script was actually executed and not just skipped.
-                Assert.IsTrue(await ColumnExistsAsync(db, "Metadataset", "Content"),
-                    "The Metadataset.Content column (added by the final upgrade script) should exist after the upgrade.");
+                Assert.IsTrue(await ColumnExistsAsync(db, "Fileset", "Label"),
+                    "The Fileset.Label column (added by the final upgrade script) should exist after the upgrade.");
             }
         }
 
@@ -204,7 +204,7 @@ namespace Duplicati.UnitTest
 
             // Drop the column the most recent upgrade script introduces, so that
             // re-applying that script is valid.
-            cmd.CommandText = @"ALTER TABLE ""Metadataset"" DROP COLUMN ""Content""";
+            cmd.CommandText = @"ALTER TABLE ""Fileset"" DROP COLUMN ""Label""";
             await cmd.ExecuteNonQueryAsync();
 
             cmd.CommandText = @"UPDATE ""Version"" SET ""Version"" = @ver";

--- a/Duplicati/UnitTest/DeleteHandlerTests.cs
+++ b/Duplicati/UnitTest/DeleteHandlerTests.cs
@@ -39,6 +39,7 @@ namespace Duplicati.UnitTest
             public DateTime Time { get; }
             public long FileCount { get; }
             public long FileSizes { get; }
+            public string Label { get; }
 
             public Fileset(int version, int backupType, DateTime time)
             {

--- a/Duplicati/WebserverCore/Dto/V2/ListFilesetsResponseDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/ListFilesetsResponseDto.cs
@@ -96,4 +96,9 @@ public sealed record ListFilesetsResponseItem
     /// The total size of the fileset
     /// </summary>
     public required long? FileSizes { get; init; }
+
+    /// <summary>
+    /// The label assigned to the version, or null if no label is set
+    /// </summary>
+    public string? Label { get; init; }
 }

--- a/Duplicati/WebserverCore/Dto/V2/SetVersionLabelRequestDto.cs
+++ b/Duplicati/WebserverCore/Dto/V2/SetVersionLabelRequestDto.cs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+namespace Duplicati.WebserverCore.Dto.V2;
+
+/// <summary>
+/// The request DTO for updating the label of a backup version.
+/// </summary>
+public sealed record SetVersionLabelRequestDto
+{
+    /// <summary>
+    /// The backup ID to update the version label for.
+    /// </summary>
+    public required string BackupId { get; init; }
+
+    /// <summary>
+    /// The version to update, as reported by the list-filesets endpoint.
+    /// </summary>
+    public required long Version { get; init; }
+
+    /// <summary>
+    /// The label to assign to the version, or null/empty to clear the label.
+    /// The label is stored in the local database and included in the
+    /// labels.json file of the next backup.
+    /// </summary>
+    public string? Label { get; init; }
+}
+
+/// <summary>
+/// The response DTO for updating the label of a backup version.
+/// </summary>
+public sealed record SetVersionLabelResponseDto
+{
+    /// <summary>
+    /// The version that was updated.
+    /// </summary>
+    public required long Version { get; init; }
+
+    /// <summary>
+    /// The timestamp of the version that was updated.
+    /// </summary>
+    public required DateTime Time { get; init; }
+
+    /// <summary>
+    /// The label that was assigned, or null if the label was cleared.
+    /// </summary>
+    public required string? Label { get; init; }
+}

--- a/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/BackupListing.cs
@@ -106,7 +106,8 @@ public class BackupListing : IEndpointV2
                         Time = x.Time,
                         IsFullBackup = x.IsFullBackup,
                         FileCount = x.FileCount,
-                        FileSizes = x.FileSizes
+                        FileSizes = x.FileSizes,
+                        Label = x.Label
                     })
             );
         }

--- a/Duplicati/WebserverCore/Endpoints/V2/BackupSetVersionLabel.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/BackupSetVersionLabel.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Duplicati.Library.Interface;
+using Duplicati.Server;
+using Duplicati.Server.Database;
+using Duplicati.Server.Serialization.Interface;
+using Duplicati.WebserverCore.Abstractions;
+using Duplicati.WebserverCore.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Duplicati.WebserverCore.Endpoints.V2.Backup;
+
+/// <summary>
+/// Endpoint for updating the label of a backup version.
+/// The label is stored in the local database and included in the
+/// labels.json file of the next backup; updating a label does not
+/// write a new filelist volume.
+/// </summary>
+public class BackupSetVersionLabel : IEndpointV2
+{
+    public static void Map(RouteGroupBuilder group)
+    {
+        group.MapPost("/backup/set-version-label", async ([FromServices] Connection connection, [FromServices] IQueueRunnerService queueRunnerService, [FromBody] Dto.V2.SetVersionLabelRequestDto input)
+            => await ExecuteSetVersionLabelAsync(queueRunnerService, GetBackup(connection, input.BackupId), input).ConfigureAwait(false))
+            .RequireAuthorization();
+    }
+
+    private static IBackup GetBackup(Connection connection, string id)
+        => connection.GetBackup(id) ?? throw new NotFoundException("Backup not found");
+
+    private static async Task<Dto.V2.SetVersionLabelResponseDto> ExecuteSetVersionLabelAsync(IQueueRunnerService queueRunnerService, IBackup bk, Dto.V2.SetVersionLabelRequestDto input)
+    {
+        var r = await queueRunnerService.RunImmediatelyAsync(Runner.CreateSetVersionLabelTask(bk, input.Version, input.Label)).ConfigureAwait(false) as ISetVersionLabelResults;
+        if (r == null)
+            throw new ServerErrorException("No result from set version label operation");
+
+        return new Dto.V2.SetVersionLabelResponseDto()
+        {
+            Version = r.BackupVersion,
+            Time = r.Time,
+            Label = r.Label
+        };
+    }
+}

--- a/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
+++ b/Duplicati/WebserverCore/Services/SystemInfoProvider.cs
@@ -66,6 +66,7 @@ public class SystemInfoProvider(IApplicationSettings applicationSettings, Connec
         "v2:backup:list-broken-files",
         "v2:backup:purge-broken-files",
         "v2:backup:delete-versions",
+        "v2:backup:set-version-label",
 
         // "v1:subscribe:scheduler",
     ];


### PR DESCRIPTION
This PR adds the option to attach a label to a backup version. The labels have no functional purpose but can help mark different versions, if the backups are hand-curated instead of running on a schedule.

This adds the required CLI methods to handle labels, and updates output lists so they include the label.

The web API is also updated to carry the information, so the UI can show and edit labels.