### PR TITLE
Decode the Dropbox folder name once, not twice

### DIFF
--- a/Duplicati/Library/Backend/Dropbox/Dropbox.cs
+++ b/Duplicati/Library/Backend/Dropbox/Dropbox.cs
@@ -24,6 +24,8 @@ using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend
 {
     // ReSharper disable once UnusedMember.Global
@@ -45,10 +47,25 @@ namespace Duplicati.Library.Backend
         // ReSharper disable once UnusedMember.Global
         // This constructor is needed by the BackendLoader.
         public Dropbox(string url, Dictionary<string, string?> options)
+            : this(url, options, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a backend that uses the supplied <see cref="HttpClient"/>,
+        /// so the Dropbox API responses can be stubbed in tests
+        /// </summary>
+        /// <param name="url">The backend url</param>
+        /// <param name="options">The options to use</param>
+        /// <param name="httpClient">The client to use, or null to create one</param>
+        internal Dropbox(string url, Dictionary<string, string?> options, HttpClient? httpClient)
         {
             var uri = new Utility.RelaxedUri(url);
 
-            m_path = Utility.UrlEncoding.UrlDecode(uri.HostAndPath);
+            // RelaxedUri decodes both the host and the path as it parses, so HostAndPath is
+            // already decoded and decoding it again loses whatever was spelled with a percent
+            // sign: a folder named "a%20b", written as "a%2520b", arrived here as "a b".
+            m_path = uri.HostAndPath;
             if (m_path.Length != 0 && !m_path.StartsWith("/", StringComparison.Ordinal))
                 m_path = "/" + m_path;
 
@@ -58,7 +75,7 @@ namespace Duplicati.Library.Backend
             var authId = AuthIdOptionsHelper.Parse(options);
             authId.RequireCredentials(TOKEN_URL);
 
-            dbx = new DropboxHelper(authId, TimeoutOptionsHelper.Parse(options));
+            dbx = new DropboxHelper(authId, TimeoutOptionsHelper.Parse(options), httpClient);
         }
 
         /// <inheritdoc/>

--- a/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
+++ b/Duplicati/Library/Backend/Dropbox/DropboxHelper.cs
@@ -35,8 +35,8 @@ namespace Duplicati.Library.Backend
 
         private readonly TimeoutOptionsHelper.Timeouts m_timeouts;
 
-        public DropboxHelper(AuthIdOptionsHelper.AuthIdOptions authId, TimeoutOptionsHelper.Timeouts timeouts)
-            : base(authId.AuthId, "dropbox", authId.OAuthUrl)
+        public DropboxHelper(AuthIdOptionsHelper.AuthIdOptions authId, TimeoutOptionsHelper.Timeouts timeouts, HttpClient? httpClient = null)
+            : base(authId.AuthId, "dropbox", authId.OAuthUrl, httpClient)
         {
             m_timeouts = timeouts;
             base.AutoAuthHeader = true;

--- a/Duplicati/UnitTest/DropboxPathTests.cs
+++ b/Duplicati/UnitTest/DropboxPathTests.cs
@@ -1,0 +1,136 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// The destination url names a folder in the Dropbox account, and the backend passes that name
+/// to the API in the body of the request. What arrives there is what these tests read, because a
+/// folder name only means something once it has been sent.
+/// </summary>
+[TestFixture]
+public class DropboxPathTests
+{
+    /// <summary>
+    /// A host that cannot be resolved, so a request that is not stubbed fails instead of reaching
+    /// the real OAuth service
+    /// </summary>
+    private const string OAuthUrl = "http://oauth.invalid/token";
+
+    /// <summary>
+    /// Answers every call with an empty object and keeps what was asked for
+    /// </summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public string? LastBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content != null)
+                LastBody = await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    /// <summary>
+    /// Creates the folder the url names, and returns the path the request carried.
+    /// </summary>
+    private static async Task<string?> WhichFolderIsAskedForAsync(string url)
+    {
+        var handler = new RecordingHandler();
+        using var backend = new Dropbox(url, new Dictionary<string, string?>
+        {
+            // No colon, so the token is used directly and no OAuth call is made
+            ["authid"] = "test-authid",
+            ["oauth-url"] = OAuthUrl
+        }, new HttpClient(handler));
+
+        await backend.CreateFolderAsync(CancellationToken.None);
+
+        Assert.IsNotNull(handler.LastBody, "The backend sent no request");
+        return JsonNode.Parse(handler.LastBody!)?["path"]?.GetValue<string>();
+    }
+
+    /// <summary>
+    /// A folder whose name contains a percent sign is spelled with the percent encoded, and the
+    /// name has to survive being decoded exactly once on the way to the API.
+    /// </summary>
+    [TestCase("dropbox://a%2520b", "/a%20b")]
+    [TestCase("dropbox://Backup/a%2520b", "/Backup/a%20b")]
+    [TestCase("dropbox://100%2525done", "/100%25done")]
+    public async Task APercentInTheFolderNameSurvivesAsync(string url, string expected)
+        => Assert.AreEqual(expected, await WhichFolderIsAskedForAsync(url), url);
+
+    [TestCase("dropbox://Backup", "/Backup")]
+    [TestCase("dropbox://Backup/", "/Backup")]
+    [TestCase("dropbox://Backup/Sub", "/Backup/Sub")]
+    [TestCase("dropbox://My%20Folder", "/My Folder")]
+    [TestCase("dropbox://M%C3%A4ppe", "/Mäppe")]
+    [TestCase("dropbox://Backup/M%C3%A4ppe/Sub", "/Backup/Mäppe/Sub")]
+    public async Task TheRestOfTheDecodingIsUnchangedAsync(string url, string expected)
+        => Assert.AreEqual(expected, await WhichFolderIsAskedForAsync(url), url);
+
+    [Test]
+    public async Task APlusIsStillReadAsASpaceAsync()
+    {
+        // Not what a path means, and the same defect issue #4880 reported for WebDAV, but this one
+        // cannot be fixed here: it happens inside the shared parser, and this backend cannot move
+        // to System.Uri because the first segment of its url is a folder name, which is case
+        // sensitive. Pinned so the day it changes is not a surprise.
+        Assert.AreEqual("/My Folder", await WhichFolderIsAskedForAsync("dropbox://My+Folder"));
+        Assert.AreEqual("/My+Folder", await WhichFolderIsAskedForAsync("dropbox://My%2BFolder"));
+    }
+
+    /// <summary>
+    /// The backend loader picks the constructor by argument count, so the one the tests use must
+    /// not become the one it finds.
+    /// </summary>
+    [Test]
+    public void TheLoaderStillFindsTheTwoArgumentConstructor()
+    {
+        using var backend = (IBackend)Activator.CreateInstance(
+            typeof(Dropbox), "dropbox://Backup", new Dictionary<string, string?>
+            {
+                ["authid"] = "test-authid",
+                ["oauth-url"] = OAuthUrl
+            })!;
+
+        Assert.AreEqual("dropbox", backend.ProtocolKey);
+    }
+}


### PR DESCRIPTION
Follows up one of the two places [#7197](https://github.com/duplicati/duplicati/pull/7197) and [#7200](https://github.com/duplicati/duplicati/pull/7200) raised as "same call, reported but not changed". The Dropbox one turns out to be decidable without an account. The OneDrive one is not, and is described at the bottom.

## The symptom

**A folder whose name contains a percent sign cannot be reached.** `a%20b`, written into the destination url as `a%2520b` the way the url encoder spells it, arrives at the Dropbox API as `a b`.

## Why

`RelaxedUri` decodes as it parses. Both halves go through `UrlDecode` in the constructor:

```csharp
var h = UrlEncoding.UrlDecode(m.Groups["hostname"].Success ? m.Groups["hostname"].Value : "");
...
var p = UrlEncoding.UrlDecode(m.Groups["path"].Success ? m.Groups["path"].Value : "");
```

and `HostAndPath` only joins the two. So this is a **second** decode:

```csharp
// Dropbox.cs:51
m_path = Utility.UrlEncoding.UrlDecode(uri.HostAndPath);
```

## Why it is decidable here

`m_path` goes to the API **in the body of the request**, as the `path` of a `PathArg`:

```csharp
req.Content = JsonContent.Create(new PathArg { path = path });
```

A decoded path is what belongs there, so decoding it twice is simply wrong. No account is needed to settle that — which is the difference from the OneDrive call below.

## What changes

| destination url | before | after |
| --- | --- | --- |
| `dropbox://a%2520b` | folder `a b` | folder `a%20b` |
| `dropbox://Backup/a%2520b` | folder `Backup/a b` | folder `Backup/a%20b` |
| `dropbox://100%2525done` | folder `100%done` | folder `100%25done` |
| `dropbox://My%2BFolder` | folder `My Folder` | folder `My+Folder` |
| `dropbox://My+Folder` | folder `My Folder` | **unchanged**, see below |

An encoded plus is fixed for the same reason: `%2B` became `+` on the first decode and a space on the second.

**A plus written literally still becomes a space.** That happens inside the shared parser, and this backend cannot move to `System.Uri`: the first segment of its url is a folder name, which is case sensitive, and `System.Uri` lower-cases the authority. That is the same reason [#7145](https://github.com/duplicati/duplicati/pull/7145) left this backend where it is. A test holds the current answer so the day it changes is not a surprise.

Everything else answers what it answered before — `My%20Folder`, `M%C3%A4ppe`, nested paths, and the trailing separator.

## Tests

`DropboxPathTests` asks the backend **which folder it creates**, through an injected `HttpClient` in the shape `BoxBackend` already uses, because a folder name only means something once it has been sent. It fails on the previous code:

```
失敗 APercentInTheFolderNameSurvivesAsync("dropbox://a%2520b","/a%20b")
  Expected: "/a%20b"
  But was:  "/a b"
```

The seam is the Box one: `DropboxHelper` takes an optional `HttpClient` and hands it to `OAuthHelperHttpClient`, which already accepts one, and the public two-argument constructor delegates to an `internal` three-argument one so there is still a single constructor body. One test guards that the loader keeps finding the two-argument constructor.

Checked: `dotnet build Duplicati.slnx -c Debug --no-incremental` — 0 errors and the same 3 warnings as master. `DropboxPathTests`, `BoxEntryLookupTests`, `BoxFolderResolutionTests`, `UriUtilityTests`, `UrlEncodingTests` and `FolderExistsBackend` run together — **130 passed, 0 failed**.

## The OneDrive call is not the same fix

[`MicrosoftGraphBackend.cs:683`](https://github.com/duplicati/duplicati/blob/master/Duplicati/Library/Backend/OneDrive/MicrosoftGraphBackend.cs#L683) spells the same expression, but removing the second decode there would not be enough, and on its own would leave the backend differently wrong.

`RootPath` is not sent in a body. It is concatenated into the request **url**, in nine places:

```csharp
string.Format("{0}/root:{1}:/children", drivePrefix, this.RootPath)
string.Format("{0}/root:{1}{2}:/content", drivePrefix, this.RootPath, NormalizeSlashes(remotename))
```

Graph's addressing puts the path inside the url, so it has to be percent-encoded there. `RootPath` is decoded, so:

| folder | url that is built | |
| --- | --- | --- |
| `a b` | `.../root:/a%20b:/children` | .NET escapes the space, so it happens to work |
| `a%20b` | `.../root:/a%20b:/children` | **the same url** — it reaches the other folder |
| `a#b` | `.../root:/a` | the `#` starts a fragment and the rest is cut |

Dropping the second decode alone leaves the `a%20b` row still colliding, because the composition would then have to encode. That is a second change, across those nine sites, and where to stop encoding is not obvious: the comment at the top of that file records that these urls are built as strings precisely because `System.Uri` rejects the `:` in Graph's syntax.

So this one needs a real account to settle, and is left alone here rather than half-fixed.
