### PR TITLE
Retain url query string values

### DIFF
--- a/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
+++ b/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
@@ -193,12 +193,12 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
             [AUTH_API_KEY_OPTION] = apiKey,
         };
 
-        var qp = uri.QueryParameters;
+        var qp = uri.GetEncodedQueryParameters();
         foreach (var kvp in opts)
             if (!string.IsNullOrWhiteSpace(kvp.Value) && string.IsNullOrWhiteSpace(qp.Get(kvp.Key)))
                 qp[kvp.Key] = Utility.UrlEncoding.UrlEncode(kvp.Value);
 
-        var query = Utility.UrlEncoding.BuildUriQuery(qp);
+        var query = Utility.UrlEncoding.BuildUriQuery(qp, true);
 
         if (string.IsNullOrWhiteSpace(uri.HostAndPath) && !string.IsNullOrWhiteSpace(endpoint))
             uri = new Utility.RelaxedUri(endpoint).SetScheme(uri.Scheme).SetQuery(null);

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -188,7 +188,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         /// <inheritdoc />
         public async IAsyncEnumerable<IFileEntry> ListAsync([EnumeratorCancellation] CancellationToken cancelToken)
         {
-            var url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.UrlEncoding.UrlEncode(m_prefix));
+            var url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, m_prefix);
             while (true)
             {
                 var resp = await HandleListExceptions(() =>
@@ -219,7 +219,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
                 var token = resp.nextPageToken;
                 if (string.IsNullOrWhiteSpace(token))
                     break;
-                url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, Utility.UrlEncoding.UrlEncode(m_prefix), token);
+                url = WebApi.GoogleCloudStorage.ListUrl(m_bucket, m_prefix, token);
             }
         }
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -566,8 +566,8 @@ namespace Duplicati.Library.Backend.GoogleDrive
                 "trashed=false"
             };
 
-            var encodedFileQuery = Utility.UrlEncoding.UrlEncode(string.Join(" and ", fileQuery.Where(x => x != null)));
-            var url = WebApi.GoogleDrive.ListUrl(encodedFileQuery, m_teamDriveID);
+            var fileQueryString = string.Join(" and ", fileQuery.Where(x => x != null));
+            var url = WebApi.GoogleDrive.ListUrl(fileQueryString, m_teamDriveID);
 
             while (true)
             {
@@ -587,7 +587,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
                 if (string.IsNullOrWhiteSpace(token))
                     break;
 
-                url = WebApi.GoogleDrive.ListUrl(encodedFileQuery, m_teamDriveID, token);
+                url = WebApi.GoogleDrive.ListUrl(fileQueryString, m_teamDriveID, token);
             }
         }
 

--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -71,7 +71,7 @@ namespace Duplicati.Library.Backend.WebApi
                 { QueryParam.Project, projectId }
             };
 
-            return Utility.RelaxedUri.UriBuilder(Url.API, Path.Bucket, queryParams);
+            return Utility.RelaxedUri.UriBuilder(Url.API, Path.Bucket, queryParams, false);
         }
 
         public static string RenameUrl(string bucketId, string objectId)
@@ -98,7 +98,7 @@ namespace Duplicati.Library.Backend.WebApi
                 queryParams.Set(QueryParam.PageToken, token);
             }
 
-            return Utility.RelaxedUri.UriBuilder(Url.API, BucketObjectPath(bucketId), queryParams);
+            return Utility.RelaxedUri.UriBuilder(Url.API, BucketObjectPath(bucketId), queryParams, false);
         }
 
         public static string PutUrl(string bucketId)
@@ -108,7 +108,7 @@ namespace Duplicati.Library.Backend.WebApi
                 { QueryParam.UploadType, QueryValue.Resumable }
             };
             var path = UrlPath.Create(Path.Bucket).Append(bucketId).Append(Path.Object).ToString();
-            return Utility.RelaxedUri.UriBuilder(Url.UPLOAD, path, queryParams);
+            return Utility.RelaxedUri.UriBuilder(Url.UPLOAD, path, queryParams, false);
         }
 
         public static string GetUrl(string bucketId, string objectId)
@@ -120,7 +120,7 @@ namespace Duplicati.Library.Backend.WebApi
                 };
             var path = BucketObjectPath(bucketId, objectId);
 
-            return Utility.RelaxedUri.UriBuilder(Url.API, path, queryParams);
+            return Utility.RelaxedUri.UriBuilder(Url.API, path, queryParams, false);
         }
 
         public static string MetadataUrl(string bucketId, string objectId)
@@ -252,16 +252,16 @@ namespace Duplicati.Library.Backend.WebApi
         }
 
         private static string FileQueryUrl(NameValueCollection values)
-            => Utility.RelaxedUri.UriBuilder(Url.DRIVE, Path.File, values);
+            => Utility.RelaxedUri.UriBuilder(Url.DRIVE, Path.File, values, false);
 
         private static string FileQueryUrl(string fileId, NameValueCollection? values = null)
-            => Utility.RelaxedUri.UriBuilder(Url.DRIVE, UrlPath.Create(Path.File).Append(fileId).ToString(), values);
+            => Utility.RelaxedUri.UriBuilder(Url.DRIVE, UrlPath.Create(Path.File).Append(fileId).ToString(), values, false);
 
         private static string FileUploadUrl(string fileId, NameValueCollection? values)
-            => Utility.RelaxedUri.UriBuilder(Url.UPLOAD, UrlPath.Create(Path.File).Append(fileId).ToString(), values);
+            => Utility.RelaxedUri.UriBuilder(Url.UPLOAD, UrlPath.Create(Path.File).Append(fileId).ToString(), values, false);
 
         private static string FileUploadUrl(NameValueCollection values)
-            => Utility.RelaxedUri.UriBuilder(Url.UPLOAD, Path.File, values);
+            => Utility.RelaxedUri.UriBuilder(Url.UPLOAD, Path.File, values, false);
 
         private static NameValueCollection AddTeamDriveParam(string? teamDriveId)
         {

--- a/Duplicati/Library/Main/SecretProviderHelper.cs
+++ b/Duplicati/Library/Main/SecretProviderHelper.cs
@@ -266,9 +266,9 @@ public static class SecretProviderHelper
             foreach (var (s, k) in v.Value)
             {
                 var uri = internalUriArguments[s];
-                var kp = uri.QueryParameters;
+                var kp = uri.GetEncodedQueryParameters();
                 kp[k] = Library.Utility.UrlEncoding.UrlEncode(translated[v.Key]);
-                uri = uri.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(kp));
+                uri = uri.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(kp, true));
                 internalUriArguments[s] = uri;
             }
 

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -249,7 +249,7 @@ namespace Duplicati.Library.Modules.Builtin
                 }
                 else
                 {
-                    var values = Utility.UrlEncoding.ParseQueryString(extraData);
+                    var values = Utility.UrlEncoding.ParseQueryString(extraData, true);
                     m_extraValues = values.AllKeys
                         .Where(x => !string.IsNullOrWhiteSpace(x))
                         .ToDictionary(key => key, key => values[key]);

--- a/Duplicati/Library/RestAPI/Database/Backup.cs
+++ b/Duplicati/Library/RestAPI/Database/Backup.cs
@@ -139,11 +139,11 @@ namespace Duplicati.Server.Database
                 // We cannot use url.QueryParameters since it contains decoded parameter values, which
                 // breaks assumptions made by the decode_uri function in AppUtils.js. Since we are simply
                 // removing password parameters, we will leave the parameters as they are in the target URL.
-                filteredParameters = Library.Utility.UrlEncoding.ParseQueryString(url.Query, false);
+                filteredParameters = url.GetEncodedQueryParameters();
                 foreach (var field in Connection.PasswordFieldNames)
                     filteredParameters.Remove(field);
             }
-            url = url.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters));
+            url = url.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters, true));
             this.TargetURL = url.ToString();
         }
 
@@ -172,11 +172,11 @@ namespace Duplicati.Server.Database
 
                     if (url.Query != null)
                     {
-                        var filteredParameters = Library.Utility.UrlEncoding.ParseQueryString(url.Query, false);
+                        var filteredParameters = url.GetEncodedQueryParameters();
                         foreach (var field in Connection.PasswordFieldNames)
                             filteredParameters.Remove(field);
 
-                        url = url.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters));
+                        url = url.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters, true));
                         this.Sources[i] = SourceMasking.ReplaceUrl(this.Sources[i], url.ToString());
                     }
                 }
@@ -206,10 +206,10 @@ namespace Duplicati.Server.Database
                     continue;
 
                 var url = new Duplicati.Library.Utility.RelaxedUri(target.TargetUrl);
-                var filteredParameters = url.QueryParameters;
+                var filteredParameters = url.GetEncodedQueryParameters();
                 foreach (var field in Connection.PasswordFieldNames)
                     filteredParameters.Remove(field);
-                url = url.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters));
+                url = url.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(filteredParameters, true));
                 target.TargetUrl = url.ToString();
             }
         }

--- a/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
+++ b/Duplicati/Library/RestAPI/Database/QuerystringMasking.cs
@@ -50,7 +50,7 @@ public static class QuerystringMasking
             return urlstring;
 
         var modified = false;
-        var query = Library.Utility.UrlEncoding.ParseQueryString(url.Query, false);
+        var query = url.GetEncodedQueryParameters();
         foreach (var k in query.AllKeys)
         {
             if (k is null) continue;
@@ -63,7 +63,7 @@ public static class QuerystringMasking
 
         if (!modified) return urlstring;
 
-        url = url.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(query));
+        url = url.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(query, true));
         return url.ToString();
     }
 
@@ -92,7 +92,7 @@ public static class QuerystringMasking
         if (string.IsNullOrWhiteSpace(newUb.Query))
             return newUrl;
 
-        var newQuery = Library.Utility.UrlEncoding.ParseQueryString(newUb.Query, false);
+        var newQuery = newUb.GetEncodedQueryParameters();
 
         var modified = false;
         foreach (var key in newQuery.AllKeys)
@@ -139,7 +139,7 @@ public static class QuerystringMasking
         if (!modified)
             return newUrl;
 
-        newUb = newUb.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(newQuery));
+        newUb = newUb.SetQuery(Library.Utility.UrlEncoding.BuildUriQuery(newQuery, true));
 
         return newUb.ToString();
 

--- a/Duplicati/Library/Utility/RelaxedUri.cs
+++ b/Duplicati/Library/Utility/RelaxedUri.cs
@@ -123,12 +123,22 @@ namespace Duplicati.Library.Utility
                     if (Query == null)
                         m_queryParams = new NameValueCollection();
                     else
-                        m_queryParams = UrlEncoding.ParseQueryString(Query);
+                        m_queryParams = UrlEncoding.ParseQueryString(Query, true);
                 }
 
                 return m_queryParams;
             }
         }
+
+        // TODO: Maybe we should return EncodedNameValueCollection and 
+        // DecodedNameValueCollection so the callers do not need to
+        // keep track of the flag.
+
+        /// <summary>
+        /// Returns the query parameters with the values in their original URL encoding.
+        /// </summary>
+        public NameValueCollection GetEncodedQueryParameters()
+            => UrlEncoding.ParseQueryString(Query ?? "", false);
 
         /// <summary>
         /// Gets the host and path.
@@ -407,12 +417,13 @@ namespace Duplicati.Library.Utility
         /// <param name="url">Base URL, containing schema, host, port.</param>
         /// <param name="path">Base path.</param>
         /// <param name="query">A collection of name value pairs to be translated into a query string.</param>
-        public static string UriBuilder(string url, string path, NameValueCollection? query)
+        /// <param name="preEncoded">A value indicating if the query contains pre-encoded values</param>
+        public static string UriBuilder(string url, string path, NameValueCollection? query, bool preEncoded)
         {
             var builder = new UriBuilder(url)
             {
                 Path = new UrlPath(ExtractPath(url)).Append(path).ToString(),
-                Query = query != null ? UrlEncoding.BuildUriQuery(query) : null
+                Query = query != null ? UrlEncoding.BuildUriQuery(query, preEncoded) : null
             };
             return builder.Uri.AbsoluteUri;
         }
@@ -436,7 +447,7 @@ namespace Duplicati.Library.Utility
         /// <param name="path">Base path.</param>
         public static string UriBuilder(string url, string path)
         {
-            return UriBuilder(url, path, null);
+            return UriBuilder(url, path, null, true);
         }
     }
 }

--- a/Duplicati/Library/Utility/UrlEncoding.cs
+++ b/Duplicati/Library/Utility/UrlEncoding.cs
@@ -173,17 +173,6 @@ namespace Duplicati.Library.Utility
         /// </summary>
         /// <returns>The parsed query string</returns>
         /// <param name="query">The query to parse</param>
-        public static NameValueCollection ParseQueryString(string query)
-        {
-            return ParseQueryString(query, true);
-        }
-
-        /// <summary>
-        /// Parses the query string.
-        /// This is a local implementation of System.Web.HttpUtility.ParseQueryString, kept for consistent behavior (originally added due to Mono limitations)
-        /// </summary>
-        /// <returns>The parsed query string</returns>
-        /// <param name="query">The query to parse</param>
         /// <param name="decodeValues">Whether to the parameter values should be decoded or not.</param>
         public static NameValueCollection ParseQueryString(string query, bool decodeValues)
         {
@@ -215,9 +204,8 @@ namespace Duplicati.Library.Utility
         /// <returns>The generated querystring</returns>
         /// <param name="query">A collection of name value pairs to be translated into a query string</param>
         /// <param name="delimiter">The delimiter to separate key value pairs in the query string</param>
-        public static string BuildUriQuery(NameValueCollection query, string delimiter)
+        internal static string BuildUriQuery(NameValueCollection query, string delimiter)
         {
-
             if (query == null)
                 throw new ArgumentNullException(nameof(query));
 
@@ -234,14 +222,27 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
-        /// Build the querystring to be used in a URL
+        /// Build the querystring to be used in a URL and encodes all parameters
         /// </summary>
         /// <returns>The generated querystring</returns>
         /// <param name="query">A collection of name value pairs to be translated into a query string that is
         /// ampersand delimited.</param>
-        public static string BuildUriQuery(NameValueCollection query)
+        /// <param name="preEncoded">A value indicating if the values are already encoded</param>
+        public static string BuildUriQuery(NameValueCollection query, bool preEncoded)
         {
-            return BuildUriQuery(query, "&");
+            if (preEncoded)
+                return BuildUriQuery(query, "&");
+
+            var qp = new NameValueCollection();
+            foreach (var k in query.AllKeys)
+            {
+                var v = query.Get(k);
+                qp[k] = string.IsNullOrEmpty(v)
+                    ? v
+                    : UrlEncode(v);
+            }
+
+            return BuildUriQuery(qp, "&");
         }
     }
 }

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -34,8 +34,8 @@ namespace Duplicati.UnitTest
             var baseUrl = "http://localhost";
             var path = "files";
             var query = new NameValueCollection { { "a", "b" }, { "c", "d" }, { "e", "+ %" } };
-            var url = Library.Utility.RelaxedUri.UriBuilder(baseUrl, path, query);
-            Assert.AreEqual(baseUrl + "/" + path + "?a=b&c=d&e=+%20%25", url);
+            var url = Library.Utility.RelaxedUri.UriBuilder(baseUrl, path, query, false);
+            Assert.AreEqual(baseUrl + "/" + path + "?a=b&c=d&e=%2B+%25", url);
         }
 
         [Test]

--- a/Duplicati/UnitTest/UrlEncodingTests.cs
+++ b/Duplicati/UnitTest/UrlEncodingTests.cs
@@ -138,7 +138,7 @@ namespace Duplicati.UnitTest
         [Category("Utility")]
         public static void QueryStringIsParsedCaseInsensitively()
         {
-            var parsed = Library.Utility.UrlEncoding.ParseQueryString("?Key=value&other=a+b");
+            var parsed = Library.Utility.UrlEncoding.ParseQueryString("?Key=value&other=a+b", true);
 
             Assert.AreEqual("value", parsed["key"], "The keys are compared without case");
             Assert.AreEqual("a b", parsed["other"], "The values are decoded");
@@ -157,8 +157,8 @@ namespace Duplicati.UnitTest
         [Category("Utility")]
         public static void EmptyQueryStringGivesNoValues()
         {
-            Assert.AreEqual(0, Library.Utility.UrlEncoding.ParseQueryString("").Count);
-            Assert.AreEqual(0, Library.Utility.UrlEncoding.ParseQueryString("?").Count);
+            Assert.AreEqual(0, Library.Utility.UrlEncoding.ParseQueryString("", true).Count);
+            Assert.AreEqual(0, Library.Utility.UrlEncoding.ParseQueryString("?", true).Count);
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace Duplicati.UnitTest
             var query = new NameValueCollection { { "key", "value with space" } };
 
             // The caller is responsible for encoding, which the backends rely on
-            Assert.AreEqual("key=value with space", Library.Utility.UrlEncoding.BuildUriQuery(query));
+            Assert.AreEqual("key=value with space", Library.Utility.UrlEncoding.BuildUriQuery(query, true));
             Assert.AreEqual("key=value with space", Library.Utility.UrlEncoding.BuildUriQuery(query, ";"));
         }
 
@@ -178,7 +178,7 @@ namespace Duplicati.UnitTest
         {
             var query = new NameValueCollection { { "a", "b" }, { "empty", "" }, { "c", "d" } };
 
-            Assert.AreEqual("a=b&c=d", Library.Utility.UrlEncoding.BuildUriQuery(query));
+            Assert.AreEqual("a=b&c=d", Library.Utility.UrlEncoding.BuildUriQuery(query, true));
             Assert.AreEqual("a=b;c=d", Library.Utility.UrlEncoding.BuildUriQuery(query, ";"));
         }
 
@@ -187,25 +187,25 @@ namespace Duplicati.UnitTest
         public static void TestBuildUriQuery()
         {
             var query = new NameValueCollection { { "a", "b" } };
-            var queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            var queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query, true);
             Assert.AreEqual("a=b", queryUrl);
             query.Add(new NameValueCollection { { "c", "d" } });
-            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query, true);
             Assert.AreEqual("a=b&c=d", queryUrl);
 
             // Test with space in value
             query = new NameValueCollection { { "key", "value with space" } };
-            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query, true);
             Assert.AreEqual("key=value with space", queryUrl);
 
             // Test with + in value
             query = new NameValueCollection { { "key", "value+plus" } };
-            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query, true);
             Assert.AreEqual("key=value+plus", queryUrl);
 
             // Test with % in value
             query = new NameValueCollection { { "key", "value%percent" } };
-            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query);
+            queryUrl = Library.Utility.UrlEncoding.BuildUriQuery(query, true);
             Assert.AreEqual("key=value%percent", queryUrl);
         }
     }

--- a/Duplicati/WebserverCore/Endpoints/V2/ConnectionStrings.cs
+++ b/Duplicati/WebserverCore/Endpoints/V2/ConnectionStrings.cs
@@ -146,9 +146,9 @@ namespace Duplicati.WebserverCore.Endpoints.V2
                 resultUri = resultUri.SetCredentials(resultUri.Username, csUri.Password);
 
             // Merge Query Parameters
-            // Use decodeValues=false to preserve encoding
-            var csQuery = Duplicati.Library.Utility.UrlEncoding.ParseQueryString(csUri.Query ?? "", false);
-            var backupQuery = Duplicati.Library.Utility.UrlEncoding.ParseQueryString(backupUri.Query ?? "", false);
+            // Preserve encoding to keep value strings unmodified
+            var csQuery = csUri.GetEncodedQueryParameters();
+            var backupQuery = backupUri.GetEncodedQueryParameters();
 
             var mergedQuery = new System.Collections.Specialized.NameValueCollection(backupQuery);
 
@@ -158,7 +158,7 @@ namespace Duplicati.WebserverCore.Endpoints.V2
                     mergedQuery[key] = csQuery[key];
             }
 
-            resultUri = resultUri.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(mergedQuery));
+            resultUri = resultUri.SetQuery(Duplicati.Library.Utility.UrlEncoding.BuildUriQuery(mergedQuery, true));
 
             return resultUri.ToString();
         }


### PR DESCRIPTION
This PR updates handling of url query string values.

At various points, we parse the query string into key/value pairs, modify them, and re-build the query string.

To be as true to the source as possible, we sometimes extract the raw encoded values, and sometimes the decoded values (i.e., `a%2Bb` vs `a+b`).

When combining the values back into a query string, we need to know if the values are already encoded, or should be encoded.

With this PR, callers are now required to explicitly indicate if the value are encoded or not. This also fixes some minor cases where we did not fully retain the raw encoded form, but instead did a decode+encode step that could change the literal value.