### PR TITLE
Test permissions MS365 and Google

### DIFF
--- a/proprietary/GoogleWorkspace/APIHelper.cs
+++ b/proprietary/GoogleWorkspace/APIHelper.cs
@@ -92,6 +92,96 @@ public class APIHelper
         }
     }
 
+    /// <summary>
+    /// The OAuth token info endpoint used to inspect the scopes granted to an access token.
+    /// </summary>
+    private const string TOKEN_INFO_URL = "https://oauth2.googleapis.com/tokeninfo";
+
+    /// <summary>
+    /// Determines which OAuth scopes are currently granted to the configured credentials.
+    /// </summary>
+    /// <remarks>
+    /// For a service account with domain-wide delegation, the token endpoint rejects token
+    /// requests for scopes that have not been granted to the service account in the Admin
+    /// console, so a token is requested for each scope individually to probe the grant.
+    /// There is no API to enumerate the delegated scopes, so grants outside of
+    /// <paramref name="scopes"/> cannot be detected for service accounts.
+    /// For a user credential (refresh token), the granted scopes are read from the token
+    /// info endpoint, which reports every scope consented to, including scopes outside of
+    /// <paramref name="scopes"/>.
+    /// </remarks>
+    /// <param name="scopes">The scopes to check.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The granted scopes; for service accounts a subset of <paramref name="scopes"/>.</returns>
+    public async Task<IReadOnlySet<string>> GetGrantedScopesAsync(IEnumerable<string> scopes, CancellationToken cancellationToken)
+    {
+        var requested = scopes.Distinct(StringComparer.Ordinal).ToList();
+        var granted = new HashSet<string>(StringComparer.Ordinal);
+
+        if (!string.IsNullOrEmpty(_serviceAccountJson))
+        {
+            var probes = requested.Select(async scope =>
+            {
+                try
+                {
+                    var credential = CredentialFactory.FromJson<ServiceAccountCredential>(_serviceAccountJson)
+                        .ToGoogleCredential()
+                        .CreateScoped(scope);
+
+                    if (!string.IsNullOrEmpty(_adminEmail))
+                        credential = (GoogleCredential)credential.CreateWithUser(_adminEmail);
+
+                    await ((ITokenAccess)credential).GetAccessTokenForRequestAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                    return scope;
+                }
+                catch
+                {
+                    // The scope is not granted to the service account
+                    return null;
+                }
+            });
+
+            foreach (var scope in await Task.WhenAll(probes).ConfigureAwait(false))
+                if (scope != null)
+                    granted.Add(scope);
+        }
+        else if (!string.IsNullOrEmpty(_clientId) && !string.IsNullOrEmpty(_clientSecret) && !string.IsNullOrEmpty(_refreshToken))
+        {
+            var credential = new UserCredential(new GoogleAuthorizationCodeFlow(
+                new GoogleAuthorizationCodeFlow.Initializer
+                {
+                    ClientSecrets = new ClientSecrets
+                    {
+                        ClientId = _clientId,
+                        ClientSecret = _clientSecret
+                    }
+                }),
+                "user",
+                new Google.Apis.Auth.OAuth2.Responses.TokenResponse { RefreshToken = _refreshToken });
+
+            var accessToken = await credential.GetAccessTokenForRequestAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            using var client = Duplicati.Library.Utility.HttpClientHelper.CreateClient();
+            using var response = await client.GetAsync($"{TOKEN_INFO_URL}?access_token={Uri.EscapeDataString(accessToken)}", cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            using var doc = System.Text.Json.JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            if (doc.RootElement.TryGetProperty("scope", out var scopeElement) && scopeElement.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                // Report every consented scope, including scopes that were not requested,
+                // so that grants that are not needed can be identified.
+                foreach (var scope in scopeElement.GetString()!.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                    granted.Add(scope);
+            }
+        }
+        else
+        {
+            throw new Exception("Missing credentials");
+        }
+
+        return granted;
+    }
+
     public void TestConnection()
     {
         if (_isRestoreOperation)

--- a/proprietary/GoogleWorkspace/GoogleScopes.cs
+++ b/proprietary/GoogleWorkspace/GoogleScopes.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+using Google.Apis.Admin.Directory.directory_v1;
+using Google.Apis.Calendar.v3;
+using Google.Apis.Drive.v3;
+using Google.Apis.Gmail.v1;
+using Google.Apis.Groupssettings.v1;
+using Google.Apis.HangoutsChat.v1;
+using Google.Apis.Keep.v1;
+using Google.Apis.PeopleService.v1;
+using Google.Apis.Tasks.v1;
+
+namespace Duplicati.Proprietary.GoogleWorkspace;
+
+/// <summary>
+/// Describes a Google OAuth scope and what it is required for.
+/// </summary>
+/// <param name="Name">The OAuth scope URL.</param>
+/// <param name="Description">A human readable description of the resources the scope affects.</param>
+/// <param name="RequiredForBackup">Whether the scope is required for backup operations.</param>
+/// <param name="RequiredForRestore">Whether the scope is required for restore operations.</param>
+/// <param name="CoveredBy">The URL of a write scope that includes this scope's access, if any. A granted covering scope makes this scope effectively enabled.</param>
+public sealed record RequiredGoogleScope(
+    string Name,
+    string Description,
+    bool RequiredForBackup,
+    bool RequiredForRestore,
+    string? CoveredBy = null
+);
+
+/// <summary>
+/// The Google OAuth scopes used by the Google Workspace provider.
+/// </summary>
+public static class GoogleScopes
+{
+    /// <summary>
+    /// The OAuth scopes required for backup and restore operations.
+    /// Readonly scopes with a write counterpart are only required for backup; restore
+    /// operations are expected to hold the write scope, which includes read access.
+    /// </summary>
+    public static readonly IReadOnlyList<RequiredGoogleScope> Required =
+    [
+        new(GmailService.Scope.GmailReadonly, "Read Gmail messages and labels.", true, false, GmailService.Scope.GmailModify),
+        new(GmailService.Scope.GmailModify, "Read and restore Gmail messages and labels.", false, true),
+        new(DirectoryService.Scope.AdminDirectoryUserReadonly, "Read user accounts.", true, false, DirectoryService.Scope.AdminDirectoryUser),
+        new(DirectoryService.Scope.AdminDirectoryUser, "Read, create, and update user accounts.", false, true),
+        new(DirectoryService.Scope.AdminDirectoryGroupReadonly, "Read groups and their members.", true, false, DirectoryService.Scope.AdminDirectoryGroup),
+        new(DirectoryService.Scope.AdminDirectoryGroup, "Read, create, and update groups and their members.", false, true),
+        new(DirectoryService.Scope.AdminDirectoryOrgunitReadonly, "Read organizational units.", true, false, DirectoryService.Scope.AdminDirectoryOrgunit),
+        new(DirectoryService.Scope.AdminDirectoryOrgunit, "Read, create, and update organizational units.", false, true),
+        new(CalendarService.Scope.CalendarReadonly, "Read calendars and events.", true, false, CalendarService.Scope.Calendar),
+        new(CalendarService.Scope.Calendar, "Read calendar sharing settings (ACLs), and restore calendars and events.", true, true),
+        new(DriveService.Scope.DriveReadonly, "Read Drive files and shared drives.", true, false, DriveService.Scope.Drive),
+        new(DriveService.Scope.Drive, "Read and restore Drive files and shared drives.", false, true),
+        new(PeopleServiceService.Scope.ContactsReadonly, "Read contacts.", true, false, PeopleServiceService.Scope.Contacts),
+        new(PeopleServiceService.Scope.Contacts, "Read and restore contacts.", false, true),
+        new(TasksService.Scope.TasksReadonly, "Read task lists and tasks.", true, false, TasksService.Scope.Tasks),
+        new(TasksService.Scope.Tasks, "Read and restore task lists and tasks.", false, true),
+        new(KeepService.Scope.KeepReadonly, "Read Keep notes.", true, false, KeepService.Scope.Keep),
+        new(KeepService.Scope.Keep, "Read and restore Keep notes.", false, true),
+        new(GroupssettingsService.Scope.AppsGroupsSettings, "Read and manage group settings.", true, true),
+        new(HangoutsChatService.Scope.ChatSpacesReadonly, "Read Chat spaces.", true, false),
+        new(HangoutsChatService.Scope.ChatMessagesReadonly, "Read Chat messages.", true, false),
+        new(HangoutsChatService.Scope.ChatMembershipsReadonly, "Read Chat memberships.", true, false),
+        new(HangoutsChatService.Scope.ChatMessages, "Restore Chat messages.", false, true),
+        new(HangoutsChatService.Scope.ChatSpaces, "Create Chat spaces.", false, true),
+    ];
+
+    /// <summary>
+    /// Other OAuth scopes from the same API families that are commonly granted, but never
+    /// used by the provider. For service accounts there is no API to enumerate the scopes
+    /// delegated in the Admin console, so these are probed individually to detect grants
+    /// that are not needed. The flags are always <c>false</c>; they exist only to reuse
+    /// the record shape.
+    /// </summary>
+    public static readonly IReadOnlyList<RequiredGoogleScope> KnownExtras =
+    [
+        new(GmailService.Scope.MailGoogleCom, "Full access to Gmail mailboxes.", false, false),
+        new(GmailService.Scope.GmailSend, "Send Gmail messages.", false, false),
+        new(GmailService.Scope.GmailCompose, "Create and send Gmail messages and drafts.", false, false),
+        new(GmailService.Scope.GmailInsert, "Insert Gmail messages.", false, false),
+        new(GmailService.Scope.GmailLabels, "Manage Gmail labels.", false, false),
+        new(GmailService.Scope.GmailMetadata, "Read Gmail message metadata.", false, false),
+        new(GmailService.Scope.GmailSettingsBasic, "Manage basic Gmail settings.", false, false),
+        new(GmailService.Scope.GmailSettingsSharing, "Manage Gmail sharing settings.", false, false),
+        new(DirectoryService.Scope.AdminDirectoryDomainReadonly, "Read directory domains.", false, false),
+        new(DirectoryService.Scope.AdminDirectoryDomain, "Manage directory domains.", false, false),
+        new(DirectoryService.Scope.AdminDirectoryUserschemaReadonly, "Read directory user schemas.", false, false),
+        new(DirectoryService.Scope.AdminDirectoryUserschema, "Manage directory user schemas.", false, false),
+        new(DirectoryService.Scope.AdminDirectoryRolemanagementReadonly, "Read directory role assignments.", false, false),
+        new(DirectoryService.Scope.AdminDirectoryRolemanagement, "Manage directory role assignments.", false, false),
+        new(CalendarService.Scope.CalendarEvents, "Manage calendar events.", false, false),
+        new(CalendarService.Scope.CalendarEventsReadonly, "Read calendar events.", false, false),
+        new(CalendarService.Scope.CalendarSettingsReadonly, "Read calendar settings.", false, false),
+        new(DriveService.Scope.DriveFile, "Access Drive files created or opened by the app.", false, false),
+        new(DriveService.Scope.DriveMetadata, "Manage Drive file metadata.", false, false),
+        new(DriveService.Scope.DriveMetadataReadonly, "Read Drive file metadata.", false, false),
+        new(PeopleServiceService.Scope.ContactsOtherReadonly, "Read other contacts.", false, false),
+        new(PeopleServiceService.Scope.DirectoryReadonly, "Read directory profile data.", false, false),
+        new(HangoutsChatService.Scope.ChatDelete, "Delete Chat messages and spaces.", false, false),
+        new(HangoutsChatService.Scope.ChatImport, "Import Chat spaces and messages.", false, false),
+        new(HangoutsChatService.Scope.ChatMemberships, "Manage Chat memberships.", false, false),
+        new(HangoutsChatService.Scope.ChatMessagesCreate, "Create Chat messages.", false, false),
+        new(HangoutsChatService.Scope.ChatSpacesCreate, "Create Chat spaces.", false, false),
+    ];
+}

--- a/proprietary/GoogleWorkspace/WebModule/WebModule.cs
+++ b/proprietary/GoogleWorkspace/WebModule/WebModule.cs
@@ -18,7 +18,8 @@ public class WebModule : IWebModule
     public enum Operation
     {
         ListDestination,
-        ListDestinationRestoreTargets
+        ListDestinationRestoreTargets,
+        CheckPermissions
     }
 
     private static readonly Operation DEFAULT_OPERATION = Operation.ListDestination;
@@ -79,7 +80,7 @@ public class WebModule : IWebModule
         options.TryGetValue(KEY_URL, out var url);
         options.TryGetValue(KEY_PATH, out var path);
 
-        if (op != Operation.ListDestination && op != Operation.ListDestinationRestoreTargets)
+        if (!Enum.IsDefined(op))
             throw new UserInformationException($"Unsupported operation: {op}", "UnsupportedOperation");
 
         if (string.IsNullOrWhiteSpace(url))
@@ -96,6 +97,9 @@ public class WebModule : IWebModule
 
         using var client = new SourceProvider(url, "", forwardoptions, false);
         await client.InitializeAsync(cancellationToken);
+
+        if (op == Operation.CheckPermissions)
+            return await CheckPermissionsAsync(client, cancellationToken).ConfigureAwait(false);
 
         var targetEntry = await client.GetEntryAsync((path ?? "").TrimStart('/'), isFolder: true, cancellationToken).ConfigureAwait(false);
         if (targetEntry == null)
@@ -143,6 +147,80 @@ public class WebModule : IWebModule
 
     }
 
+    /// <summary>
+    /// The result key under which the permission status list JSON is returned.
+    /// </summary>
+    private const string PERMISSIONS_RESULT_KEY = "permissions";
+
+    /// <summary>
+    /// Compares the OAuth scopes granted to the configured credentials with the scopes
+    /// required for backup and restore operations. Granted scopes that are not required
+    /// are included in the report, flagged as not needed, so that over-privileged
+    /// credentials can be identified.
+    /// </summary>
+    /// <param name="client">The initialized source provider.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A dictionary containing a single JSON-serialized list of <see cref="PermissionStatus"/>.</returns>
+    private static async Task<IDictionary<string, string>> CheckPermissionsAsync(SourceProvider client, CancellationToken cancellationToken)
+    {
+        var probe = GoogleScopes.Required.Concat(GoogleScopes.KnownExtras).Select(s => s.Name);
+        var granted = await client.ApiHelper.GetGrantedScopesAsync(probe, cancellationToken).ConfigureAwait(false);
+
+        // A scope is enabled when it is granted directly, or when a granted write scope
+        // covers it (e.g. gmail.modify includes gmail.readonly access)
+        var result = GoogleScopes.Required
+            .Select(s => new PermissionStatus
+            {
+                Name = s.Name,
+                Description = s.Description,
+                RequiredForBackup = s.RequiredForBackup,
+                RequiredForRestore = s.RequiredForRestore,
+                Enabled = granted.Contains(s.Name) || (s.CoveredBy != null && granted.Contains(s.CoveredBy))
+            })
+            .ToList();
+
+        // Include granted scopes that are not required for backup or restore
+        var requiredNames = new HashSet<string>(GoogleScopes.Required.Select(s => s.Name), StringComparer.Ordinal);
+        var extraDescriptions = GoogleScopes.KnownExtras.ToDictionary(s => s.Name, s => s.Description, StringComparer.Ordinal);
+        foreach (var extra in granted.Where(g => !requiredNames.Contains(g)).OrderBy(g => g, StringComparer.Ordinal))
+        {
+            result.Add(new PermissionStatus
+            {
+                Name = extra,
+                Description = extraDescriptions.GetValueOrDefault(extra, ""),
+                RequiredForBackup = false,
+                RequiredForRestore = false,
+                Enabled = true
+            });
+        }
+
+        return new Dictionary<string, string>
+        {
+            [PERMISSIONS_RESULT_KEY] = JsonSerializer.Serialize(result)
+        };
+    }
+
     public IDictionary<string, IDictionary<string, string>> GetLookups()
         => new Dictionary<string, IDictionary<string, string>>();
+
+    /// <summary>
+    /// The status of a single required scope returned by <see cref="Operation.CheckPermissions"/>.
+    /// </summary>
+    private sealed class PermissionStatus
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("description")]
+        public required string Description { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("requiredForBackup")]
+        public bool RequiredForBackup { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("requiredForRestore")]
+        public bool RequiredForRestore { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("enabled")]
+        public bool Enabled { get; init; }
+    }
 }

--- a/proprietary/Office365/GraphPermissions.cs
+++ b/proprietary/Office365/GraphPermissions.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+using System.Text.Json;
+using Duplicati.Library.Interface;
+
+namespace Duplicati.Proprietary.Office365;
+
+/// <summary>
+/// Describes a Microsoft Graph application permission and what it is required for.
+/// </summary>
+/// <param name="Name">The name of the application permission.</param>
+/// <param name="Description">A human readable description of the resources the permission affects.</param>
+/// <param name="RequiredForBackup">Whether the permission is required for backup operations.</param>
+/// <param name="RequiredForRestore">Whether the permission is required for restore operations.</param>
+/// <param name="CoveredBy">The name of a write permission that includes this permission's access, if any. A granted covering permission makes this permission effectively enabled.</param>
+internal sealed record RequiredGraphPermission(
+    string Name,
+    string Description,
+    bool RequiredForBackup,
+    bool RequiredForRestore,
+    string? CoveredBy = null
+);
+
+/// <summary>
+/// The Microsoft Graph application permissions used by the Office365 provider,
+/// and helpers to inspect the permissions granted to the app registration.
+/// </summary>
+internal static class GraphPermissions
+{
+    /// <summary>
+    /// The application permissions required for backup and restore operations.
+    /// Read permissions with a write counterpart are only required for backup; restore
+    /// operations are expected to hold the write permission, which includes read access.
+    /// </summary>
+    public static readonly IReadOnlyList<RequiredGraphPermission> Required =
+    [
+        new("User.Read.All", "Read user accounts, profiles, photos, and license assignments.", true, false, "User.ReadWrite.All"),
+        new("User.ReadWrite.All", "Read and update user profiles, such as restoring the profile photo.", false, true),
+        new("Group.Read.All", "Read groups, their members, owners, and conversations.", true, false, "Group.ReadWrite.All"),
+        new("Group.ReadWrite.All", "Read and create groups, and manage members, owners, and conversations.", false, true),
+        new("Mail.Read", "Read mailbox folders, messages, attachments, and inbox rules.", true, false, "Mail.ReadWrite"),
+        new("Mail.ReadWrite", "Read, create, and update mailbox folders, messages, attachments, and inbox rules.", false, true),
+        new("MailboxSettings.Read", "Read user mailbox settings.", true, false, "MailboxSettings.ReadWrite"),
+        new("MailboxSettings.ReadWrite", "Read and update user mailbox settings.", false, true),
+        new("Calendars.Read", "Read user and group calendars and events.", true, false, "Calendars.ReadWrite"),
+        new("Calendars.ReadWrite", "Read, create, and update calendars, events, and event attachments.", false, true),
+        new("Contacts.Read", "Read contact folders and contacts.", true, false, "Contacts.ReadWrite"),
+        new("Contacts.ReadWrite", "Read, create, and update contact folders, contacts, and contact photos.", false, true),
+        new("Files.Read.All", "Read OneDrive drives, files, and sharing permissions.", true, false, "Files.ReadWrite.All"),
+        new("Files.ReadWrite.All", "Read, create, and update OneDrive files and sharing permissions.", false, true),
+        new("Sites.Read.All", "Read SharePoint sites, lists, and list items.", true, false, "Sites.ReadWrite.All"),
+        new("Sites.ReadWrite.All", "Read, create, and update SharePoint sites, lists, and list items.", false, true),
+        new("Notes.Read.All", "Read OneNote notebooks, sections, and pages.", true, false, "Notes.ReadWrite.All"),
+        new("Notes.ReadWrite.All", "Read, create, and update OneNote notebooks, sections, and pages.", false, true),
+        new("Tasks.Read.All", "Read Planner plans, buckets, tasks, and To Do lists.", true, false, "Tasks.ReadWrite.All"),
+        new("Tasks.ReadWrite.All", "Read, create, and update Planner plans, buckets, tasks, and To Do lists.", false, true),
+        // Note: Team.ReadBasic.All, Channel.ReadBasic.All, TeamsTab.Read.All,
+        // TeamsAppInstallation.ReadForTeam.All, TeamsTab.ReadWrite.All, and
+        // TeamsAppInstallation.ReadWriteForTeam.All are the least-privileged permissions
+        // for reading teams, channels, tabs, and installed apps, and for creating tabs
+        // and installing apps, but Graph also accepts Group.Read.All / Group.ReadWrite.All
+        // for those endpoints. Since the group permissions are already required, the
+        // Teams-specific permissions are redundant and deliberately not listed.
+        new("TeamMember.Read.All", "Read team memberships.", true, false),
+        new("Channel.Create", "Create channels when restoring.", false, true),
+        new("ChannelMessage.Read.All", "Read Teams channel messages and replies. Restore reads messages to detect duplicates.", true, true),
+        new("Chat.Read.All", "Read Teams chat messages.", true, false),
+        new("Teamwork.Migrate.All", "Restore Teams channels and channel messages in migration mode.", false, true),
+    ];
+
+    /// <summary>
+    /// Extracts the granted application permissions from an access token acquired through
+    /// the OAuth2 client credentials flow. The granted application permissions are listed
+    /// in the token's <c>roles</c> claim, so no additional Graph API call is required.
+    /// </summary>
+    /// <param name="accessToken">The access token to inspect.</param>
+    /// <returns>The names of the granted application permissions.</returns>
+    public static IReadOnlySet<string> ExtractGrantedRoles(string accessToken)
+    {
+        var parts = accessToken.Split('.');
+        if (parts.Length < 2)
+            throw new UserInformationException("The access token is not a valid JWT token.", "InvalidAccessToken");
+
+        // The payload segment is base64url encoded
+        var base64 = parts[1].Replace('-', '+').Replace('_', '/');
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+
+        var roles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        using var doc = JsonDocument.Parse(Convert.FromBase64String(base64));
+        if (doc.RootElement.TryGetProperty("roles", out var rolesElement) && rolesElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var role in rolesElement.EnumerateArray())
+            {
+                if (role.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(role.GetString()))
+                    roles.Add(role.GetString()!);
+            }
+        }
+
+        return roles;
+    }
+}

--- a/proprietary/Office365/SourceProvider/SourceProvider.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.cs
@@ -243,6 +243,18 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     public Task TestAsync(CancellationToken cancellationToken)
         => _apiHelper.AcquireAccessTokenAsync(false, cancellationToken);
 
+    /// <summary>
+    /// Gets the application permissions granted to the app registration, as listed in
+    /// the roles claim of the acquired access token.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The names of the granted application permissions.</returns>
+    internal async Task<IReadOnlySet<string>> GetGrantedApplicationPermissionsAsync(CancellationToken cancellationToken)
+    {
+        var token = await _apiHelper.AcquireAccessTokenAsync(false, cancellationToken).ConfigureAwait(false);
+        return GraphPermissions.ExtractGrantedRoles(token);
+    }
+
     /// <inheritdoc />
     public async IAsyncEnumerable<ISourceProviderEntry> EnumerateAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/proprietary/Office365/WebModule/WebModule.cs
+++ b/proprietary/Office365/WebModule/WebModule.cs
@@ -17,7 +17,8 @@ public class WebModule : IWebModule
     {
         ListDestination,
         ListDestinationRestoreTargets,
-        CountItems
+        CountItems,
+        CheckPermissions
     }
 
     private static readonly Operation DEFAULT_OPERATION = Operation.ListDestination;
@@ -99,6 +100,9 @@ public class WebModule : IWebModule
         if (op == Operation.CountItems)
             return await CountItemsAsync(client, cancellationToken).ConfigureAwait(false);
 
+        if (op == Operation.CheckPermissions)
+            return await CheckPermissionsAsync(client, cancellationToken).ConfigureAwait(false);
+
         var targetEntry = await client.GetEntryAsync((path ?? "").TrimStart('/'), isFolder: true, cancellationToken).ConfigureAwait(false);
         if (targetEntry == null)
             throw new DirectoryNotFoundException($"Path not found: {path}");
@@ -149,6 +153,57 @@ public class WebModule : IWebModule
     /// The result key under which the item-count breakdown JSON is returned.
     /// </summary>
     private const string COUNT_RESULT_KEY = "counts";
+
+    /// <summary>
+    /// The result key under which the permission status list JSON is returned.
+    /// </summary>
+    private const string PERMISSIONS_RESULT_KEY = "permissions";
+
+    /// <summary>
+    /// Compares the application permissions granted to the app registration with the
+    /// permissions required for backup and restore operations. Granted permissions that
+    /// are not required are included in the report, flagged as not needed, so that
+    /// over-privileged app registrations can be identified.
+    /// </summary>
+    /// <param name="client">The initialized source provider.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A dictionary containing a single JSON-serialized list of <see cref="PermissionStatus"/>.</returns>
+    private static async Task<IDictionary<string, string>> CheckPermissionsAsync(SourceProvider client, CancellationToken cancellationToken)
+    {
+        var granted = await client.GetGrantedApplicationPermissionsAsync(cancellationToken).ConfigureAwait(false);
+
+        // A permission is enabled when it is granted directly, or when a granted write
+        // permission covers it (e.g. User.ReadWrite.All includes User.Read.All access)
+        var result = GraphPermissions.Required
+            .Select(p => new PermissionStatus
+            {
+                Name = p.Name,
+                Description = p.Description,
+                RequiredForBackup = p.RequiredForBackup,
+                RequiredForRestore = p.RequiredForRestore,
+                Enabled = granted.Contains(p.Name) || (p.CoveredBy != null && granted.Contains(p.CoveredBy))
+            })
+            .ToList();
+
+        // Include granted permissions that are not required for backup or restore
+        var known = new HashSet<string>(GraphPermissions.Required.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
+        foreach (var extra in granted.Where(g => !known.Contains(g)).OrderBy(g => g, StringComparer.OrdinalIgnoreCase))
+        {
+            result.Add(new PermissionStatus
+            {
+                Name = extra,
+                Description = "",
+                RequiredForBackup = false,
+                RequiredForRestore = false,
+                Enabled = true
+            });
+        }
+
+        return new Dictionary<string, string>
+        {
+            [PERMISSIONS_RESULT_KEY] = JsonSerializer.Serialize(result)
+        };
+    }
 
     /// <summary>
     /// Counts the number of top-level items (users, groups, sites) and, within each
@@ -234,6 +289,27 @@ public class WebModule : IWebModule
 
     public IDictionary<string, IDictionary<string, string>> GetLookups()
         => new Dictionary<string, IDictionary<string, string>>();
+
+    /// <summary>
+    /// The status of a single required permission returned by <see cref="Operation.CheckPermissions"/>.
+    /// </summary>
+    private sealed class PermissionStatus
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("description")]
+        public required string Description { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("requiredForBackup")]
+        public bool RequiredForBackup { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("requiredForRestore")]
+        public bool RequiredForRestore { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("enabled")]
+        public bool Enabled { get; init; }
+    }
 
     /// <summary>
     /// The item-count breakdown returned by <see cref="Operation.CountItems"/>.


### PR DESCRIPTION
This PR adds two new webmodule functions that check permissions against a known list.

This enables the end-user to verify that the current permissions they have granted fits what is actually required to run the backup or restore.