### PR TITLE
Improve detection and notifications for zero-length entries

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalRepairDatabase.cs
@@ -1968,6 +1968,246 @@ namespace Duplicati.Library.Main.Database.Local
                 );
         }
 
+        /// <summary>
+        /// Removes <c>BlocksetEntry</c> and <c>BlocklistHash</c> rows that reference a blockset which no
+        /// longer exists.
+        /// </summary>
+        /// <remarks>
+        /// These rows are dangerous rather than merely untidy: blockset IDs are plain rowids, so a later
+        /// insert can reuse the ID of the deleted blockset and silently adopt the stale block mapping,
+        /// producing a blockset whose contents belong to a completely different file.
+        /// <para>
+        /// Note that this deliberately does <em>not</em> delete unreferenced <c>Blockset</c> rows. Repair
+        /// recreates missing file entries from the filelists at the destination, and those entries need
+        /// the block mapping of their blockset, which the filelists do not carry. A blockset can therefore
+        /// be temporarily unreferenced while repair is running, and deleting it leaves a blockset with a
+        /// recorded length but no blocks once the file entry is recreated.
+        /// </para>
+        /// </remarks>
+        /// <param name="dryrun">If <c>true</c>, only report what would be removed.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited returns the number of rows removed, or the number that would be removed in a dry-run.</returns>
+        public async Task<long> FixOrphanBlocksetEntriesAsync(bool dryrun, CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            // Matches rows attached to a blockset that is not in the Blockset table
+            const string orphanFilter = @"
+                WHERE ""BlocksetID"" NOT IN (
+                    SELECT ""ID""
+                    FROM ""Blockset""
+                )
+            ";
+
+            var orphanEntries = await cmd.ExecuteScalarInt64Async($@"
+                SELECT COUNT(*)
+                FROM ""BlocksetEntry""
+                {orphanFilter}
+            ", 0, token)
+                .ConfigureAwait(false);
+
+            var orphanBlocklistHashes = await cmd.ExecuteScalarInt64Async($@"
+                SELECT COUNT(*)
+                FROM ""BlocklistHash""
+                {orphanFilter}
+            ", 0, token)
+                .ConfigureAwait(false);
+
+            var total = orphanEntries + orphanBlocklistHashes;
+            if (total <= 0)
+                return 0;
+
+            if (dryrun)
+            {
+                Logging.Log.WriteDryrunMessage(LOGTAG, "OrphanBlocksetEntries", "Would remove {0} blockset entries and {1} blocklist hashes referencing non-existing blocksets", orphanEntries, orphanBlocklistHashes);
+                return total;
+            }
+
+            Logging.Log.WriteInformationMessage(LOGTAG, "OrphanBlocksetEntries", "Removing {0} blockset entries and {1} blocklist hashes referencing non-existing blocksets", orphanEntries, orphanBlocklistHashes);
+
+            await cmd.ExecuteNonQueryAsync($@"
+                DELETE FROM ""BlocksetEntry""
+                {orphanFilter}
+            ", token)
+                .ConfigureAwait(false);
+
+            await cmd.ExecuteNonQueryAsync($@"
+                DELETE FROM ""BlocklistHash""
+                {orphanFilter}
+            ", token)
+                .ConfigureAwait(false);
+
+            await m_rtr.CommitAsync("FixOrphanBlocksetEntries", true, token)
+                .ConfigureAwait(false);
+
+            return total;
+        }
+
+        /// <summary>
+        /// Strips the blocks off the shared empty-file blockset, if any have become attached to it.
+        /// </summary>
+        /// <remarks>
+        /// The blockset is identified by both a recorded length of 0 and the file hash of zero bytes, so a
+        /// corrupt blockset that merely claims to be zero-length is not mistaken for it. This is the only
+        /// blockset whose recorded length is authoritative, and therefore the only one whose blocks may be
+        /// removed: every empty file in the backup shares it, so blocks attached to it make the
+        /// consistency check fail for all of them at once. Any other length mismatch must be reported
+        /// instead of emptied - see <see cref="ReportBlocksetLengthMismatchesAsync"/> - because stripping
+        /// the blocks off a corrupt blockset would turn a broken file into one that silently restores as
+        /// empty.
+        /// </remarks>
+        /// <param name="emptyFileHash">The base64 encoded file hash of zero bytes, see <see cref="Utility.CalculateEmptyFileHash"/>.</param>
+        /// <param name="dryrun">If <c>true</c>, only report what would be removed.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited returns the number of rows removed, or the number that would be removed in a dry-run.</returns>
+        public async Task<long> FixEmptyBlocksetWithBlocksAsync(string emptyFileHash, bool dryrun, CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            const string emptyBlocksets = @"
+                SELECT ""ID""
+                FROM ""Blockset""
+                WHERE
+                    ""Length"" = 0
+                    AND ""FullHash"" = @EmptyFileHash
+            ";
+
+            var attachedEntries = await cmd.SetCommandAndParameters($@"
+                SELECT COUNT(*)
+                FROM ""BlocksetEntry""
+                WHERE ""BlocksetID"" IN ({emptyBlocksets})
+            ")
+                .SetParameterValue("@EmptyFileHash", emptyFileHash)
+                .ExecuteScalarInt64Async(0, token)
+                .ConfigureAwait(false);
+
+            var attachedBlocklistHashes = await cmd.SetCommandAndParameters($@"
+                SELECT COUNT(*)
+                FROM ""BlocklistHash""
+                WHERE ""BlocksetID"" IN ({emptyBlocksets})
+            ")
+                .SetParameterValue("@EmptyFileHash", emptyFileHash)
+                .ExecuteScalarInt64Async(0, token)
+                .ConfigureAwait(false);
+
+            var total = attachedEntries + attachedBlocklistHashes;
+            if (total <= 0)
+                return 0;
+
+            if (dryrun)
+            {
+                Logging.Log.WriteDryrunMessage(LOGTAG, "EmptyBlocksetWithBlocks", "Would remove {0} blocks and {1} blocklist hashes attached to the shared empty-file blockset", attachedEntries, attachedBlocklistHashes);
+                return total;
+            }
+
+            Logging.Log.WriteInformationMessage(LOGTAG, "EmptyBlocksetWithBlocks", "Removing {0} blocks and {1} blocklist hashes attached to the shared empty-file blockset", attachedEntries, attachedBlocklistHashes);
+
+            await cmd.SetCommandAndParameters($@"
+                DELETE FROM ""BlocksetEntry""
+                WHERE ""BlocksetID"" IN ({emptyBlocksets})
+            ")
+                .SetParameterValue("@EmptyFileHash", emptyFileHash)
+                .ExecuteNonQueryAsync(true, token)
+                .ConfigureAwait(false);
+
+            await cmd.SetCommandAndParameters($@"
+                DELETE FROM ""BlocklistHash""
+                WHERE ""BlocksetID"" IN ({emptyBlocksets})
+            ")
+                .SetParameterValue("@EmptyFileHash", emptyFileHash)
+                .ExecuteNonQueryAsync(true, token)
+                .ConfigureAwait(false);
+
+            await m_rtr.CommitAsync("FixEmptyBlocksetWithBlocks", true, token)
+                .ConfigureAwait(false);
+
+            return total;
+        }
+
+        /// <summary>
+        /// Reports blocksets whose recorded length does not match the summed size of the blocks they
+        /// reference. These cannot be repaired locally, since there is no way to tell whether the length
+        /// or the block mapping is the damaged part.
+        /// </summary>
+        /// <remarks>
+        /// The shared empty-file blockset is excluded, because <see cref="FixEmptyBlocksetWithBlocksAsync"/>
+        /// handles it and reports on it separately. Run this last, so mismatches that earlier repair steps
+        /// have already resolved are not reported as the user's problem.
+        /// </remarks>
+        /// <param name="emptyFileHash">The base64 encoded file hash of zero bytes, see <see cref="Utility.CalculateEmptyFileHash"/>.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited returns the number of mismatching blocksets.</returns>
+        public async Task<long> ReportBlocksetLengthMismatchesAsync(string emptyFileHash, CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            // Note that a blockset with no entries at all has a calculated length of 0, so a non-empty
+            // blockset with no blocks is reported here as well.
+            var mismatches = @"
+                SELECT
+                    ""A"".""ID"",
+                    ""A"".""Length"",
+                    IFNULL(""B"".""CalcLen"", 0) AS ""CalcLen""
+                FROM ""Blockset"" ""A""
+                LEFT OUTER JOIN (
+                    SELECT
+                        ""BlocksetEntry"".""BlocksetID"",
+                        SUM(""Block"".""Size"") AS ""CalcLen""
+                    FROM ""BlocksetEntry""
+                    LEFT OUTER JOIN ""Block""
+                        ON ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
+                    GROUP BY ""BlocksetEntry"".""BlocksetID""
+                ) ""B""
+                    ON ""A"".""ID"" = ""B"".""BlocksetID""
+                WHERE
+                    ""A"".""Length"" != IFNULL(""B"".""CalcLen"", 0)
+                    AND NOT (
+                        ""A"".""Length"" = 0
+                        AND ""A"".""FullHash"" = @EmptyFileHash
+                    )
+            ";
+
+            var count = await cmd.SetCommandAndParameters($@"
+                SELECT COUNT(*)
+                FROM ({mismatches})
+            ")
+                .SetParameterValue("@EmptyFileHash", emptyFileHash)
+                .ExecuteScalarInt64Async(0, token)
+                .ConfigureAwait(false);
+
+            if (count <= 0)
+                return 0;
+
+            var examples = new List<string>();
+            cmd.SetCommandAndParameters($@"
+                SELECT
+                    ""M"".""ID"",
+                    ""M"".""Length"",
+                    ""M"".""CalcLen"",
+                    (
+                        SELECT ""File"".""Path""
+                        FROM ""File""
+                        WHERE ""File"".""BlocksetID"" = ""M"".""ID""
+                        LIMIT 1
+                    ) AS ""Path""
+                FROM ({mismatches}) ""M""
+                LIMIT 5
+            ")
+                .SetParameterValue("@EmptyFileHash", emptyFileHash);
+
+            await foreach (var rd in cmd.ExecuteReaderEnumerableAsync(token).ConfigureAwait(false))
+                examples.Add($"blocksetid {rd.ConvertValueToInt64(0)}: dbsize {rd.ConvertValueToInt64(1)}, actual size {rd.ConvertValueToInt64(2)}, path {rd.ConvertValueToString(3) ?? "<metadata>"}");
+
+            Logging.Log.WriteWarningMessage(LOGTAG, "BlocksetLengthMismatch", null,
+                "Found {0} blockset(s) with a recorded length that does not match the blocks they reference. This cannot be repaired, as it is not possible to tell whether the length or the blocks are wrong. Use the list-broken-files and purge-broken-files commands to handle the affected files. Examples: {1}{2}",
+                count, Environment.NewLine, string.Join(Environment.NewLine, examples));
+
+            return count;
+        }
+
         public async Task FixEmptyMetadatasetsAsync(Options options, CancellationToken token)
         {
             using var cmd = m_connection.CreateCommand(@"

--- a/Duplicati/Library/Main/Operation/RepairHandler.cs
+++ b/Duplicati/Library/Main/Operation/RepairHandler.cs
@@ -1410,6 +1410,17 @@ namespace Duplicati.Library.Main.Operation
             if (await db.RepairInProgressAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false) || await db.PartiallyRecreatedAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false))
                 Logging.Log.WriteWarningMessage(LOGTAG, "InProgressDatabase", null, "The database is marked as \"in-progress\" and may be incomplete.");
 
+            // The shared empty-file blockset is the only blockset for which a recorded length of 0 is
+            // legitimate, and it is identified by hash as well as by length.
+            var emptyFileHash = Utility.CalculateEmptyFileHash(m_options);
+
+            await db
+                .FixOrphanBlocksetEntriesAsync(m_options.Dryrun, m_result.TaskControl.ProgressToken)
+                .ConfigureAwait(false);
+            await db
+                .FixEmptyBlocksetWithBlocksAsync(emptyFileHash, m_options.Dryrun, m_result.TaskControl.ProgressToken)
+                .ConfigureAwait(false);
+
             await db.FixDuplicateMetahashAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false);
             await db.FixDuplicateFileentriesAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false);
             await db.FixDuplicatePathsInFilesetsAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false);
@@ -1421,6 +1432,11 @@ namespace Duplicati.Library.Main.Operation
                 .ConfigureAwait(false);
             await db
                 .FixEmptyMetadatasetsAsync(m_options, m_result.TaskControl.ProgressToken)
+                .ConfigureAwait(false);
+
+            // Run this last, so mismatches that the steps above have resolved are not reported.
+            await db
+                .ReportBlocksetLengthMismatchesAsync(emptyFileHash, m_result.TaskControl.ProgressToken)
                 .ConfigureAwait(false);
         }
 

--- a/Duplicati/Library/Main/Utility.cs
+++ b/Duplicati/Library/Main/Utility.cs
@@ -133,6 +133,27 @@ namespace Duplicati.Library.Main
             => new Metahash(values, options);
 
         /// <summary>
+        /// Computes the file hash of a zero-byte file, base64 encoded.
+        /// </summary>
+        /// <remarks>
+        /// This is the hash of the blockset that every empty file in the backup shares.
+        /// Because <c>Blockset</c> is unique on <c>("FullHash", "Length")</c>, there is at most one
+        /// such row, and it is the only blockset for which a recorded length of 0 is legitimate.
+        /// Matching on the hash as well as the length makes it possible to tell that row apart from a
+        /// corrupt blockset that merely claims to be zero-length while still having blocks attached.
+        /// </remarks>
+        /// <param name="options">The options to use for hashing</param>
+        /// <returns>The base64 encoded file hash of zero bytes</returns>
+        public static string CalculateEmptyFileHash(Options options)
+        {
+            using var filehasher = HashFactory.CreateHasher(options.FileHashAlgorithm);
+            if (filehasher == null)
+                throw new Interface.UserInformationException(Strings.Common.InvalidHashAlgorithm(options.FileHashAlgorithm), "FileHashAlgorithmNotSupported");
+
+            return Convert.ToBase64String(filehasher.ComputeHash(Array.Empty<byte>()));
+        }
+
+        /// <summary>
         /// Updates the options with settings from the data, if any.
         /// </summary>
         /// <param name="db">The database to read from.</param>

--- a/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
+++ b/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
@@ -1,0 +1,283 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Main;
+using Duplicati.Library.Main.Database;
+using Duplicati.Library.Main.Database.Local;
+using Duplicati.Library.SQLiteHelper;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Tests for the repair operations around the shared empty-file blockset.
+/// </summary>
+/// <remarks>
+/// <c>Blockset</c> is unique on <c>("FullHash", "Length")</c>, so there is at most one zero-length
+/// blockset, and it is the blockset that every empty file in the backup uses as its content. Blocks
+/// attached to that one row therefore make the consistency check fail for every empty file at once.
+/// </remarks>
+public class ZeroLengthMetadataTests : BasicSetupHelper
+{
+    /// <summary>
+    /// Creates a backup containing a regular file and an empty file, so that the shared empty-file
+    /// blockset exists, and returns the options used.
+    /// </summary>
+    private async Task<Dictionary<string, string>> BackupWithEmptyFileAsync()
+    {
+        var options = new Dictionary<string, string>(this.TestOptions);
+        File.WriteAllText(Path.Combine(this.DATAFOLDER, "a.txt"), "some data");
+        File.WriteAllText(Path.Combine(this.DATAFOLDER, "empty.txt"), string.Empty);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+        return options;
+    }
+
+    /// <summary>
+    /// Returns the ID of the shared empty-file blockset, asserting that it exists.
+    /// </summary>
+    private static long GetSharedEmptyBlocksetId(SqliteCommand cmd, string emptyFileHash)
+    {
+        var id = cmd
+            .SetCommandAndParameters(@"SELECT ""ID"" FROM ""Blockset"" WHERE ""Length"" = 0 AND ""FullHash"" = @Hash")
+            .SetParameterValue("@Hash", emptyFileHash)
+            .ExecuteScalarInt64(-1);
+
+        Assert.That(id, Is.GreaterThanOrEqualTo(0), "The shared empty-file blockset was not found");
+        return id;
+    }
+
+    /// <summary>
+    /// Counts the blockset entries attached to a blockset.
+    /// </summary>
+    private static long CountBlocksetEntries(SqliteCommand cmd, long blocksetId)
+        => cmd
+            .SetCommandAndParameters(@"SELECT COUNT(*) FROM ""BlocksetEntry"" WHERE ""BlocksetID"" = @Id")
+            .SetParameterValue("@Id", blocksetId)
+            .ExecuteScalarInt64(0);
+
+    /// <summary>
+    /// Attaches an existing block to a blockset, simulating the damage seen in the wild.
+    /// </summary>
+    private static async Task AttachBlockAsync(SqliteCommand cmd, long blocksetId)
+    {
+        var blockId = cmd.ExecuteScalarInt64(@"SELECT ""ID"" FROM ""Block"" ORDER BY ""ID"" LIMIT 1", -1);
+        Assert.That(blockId, Is.GreaterThanOrEqualTo(0), "No blocks in the backup");
+
+        await cmd
+            .SetCommandAndParameters(@"INSERT INTO ""BlocksetEntry"" (""BlocksetID"", ""Index"", ""BlockID"") VALUES (@BlocksetId, 0, @BlockId)")
+            .SetParameterValue("@BlocksetId", blocksetId)
+            .SetParameterValue("@BlockId", blockId)
+            .ExecuteNonQueryAsync();
+    }
+
+    [Test]
+    [Category("RepairHandler")]
+    public async Task RepairStripsBlocksFromSharedEmptyBlocksetAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        long emptyBlocksetId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            emptyBlocksetId = GetSharedEmptyBlocksetId(cmd, emptyFileHash);
+            await AttachBlockAsync(cmd, emptyBlocksetId);
+        }
+
+        // The empty file now claims a length of 0 while referencing a block, which the consistency
+        // check reports for every empty file sharing the blockset.
+        Assert.ThrowsAsync<DatabaseInconsistencyException>(async () =>
+        {
+            await using var db = await LocalDatabase.CreateLocalDatabaseAsync(this.DBFILE, "verify", true, null, CancellationToken.None);
+            await db.VerifyConsistencyAsync(opts.Blocksize, opts.BlockhashSize, true, CancellationToken.None);
+        });
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var res = await c.RepairAsync();
+            Assert.That(res.Errors.Count(), Is.EqualTo(0));
+            Assert.That(res.Warnings.Count(), Is.EqualTo(0));
+        }
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+            Assert.That(CountBlocksetEntries(cmd, emptyBlocksetId), Is.EqualTo(0), "Blocks should have been stripped from the shared empty blockset");
+
+        await using (var db = await LocalDatabase.CreateLocalDatabaseAsync(this.DBFILE, "verify", true, null, CancellationToken.None))
+            await db.VerifyConsistencyAsync(opts.Blocksize, opts.BlockhashSize, true, CancellationToken.None);
+    }
+
+    [Test]
+    [Category("RepairHandler")]
+    public async Task RepairRemovesOrphanedBlocksetEntriesAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+
+        long orphanBlocksetId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            // A blockset ID that does not exist; the rowid may be handed out again by a later insert,
+            // which is what makes these rows dangerous rather than merely untidy.
+            orphanBlocksetId = cmd.ExecuteScalarInt64(@"SELECT IFNULL(MAX(""ID""), 0) + 1000 FROM ""Blockset""", -1);
+            await AttachBlockAsync(cmd, orphanBlocksetId);
+
+            await cmd
+                .SetCommandAndParameters(@"INSERT INTO ""BlocklistHash"" (""BlocksetID"", ""Index"", ""Hash"") VALUES (@Id, 0, 'orphan-blocklist-hash')")
+                .SetParameterValue("@Id", orphanBlocksetId)
+                .ExecuteNonQueryAsync();
+        }
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var res = await c.RepairAsync();
+            Assert.That(res.Errors.Count(), Is.EqualTo(0));
+            Assert.That(res.Warnings.Count(), Is.EqualTo(0));
+        }
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            Assert.That(CountBlocksetEntries(cmd, orphanBlocksetId), Is.EqualTo(0), "Orphaned blockset entries should have been removed");
+            Assert.That(
+                cmd.SetCommandAndParameters(@"SELECT COUNT(*) FROM ""BlocklistHash"" WHERE ""BlocksetID"" = @Id")
+                    .SetParameterValue("@Id", orphanBlocksetId)
+                    .ExecuteScalarInt64(0),
+                Is.EqualTo(0),
+                "Orphaned blocklist hashes should have been removed");
+        }
+
+        await using (var db = await LocalDatabase.CreateLocalDatabaseAsync(this.DBFILE, "verify", true, null, CancellationToken.None))
+            await db.VerifyConsistencyAsync(opts.Blocksize, opts.BlockhashSize, true, CancellationToken.None);
+    }
+
+    [Test]
+    [Category("RepairHandler")]
+    public async Task RepairReportsButDoesNotEmptyFalselyZeroLengthBlocksetAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        long emptyBlocksetId;
+        long corruptBlocksetId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            emptyBlocksetId = GetSharedEmptyBlocksetId(cmd, emptyFileHash);
+            await AttachBlockAsync(cmd, emptyBlocksetId);
+
+            // A file blockset that keeps its blocks and its real hash, but is falsely marked as
+            // zero-length. Stripping its blocks would turn a broken file into one that silently
+            // restores as empty, so it must be reported instead.
+            corruptBlocksetId = cmd.ExecuteScalarInt64(@"
+                SELECT ""B"".""ID""
+                FROM ""Blockset"" ""B""
+                JOIN ""FileLookup"" ""F"" ON ""F"".""BlocksetID"" = ""B"".""ID""
+                WHERE ""B"".""Length"" > 0
+                LIMIT 1
+            ", -1);
+            Assert.That(corruptBlocksetId, Is.GreaterThanOrEqualTo(0), "No file blockset found");
+
+            await cmd
+                .SetCommandAndParameters(@"UPDATE ""Blockset"" SET ""Length"" = 0 WHERE ""ID"" = @Id")
+                .SetParameterValue("@Id", corruptBlocksetId)
+                .ExecuteNonQueryAsync();
+        }
+
+        await using (var db = await LocalRepairDatabase.CreateRepairDatabaseAsync(this.DBFILE, null, CancellationToken.None))
+        {
+            // Only the shared empty blockset is emptied, even though both now claim a length of 0.
+            var stripped = await db.FixEmptyBlocksetWithBlocksAsync(emptyFileHash, false, CancellationToken.None);
+            Assert.That(stripped, Is.EqualTo(1), "Only the shared empty blockset should have been stripped");
+
+            var mismatches = await db.ReportBlocksetLengthMismatchesAsync(emptyFileHash, CancellationToken.None);
+            Assert.That(mismatches, Is.EqualTo(1), "The falsely zero-length blockset should be reported as unrepairable");
+
+            await db.Transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            Assert.That(CountBlocksetEntries(cmd, emptyBlocksetId), Is.EqualTo(0), "Blocks should have been stripped from the shared empty blockset");
+            Assert.That(CountBlocksetEntries(cmd, corruptBlocksetId), Is.GreaterThan(0), "The falsely zero-length blockset must keep its blocks");
+        }
+
+        // Repair cannot fix this state, and must not pretend otherwise: the consistency check that
+        // guards the remote repair still refuses to proceed.
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            Assert.ThrowsAsync<DatabaseInconsistencyException>(() => c.RepairAsync());
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+            Assert.That(CountBlocksetEntries(cmd, corruptBlocksetId), Is.GreaterThan(0), "The falsely zero-length blockset must keep its blocks");
+    }
+
+    [Test]
+    [Category("RepairHandler")]
+    public async Task DryrunDoesNotChangeTheDatabaseAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        long emptyBlocksetId;
+        long orphanBlocksetId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            emptyBlocksetId = GetSharedEmptyBlocksetId(cmd, emptyFileHash);
+            await AttachBlockAsync(cmd, emptyBlocksetId);
+
+            orphanBlocksetId = cmd.ExecuteScalarInt64(@"SELECT IFNULL(MAX(""ID""), 0) + 1000 FROM ""Blockset""", -1);
+            await AttachBlockAsync(cmd, orphanBlocksetId);
+        }
+
+        await using (var db = await LocalRepairDatabase.CreateRepairDatabaseAsync(this.DBFILE, null, CancellationToken.None))
+        {
+            Assert.That(await db.FixOrphanBlocksetEntriesAsync(true, CancellationToken.None), Is.EqualTo(1));
+            Assert.That(await db.FixEmptyBlocksetWithBlocksAsync(emptyFileHash, true, CancellationToken.None), Is.EqualTo(1));
+
+            await db.Transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            Assert.That(CountBlocksetEntries(cmd, emptyBlocksetId), Is.EqualTo(1), "A dry-run must not strip blocks");
+            Assert.That(CountBlocksetEntries(cmd, orphanBlocksetId), Is.EqualTo(1), "A dry-run must not remove orphaned entries");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds extended detection for blocksets that are the wrong length.

It also has cleanups that ensures we can recognize valid (but unwanted) zero-length entries from invalid ones.