### PR TITLE
Replace missing metadata with empty metadata, not with another blockset

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -3349,15 +3349,20 @@ namespace Duplicati.Library.Main.Database.Local
         }
 
         /// <summary>
-        /// Returns the ID of an empty metadata blockset. If no empty blockset is found, it returns the ID of the smallest blockset that is not in the given block volume IDs.
-        /// If no such blockset is found, it returns -1.
+        /// Returns the ID of a blockset that really is empty metadata, or -1 when the database
+        /// holds none that survives the given block volumes.
         /// </summary>
+        /// <remarks>
+        /// This answers only with an empty metadata blockset or a zero-length one. It never hands
+        /// back a blockset that belongs to some other file, which is what
+        /// <see cref="GetEmptyMetadataBlocksetIdAsync"/> falls back to.
+        /// </remarks>
         /// <param name="blockVolumeIds">The volume ids to ignore when searching for a suitable metadata block.</param>
         /// <param name="emptyHash">The hash of the empty blockset.</param>
         /// <param name="emptyHashSize">The size of the empty blockset.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
-        /// <returns>A task that when awaited contains the ID of the empty metadata blockset, or -1 if no suitable blockset is found</returns>
-        public async Task<long> GetEmptyMetadataBlocksetIdAsync(IEnumerable<long> blockVolumeIds, string emptyHash, long emptyHashSize, CancellationToken token)
+        /// <returns>A task that when awaited contains the ID of the empty metadata blockset, or -1 if there is none</returns>
+        public async Task<long> FindEmptyMetadataBlocksetIdAsync(IEnumerable<long> blockVolumeIds, string emptyHash, long emptyHashSize, CancellationToken token)
         {
             await using var tmptable = await TemporaryDbValueList.CreateAsync(this, blockVolumeIds, token)
                 .ConfigureAwait(false);
@@ -3416,36 +3421,58 @@ namespace Duplicati.Library.Main.Database.Local
                   .ConfigureAwait(false);
             }
 
-            // No empty block found, pick the smallest one
-            if (res < 0)
-            {
-                cmd.SetCommandAndParameters(@"
-                    SELECT ""Blockset"".""ID""
-                    FROM
-                        ""BlocksetEntry"",
-                        ""Blockset"",
-                        ""Metadataset"",
-                        ""Block""
-                    WHERE
-                        ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID""
-                        AND ""BlocksetEntry"".""BlocksetID"" = ""Blockset"".""ID""
-                        AND ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
-                        AND ""Block"".""VolumeID"" NOT IN (@BlockVolumeIds)
-                        AND ""Blockset"".""Length"" > 0
-                    ORDER BY ""Blockset"".""Length"" ASC
-                    LIMIT 1
-                ");
-
-                await cmd
-                  .ExpandInClauseParameterMssqliteAsync("@BlockVolumeIds", tmptable, token)
-                  .ConfigureAwait(false);
-
-                res = await cmd
-                  .ExecuteScalarInt64Async(-1, token)
-                  .ConfigureAwait(false);
-            }
-
             return res;
+        }
+
+        /// <summary>
+        /// Returns the ID of an empty metadata blockset. If no empty blockset is found, it returns the ID of the smallest blockset that is not in the given block volume IDs.
+        /// If no such blockset is found, it returns -1.
+        /// </summary>
+        /// <remarks>
+        /// The last step answers with another file's metadata. A caller that puts the result on a
+        /// file should ask <see cref="FindEmptyMetadataBlocksetIdAsync"/> instead and handle the
+        /// absence itself, rather than dressing a file in metadata that belongs to something else.
+        /// </remarks>
+        /// <param name="blockVolumeIds">The volume ids to ignore when searching for a suitable metadata block.</param>
+        /// <param name="emptyHash">The hash of the empty blockset.</param>
+        /// <param name="emptyHashSize">The size of the empty blockset.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the ID of the blockset to use, or -1 if no suitable blockset is found</returns>
+        public async Task<long> GetEmptyMetadataBlocksetIdAsync(IEnumerable<long> blockVolumeIds, string emptyHash, long emptyHashSize, CancellationToken token)
+        {
+            var res = await FindEmptyMetadataBlocksetIdAsync(blockVolumeIds, emptyHash, emptyHashSize, token)
+                .ConfigureAwait(false);
+            if (res >= 0)
+                return res;
+
+            await using var tmptable = await TemporaryDbValueList.CreateAsync(this, blockVolumeIds, token)
+                .ConfigureAwait(false);
+
+            // No empty block found, pick the smallest one
+            await using var cmd = Connection.CreateCommand(@"
+                SELECT ""Blockset"".""ID""
+                FROM
+                    ""BlocksetEntry"",
+                    ""Blockset"",
+                    ""Metadataset"",
+                    ""Block""
+                WHERE
+                    ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID""
+                    AND ""BlocksetEntry"".""BlocksetID"" = ""Blockset"".""ID""
+                    AND ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
+                    AND ""Block"".""VolumeID"" NOT IN (@BlockVolumeIds)
+                    AND ""Blockset"".""Length"" > 0
+                ORDER BY ""Blockset"".""Length"" ASC
+                LIMIT 1
+            ")
+                .SetTransaction(m_rtr);
+
+            await cmd.ExpandInClauseParameterMssqliteAsync("@BlockVolumeIds", tmptable, token)
+                .ConfigureAwait(false);
+
+            return await cmd
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
         }
 
         public virtual void Dispose()

--- a/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
@@ -36,6 +36,11 @@ namespace Duplicati.Library.Main.Database.Local
     internal class LocalListBrokenFilesDatabase : LocalDatabase
     {
         /// <summary>
+        /// The tag used for logging from this class.
+        /// </summary>
+        private static readonly string LOGTAG_LISTBROKEN = Logging.Log.LogTagFromType<LocalListBrokenFilesDatabase>();
+
+        /// <summary>
         /// SQL query to get the IDs of all block volumes.
         /// </summary>
         private static readonly string BLOCK_VOLUME_IDS = $@"
@@ -445,6 +450,89 @@ namespace Duplicati.Library.Main.Database.Local
             return await cmd
                 .ExecuteScalarInt64Async(0, token)
                 .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Records the empty metadata block that was just written to a volume, and the blockset
+        /// pointing at it, so files whose own metadata is gone can be given empty metadata rather
+        /// than metadata belonging to some other file.
+        /// </summary>
+        /// <param name="volumeId">The volume the block was written to.</param>
+        /// <param name="blockHash">The hash of the block.</param>
+        /// <param name="fullHash">The hash of the metadata as a whole.</param>
+        /// <param name="size">The size of the metadata in bytes.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the ID of the new blockset.</returns>
+        public async Task<long> AddEmptyMetadataBlocksetAsync(long volumeId, string blockHash, string fullHash, long size, CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand(m_rtr);
+
+            // The id is chosen rather than left to the database. Removing the missing volumes
+            // deleted Block rows but left the BlocksetEntry rows that pointed at them, and SQLite
+            // hands a deleted row id out again on the next insert. A block landing on one of those
+            // ids would silently reattach a blockset that is supposed to look broken, and the file
+            // would keep metadata that is no longer there.
+            var blockId = await cmd.SetCommandAndParameters(@"
+                INSERT INTO ""Block"" (
+                    ""ID"",
+                    ""Hash"",
+                    ""Size"",
+                    ""VolumeID""
+                )
+                SELECT
+                    MAX(""Used"") + 1,
+                    @Hash,
+                    @Size,
+                    @VolumeID
+                FROM (
+                    SELECT COALESCE(MAX(""ID""), 0) AS ""Used"" FROM ""Block""
+                    UNION ALL
+                    SELECT COALESCE(MAX(""BlockID""), 0) FROM ""BlocksetEntry""
+                    UNION ALL
+                    SELECT COALESCE(MAX(""BlockID""), 0) FROM ""DuplicateBlock""
+                );
+                SELECT last_insert_rowid();
+            ")
+                .SetParameterValue("@Hash", blockHash)
+                .SetParameterValue("@Size", size)
+                .SetParameterValue("@VolumeID", volumeId)
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+
+            var blocksetId = await cmd.SetCommandAndParameters(@"
+                INSERT INTO ""Blockset"" (
+                    ""Length"",
+                    ""FullHash""
+                )
+                VALUES (
+                    @Length,
+                    @FullHash
+                );
+                SELECT last_insert_rowid();
+            ")
+                .SetParameterValue("@Length", size)
+                .SetParameterValue("@FullHash", fullHash)
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+
+            await cmd.SetCommandAndParameters(@"
+                INSERT INTO ""BlocksetEntry"" (
+                    ""BlocksetID"",
+                    ""Index"",
+                    ""BlockID""
+                )
+                VALUES (
+                    @BlocksetID,
+                    0,
+                    @BlockID
+                )
+            ")
+                .SetParameterValue("@BlocksetID", blocksetId)
+                .SetParameterValue("@BlockID", blockId)
+                .ExecuteNonQueryAsync(true, token)
+                .ConfigureAwait(false);
+
+            return blocksetId;
         }
     }
 }

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -24,9 +24,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Duplicati.Library.Interface;
+using Duplicati.Library.Main.Database;
 using Duplicati.Library.Main.Database.Local;
+using Duplicati.Library.Main.Volumes;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -105,15 +109,21 @@ namespace Duplicati.Library.Main.Operation
                 {
                     var emptymetadata = Utility.WrapMetadata(new Dictionary<string, string>(), m_options);
                     replacementMetadataBlocksetId = await db
-                        .GetEmptyMetadataBlocksetIdAsync(
+                        .FindEmptyMetadataBlocksetIdAsync(
                             (missing ?? []).Select(x => x.ID),
                             emptymetadata.FileHash,
                             emptymetadata.Blob.Length,
                             m_result.TaskControl.ProgressToken
                         )
                         .ConfigureAwait(false);
+
+                    // An ordinary backup holds no empty metadata, so there is usually nothing to
+                    // find. Rather than dressing the files in whatever other metadata happens to be
+                    // smallest, the empty metadata is written now: it is a constant, so it can
+                    // always be produced.
                     if (replacementMetadataBlocksetId < 0)
-                        throw new UserInformationException($"Failed to locate an empty metadata blockset to replace missing metadata. Set the option --disable-replace-missing-metadata=true to ignore this and drop files with missing metadata.", "FailedToLocateEmptyMetadataBlockset");
+                        replacementMetadataBlocksetId = await StoreEmptyMetadataAsync(backendManager, db, emptymetadata, m_result.TaskControl.ProgressToken)
+                            .ConfigureAwait(false);
                 }
 
                 var fully_emptied = compare_list.Where(x => x.RemoveCount == x.SetCount).ToArray();
@@ -219,6 +229,71 @@ namespace Duplicati.Library.Main.Operation
             }
 
             m_result.OperationProgressUpdater.UpdateProgress(1.0f);
+        }
+
+        /// <summary>
+        /// Writes the empty metadata to the destination as a volume of its own and records it, so
+        /// a file that lost its metadata can be given metadata that says nothing rather than
+        /// metadata that belongs to something else.
+        /// </summary>
+        /// <remarks>
+        /// This deliberately does not commit or wait for the backend. It runs inside the
+        /// transaction the purge is already holding, and the rows it writes are committed with the
+        /// rest of the purge. Committing here instead leaves the later ReplaceMetadata matching
+        /// nothing, which is how the substitution went unnoticed while it was being replaced.
+        /// </remarks>
+        /// <param name="backendManager">The backend manager to upload with.</param>
+        /// <param name="db">The database to record the new blockset in.</param>
+        /// <param name="emptymetadata">The empty metadata to store.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the ID of the new blockset.</returns>
+        private async Task<long> StoreEmptyMetadataAsync(IBackendManager backendManager, LocalListBrokenFilesDatabase db, IMetahash emptymetadata, CancellationToken cancellationToken)
+        {
+            string blockHash;
+            using (var blockhasher = HashFactory.CreateHasher(m_options.BlockHashAlgorithm))
+                blockHash = Convert.ToBase64String(blockhasher.ComputeHash(emptymetadata.Blob));
+
+            var blockVolume = new BlockVolumeWriter(m_options);
+            blockVolume.VolumeID = await db
+                .RegisterRemoteVolumeAsync(blockVolume.RemoteFilename, RemoteVolumeType.Blocks, RemoteVolumeState.Temporary, cancellationToken)
+                .ConfigureAwait(false);
+            await blockVolume
+                .AddBlockAsync(blockHash, emptymetadata.Blob, 0, emptymetadata.Blob.Length, CompressionHint.Default)
+                .ConfigureAwait(false);
+            blockVolume.Close();
+
+            var blocksetId = await db
+                .AddEmptyMetadataBlocksetAsync(blockVolume.VolumeID, blockHash, emptymetadata.FileHash, emptymetadata.Blob.Length, cancellationToken)
+                .ConfigureAwait(false);
+
+            IndexVolumeWriter? indexVolume = null;
+            if (m_options.IndexfilePolicy != Options.IndexFileStrategy.None)
+            {
+                indexVolume = new IndexVolumeWriter(m_options);
+                indexVolume.VolumeID = await db
+                    .RegisterRemoteVolumeAsync(indexVolume.RemoteFilename, RemoteVolumeType.Index, RemoteVolumeState.Temporary, cancellationToken)
+                    .ConfigureAwait(false);
+                indexVolume.StartVolume(blockVolume.RemoteFilename);
+                indexVolume.AddBlock(blockHash, emptymetadata.Blob.Length);
+                await db
+                    .AddIndexBlockLinkAsync(indexVolume.VolumeID, blockVolume.VolumeID, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (m_options.Dryrun)
+            {
+                Logging.Log.WriteDryrunMessage(LOGTAG, "WouldStoreEmptyMetadata", "would upload {0}, holding the empty metadata that replaces what is missing", blockVolume.RemoteFilename);
+                return blocksetId;
+            }
+
+            await db
+                .UpdateRemoteVolumeAsync(blockVolume.RemoteFilename, RemoteVolumeState.Uploading, -1, null, cancellationToken)
+                .ConfigureAwait(false);
+            await backendManager.PutAsync(blockVolume, indexVolume, null, false, null, cancellationToken)
+                .ConfigureAwait(false);
+
+            Logging.Log.WriteInformationMessage(LOGTAG, "StoredEmptyMetadata", "Stored the empty metadata in {0}, to replace metadata that is missing", blockVolume.RemoteFilename);
+            return blocksetId;
         }
     }
 }

--- a/Duplicati/UnitTest/ReplacementMetadataTests.cs
+++ b/Duplicati/UnitTest/ReplacementMetadataTests.cs
@@ -1,0 +1,176 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.Main;
+using Duplicati.Library.Main.Database;
+using Duplicati.Library.SQLiteHelper;
+using NUnit.Framework;
+using ClassicAssert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A file whose data is intact but whose metadata volume is gone is kept by purge-broken-files,
+/// with replacement metadata. The replacement is supposed to be empty metadata, which says
+/// nothing about the file, rather than metadata that describes something else.
+/// </summary>
+public class ReplacementMetadataTests : BasicSetupHelper
+{
+    private Dictionary<string, string> BackupOptions()
+        => TestOptions.Expand(new { blocksize = "1kb", no_encryption = true, dblock_size = "20kb" });
+
+    /// <summary>
+    /// The first run stores the data of "a". Touching only its timestamp makes the second run
+    /// store one thing, a new metadata block, in a volume of its own. Deleting that volume loses
+    /// the metadata of the newest version and nothing else.
+    /// </summary>
+    private async Task<(string Hash, int Size)> LoseOnlyTheMetadataAsync(Dictionary<string, string> testopts)
+    {
+        var emptymeta = Library.Main.Utility.WrapMetadata(new Dictionary<string, string>(), new Options(testopts));
+
+        var patha = Path.Combine(DATAFOLDER, "a");
+        var data = new byte[1024 * 60];
+        Random.Shared.NextBytes(data);
+        File.WriteAllBytes(patha, data);
+        File.SetLastWriteTimeUtc(patha, new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc));
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+        var afterFirst = Directory.GetFiles(TARGETFOLDER, "*.dblock.*", SearchOption.TopDirectoryOnly).ToHashSet();
+
+        // A second apart, or both filesets land on the same timestamp and the purge stops for that
+        // reason instead of doing what this is about.
+        await Task.Delay(1500);
+        File.SetLastWriteTimeUtc(patha, new DateTime(2010, 10, 10, 10, 10, 10, DateTimeKind.Utc));
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+        var fromSecond = Directory.GetFiles(TARGETFOLDER, "*.dblock.*", SearchOption.TopDirectoryOnly)
+            .Where(x => !afterFirst.Contains(x)).ToList();
+
+        Assert.That(fromSecond, Has.Count.EqualTo(1),
+            "The second run was expected to write one volume, holding only the new metadata block");
+
+        File.Delete(fromSecond[0]);
+        return (emptymeta.FileHash, emptymeta.Blob.Length);
+    }
+
+    /// <summary>
+    /// Runs the recovery the way the messages tell a user to: repair reports the missing volume
+    /// and points at purge-broken-files, which is then run.
+    /// </summary>
+    private async Task RecoverAsync(Dictionary<string, string> testopts)
+    {
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            Assert.ThrowsAsync<Library.Interface.UserInformationException>(() => c.RepairAsync(),
+                "Repair is expected to report the missing volume and point at purge-broken-files");
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            TestUtils.AssertResults(await c.PurgeBrokenFilesAsync(null));
+    }
+
+    /// <summary>
+    /// Reads the metadata the newest version of "a" points at. The older version keeps its own and
+    /// is not part of this.
+    /// </summary>
+    private async Task<(long Length, string FullHash)> ReadNewestMetadataOfAAsync()
+    {
+        await using var con = await SQLiteLoader.LoadConnectionAsync(DBFILE);
+        await using var cmd = con.CreateCommand();
+        cmd.SetCommandAndParameters(@"
+            SELECT ""Blockset"".""Length"", ""Blockset"".""FullHash""
+            FROM ""Fileset""
+            JOIN ""FilesetEntry"" ON ""FilesetEntry"".""FilesetID"" = ""Fileset"".""ID""
+            JOIN ""File"" ON ""File"".""ID"" = ""FilesetEntry"".""FileID""
+            JOIN ""Metadataset"" ON ""File"".""MetadataID"" = ""Metadataset"".""ID""
+            JOIN ""Blockset"" ON ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID""
+            WHERE ""Fileset"".""Timestamp"" = (SELECT MAX(""Timestamp"") FROM ""Fileset"")
+                AND ""File"".""Path"" LIKE '%a'");
+
+        await using var rd = await cmd.ExecuteReaderAsync();
+        Assert.That(await rd.ReadAsync(), Is.True, "The file was dropped instead of being kept");
+        return (rd.ConvertValueToInt64(0), rd.ConvertValueToString(1) ?? "");
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task TheReplacementIsEmptyMetadataAndNotAnotherBlocksetAsync()
+    {
+        var testopts = BackupOptions();
+        var (emptyHash, emptySize) = await LoseOnlyTheMetadataAsync(testopts);
+        await RecoverAsync(testopts);
+
+        var metadata = await ReadNewestMetadataOfAAsync();
+
+        // Both the file's own metadata and the previous version's are 137 bytes here, so the hash
+        // is what tells empty metadata apart from a blockset that describes something else.
+        ClassicAssert.AreEqual(emptyHash, metadata.FullHash,
+            "The file was handed a metadata blockset that belongs to something else");
+        ClassicAssert.AreEqual(emptySize, metadata.Length,
+            "The replacement metadata is not the empty metadata");
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task TheDataAndTheOlderVersionSurviveAsync()
+    {
+        var testopts = BackupOptions();
+        await LoseOnlyTheMetadataAsync(testopts);
+        var expected = await File.ReadAllBytesAsync(Path.Combine(DATAFOLDER, "a"));
+        await RecoverAsync(testopts);
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts.Expand(new { restore_path = RESTOREFOLDER }), null))
+            TestUtils.AssertResults(await c.RestoreAsync(null));
+
+        var restored = Path.Combine(RESTOREFOLDER, "a");
+        ClassicAssert.IsTrue(File.Exists(restored), "The file was not restored");
+        ClassicAssert.AreEqual(expected, await File.ReadAllBytesAsync(restored), "The restored data does not match");
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task ADryRunWritesNothingToTheDestinationAsync()
+    {
+        var testopts = BackupOptions();
+        await LoseOnlyTheMetadataAsync(testopts);
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            Assert.ThrowsAsync<Library.Interface.UserInformationException>(() => c.RepairAsync());
+
+        var before = Directory.GetFiles(TARGETFOLDER, "*", SearchOption.TopDirectoryOnly).ToHashSet();
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts.Expand(new { dry_run = true }), null))
+            await c.PurgeBrokenFilesAsync(null);
+
+        var after = Directory.GetFiles(TARGETFOLDER, "*", SearchOption.TopDirectoryOnly).ToHashSet();
+        Assert.That(after, Is.EquivalentTo(before), "A dry run wrote to the destination");
+    }
+}


### PR DESCRIPTION
This is another way at what draft [#7052](https://github.com/duplicati/duplicati/pull/7052) is reaching for. **The aim there is right** — a repair should always have empty metadata to point at — and this arrives at it from the other end: rather than putting the block in every backup in advance, the one command that needs it writes it when it needs it.

## What a file is handed today

`purge-broken-files` keeps a file whose data survived but whose metadata is gone, and gives it replacement metadata. It describes that as empty metadata, and the error it throws when it cannot find any calls it "an empty metadata blockset". What a file actually gets is whatever metadata blockset happens to be smallest:

```csharp
// LocalDatabase.cs, GetEmptyMetadataBlocksetIdAsync
// No empty block found, pick the smallest one
    ...
    AND "Blockset"."Length" > 0
ORDER BY "Blockset"."Length" ASC
LIMIT 1
```

The XML doc says so outright: *"If no empty blockset is found, it returns the ID of the smallest blockset that is not in the given block volume IDs."*

**That step is not a rare fallback.** Measured on an ordinary backup, the database holds:

```
zero-length blocksets     = 0
empty-metadata blocksets  = 0
```

so the first two steps find nothing and the third one answers every time.

## What that does, end to end

A file that keeps its data and loses only the volume that held its metadata:

```
before purge   version 1 of "a" -> blockset 2   (its own metadata)
               version 2 of "a" -> blockset 4   (its own metadata, volume gone)
after purge    version 2 of "a" -> blockset 2
```

**The newest version came back wearing the previous version's metadata**, a timestamp it never had. With more than one file in the backup, `ORDER BY Length ASC` reaches another file's metadata just as easily — its timestamps, its attributes, and on Unix its ownership and permissions.

## The change

The empty metadata is a constant; the caller computes it two lines above and then throws it away. So:

- `GetEmptyMetadataBlocksetIdAsync` keeps its behaviour for its other caller, and the two steps that answer with *real* empty metadata are split out as `FindEmptyMetadataBlocksetIdAsync`.
- `purge-broken-files` asks the strict one, and when there is nothing to find it writes the five bytes to the destination as a volume of its own and points the file at that.

Two details of the write are deliberate, and both were found by measuring rather than by reading:

**It does not commit or wait for the backend.** The first version did, and the later `ReplaceMetadata` then matched **0 rows** — so the substitution would have quietly survived the change meant to remove it. It runs inside the transaction the purge already holds.

**It chooses the row id instead of letting the database pick.** Removing the missing volumes deletes `Block` rows and leaves the `BlocksetEntry` rows that pointed at them, and SQLite hands those ids out again:

```
metadataset 3  blockset 4  liveblocks 1  entries 1  blockids 65  sizes 5
```

Blockset 4 is the blockset whose block is gone, and it had reattached to the five-byte block that had just been inserted on the reused id — so it stopped looking broken. Deleting those dangling entries instead is not an option: they are how a file with missing data is recognised, and dropping them makes the consistency check report the wrong size for the file (`actual size 99332, dbsize 1024`).

## Tests

`ReplacementMetadataTests` covers what the file is handed, that its data and the older version are untouched, and that a dry run writes nothing. The first one fails without this change:

```
The file was handed a metadata blockset that belongs to something else
Expected: "qiXpeARtaA74dA2Dfm3lvB4qLcYInb2hASVEtTjVP2U="
But was:  "jKUnvj12LgA4Y9R295OyRLbhKbXqHPDIy7kWjnxYG3A="
```

The state it needs — data intact, metadata gone — is built by backing the file up, touching only its timestamp and backing it up again, which puts one metadata block in a volume of its own, then deleting that volume.

Checked: `dotnet build Duplicati.slnx -c Debug --no-incremental` — 0 errors and the same 3 warnings as master. `ReplacementMetadataTests`, `RepairWithMissingRemoteFiles`, `Issue5987`, `Issue6504` and `RepairHandlerTests` run together — **58 passed, 0 failed**. The whole suite was run on a fork before opening this: unit tests, integration tests and Playwright, **green on ubuntu, macOS and Windows**.

## Noticed, not changed

- **`FixEmptyMetadatasetsAsync` in the repair path uses the same third step.** It runs in `RunRepairCommonAsync`, which has no backend to upload to, so it cannot write the constant the way this does. Left alone; it needs a decision this PR should not make. In practice its precondition means a zero-length blockset exists, so the second step usually answers there.
- **Why not seed the block in every backup, as #7052 does.** Measured across a database recreate:
  ```
  after backup    Block rows for the empty-metadata hash = 1,  Metadataset = 4
  after recreate  Block rows for the empty-metadata hash = 0,  Metadataset = 3
  ```
  The seed is a `Metadataset` no file references, so nothing in the dlist brings it back and a recreate drops it, leaving the block orphaned in the dblock and the guarantee gone. It also fails 22 unit tests, because a block with no source file cannot be rebuilt by repair.
