### PR TITLE
Parse the sharepoint url with System.Uri

### DIFF
--- a/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
+++ b/Duplicati/Library/Backend/SharePoint/SharePointBackend.cs
@@ -29,6 +29,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using SP = Microsoft.SharePoint.Client;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend
 {
 
@@ -113,6 +115,59 @@ namespace Duplicati.Library.Backend
 
         #region [Constructors]
 
+        /// <summary>
+        /// The parts of a sharepoint url that the backend configures itself from.
+        /// </summary>
+        /// <param name="Host">The server to connect to. An IPv6 literal keeps its brackets.</param>
+        /// <param name="Port">The port, or -1 when the url does not name one.</param>
+        /// <param name="Path">The path, decoded and without a leading separator, with the double
+        /// slash that marks the end of the web left in place.</param>
+        /// <param name="ServerRelativePath">The same path rooted, ending in a separator and with
+        /// the marker taken out, which is what the requests name folders and files with.</param>
+        /// <param name="Username">The user from the url, or null when it has none.</param>
+        /// <param name="Password">The password from the url, or null when it has none.</param>
+        /// <remarks>
+        /// Both paths are returned so the constructor only has to assign them. The url is the only
+        /// input the backend has, and a test that starts from anything else cannot see what the
+        /// parser did to it on the way in.
+        /// </remarks>
+        internal readonly record struct SharePointUrl(string Host, int Port, string Path, string ServerRelativePath, string? Username, string? Password);
+
+        /// <summary>
+        /// Splits a sharepoint url into the parts the backend needs.
+        /// </summary>
+        /// <param name="url">The url to split.</param>
+        /// <returns>The parts the backend needs.</returns>
+        internal static SharePointUrl ParseSharePointUrl(string url)
+        {
+            var uri = new System.Uri(url);
+            uri.RequireHost(url);
+            uri.RequireNoFragment(url);
+
+            // The path arrives escaped and with its leading separator, where the previous parser
+            // handed it over decoded and without one. A double slash is what the user writes to
+            // say where the web ends, and it survives both the parser and the decoding.
+            var path = System.Uri.UnescapeDataString(uri.AbsolutePath);
+            if (path.StartsWith("/", StringComparison.Ordinal))
+                path = path.Substring(1);
+
+            var serverRelPath = path;
+            if (!serverRelPath.StartsWith("/", StringComparison.Ordinal))
+                serverRelPath = "/" + serverRelPath;
+            serverRelPath = Util.AppendDirSeparator(serverRelPath, "/");
+            // remove marker for SP-Web
+            serverRelPath = serverRelPath.Replace("//", "/");
+
+            // The user info is not decoded, so it is decoded here.
+            var userinfo = uri.UserInfo.Split(new[] { ':' }, 2);
+            var username = userinfo.Length > 0 && userinfo[0].Length > 0 ? System.Uri.UnescapeDataString(userinfo[0]) : null;
+            var password = userinfo.Length > 1 ? System.Uri.UnescapeDataString(userinfo[1]) : null;
+
+            // mssp is not a scheme with a registered default port, so an url without one answers
+            // -1 here, the same way the previous parser did.
+            return new SharePointUrl(uri.Host, uri.Port, path, serverRelPath, username, password);
+        }
+
         public SharePointBackend()
         {
             m_serverRelPath = null!;
@@ -149,21 +204,17 @@ namespace Duplicati.Library.Backend
             catch { }
 
 
-            var u = new Utility.RelaxedUri(url);
-            u.RequireHost();
+            var u = ParseSharePointUrl(url);
 
-            // Create sanitized plain https-URI (note: still has double slashes for processing web)
+            // Create sanitized plain https-URI (note: still has double slashes for processing web).
+            // The builder stays as it was: FindCorrectWebPathAsync makes the candidate web urls
+            // with it and reads them back with the same parser, so the two go together.
             m_orgUrl = new Utility.RelaxedUri("https", u.Host, u.Path, null, null, null, u.Port);
 
             // Actual path to Web will be searched for on first use. Ctor should not throw.
             m_spWebUrl = null;
 
-            m_serverRelPath = u.Path;
-            if (!m_serverRelPath.StartsWith("/", StringComparison.Ordinal))
-                m_serverRelPath = "/" + m_serverRelPath;
-            m_serverRelPath = Util.AppendDirSeparator(m_serverRelPath, "/");
-            // remove marker for SP-Web
-            m_serverRelPath = m_serverRelPath.Replace("//", "/");
+            m_serverRelPath = u.ServerRelativePath;
 
             // Authentication settings processing:
             // Default: try integrated auth (will normally not work for Office365, but maybe with on-prem SharePoint...).

--- a/Duplicati/UnitTest/SharePointUrlTests.cs
+++ b/Duplicati/UnitTest/SharePointUrlTests.cs
@@ -1,0 +1,177 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Covers how a sharepoint url is split into the parts the backend configures itself from.
+    /// Both derived paths are asserted from the whole url, because the parser is what the backend
+    /// sees the url through and a test that starts from a path cannot see what it did.
+    /// </summary>
+    [TestFixture]
+    [Category("UriUtility")]
+    public class SharePointUrlTests
+    {
+        [TestCase("mssp://host", "host", -1)]
+        [TestCase("mssp://host/sites/Team/", "host", -1)]
+        [TestCase("mssp://host:8443/sites/Team/", "host", 8443)]
+        // 443 is the https port, but mssp is not a scheme the url parser knows a default for
+        [TestCase("mssp://host:443/sites/Team/", "host", 443)]
+        [TestCase("mssp://[1:2:3::4]:8443/p/", "[1:2:3::4]", 8443)]
+        [TestCase("mssp://[fe80::1]/p/", "[fe80::1]", -1)]
+        public void TheHostAndPortAreTakenFromTheUrl(string url, string host, int port)
+        {
+            var parsed = SharePointBackend.ParseSharePointUrl(url);
+            Assert.AreEqual(host, parsed.Host, url);
+            Assert.AreEqual(port, parsed.Port, url);
+        }
+
+        /// <summary>
+        /// A double slash is the hint the user writes to say where the sharepoint web ends.
+        /// FindCorrectWebPathAsync looks for it in Path, and ServerRelativePath is the same path
+        /// with the marker taken out, so both have to come out of the parser intact.
+        /// </summary>
+        [TestCase("mssp://host/sites/Team/Docs/", "sites/Team/Docs/", "/sites/Team/Docs/")]
+        [TestCase("mssp://host/sites/Team//Docs/", "sites/Team//Docs/", "/sites/Team/Docs/")]
+        [TestCase("mssp://host/sites/Team///Docs/", "sites/Team///Docs/", "/sites/Team//Docs/")]
+        // A marker in the first position is eaten with the leading separator, as it was before
+        [TestCase("mssp://host//Docs/", "/Docs/", "/Docs/")]
+        [TestCase("mssp://host//", "/", "/")]
+        [TestCase("mssp://host/", "", "/")]
+        [TestCase("mssp://host", "", "/")]
+        // The query carries the backend options and is not part of the path
+        [TestCase("mssp://host/sites/Team//Docs/?integrated-authentication=true", "sites/Team//Docs/", "/sites/Team/Docs/")]
+        public void TheWebMarkerSurvivesInThePathAndIsTakenOutOfTheServerRelativeOne(string url, string path, string serverRelative)
+        {
+            var parsed = SharePointBackend.ParseSharePointUrl(url);
+            Assert.AreEqual(path, parsed.Path, url);
+            Assert.AreEqual(serverRelative, parsed.ServerRelativePath, url);
+        }
+
+        // A '+' is a character in a path. Only a query string spells a space that way, which is
+        // what issue #4880 reported for the webdav backend; this backend read it the same way.
+        [TestCase("mssp://host/sites/My+Folder/", "/sites/My+Folder/")]
+        [TestCase("mssp://host/sites/a+b/c+d/", "/sites/a+b/c+d/")]
+        // The encoded spelling of the same character
+        [TestCase("mssp://host/sites/My%2BFolder/", "/sites/My+Folder/")]
+        // A space is spelled the way a path spells one
+        [TestCase("mssp://host/sites/My%20Folder/", "/sites/My Folder/")]
+        [TestCase("mssp://host/sites/M%C3%A4ppe/", "/sites/Mäppe/")]
+        [TestCase("mssp://host/sites/über/", "/sites/über/")]
+        // A percent sign that is part of the folder name is spelled encoded, and is decoded once
+        [TestCase("mssp://host/sites/a%2520b/", "/sites/a%20b/")]
+        // The path names the remote folder, so its case has to survive
+        [TestCase("mssp://host/Sites/Team/", "/Sites/Team/")]
+        // The path is decoded before the marker is taken out, as it was before
+        [TestCase("mssp://host/a%2Fb/", "/a/b/")]
+        public void TheServerRelativePathKeepsWhatTheUserAskedFor(string url, string expected)
+            => Assert.AreEqual(expected, SharePointBackend.ParseSharePointUrl(url).ServerRelativePath, url);
+
+        [TestCase("mssp://host/p/", null, null)]
+        [TestCase("mssp://user@host/p/", "user", null)]
+        [TestCase("mssp://user:secret@host/p/", "user", "secret")]
+        // A colon with nothing after it is an empty password, not a missing one
+        [TestCase("mssp://user:@host/p/", "user", "")]
+        [TestCase("mssp://us%65r:p%40ss@host/p/", "user", "p@ss")]
+        [TestCase("mssp://user%20name:p%3Ass@host/p/", "user name", "p:ss")]
+        public void TheCredentialsAreDecoded(string url, string? username, string? password)
+        {
+            var parsed = SharePointBackend.ParseSharePointUrl(url);
+            Assert.AreEqual(username, parsed.Username, url);
+            Assert.AreEqual(password, parsed.Password, url);
+        }
+
+        [TestCase("mssp:///p/")]
+        [TestCase("mssp://")]
+        public void AUrlWithoutAHostIsRejected(string url)
+            => Assert.Throws<ArgumentException>(() => SharePointBackend.ParseSharePointUrl(url), url);
+
+        [Test]
+        public void TheHostIsLowerCased()
+        {
+            // The previous parser kept the case. A host name is a dns name or an ip literal and
+            // neither is case sensitive, unlike the path, which still keeps its case above.
+            Assert.AreEqual("host.example.com", SharePointBackend.ParseSharePointUrl("mssp://Host.Example.COM/Sites/Team/").Host);
+        }
+
+        [Test]
+        public void ADotDotSegmentIsResolved()
+        {
+            // The previous parser passed "a/../b" through and named a folder with it.
+            Assert.AreEqual("/b/", SharePointBackend.ParseSharePointUrl("mssp://host/a/../b/").ServerRelativePath);
+        }
+
+        [Test]
+        public void AFragmentIsReportedRatherThanSilentlyDroppingTheRestOfThePath()
+        {
+            // A '#' starts a fragment, so "backup#1" is not a folder name. The previous parser had
+            // no fragment and kept the characters, which quietly used a different folder.
+            Assert.Throws<UserInformationException>(() => SharePointBackend.ParseSharePointUrl("mssp://host/backup#1/"));
+            // The encoded spelling is a folder name and still works
+            Assert.AreEqual("/backup#1/", SharePointBackend.ParseSharePointUrl("mssp://host/backup%231/").ServerRelativePath);
+        }
+
+        [TestCase("mssp://host:99999/p/")]
+        [TestCase("mssp://user:p@ss@host/p/")]
+        public void AUrlThatCannotMeanWhatItSaysIsRejected(string url)
+        {
+            // The previous parser answered port 99999, and read the host of the second one as
+            // "ss@host", so both went somewhere the user did not name.
+            Assert.Throws<UriFormatException>(() => SharePointBackend.ParseSharePointUrl(url), url);
+        }
+
+        /// <summary>
+        /// The constructor is documented as not throwing, because the web is only searched for on
+        /// first use. This is the one place the wiring from the parse method to the fields shows.
+        /// </summary>
+        [Test]
+        public async Task TheConstructorTakesTheUrlAndReportsTheHostAsync()
+        {
+            var backend = new SharePointBackend("mssp://Host.Example.COM/sites/Team//Docs/", new Dictionary<string, string?>());
+
+            Assert.AreEqual("mssp", backend.ProtocolKey);
+            Assert.AreEqual(new[] { "host.example.com" }, await backend.GetDNSNamesAsync(CancellationToken.None));
+        }
+
+        /// <summary>
+        /// The backend loader picks the constructor by argument count.
+        /// </summary>
+        [Test]
+        public void TheLoaderStillFindsTheTwoArgumentConstructor()
+        {
+            var backend = (IBackend)Activator.CreateInstance(
+                typeof(SharePointBackend), "mssp://host/sites/Team/", new Dictionary<string, string?>())!;
+
+            Assert.AreEqual("mssp", backend.ProtocolKey);
+        }
+    }
+}


### PR DESCRIPTION
The last of the five backends [#7145](https://github.com/duplicati/duplicati/pull/7145) listed as able to move off `RelaxedUri`. SSHv2, SMB, FTP, pCloud and Tahoe-LAFS are done; WEBDAV is in [#7200](https://github.com/duplicati/duplicati/pull/7200). This one has no overlap with either.

What decides whether a backend can move is whether the authority is a server name, because `System.Uri` lower-cases it. `mssp` names a server.

## Why it is worth doing here

This backend read a `+` in the path as a space, the same way the webdav one did in [#4880](https://github.com/duplicati/duplicati/issues/4880): the relaxed parser applies the query string rule to the path. A destination in a folder named `My+Folder` named `My Folder` instead. Nobody reported it here, but it is the same defect and the same fix.

## The double slash had to be checked first

Unlike the other four, this backend gives a character in the path a meaning of its own. **A double slash is the hint the user writes to say where the sharepoint web ends:**

```csharp
// Create sanitized plain https-URI (note: still has double slashes for processing web)
...
m_serverRelPath = m_serverRelPath.Replace("//", "/");   // remove marker for SP-Web
```

`FindCorrectWebPathAsync` looks for it with `path.IndexOf("//")`. If `System.Uri` collapsed it, this conversion would not be possible at all. **It does not** — measured, not assumed:

```
mssp://host/sites/Team//Docs/
  before   path sites/Team//Docs/    marker at 10, web hint "sites/Team"
  after    path sites/Team//Docs/    marker at 10, web hint "sites/Team"
```

`..` is resolved, `//` is not. Both were measured against the running parser before any code changed.

## Shape

`ParseSharePointUrl` returns **both** derived paths — the one with the marker, which the web search reads, and the one without, which names folders and files — so the constructor only assigns them:

```csharp
var u = ParseSharePointUrl(url);
m_orgUrl = new Utility.RelaxedUri("https", u.Host, u.Path, null, null, null, u.Port);
m_serverRelPath = u.ServerRelativePath;
```

The url is the only input this backend has, and a test that starts from anything else cannot see what the parser did to it on the way in. That is how #7197 came to be merged without fixing what it was for, so the seam is placed to make that impossible here.

`RequireHost` and `RequireNoFragment` in `Duplicati/Library/Utility/UriExtensions.cs` are reused as they are.

**The builder is left alone.** `FindCorrectWebPathAsync` makes the candidate web urls with `RelaxedUri` and `SharePointBackend.cs:109` / `:667` read them back with the same parser — they are a matched pair, so changing one side alone would be wrong.

## What changes for a user

| | before | after |
| --- | --- | --- |
| `mssp://host/sites/My+Folder/` | folder `My Folder` | folder `My+Folder` |
| `mssp://Host.Example.COM/p/` | host kept as typed | host lower-cased |
| `mssp://host/a/../b/` | asked for as typed | resolved to `/b/` |
| `mssp://host/backup#1/` | a different folder, silently | **reported to the user** |
| `mssp://host:99999/p/` | port 99999 | **reported to the user** |
| `mssp://user:p@ss@host/p/` | host `ss@host` | **reported to the user** |

Everything else answers what it answered before: the empty path, a marker in the first position (`mssp://host//Docs/`, where it is eaten along with the leading separator, as it was), a triple slash, an encoded separator, an encoded percent sign, and the credentials.

## Tests

`SharePointUrlTests` is new. This backend talks through CSOM's `ClientContext`, so there is no http seam to record a request through the way #7200 does — instead every case starts from a **whole url** and asserts both derived paths, which is the same coverage by a different route.

Pointing `ParseSharePointUrl` back at the old parser leaves 10 red, and they are the rows in the table above.

Two of the tests only guard the wiring: the constructor is documented as not throwing (the web is searched for on first use), so one builds the backend and checks `GetDNSNamesAsync`, and one checks the loader still finds the two-argument constructor.

Checked: `dotnet build Duplicati.slnx -c Debug --no-incremental` — 0 errors and the same 3 warnings as master. The url-parsing suites run together — `SharePointUrlTests`, `WebDavUrlTests`, `UrlEncodingTests`, `UriUtilityTests`, `SshUrlTests`, `FtpUrlTests`, `SmbUrlTests`, `TahoeUrlTests`, `PCloudUrlTests`, `S3BackendEndpointParsingTests` — **301 passed, 0 failed**.

## Noticed, not changed

`SharePointBackend.cs:670` decodes `m_serverRelPath` a second time:

```csharp
folderNames = Array.ConvertAll(folderNames, fold => System.Net.WebUtility.UrlDecode(fold));
```

`m_serverRelPath` is already decoded, and `WebUtility.UrlDecode` is the query string decoder, so it turns a `+` back into a space — the same defect this PR removes from the entry, in the one method that reaches it. Only `DoCreateFolderAsync` goes through it, so folder creation disagrees with every other call about the name.

It is left alone because the surrounding code re-encodes with `HttpUtility.UrlPathEncode` while the other call sites pass `m_serverRelPath` straight to CSOM, so those two already disagree about whether CSOM wants an encoded or a decoded server relative url. **Which one is right cannot be settled without a SharePoint instance to try it against**, and guessing is what put a change in #7197 that looked like a fix and was not.
