### PR TITLE
Avoid defective metadata for repair

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -3350,103 +3350,144 @@ namespace Duplicati.Library.Main.Database.Local
         }
 
         /// <summary>
-        /// Returns the ID of an empty metadata blockset. If no empty blockset is found, it returns the ID of the smallest blockset that is not in the given block volume IDs.
-        /// If no such blockset is found, it returns -1.
+        /// SQL fragment listing the ids of the volumes that can currently supply blocks: volumes that are
+        /// block volumes and are not on their way out of the backup.
         /// </summary>
-        /// <param name="blockVolumeIds">The volume ids to ignore when searching for a suitable metadata block.</param>
-        /// <param name="emptyHash">The hash of the empty blockset.</param>
-        /// <param name="emptyHashSize">The size of the empty blockset.</param>
+        private static readonly string LIVE_BLOCK_VOLUME_IDS = @$"
+            SELECT ""ID""
+            FROM ""RemoteVolume""
+            WHERE
+                ""Type"" = '{RemoteVolumeType.Blocks}'
+                AND ""State"" NOT IN (
+                    '{RemoteVolumeState.Deleted}',
+                    '{RemoteVolumeState.Deleting}',
+                    '{RemoteVolumeState.Temporary}'
+                )
+        ";
+
+        /// <summary>
+        /// Builds a SQL predicate that is true when the blockset identified by
+        /// <paramref name="blocksetIdExpression"/> can actually be restored.
+        /// </summary>
+        /// <remarks>
+        /// A restorable blockset has at least one <c>BlocksetEntry</c>, and none of its entries points at a
+        /// missing <c>Block</c> row, at a volume in <c>@BlockVolumeIds</c>, or at a volume that is not a
+        /// live block volume. Testing only that a <c>Block</c> row exists is not enough: that is what made
+        /// the old lookup hand out blocksets whose blocks were in a volume that was about to be removed.
+        /// <para>
+        /// The query using this fragment must expand the <c>@BlockVolumeIds</c> parameter with the volume
+        /// ids to treat as unavailable. An empty collection expands to <c>IN ()</c>, which SQLite accepts
+        /// and evaluates as false, so nothing is excluded.
+        /// </para>
+        /// </remarks>
+        /// <param name="blocksetIdExpression">The SQL expression identifying the blockset to test.</param>
+        /// <returns>A SQL predicate.</returns>
+        private static string BLOCKSET_IS_FULLY_AVAILABLE(string blocksetIdExpression) => @$"
+            EXISTS (
+                SELECT 1
+                FROM ""BlocksetEntry""
+                WHERE ""BlocksetEntry"".""BlocksetID"" = {blocksetIdExpression}
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                FROM ""BlocksetEntry""
+                LEFT JOIN ""Block""
+                    ON ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
+                WHERE
+                    ""BlocksetEntry"".""BlocksetID"" = {blocksetIdExpression}
+                    AND (
+                        ""Block"".""ID"" IS NULL
+                        OR ""Block"".""VolumeID"" IN (@BlockVolumeIds)
+                        OR ""Block"".""VolumeID"" NOT IN ({LIVE_BLOCK_VOLUME_IDS})
+                    )
+            )
+        ";
+
+        /// <summary>
+        /// Finds the blockset with the given hash and size, but only if it can be used as replacement
+        /// metadata: it must be non-empty and all of its blocks must be available.
+        /// </summary>
+        /// <remarks>
+        /// A blockset with a length of 0 is never a valid metadata blockset. Metadata always has contents -
+        /// the smallest possible blob is a serialized empty dictionary - so a metadata entry with length 0
+        /// can never be restored. Worse, <c>Blockset</c> is unique on <c>("FullHash", "Length")</c>, so
+        /// there is only one zero-length blockset and it is the one that every empty file in the backup uses
+        /// as its content. Handing it out as metadata therefore entangles the damaged metadata with every
+        /// empty file in the backup.
+        /// </remarks>
+        /// <param name="blockVolumeIds">The ids of the volumes to treat as unavailable.</param>
+        /// <param name="fullHash">The hash of the wanted blockset.</param>
+        /// <param name="size">The length of the wanted blockset.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
-        /// <returns>A task that when awaited contains the ID of the empty metadata blockset, or -1 if no suitable blockset is found</returns>
-        public async Task<long> GetEmptyMetadataBlocksetIdAsync(IEnumerable<long> blockVolumeIds, string emptyHash, long emptyHashSize, CancellationToken token)
+        /// <returns>A task that when awaited contains the id of the blockset, or -1 if it is not present or not available.</returns>
+        public async Task<long> FindExactMetadataBlocksetIdAsync(IEnumerable<long> blockVolumeIds, string fullHash, long size, CancellationToken token)
         {
+            // See the remarks above: a zero-length blockset can never hold restorable metadata.
+            if (size <= 0)
+                return -1;
+
             await using var tmptable = await TemporaryDbValueList.CreateAsync(this, blockVolumeIds, token)
                 .ConfigureAwait(false);
 
-            await using var cmd = Connection.CreateCommand(@"
-                SELECT ""ID""
+            await using var cmd = Connection.CreateCommand(@$"
+                SELECT ""Blockset"".""ID""
                 FROM ""Blockset""
                 WHERE
-                    ""FullHash"" = @EmptyHash
-                    AND ""Length"" == @EmptyHashSize
-                    AND ""ID"" NOT IN (
-                        SELECT ""BlocksetID""
-                        FROM
-                            ""BlocksetEntry"",
-                            ""Block""
-                        WHERE
-                            ""BlocksetEntry"".""BlockID"" = ""Block"".""ID""
-                            AND ""Block"".""VolumeID"" NOT IN (@BlockVolumeIds)
-                    )
+                    ""Blockset"".""FullHash"" = @FullHash
+                    AND ""Blockset"".""Length"" = @Size
+                    AND ""Blockset"".""Length"" > 0
+                    AND {BLOCKSET_IS_FULLY_AVAILABLE(@"""Blockset"".""ID""")}
+                LIMIT 1
             ")
                 .SetTransaction(m_rtr)
-                .SetParameterValue("@EmptyHash", emptyHash)
-                .SetParameterValue("@EmptyHashSize", emptyHashSize);
+                .SetParameterValue("@FullHash", fullHash)
+                .SetParameterValue("@Size", size);
 
             await cmd.ExpandInClauseParameterMssqliteAsync("@BlockVolumeIds", tmptable, token)
                 .ConfigureAwait(false);
 
-            var res = await cmd.ExecuteScalarInt64Async(-1, token)
+            return await cmd.ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Finds the smallest available blockset that is already used as metadata.
+        /// </summary>
+        /// <remarks>
+        /// This is a last resort: the returned blockset is restorable, but its contents do not describe the
+        /// files it gets assigned to, so the affected files lose their original permissions and timestamps.
+        /// As with <see cref="FindExactMetadataBlocksetIdAsync"/>, zero-length blocksets are excluded
+        /// because they can never hold restorable metadata.
+        /// </remarks>
+        /// <param name="blockVolumeIds">The ids of the volumes to treat as unavailable.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the id of the blockset, or -1 if no usable blockset exists.</returns>
+        public async Task<long> FindSmallestUsableMetadataBlocksetIdAsync(IEnumerable<long> blockVolumeIds, CancellationToken token)
+        {
+            await using var tmptable = await TemporaryDbValueList.CreateAsync(this, blockVolumeIds, token)
                 .ConfigureAwait(false);
 
-            // No empty block found, try to find a zero-length block instead
-            if (res < 0 && emptyHashSize != 0)
-            {
-                cmd.SetCommandAndParameters(@"
-                    SELECT ""ID""
-                    FROM ""Blockset""
-                    WHERE
-                        ""Length"" == @EmptyHashSize
-                        AND ""ID"" NOT IN (
-                            SELECT ""BlocksetID""
-                            FROM
-                                ""BlocksetEntry"",
-                                ""Block""
-                            WHERE
-                                ""BlocksetEntry"".""BlockID"" = ""Block"".""ID""
-                                AND ""Block"".""VolumeID"" NOT IN (@BlockVolumeIds)
-                        )
-                ")
-                .SetParameterValue("@EmptyHashSize", 0);
+            await using var cmd = Connection.CreateCommand(@$"
+                SELECT ""Blockset"".""ID""
+                FROM ""Blockset""
+                WHERE
+                    ""Blockset"".""Length"" > 0
+                    AND EXISTS (
+                        SELECT 1
+                        FROM ""Metadataset""
+                        WHERE ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID""
+                    )
+                    AND {BLOCKSET_IS_FULLY_AVAILABLE(@"""Blockset"".""ID""")}
+                ORDER BY ""Blockset"".""Length"" ASC
+                LIMIT 1
+            ")
+                .SetTransaction(m_rtr);
 
-                await cmd.ExpandInClauseParameterMssqliteAsync("@BlockVolumeIds", tmptable, token)
-                         .ConfigureAwait(false);
+            await cmd.ExpandInClauseParameterMssqliteAsync("@BlockVolumeIds", tmptable, token)
+                .ConfigureAwait(false);
 
-                res = await cmd
-                  .ExecuteScalarInt64Async(-1, token)
-                  .ConfigureAwait(false);
-            }
-
-            // No empty block found, pick the smallest one
-            if (res < 0)
-            {
-                cmd.SetCommandAndParameters(@"
-                    SELECT ""Blockset"".""ID""
-                    FROM
-                        ""BlocksetEntry"",
-                        ""Blockset"",
-                        ""Metadataset"",
-                        ""Block""
-                    WHERE
-                        ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID""
-                        AND ""BlocksetEntry"".""BlocksetID"" = ""Blockset"".""ID""
-                        AND ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
-                        AND ""Block"".""VolumeID"" NOT IN (@BlockVolumeIds)
-                        AND ""Blockset"".""Length"" > 0
-                    ORDER BY ""Blockset"".""Length"" ASC
-                    LIMIT 1
-                ");
-
-                await cmd
-                  .ExpandInClauseParameterMssqliteAsync("@BlockVolumeIds", tmptable, token)
-                  .ConfigureAwait(false);
-
-                res = await cmd
-                  .ExecuteScalarInt64Async(-1, token)
-                  .ConfigureAwait(false);
-            }
-
-            return res;
+            return await cmd.ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
         }
 
         public virtual void Dispose()

--- a/Duplicati/Library/Main/Database/Local/LocalRepairDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalRepairDatabase.cs
@@ -2226,10 +2226,21 @@ namespace Duplicati.Library.Main.Database.Local
 
             Logging.Log.WriteInformationMessage(LOGTAG, "ZeroLengthMetadata", "Found {0} zero-length metadata entries", emptyMetaCount);
 
-            // Create replacement metadata
+            // Locate replacement metadata: the canonical empty metadata blob if it happens to be stored in
+            // this backup, otherwise the smallest metadata that is actually restorable. The latter does not
+            // describe the files it gets assigned to, so they lose their permissions and timestamps.
             var emptyMeta = Utility.WrapMetadata(new Dictionary<string, string>(), options);
-            var emptyBlocksetId = await GetEmptyMetadataBlocksetIdAsync(Array.Empty<long>(), emptyMeta.FileHash, emptyMeta.Blob.Length, token)
+            var emptyBlocksetId = await FindExactMetadataBlocksetIdAsync(Array.Empty<long>(), emptyMeta.FileHash, emptyMeta.Blob.Length, token)
                 .ConfigureAwait(false);
+
+            if (emptyBlocksetId < 0)
+            {
+                emptyBlocksetId = await FindSmallestUsableMetadataBlocksetIdAsync(Array.Empty<long>(), token)
+                    .ConfigureAwait(false);
+
+                if (emptyBlocksetId >= 0)
+                    Logging.Log.WriteInformationMessage(LOGTAG, "ReplacementMetadataIsNotEmpty", "The empty metadata entry is not present in the backup, using the smallest available metadata as replacement. The affected files will lose their original permissions and timestamps.");
+            }
 
             if (emptyBlocksetId < 0)
                 throw new Interface.UserInformationException(

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -104,14 +104,32 @@ namespace Duplicati.Library.Main.Operation
                 if (!m_options.DisableReplaceMissingMetadata)
                 {
                     var emptymetadata = Utility.WrapMetadata(new Dictionary<string, string>(), m_options);
+                    // The volumes that are missing cannot supply blocks, so a blockset that depends on them
+                    // is no more restorable than the metadata we are replacing.
+                    var unavailableVolumeIds = (missing ?? []).Select(x => x.ID).ToArray();
+
                     replacementMetadataBlocksetId = await db
-                        .GetEmptyMetadataBlocksetIdAsync(
-                            (missing ?? []).Select(x => x.ID),
+                        .FindExactMetadataBlocksetIdAsync(
+                            unavailableVolumeIds,
                             emptymetadata.FileHash,
                             emptymetadata.Blob.Length,
                             m_result.TaskControl.ProgressToken
                         )
                         .ConfigureAwait(false);
+
+                    if (replacementMetadataBlocksetId < 0)
+                    {
+                        // The canonical empty metadata blob is not stored in this backup, so fall back to
+                        // the smallest metadata that is actually restorable. Its contents do not describe
+                        // the files it gets assigned to, so they lose their permissions and timestamps.
+                        replacementMetadataBlocksetId = await db
+                            .FindSmallestUsableMetadataBlocksetIdAsync(unavailableVolumeIds, m_result.TaskControl.ProgressToken)
+                            .ConfigureAwait(false);
+
+                        if (replacementMetadataBlocksetId >= 0)
+                            Logging.Log.WriteInformationMessage(LOGTAG, "ReplacementMetadataIsNotEmpty", "The empty metadata entry is not present in the backup, using the smallest available metadata as replacement. The affected files will lose their original permissions and timestamps.");
+                    }
+
                     if (replacementMetadataBlocksetId < 0)
                         throw new UserInformationException($"Failed to locate an empty metadata blockset to replace missing metadata. Set the option --disable-replace-missing-metadata=true to ignore this and drop files with missing metadata.", "FailedToLocateEmptyMetadataBlockset");
                 }

--- a/Duplicati/UnitTest/EmptyMetadataTests.cs
+++ b/Duplicati/UnitTest/EmptyMetadataTests.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Duplicati.Library.Main;
 using Duplicati.Library.Main.Database;
 using Duplicati.Library.Main.Database.Local;
@@ -92,12 +93,15 @@ public class EmptyMetadataTests : BasicSetupHelper
 
         await using (var db = await LocalListBrokenFilesDatabase.CreateAsync(DBFILE, null, CancellationToken.None).ConfigureAwait(false))
         {
-            var blockVolumeIds = Array.Empty<long>();
+            var unavailableVolumeIds = Array.Empty<long>();
 
-            var emptyId = await db.GetEmptyMetadataBlocksetIdAsync(blockVolumeIds, emptyMeta.FileHash, emptyMeta.Blob.Length, CancellationToken.None);
-            Assert.That(emptyId, Is.GreaterThanOrEqualTo(0), "Empty metadata blockset not found");
+            var replacementId = await db.FindExactMetadataBlocksetIdAsync(unavailableVolumeIds, emptyMeta.FileHash, emptyMeta.Blob.Length, CancellationToken.None);
+            if (replacementId < 0)
+                replacementId = await db.FindSmallestUsableMetadataBlocksetIdAsync(unavailableVolumeIds, CancellationToken.None);
 
-            var replaced = await db.ReplaceMetadataAsync(filesetId, emptyId, CancellationToken.None);
+            Assert.That(replacementId, Is.GreaterThanOrEqualTo(0), "No replacement metadata blockset found");
+
+            var replaced = await db.ReplaceMetadataAsync(filesetId, replacementId, CancellationToken.None);
             Assert.That(replaced, Is.GreaterThan(0), "No metadata rows replaced");
 
             await db.Transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
@@ -108,13 +112,19 @@ public class EmptyMetadataTests : BasicSetupHelper
     }
 
     /// <summary>
-    /// Tests that GetEmptyMetadataBlocksetId works correctly with a large number of block volume IDs
-    /// that triggers the temporary table code path (when count > CHUNK_SIZE = 128).
+    /// Tests that the replacement metadata lookups work with a large number of unavailable volume IDs,
+    /// which triggers the temporary table code path (when count > CHUNK_SIZE = 128), and that a blockset
+    /// stored in an unavailable volume is not offered as a replacement.
     /// </summary>
     [Test]
     [Category("Database")]
-    public async Task GetEmptyMetadataBlocksetId_WithLargeInput_UsesTemporaryTable_Async()
+    public async Task FindMetadataBlocksetId_WithLargeInput_UsesTemporaryTable_Async()
     {
+        const string METADATA_HASH = "bWV0YWRhdGEtYmxvY2s=";
+        const string BLOCK_HASH = "bWV0YWRhdGEtYmxvY2staGFzaA==";
+        const long METADATA_SIZE = 2;
+        const long BLOCK_VOLUME_ID = 151;
+
         using var dbfile = new TempFile();
         using var db = await SQLiteLoader.LoadConnectionAsync(dbfile);
 
@@ -127,37 +137,122 @@ public class EmptyMetadataTests : BasicSetupHelper
         cmd.CommandText = @"INSERT INTO ""Operation"" (""Description"", ""Timestamp"") VALUES ('Test', 0)";
         await cmd.ExecuteNonQueryAsync();
 
-        // Create 150 block volume IDs (exceeds CHUNK_SIZE of 128) to trigger temporary table path
-        var blockVolumeIds = new List<long>();
-        for (int i = 0; i < 150; i++)
+        // Create 150 volume IDs (exceeds CHUNK_SIZE of 128) to trigger the temporary table path,
+        // plus one more that holds the block the candidate blockset is made of
+        var unavailableVolumeIds = new List<long>();
+        for (var i = 1; i <= BLOCK_VOLUME_ID; i++)
         {
-            blockVolumeIds.Add(i + 1);
+            if (i != BLOCK_VOLUME_ID)
+                unavailableVolumeIds.Add(i);
 
-            // Insert a remote volume for each block volume ID
             cmd.CommandText = $@"
                 INSERT INTO ""Remotevolume"" (""ID"", ""OperationID"", ""Name"", ""Type"", ""State"", ""VerificationCount"", ""DeleteGraceTime"", ""ArchiveTime"", ""LockExpirationTime"")
-                VALUES ({i + 1}, 1, 'block-volume-{i}.zip', 'Blocks', 'Verified', 0, 0, 0, 0)";
+                VALUES ({i}, 1, 'block-volume-{i}.zip', 'Blocks', 'Verified', 0, 0, 0, 0)";
             await cmd.ExecuteNonQueryAsync();
         }
 
-        // Insert a blockset entry that represents empty metadata (hash of empty data)
-        // This will be found when GetEmptyMetadataBlocksetId is called
-        cmd.CommandText = @"
-            INSERT INTO ""Blockset"" (""ID"", ""FullHash"", ""Length"")
-            VALUES (1, 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 0)";
+        Assert.That(unavailableVolumeIds.Count, Is.GreaterThan(128), "The temporary table path is only used above the chunk size");
+
+        // A realistic replacement candidate: a non-empty blockset, backed by a real block in an
+        // available volume, that is already used as metadata
+        cmd.CommandText = $@"
+            INSERT INTO ""Block"" (""ID"", ""Hash"", ""Size"", ""VolumeID"") VALUES (1, '{BLOCK_HASH}', {METADATA_SIZE}, {BLOCK_VOLUME_ID});
+            INSERT INTO ""Blockset"" (""ID"", ""FullHash"", ""Length"") VALUES (1, '{METADATA_HASH}', {METADATA_SIZE});
+            INSERT INTO ""BlocksetEntry"" (""BlocksetID"", ""Index"", ""BlockID"") VALUES (1, 0, 1);
+            INSERT INTO ""Metadataset"" (""ID"", ""BlocksetID"") VALUES (1, 1);
+        ";
         await cmd.ExecuteNonQueryAsync();
 
         // Close the connection so LocalDatabase can open it
         await db.CloseAsync();
 
-        // Create LocalListBrokenFilesDatabase instance (which inherits GetEmptyMetadataBlocksetId from LocalDatabase)
         await using var localDb = await LocalListBrokenFilesDatabase.CreateAsync(dbfile, null, CancellationToken.None).ConfigureAwait(false);
 
-        // Act: Call GetEmptyMetadataBlocksetId with 150 block volume IDs
-        // This should trigger the temporary table code path
-        var emptyId = await localDb.GetEmptyMetadataBlocksetIdAsync(blockVolumeIds, "da39a3ee5e6b4b0d3255bfef95601890afd80709", 0, CancellationToken.None);
+        Assert.That(
+            await localDb.FindExactMetadataBlocksetIdAsync(unavailableVolumeIds, METADATA_HASH, METADATA_SIZE, CancellationToken.None),
+            Is.EqualTo(1),
+            "The exact blockset should be found when its volume is available");
 
-        // Assert: Should find the empty metadata blockset (ID = 1)
-        Assert.That(emptyId, Is.EqualTo(1));
+        Assert.That(
+            await localDb.FindSmallestUsableMetadataBlocksetIdAsync(unavailableVolumeIds, CancellationToken.None),
+            Is.EqualTo(1),
+            "The blockset should be usable as a fallback when its volume is available");
+
+        // Excluding the volume that holds the block makes the blockset unrestorable, so neither lookup
+        // may offer it
+        var allVolumesUnavailable = unavailableVolumeIds.Append(BLOCK_VOLUME_ID).ToList();
+
+        Assert.That(
+            await localDb.FindExactMetadataBlocksetIdAsync(allVolumesUnavailable, METADATA_HASH, METADATA_SIZE, CancellationToken.None),
+            Is.EqualTo(-1),
+            "A blockset in an unavailable volume must not be returned");
+
+        Assert.That(
+            await localDb.FindSmallestUsableMetadataBlocksetIdAsync(allVolumesUnavailable, CancellationToken.None),
+            Is.EqualTo(-1),
+            "A blockset in an unavailable volume must not be returned as a fallback");
+    }
+
+    /// <summary>
+    /// The shared zero-length blockset is the content of every empty file in the backup, so it must never
+    /// be handed out as replacement metadata: it has no blocks and can therefore not be restored, and
+    /// assigning it entangles the damaged metadata with every empty file.
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task ReplacementMetadataIsNeverTheSharedEmptyBlocksetAsync()
+    {
+        var testopts = TestOptions.Expand(new { no_encryption = true });
+
+        File.WriteAllText(Path.Combine(DATAFOLDER, "file.txt"), "data");
+        File.WriteAllText(Path.Combine(DATAFOLDER, "empty.txt"), string.Empty);
+
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            TestUtils.AssertResults(await c.BackupAsync(new[] { DATAFOLDER }));
+
+        var opts = new Options(testopts);
+        var emptyMeta = Duplicati.Library.Main.Utility.WrapMetadata(new Dictionary<string, string>(), opts);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        long sharedEmptyBlocksetId;
+        using (var db = await SQLiteLoader.LoadConnectionAsync(DBFILE))
+        using (var cmd = db.CreateCommand())
+        {
+            sharedEmptyBlocksetId = cmd
+                .SetCommandAndParameters(@"SELECT ""ID"" FROM ""Blockset"" WHERE ""Length"" = 0 AND ""FullHash"" = @Hash")
+                .SetParameterValue("@Hash", emptyFileHash)
+                .ExecuteScalarInt64(-1);
+            Assert.That(sharedEmptyBlocksetId, Is.GreaterThanOrEqualTo(0), "The shared empty-file blockset was not found");
+        }
+
+        await using var localDb = await LocalListBrokenFilesDatabase.CreateAsync(DBFILE, null, CancellationToken.None).ConfigureAwait(false);
+        var unavailableVolumeIds = Array.Empty<long>();
+
+        // The canonical empty metadata blob is not stored by a normal backup, so the exact lookup finds
+        // nothing rather than falling back to the shared zero-length blockset
+        Assert.That(
+            await localDb.FindExactMetadataBlocksetIdAsync(unavailableVolumeIds, emptyMeta.FileHash, emptyMeta.Blob.Length, CancellationToken.None),
+            Is.EqualTo(-1),
+            "The empty metadata blob is not stored in this backup");
+
+        var fallbackId = await localDb.FindSmallestUsableMetadataBlocksetIdAsync(unavailableVolumeIds, CancellationToken.None);
+        Assert.That(fallbackId, Is.GreaterThanOrEqualTo(0), "No fallback metadata blockset found");
+        Assert.That(fallbackId, Is.Not.EqualTo(sharedEmptyBlocksetId), "The shared empty-file blockset must never be used as metadata");
+
+        using (var db = await SQLiteLoader.LoadConnectionAsync(DBFILE))
+        using (var cmd = db.CreateCommand())
+        {
+            var length = cmd
+                .SetCommandAndParameters(@"SELECT ""Length"" FROM ""Blockset"" WHERE ""ID"" = @Id")
+                .SetParameterValue("@Id", fallbackId)
+                .ExecuteScalarInt64(-1);
+            Assert.That(length, Is.GreaterThan(0), "Replacement metadata must have contents");
+
+            var blocks = cmd
+                .SetCommandAndParameters(@"SELECT COUNT(*) FROM ""BlocksetEntry"" WHERE ""BlocksetID"" = @Id")
+                .SetParameterValue("@Id", fallbackId)
+                .ExecuteScalarInt64(0);
+            Assert.That(blocks, Is.GreaterThan(0), "Replacement metadata must have blocks to restore from");
+        }
     }
 }


### PR DESCRIPTION
This PR adds an improved way to find metadata entries for repairs, such that we avoid assigning a metadata entry that is *also* defective.