### PR TITLE
Detect unrestorable metadata

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -1951,6 +1951,22 @@ namespace Duplicati.Library.Main.Database.Local
             if (await cmd.ExecuteScalarInt64Async(token).ConfigureAwait(false) != 0)
                 throw new DatabaseInconsistencyException("Detected non-empty blocksets with no associated blocks!");
 
+            // Metadata always has contents - the smallest possible blob is a serialized empty dictionary -
+            // so a metadata entry with a length of 0 can never be restored. This is a warning rather than an
+            // exception: it must not fail otherwise-working backups, and purge-broken-files can recover the
+            // affected files.
+            cmd.SetCommandAndParameters(@"
+                SELECT COUNT(*)
+                FROM ""Metadataset""
+                JOIN ""Blockset""
+                    ON ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID""
+                WHERE ""Blockset"".""Length"" = 0
+            ");
+
+            var zeroLengthMetadata = await cmd.ExecuteScalarInt64Async(0, token).ConfigureAwait(false);
+            if (zeroLengthMetadata != 0)
+                Logging.Log.WriteWarningMessage(LOGTAG, "ZeroLengthMetadata", null, "Found {0} metadata entrie(s) with a length of 0, which cannot be restored. Run repair to fix it, or use the {1} and {2} commands to recover the affected files.", zeroLengthMetadata, "list-broken-files", "purge-broken-files");
+
             cmd.SetCommandAndParameters(@"
                 SELECT COUNT(*)
                 FROM ""FileLookup""

--- a/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
@@ -44,23 +44,171 @@ namespace Duplicati.Library.Main.Database.Local
             WHERE ""Type"" = '{Library.Utility.Utility.FormatInvariantValue(RemoteVolumeType.Blocks)}'
         ";
 
-        // Invalid blocksets include those that:
-        // - Have BlocksetEntries with unknown/invalid blocks (meaning the data to rebuild the blockset isn't available)
-        //   - Invalid blocks include those that appear to be in non-Blocks volumes (e.g., are listed as being in an Index or Files volume) or that appear in an unknown volume (-1)
-        // - Have BlocklistHash entries with unknown/invalid blocks (meaning the data which defines the list of hashes that makes up the blockset isn't available)
-        // - Are defined in the Blockset table but have no entries in the BlocksetEntries table (this can happen during recreate if Files volumes reference blocksets that are not found in any Index files)
-        // However, blocksets with a length of 0 are excluded from this check, as the corresponding blocks for these are not needed.
+        /// <summary>
+        /// SQL query returning the ids of the zero-length blocksets that are valid.
+        /// </summary>
+        /// <remarks>
+        /// Because <c>Blockset</c> is unique on <c>("FullHash", "Length")</c> there is at most one
+        /// zero-length blockset, and it is the blockset that every empty file in the backup uses as its
+        /// content. It has no blocks, and needs none, so it is the one case where a blockset without blocks
+        /// is not damage.
+        /// </remarks>
+        private static readonly string VALID_EMPTY_BLOCKSET_IDS = @"
+            SELECT ""A"".""ID""
+            FROM ""Blockset"" ""A""
+            LEFT JOIN ""BlocksetEntry"" ""B""
+                ON ""A"".""ID"" = ""B"".""BlocksetID""
+            WHERE
+                ""A"".""Length"" = 0
+                AND ""B"".""BlocksetID"" IS NULL
+        ";
 
         /// <summary>
-        /// SQL query to get the IDs of broken files.
-        /// A broken file is one that has a BlocksetID that is not in the list of valid blocksets, or that has a MetadataID that is not in the list of valid metadata blocksets.
+        /// SQL query returning the ids of the blocksets that cannot be restored.
         /// </summary>
-        private static readonly string BROKEN_FILE_IDS = $@"
+        /// <remarks>
+        /// A blockset is invalid when it:
+        /// <list type="bullet">
+        /// <item>has <c>BlocksetEntry</c> rows referencing unknown or invalid blocks, meaning the data to
+        /// rebuild the blockset is not available. Invalid blocks are those that appear to be in non-Blocks
+        /// volumes (e.g. are listed as being in an Index or Files volume) or in an unknown volume (-1);</item>
+        /// <item>has <c>BlocklistHash</c> rows referencing unknown or invalid blocks, meaning the data that
+        /// defines the list of hashes making up the blockset is not available;</item>
+        /// <item>is defined in <c>Blockset</c> but has no <c>BlocksetEntry</c> rows, which can happen during
+        /// a recreate if Files volumes reference blocksets that are not found in any Index file;</item>
+        /// <item>records a length that does not match the summed size of the blocks it references, so there
+        /// is no way to tell whether the length or the block mapping is the damaged part;</item>
+        /// <item>records a length of 0 while having blocks attached, which is the same damage seen from the
+        /// other side, and is called out separately because it is the state that caused this check to be
+        /// written.</item>
+        /// </list>
+        /// The single legitimately zero-length blockset is exempted, see <see cref="VALID_EMPTY_BLOCKSET_IDS"/>.
+        /// </remarks>
+        private static readonly string INVALID_BLOCKSET_IDS = $@"
+            SELECT DISTINCT ""BlocksetID""
+            FROM (
+                SELECT ""BlocksetID""
+                FROM ""BlocksetEntry""
+                WHERE ""BlockID"" NOT IN (
+                    SELECT ""ID""
+                    FROM ""Block""
+                    WHERE ""VolumeID"" IN ({BLOCK_VOLUME_IDS})
+                )
+                UNION
+                    SELECT ""BlocksetID""
+                    FROM ""BlocklistHash""
+                    WHERE ""Hash"" NOT IN (
+                        SELECT ""Hash""
+                        FROM ""Block""
+                        WHERE ""VolumeID"" IN ({BLOCK_VOLUME_IDS})
+                    )
+                UNION
+                    SELECT ""A"".""ID"" AS ""BlocksetID""
+                    FROM ""Blockset"" ""A""
+                    LEFT JOIN ""BlocksetEntry"" ""B""
+                        ON ""A"".""ID"" = ""B"".""BlocksetID""
+                    WHERE
+                        ""A"".""Length"" > 0
+                        AND ""B"".""BlocksetID"" IS NULL
+                UNION
+                    SELECT ""A"".""ID"" AS ""BlocksetID""
+                    FROM ""Blockset"" ""A""
+                    LEFT JOIN (
+                        SELECT
+                            ""BlocksetEntry"".""BlocksetID"",
+                            SUM(""Block"".""Size"") AS ""CalcLen""
+                        FROM ""BlocksetEntry""
+                        LEFT JOIN ""Block""
+                            ON ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
+                        GROUP BY ""BlocksetEntry"".""BlocksetID""
+                    ) ""C""
+                        ON ""A"".""ID"" = ""C"".""BlocksetID""
+                    WHERE ""A"".""Length"" != IFNULL(""C"".""CalcLen"", 0)
+                UNION
+                    SELECT ""BlocksetEntry"".""BlocksetID""
+                    FROM ""BlocksetEntry""
+                    JOIN ""Blockset""
+                        ON ""Blockset"".""ID"" = ""BlocksetEntry"".""BlocksetID""
+                    WHERE ""Blockset"".""Length"" = 0
+            )
+            WHERE ""BlocksetID"" NOT IN ({VALID_EMPTY_BLOCKSET_IDS})
+        ";
+
+        /// <summary>
+        /// Returns the SQL query for the ids of the blocksets that cannot be restored.
+        /// </summary>
+        /// <remarks>
+        /// This currently just hands out a constant, and is asynchronous only so that it can be changed into
+        /// a lookup that materializes the classification into a temporary table when it is requested more
+        /// than once. The classification aggregates over every row of <c>BlocksetEntry</c> joined to
+        /// <c>Block</c>, and the broken-file query is evaluated once per fileset, so evaluating it inline
+        /// every time is a full scan per fileset.
+        /// <para>
+        /// Callers must resolve it once per query they build, and pass the string down, or a single query
+        /// build will look like several requests to the caching version.
+        /// </para>
+        /// </remarks>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the SQL query.</returns>
+        private Task<string> InvalidBlocksetIdsQueryAsync(CancellationToken token)
+            => Task.FromResult(INVALID_BLOCKSET_IDS);
+
+        /// <summary>
+        /// Builds the SQL query for the blocksets that can hold restorable metadata.
+        /// </summary>
+        /// <remarks>
+        /// Metadata always has contents - the smallest possible blob is a serialized empty dictionary - so a
+        /// metadata entry with a length of 0 can never be restored, no matter how healthy the blockset looks
+        /// otherwise. Everything about replaceable metadata is derived from this one predicate, so the
+        /// detection cannot drift from what the replacement does.
+        /// </remarks>
+        /// <param name="invalidBlocksetIdsQuery">The query returned by <see cref="InvalidBlocksetIdsQueryAsync"/>.</param>
+        /// <returns>A SQL query returning blockset ids.</returns>
+        private static string UsableMetadataBlocksetIdsQuery(string invalidBlocksetIdsQuery) => $@"
+            SELECT ""ID""
+            FROM ""Blockset""
+            WHERE
+                ""Length"" > 0
+                AND ""ID"" NOT IN ({invalidBlocksetIdsQuery})
+        ";
+
+        /// <summary>
+        /// Builds the SQL query for the IDs of broken files.
+        /// </summary>
+        /// <remarks>
+        /// A file is broken when its content blockset is invalid, or when its metadata cannot be restored.
+        /// The metadata condition is expressed as <c>NOT IN (usable)</c> rather than <c>IN (unusable)</c>:
+        /// a <c>Metadataset</c> row can point at a blockset id that no longer exists at all, and an
+        /// <c>IN (unusable)</c> formulation misses that, since the unusable set is derived from
+        /// <c>Blockset</c> rows that are gone.
+        /// </remarks>
+        /// <param name="ignoreReplaceableMetadata">If <c>true</c>, files that are only broken because their
+        /// metadata needs replacing are not reported. This projects the state after a replacement, and is
+        /// exact by construction, since the condition is dropped rather than inverted.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the SQL query.</returns>
+        private async Task<string> BrokenFileIdsQueryAsync(bool ignoreReplaceableMetadata, CancellationToken token)
+        {
+            // Resolve once per query build, so a single build cannot count as two requests
+            var invalidBlocksetIdsQuery = await InvalidBlocksetIdsQueryAsync(token).ConfigureAwait(false);
+
+            // NULL is not covered by NOT IN, so a missing Metadataset row needs the explicit null check
+            // below. No replacement can fix that anyway, so it is reported unconditionally.
+            var metadataCondition = ignoreReplaceableMetadata
+                ? string.Empty
+                : $@"
+                OR (
+                    ""IsMetadata"" = 1
+                    AND ""BlocksetID"" NOT IN ({UsableMetadataBlocksetIdsQuery(invalidBlocksetIdsQuery)})
+                )";
+
+            return $@"
             SELECT DISTINCT ""ID""
             FROM (
                 SELECT
                     ""ID"" AS ""ID"",
-                    ""BlocksetID"" AS ""BlocksetID""
+                    ""BlocksetID"" AS ""BlocksetID"",
+                    0 AS ""IsMetadata""
                 FROM ""FileLookup""
                 WHERE
                     ""BlocksetID"" != {Library.Utility.Utility.FormatInvariantValue(FOLDER_BLOCKSET_ID)}
@@ -68,52 +216,28 @@ namespace Duplicati.Library.Main.Database.Local
                 UNION
                     SELECT
                         ""A"".""ID"" AS ""ID"",
-                        ""B"".""BlocksetID"" AS ""BlocksetID""
+                        ""B"".""BlocksetID"" AS ""BlocksetID"",
+                        1 AS ""IsMetadata""
                     FROM ""FileLookup"" ""A""
                     LEFT JOIN ""Metadataset"" ""B""
                         ON ""A"".""MetadataID"" = ""B"".""ID""
             )
             WHERE
                 ""BlocksetID"" IS NULL
-                OR ""BlocksetID"" IN (
-                    SELECT DISTINCT ""BlocksetID""
-                    FROM (
-                        SELECT ""BlocksetID""
-                        FROM ""BlocksetEntry""
-                        WHERE ""BlockID"" NOT IN (
-                            SELECT ""ID""
-                            FROM ""Block""
-                            WHERE ""VolumeID"" IN ({BLOCK_VOLUME_IDS})
-                        )
-                        UNION
-                            SELECT ""BlocksetID""
-                            FROM ""BlocklistHash""
-                            WHERE ""Hash"" NOT IN (
-                                SELECT ""Hash""
-                                FROM ""Block""
-                                WHERE ""VolumeID"" IN ({BLOCK_VOLUME_IDS})
-                            )
-                        UNION
-                            SELECT ""A"".""ID"" AS ""BlocksetID""
-                            FROM ""Blockset"" ""A""
-                            LEFT JOIN ""BlocksetEntry"" ""B""
-                                ON ""A"".""ID"" = ""B"".""BlocksetID""
-                            WHERE
-                                ""A"".""Length"" > 0
-                                AND ""B"".""BlocksetID"" IS NULL
-                    )
-                    WHERE ""BlocksetID"" NOT IN (
-                        SELECT ""ID""
-                        FROM ""Blockset""
-                        WHERE ""Length"" == 0
-                    )
-                )
-        ";
+                OR (
+                    ""IsMetadata"" = 0
+                    AND ""BlocksetID"" IN ({invalidBlocksetIdsQuery})
+                ){metadataCondition}
+            ";
+        }
 
         /// <summary>
-        /// SQL query to get the broken filesets, i.e., filesets that contain broken files.
+        /// Builds the SQL query for the broken filesets, i.e., filesets that contain broken files.
         /// </summary>
-        private static readonly string BROKEN_FILE_SETS = $@"
+        /// <param name="ignoreReplaceableMetadata">If <c>true</c>, files that are only broken because their metadata needs replacing are not counted.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the SQL query.</returns>
+        private async Task<string> BrokenFileSetsQueryAsync(bool ignoreReplaceableMetadata, CancellationToken token) => $@"
             SELECT DISTINCT
                 ""B"".""Timestamp"",
                 ""A"".""FilesetID"",
@@ -123,13 +247,16 @@ namespace Duplicati.Library.Main.Database.Local
                 ""Fileset"" ""B""
             WHERE
                 ""A"".""FilesetID"" = ""B"".""ID""
-                AND ""A"".""FileID"" IN ({BROKEN_FILE_IDS})
+                AND ""A"".""FileID"" IN ({await BrokenFileIdsQueryAsync(ignoreReplaceableMetadata, token).ConfigureAwait(false)})
         ";
 
         /// <summary>
-        /// SQL query to get the names and lengths of broken files.
+        /// Builds the SQL query for the names and lengths of broken files.
         /// </summary>
-        private static readonly string BROKEN_FILE_NAMES = $@"
+        /// <param name="ignoreReplaceableMetadata">If <c>true</c>, files that are only broken because their metadata needs replacing are not reported.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the SQL query.</returns>
+        private async Task<string> BrokenFileNamesQueryAsync(bool ignoreReplaceableMetadata, CancellationToken token) => $@"
             SELECT
                 ""A"".""Path"",
                 ""B"".""Length""
@@ -137,7 +264,7 @@ namespace Duplicati.Library.Main.Database.Local
             LEFT JOIN ""Blockset"" ""B""
                 ON (""A"".""BlocksetID"" = ""B"".""ID"")
             WHERE
-                ""A"".""ID"" IN ({BROKEN_FILE_IDS})
+                ""A"".""ID"" IN ({await BrokenFileIdsQueryAsync(ignoreReplaceableMetadata, token).ConfigureAwait(false)})
                 AND ""A"".""ID"" IN (
                     SELECT ""FileID""
                     FROM ""FilesetEntry""
@@ -146,15 +273,22 @@ namespace Duplicati.Library.Main.Database.Local
         ";
 
         /// <summary>
-        /// SQL query to insert broken file IDs into a specified table.
+        /// Builds the SQL statement that inserts broken file IDs into a specified table. This only builds the
+        /// statement, it does not execute it, see <see cref="InsertBrokenFileIDsIntoTableAsync"/>.
         /// The table must have a single column with the same name as the ID field name.
         /// </summary>
-        private static string INSERT_BROKEN_IDS(string tablename, string IDfieldname) => $@"
+        /// <param name="tablename">The name of the table to insert into.</param>
+        /// <param name="IDfieldname">The name of the ID field in the table.</param>
+        /// <param name="ignoreReplaceableMetadata">If <c>true</c>, files that are only broken because their metadata needs replacing are not inserted.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the SQL statement.</returns>
+        private async Task<string> InsertBrokenIdsStatementAsync(string tablename, string IDfieldname, bool ignoreReplaceableMetadata, CancellationToken token) => $@"
             INSERT INTO ""{tablename}"" (
                 ""{IDfieldname}""
             )
-            {BROKEN_FILE_IDS}
-            AND ""ID"" IN (
+            SELECT ""ID""
+            FROM ({await BrokenFileIdsQueryAsync(ignoreReplaceableMetadata, token).ConfigureAwait(false)})
+            WHERE ""ID"" IN (
                 SELECT ""FileID""
                 FROM ""FilesetEntry""
                 WHERE ""FilesetID"" = @FilesetId
@@ -204,11 +338,13 @@ namespace Duplicati.Library.Main.Database.Local
         /// </summary>
         /// <param name="time">The time to filter filesets by.</param>
         /// <param name="versions">Optional array of versions to filter filesets by. If null, all versions are considered.</param>
+        /// <param name="ignoreReplaceableMetadata">If <c>true</c>, files that are only broken because their metadata needs replacing are not counted, which projects the state after a replacement.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <returns>An asynchronous enumerable of broken file IDs.</returns>
-        public async IAsyncEnumerable<(DateTime FilesetTime, long FilesetID, long RemoveFileCount)> GetBrokenFilesetsAsync(DateTime time, long[]? versions, [EnumeratorCancellation] CancellationToken token)
+        public async IAsyncEnumerable<(DateTime FilesetTime, long FilesetID, long RemoveFileCount)> GetBrokenFilesetsAsync(DateTime time, long[]? versions, bool ignoreReplaceableMetadata, [EnumeratorCancellation] CancellationToken token)
         {
-            var query = BROKEN_FILE_SETS;
+            var query = await BrokenFileSetsQueryAsync(ignoreReplaceableMetadata, token)
+                .ConfigureAwait(false);
             var clause = await GetFilelistWhereClauseAsync(time, versions, null, false, token)
                 .ConfigureAwait(false);
 
@@ -240,12 +376,16 @@ namespace Duplicati.Library.Main.Database.Local
         /// Returns all broken file IDs, i.e., files that reference blocksets or blocks that are not available.
         /// </summary>
         /// <param name="filesetid">The fileset ID to filter by.</param>
+        /// <param name="ignoreReplaceableMetadata">If <c>true</c>, files that are only broken because their metadata needs replacing are not reported.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <returns>An asynchronous enumerable of broken file IDs.</returns>
-        public async IAsyncEnumerable<Tuple<string, long>> GetBrokenFilenamesAsync(long filesetid, [EnumeratorCancellation] CancellationToken token)
+        public async IAsyncEnumerable<Tuple<string, long>> GetBrokenFilenamesAsync(long filesetid, bool ignoreReplaceableMetadata, [EnumeratorCancellation] CancellationToken token)
         {
+            var query = await BrokenFileNamesQueryAsync(ignoreReplaceableMetadata, token)
+                .ConfigureAwait(false);
+
             await using var cmd = Connection.CreateCommand(m_rtr)
-                .SetCommandAndParameters(BROKEN_FILE_NAMES)
+                .SetCommandAndParameters(query)
                 .SetParameterValue("@FilesetId", filesetid);
 
             await foreach (var rd in cmd.ExecuteReaderEnumerableAsync(token).ConfigureAwait(false))
@@ -292,12 +432,16 @@ namespace Duplicati.Library.Main.Database.Local
         /// <param name="filesetid">The filset id for the current operation.</param>
         /// <param name="tablename">The name of the table to insert into.</param>
         /// <param name="IDfieldname">The name of the ID field in the table.</param>
+        /// <param name="ignoreReplaceableMetadata">If <c>true</c>, files that are only broken because their metadata needs replacing are not inserted.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <returns>A task that completes when the insertion is finished.</returns>
-        public async Task InsertBrokenFileIDsIntoTableAsync(long filesetid, string tablename, string IDfieldname, CancellationToken token)
+        public async Task InsertBrokenFileIDsIntoTableAsync(long filesetid, string tablename, string IDfieldname, bool ignoreReplaceableMetadata, CancellationToken token)
         {
+            var query = await InsertBrokenIdsStatementAsync(tablename, IDfieldname, ignoreReplaceableMetadata, token)
+                .ConfigureAwait(false);
+
             await using var cmd = Connection.CreateCommand(m_rtr)
-                .SetCommandAndParameters(INSERT_BROKEN_IDS(tablename, IDfieldname))
+                .SetCommandAndParameters(query)
                 .SetParameterValue("@FilesetId", filesetid);
 
             await cmd.ExecuteNonQueryAsync(true, token)
@@ -305,18 +449,79 @@ namespace Duplicati.Library.Main.Database.Local
         }
 
         /// <summary>
-        /// Replaces the metadata blockset ID in the Metadataset table with the empty blockset ID for all fileset entries that are not in any block volume.
-        /// This is used to clean up the metadata blocksets that are now missing.
+        /// Returns the ids of the filesets that reference metadata which needs replacing.
         /// </summary>
+        /// <remarks>
+        /// Only <c>Metadataset</c> rows that actually exist are considered, since a missing row is not
+        /// something a replacement can fix.
+        /// </remarks>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the fileset ids.</returns>
+        public async Task<HashSet<long>> GetFilesetsWithReplaceableMetadataAsync(CancellationToken token)
+        {
+            var invalidBlocksetIdsQuery = await InvalidBlocksetIdsQueryAsync(token).ConfigureAwait(false);
+
+            await using var cmd = Connection.CreateCommand($@"
+                SELECT DISTINCT ""FilesetEntry"".""FilesetID""
+                FROM ""FilesetEntry""
+                JOIN ""FileLookup""
+                    ON ""FileLookup"".""ID"" = ""FilesetEntry"".""FileID""
+                JOIN ""Metadataset""
+                    ON ""Metadataset"".""ID"" = ""FileLookup"".""MetadataID""
+                WHERE ""Metadataset"".""BlocksetID"" NOT IN ({UsableMetadataBlocksetIdsQuery(invalidBlocksetIdsQuery)})
+            ")
+                .SetTransaction(m_rtr);
+
+            var result = new HashSet<long>();
+            await foreach (var rd in cmd.ExecuteReaderEnumerableAsync(token).ConfigureAwait(false))
+                result.Add(rd.ConvertValueToInt64(0, -1));
+
+            return result;
+        }
+
+        /// <summary>
+        /// Repoints the metadata of the given fileset at the replacement blockset, for every metadata entry
+        /// that cannot be restored.
+        /// </summary>
+        /// <remarks>
+        /// <c>Metadataset.BlocksetID</c> is repointed rather than <c>FileLookup.MetadataID</c>, because
+        /// <c>FileLookup</c> is unique on <c>("PrefixID", "Path", "BlocksetID", "MetadataID")</c> and
+        /// repointing it can therefore collide, while <c>Metadataset.BlocksetID</c> has a non-unique index.
+        /// <para>
+        /// Metadata rows are shared between filesets, so the returned row count is not a per-fileset
+        /// recovery count: the first fileset repairs rows that later filesets also use, and those would then
+        /// report zero.
+        /// </para>
+        /// </remarks>
         /// <param name="filesetId">The filesetId to target.</param>
-        /// <param name="emptyBlocksetId">The empty blockset ID to replace with.</param>
+        /// <param name="replacementBlocksetId">The blockset ID to point the damaged metadata at.</param>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <returns>A task that when awaited contains the number of rows affected</returns>
-        public async Task<int> ReplaceMetadataAsync(long filesetId, long emptyBlocksetId, CancellationToken token)
+        public async Task<int> ReplaceMetadataAsync(long filesetId, long replacementBlocksetId, CancellationToken token)
         {
-            await using var cmd = m_connection.CreateCommand(@"
+            var invalidBlocksetIdsQuery = await InvalidBlocksetIdsQueryAsync(token).ConfigureAwait(false);
+            var usableMetadataBlocksetIdsQuery = UsableMetadataBlocksetIdsQuery(invalidBlocksetIdsQuery);
+
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            // Refuse to hand out something that is not restorable itself, as that would silently turn one
+            // kind of unrestorable metadata into another
+            var replacementIsUsable = await cmd.SetCommandAndParameters($@"
+                SELECT COUNT(*)
+                FROM ({usableMetadataBlocksetIdsQuery})
+                WHERE ""ID"" = @ReplacementBlocksetID
+            ")
+                .SetParameterValue("@ReplacementBlocksetID", replacementBlocksetId)
+                .ExecuteScalarInt64Async(0, token)
+                .ConfigureAwait(false);
+
+            if (replacementIsUsable == 0)
+                throw new Interface.UserInformationException($"The blockset {replacementBlocksetId} cannot be used as replacement metadata, as it is not restorable itself.", "ReplacementMetadataNotUsable");
+
+            return await cmd.SetCommandAndParameters($@"
                 UPDATE ""Metadataset""
-                SET ""BlocksetID"" = @EmptyBlocksetID
+                SET ""BlocksetID"" = @ReplacementBlocksetID
                 WHERE
                     ""ID"" IN (
                         SELECT ""FileLookup"".""MetadataID""
@@ -327,19 +532,12 @@ namespace Duplicati.Library.Main.Database.Local
                             ""FilesetEntry"".""FilesetId"" = @FilesetID
                             AND ""FileLookup"".""ID"" = ""FilesetEntry"".""FileID""
                     )
-                    AND ""BlocksetID"" NOT IN (
-                        SELECT ""BlocksetID""
-                        FROM
-                            ""BlocksetEntry"",
-                            ""Block""
-                        WHERE ""BlocksetEntry"".""BlockID"" = ""Block"".""ID""
-                    )
+                    AND ""BlocksetID"" NOT IN ({usableMetadataBlocksetIdsQuery})
             ")
-                .SetTransaction(m_rtr)
-                .SetParameterValue("@EmptyBlocksetID", emptyBlocksetId)
-                .SetParameterValue("@FilesetID", filesetId);
-
-            return await cmd.ExecuteNonQueryAsync(true, token).ConfigureAwait(false);
+                .SetParameterValue("@ReplacementBlocksetID", replacementBlocksetId)
+                .SetParameterValue("@FilesetID", filesetId)
+                .ExecuteNonQueryAsync(true, token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/ListBrokenFilesHandler.cs
@@ -65,7 +65,7 @@ namespace Duplicati.Library.Main.Operation
         {
             List<Database.RemoteVolumeEntry>? missing = null;
             var brokensets = await db
-                .GetBrokenFilesetsAsync(options.Time, options.Version, result.TaskControl.ProgressToken)
+                .GetBrokenFilesetsAsync(options.Time, options.Version, ignoreReplaceableMetadata: false, result.TaskControl.ProgressToken)
                 .ToArrayAsync(cancellationToken: result.TaskControl.ProgressToken)
                 .ConfigureAwait(false);
 
@@ -107,7 +107,7 @@ namespace Duplicati.Library.Main.Operation
                         .ConfigureAwait(false);
 
                 brokensets = await db
-                    .GetBrokenFilesetsAsync(options.Time, options.Version, result.TaskControl.ProgressToken)
+                    .GetBrokenFilesetsAsync(options.Time, options.Version, ignoreReplaceableMetadata: false, result.TaskControl.ProgressToken)
                     .ToArrayAsync()
                     .ConfigureAwait(false);
             }
@@ -165,7 +165,7 @@ namespace Duplicati.Library.Main.Operation
                                 x.Timestamp,
                                 callbackhandler == null && !m_options.ListSetsOnly
                                     ? await db
-                                        .GetBrokenFilenamesAsync(x.FilesetID, m_result.TaskControl.ProgressToken)
+                                        .GetBrokenFilenamesAsync(x.FilesetID, ignoreReplaceableMetadata: false, m_result.TaskControl.ProgressToken)
                                         .ToArrayAsync(cancellationToken: m_result.TaskControl.ProgressToken)
                                         .ConfigureAwait(false)
                                     : new MockList<Tuple<string, long>>((int)x.BrokenCount)
@@ -175,7 +175,7 @@ namespace Duplicati.Library.Main.Operation
 
             if (callbackhandler != null)
                 foreach (var bs in brokenfilesets)
-                    await foreach (var fe in db.GetBrokenFilenamesAsync(bs.FilesetID, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
+                    await foreach (var fe in db.GetBrokenFilenamesAsync(bs.FilesetID, ignoreReplaceableMetadata: false, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
                         if (!callbackhandler(bs.Version, bs.Timestamp, bs.BrokenCount, fe.Item1, fe.Item2))
                             break;
         }

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -87,21 +87,31 @@ namespace Duplicati.Library.Main.Operation
                     .ToListAsync(cancellationToken: m_result.TaskControl.ProgressToken)
                     .ConfigureAwait(false);
 
-                var compare_list = sets.Select(async x => new
-                {
-                    FilesetID = x.FilesetID,
-                    Timestamp = x.FilesetTime,
-                    RemoveCount = x.RemoveCount,
-                    Version = filesets.FindIndex(y => y.Key == x.FilesetID),
-                    SetCount = await db
-                        .GetFilesetFileCountAsync(x.FilesetID, m_result.TaskControl.ProgressToken)
-                        .ConfigureAwait(false)
-                })
-                    .Select(x => x.Result)
-                    .ToArray();
-
+                var replaceMetadata = !m_options.DisableReplaceMissingMetadata;
                 var replacementMetadataBlocksetId = -1L;
-                if (!m_options.DisableReplaceMissingMetadata)
+                // The number of files per fileset that the replacement recovers, i.e. that were only broken
+                // because their metadata could not be restored.
+                var recoveredFileCounts = new Dictionary<long, long>();
+
+                if (replaceMetadata)
+                {
+                    // Metadata rows are shared between filesets, but only the selected filesets get a new
+                    // filelist. Replacing the shared rows while some filelist keeps referencing the old
+                    // metadata means a later database recreate reintroduces the damage, so refuse to do it.
+                    // Without a version filter every fileset with replaceable metadata is broken, and is
+                    // therefore part of the selection, so this can only trigger for a scoped purge.
+                    var outsideSelection = (await db.GetFilesetsWithReplaceableMetadataAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false))
+                        .Except(sets.Select(x => x.FilesetID))
+                        .ToArray();
+
+                    if (outsideSelection.Length > 0)
+                    {
+                        Logging.Log.WriteWarningMessage(LOGTAG, "ReplaceableMetadataOutsideSelection", null, "Not replacing metadata that cannot be restored, because {0} fileset(s) outside the selected versions reference the same metadata entries, and only the selected filelists are rewritten. The affected files are removed from the selected version(s) instead. Run {1} without {2} and {3} to recover them by replacing the metadata.", outsideSelection.Length, "purge-broken-files", "--version", "--time");
+                        replaceMetadata = false;
+                    }
+                }
+
+                if (replaceMetadata)
                 {
                     var emptymetadata = Utility.WrapMetadata(new Dictionary<string, string>(), m_options);
                     // The volumes that are missing cannot supply blocks, so a blockset that depends on them
@@ -133,6 +143,42 @@ namespace Duplicati.Library.Main.Operation
                     if (replacementMetadataBlocksetId < 0)
                         throw new UserInformationException($"Failed to locate an empty metadata blockset to replace missing metadata. Set the option --disable-replace-missing-metadata=true to ignore this and drop files with missing metadata.", "FailedToLocateEmptyMetadataBlockset");
                 }
+
+                // Project the per-fileset broken-file counts for the state after the replacement. Without
+                // this, a fileset whose files are only metadata-broken counts as fully broken and gets
+                // deleted, instead of being rewritten with the replacement metadata.
+                var brokenCounts = sets.ToDictionary(x => x.FilesetID, x => x.RemoveCount);
+                if (replaceMetadata)
+                {
+                    var projected = new Dictionary<long, long>();
+                    await foreach (var p in db.GetBrokenFilesetsAsync(m_options.Time, m_options.Version, ignoreReplaceableMetadata: true, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
+                        projected[p.FilesetID] = p.RemoveFileCount;
+
+                    foreach (var set in sets)
+                    {
+                        var remaining = projected.TryGetValue(set.FilesetID, out var r) ? r : 0;
+                        recoveredFileCounts[set.FilesetID] = set.RemoveCount - remaining;
+                        brokenCounts[set.FilesetID] = remaining;
+                    }
+
+                    var recovered = recoveredFileCounts.Values.Sum();
+                    if (recovered > 0)
+                        Logging.Log.WriteWarningMessage(LOGTAG, "MetadataReplacedWithEmpty", null, "Recovering {0} file(s) by replacing metadata that cannot be restored. The affected files keep their contents, but lose their original permissions and timestamps. Use {1} to remove them instead.", recovered, "--disable-replace-missing-metadata");
+                }
+
+                var compare_list = sets.Select(async x => new
+                {
+                    FilesetID = x.FilesetID,
+                    Timestamp = x.FilesetTime,
+                    RemoveCount = brokenCounts[x.FilesetID],
+                    RecoverCount = recoveredFileCounts.TryGetValue(x.FilesetID, out var recovered) ? recovered : 0,
+                    Version = filesets.FindIndex(y => y.Key == x.FilesetID),
+                    SetCount = await db
+                        .GetFilesetFileCountAsync(x.FilesetID, m_result.TaskControl.ProgressToken)
+                        .ConfigureAwait(false)
+                })
+                    .Select(x => x.Result)
+                    .ToArray();
 
                 var fully_emptied = compare_list.Where(x => x.RemoveCount == x.SetCount).ToArray();
                 var to_purge = compare_list.Where(x => x.RemoveCount != x.SetCount).ToArray();
@@ -178,7 +224,7 @@ namespace Duplicati.Library.Main.Operation
 
                     foreach (var bs in to_purge)
                     {
-                        Logging.Log.WriteInformationMessage(LOGTAG, "PurgingFiles", "Purging {0} file(s) from fileset {1}", bs.RemoveCount, bs.Timestamp.ToLocalTime());
+                        Logging.Log.WriteInformationMessage(LOGTAG, "PurgingFiles", "Purging {0} file(s) from fileset {1}, recovering {2} file(s) with replacement metadata", bs.RemoveCount, bs.Timestamp.ToLocalTime(), bs.RecoverCount);
                         var opts = new Options(new Dictionary<string, string?>(m_options.RawOptions));
 
                         await using (var pgdb = await LocalPurgeDatabase.CreateAsync(db, null, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
@@ -203,10 +249,20 @@ namespace Duplicati.Library.Main.Operation
 
                                 // Update entries that would be removed because of missing metadata
                                 var updatedEntries = 0;
-                                if (!m_options.DisableReplaceMissingMetadata)
-                                    updatedEntries = await db.ReplaceMetadataAsync(filesetid, replacementMetadataBlocksetId, m_result.TaskControl.ProgressToken);
+                                if (replaceMetadata)
+                                {
+                                    await db.ReplaceMetadataAsync(filesetid, replacementMetadataBlocksetId, m_result.TaskControl.ProgressToken);
 
-                                await db.InsertBrokenFileIDsIntoTableAsync(filesetid, tablename, "FileID", m_result.TaskControl.ProgressToken);
+                                    // Report the projected recovery, not the number of rows the update
+                                    // touched: metadata rows are shared between filesets, so the first
+                                    // fileset repairs rows the later ones also use, and they would all
+                                    // report zero. A non-zero count here is what makes PurgeFilesHandler
+                                    // write a new filelist even when nothing is removed, which is what
+                                    // persists the replacement at the destination.
+                                    updatedEntries = (int)bs.RecoverCount;
+                                }
+
+                                await db.InsertBrokenFileIDsIntoTableAsync(filesetid, tablename, "FileID", ignoreReplaceableMetadata: replaceMetadata, m_result.TaskControl.ProgressToken);
                                 return updatedEntries;
                             }).ConfigureAwait(false);
                         }

--- a/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
+++ b/Duplicati/Library/Main/Operation/RecreateDatabaseHandler.cs
@@ -727,7 +727,7 @@ namespace Duplicati.Library.Main.Operation
                 await using (var lbfdb = await LocalListBrokenFilesDatabase.CreateAsync(restoredb, null, m_result.TaskControl.ProgressToken).ConfigureAwait(false))
                 {
                     var broken = await lbfdb
-                        .GetBrokenFilesetsAsync(new DateTime(0), null, m_result.TaskControl.ProgressToken)
+                        .GetBrokenFilesetsAsync(new DateTime(0), null, ignoreReplaceableMetadata: false, m_result.TaskControl.ProgressToken)
                         .CountAsync(cancellationToken: m_result.TaskControl.ProgressToken)
                         .ConfigureAwait(false);
 

--- a/Duplicati/UnitTest/PurgeTesting.cs
+++ b/Duplicati/UnitTest/PurgeTesting.cs
@@ -273,14 +273,18 @@ namespace Duplicati.UnitTest
             {
                 var purgeResults = await c.PurgeBrokenFilesAsync(null);
                 Assert.AreEqual(0, purgeResults.Errors.Count());
-                Assert.AreEqual(0, purgeResults.Warnings.Count());
+                // The deleted dblock also held metadata, so the affected files are recovered by
+                // assigning replacement metadata, which is reported as a warning
+                Assert.AreEqual(1, purgeResults.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")));
+                Assert.AreEqual(0, purgeResults.Warnings.Count(x => !x.Contains("MetadataReplacedWithEmpty")));
             }
 
             using (var c = new Library.Main.Controller("file://" + TARGETFOLDER, testopts, null))
             {
                 var brk = await c.PurgeBrokenFilesAsync(null);
                 Assert.AreEqual(0, brk.Errors.Count());
-                Assert.AreEqual(0, brk.Warnings.Count());
+                Assert.AreEqual(1, brk.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")));
+                Assert.AreEqual(0, brk.Warnings.Count(x => !x.Contains("MetadataReplacedWithEmpty")));
 
                 var modFilesets = 0L;
                 if (brk.DeleteResults != null)

--- a/Duplicati/UnitTest/RepairWithMissingRemoteFiles.cs
+++ b/Duplicati/UnitTest/RepairWithMissingRemoteFiles.cs
@@ -420,8 +420,11 @@ namespace Duplicati.UnitTest
                 // Ensure that the partial repair did not clean up fully
                 Assert.ThrowsAsync<RemoteListVerificationException>(() => c.TestAsync());
 
-                // Purge broken files should be possible
-                TestUtils.AssertResults(await c.PurgeBrokenFilesAsync(null));
+                // Purge broken files should be possible, recovering the files whose metadata was in the
+                // deleted volume by assigning replacement metadata
+                var purgeRes = await c.PurgeBrokenFilesAsync(null);
+                Assert.That(purgeRes.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")), Is.EqualTo(1), "Purge should report the replaced metadata.");
+                TestUtils.AssertResults(purgeRes, "MetadataReplacedWithEmpty");
                 TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
             }
 
@@ -474,8 +477,11 @@ namespace Duplicati.UnitTest
                 // Ensure that the partial repair did not clean up fully
                 Assert.ThrowsAsync<RemoteListVerificationException>(() => c.TestAsync());
 
-                // Purge broken files should be possible
-                TestUtils.AssertResults(await c.PurgeBrokenFilesAsync(null));
+                // Purge broken files should be possible, recovering the files whose metadata was in the
+                // deleted volume by assigning replacement metadata
+                var purgeRes = await c.PurgeBrokenFilesAsync(null);
+                Assert.That(purgeRes.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")), Is.EqualTo(1), "Purge should report the replaced metadata.");
+                TestUtils.AssertResults(purgeRes, "MetadataReplacedWithEmpty");
                 TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
 
                 var files = (await c.ListAsync("*")).Files.ToList();
@@ -570,8 +576,11 @@ namespace Duplicati.UnitTest
                     TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
                 }
 
-                // Purge broken files should be possible
-                TestUtils.AssertResults(await c.PurgeBrokenFilesAsync(null));
+                // Purge broken files should be possible. Destroying the metadata leaves files that are
+                // only metadata-broken, and those are recovered with replacement metadata rather than removed
+                var purgeRes = await c.PurgeBrokenFilesAsync(null);
+                Assert.That(purgeRes.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")), Is.EqualTo(destroyMetadata ? 1 : 0), "Purge should only report replaced metadata when the metadata was destroyed.");
+                TestUtils.AssertResults(purgeRes, "MetadataReplacedWithEmpty");
                 TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
             }
 

--- a/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
+++ b/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
@@ -84,6 +84,40 @@ public class ZeroLengthMetadataTests : BasicSetupHelper
             .ExecuteScalarInt64(0);
 
     /// <summary>
+    /// Points the metadata of the named file at the shared empty-file blockset, which is the state
+    /// reported in the wild: a metadata entry with a length of 0, sharing its blockset with every empty
+    /// file in the backup.
+    /// </summary>
+    /// <returns>The metadata id that was repointed.</returns>
+    private static async Task<long> PointMetadataAtSharedEmptyBlocksetAsync(SqliteCommand cmd, string path, long sharedEmptyBlocksetId)
+    {
+        var metadataId = cmd
+            .SetCommandAndParameters(@"SELECT ""MetadataID"" FROM ""File"" WHERE ""Path"" LIKE @Path")
+            .SetParameterValue("@Path", "%" + path)
+            .ExecuteScalarInt64(-1);
+
+        Assert.That(metadataId, Is.GreaterThanOrEqualTo(0), $"No metadata found for {path}");
+
+        var updated = await cmd
+            .SetCommandAndParameters(@"UPDATE ""Metadataset"" SET ""BlocksetID"" = @BlocksetId WHERE ""ID"" = @Id")
+            .SetParameterValue("@BlocksetId", sharedEmptyBlocksetId)
+            .SetParameterValue("@Id", metadataId)
+            .ExecuteNonQueryAsync();
+
+        Assert.That(updated, Is.EqualTo(1), "Metadata was not repointed");
+        return metadataId;
+    }
+
+    /// <summary>
+    /// Returns the blockset the given metadata entry points at.
+    /// </summary>
+    private static long GetMetadataBlocksetId(SqliteCommand cmd, long metadataId)
+        => cmd
+            .SetCommandAndParameters(@"SELECT ""BlocksetID"" FROM ""Metadataset"" WHERE ""ID"" = @Id")
+            .SetParameterValue("@Id", metadataId)
+            .ExecuteScalarInt64(-1);
+
+    /// <summary>
     /// Attaches an existing block to a blockset, simulating the damage seen in the wild.
     /// </summary>
     private static async Task AttachBlockAsync(SqliteCommand cmd, long blocksetId)
@@ -278,6 +312,175 @@ public class ZeroLengthMetadataTests : BasicSetupHelper
         {
             Assert.That(CountBlocksetEntries(cmd, emptyBlocksetId), Is.EqualTo(1), "A dry-run must not strip blocks");
             Assert.That(CountBlocksetEntries(cmd, orphanBlocksetId), Is.EqualTo(1), "A dry-run must not remove orphaned entries");
+        }
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task ListBrokenFilesReportsUnrestorableMetadataAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+            await PointMetadataAtSharedEmptyBlocksetAsync(cmd, "a.txt", GetSharedEmptyBlocksetId(cmd, emptyFileHash));
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var res = await c.ListBrokenFilesAsync(null);
+            Assert.That(res.Errors.Count(), Is.EqualTo(0));
+
+            var broken = res.BrokenFiles.SelectMany(x => x.Item3).Select(x => x.Item1).ToArray();
+            Assert.That(broken.Length, Is.EqualTo(1), "Expected exactly one broken file, got: " + string.Join(", ", broken));
+            Assert.That(broken[0], Does.EndWith("a.txt"), "The file with the unrestorable metadata should be reported");
+        }
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task PurgeRecoversUnrestorableMetadataAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        long metadataId;
+        long emptyBlocksetId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            emptyBlocksetId = GetSharedEmptyBlocksetId(cmd, emptyFileHash);
+            metadataId = await PointMetadataAtSharedEmptyBlocksetAsync(cmd, "a.txt", emptyBlocksetId);
+        }
+
+        var dlistsBefore = Directory.GetFiles(this.TARGETFOLDER, "*.dlist.*").Length;
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var res = await c.PurgeBrokenFilesAsync(null);
+            Assert.That(res.Errors.Count(), Is.EqualTo(0));
+            Assert.That(res.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")), Is.EqualTo(1), "The recovery should be reported");
+            TestUtils.AssertResults(res, "MetadataReplacedWithEmpty");
+
+            Assert.That(res.DeleteResults, Is.Null, "No fileset should have been deleted");
+            Assert.That(res.PurgeResults?.RemovedFileCount, Is.EqualTo(0), "No file should have been removed");
+            Assert.That(res.PurgeResults?.RewrittenFileLists, Is.EqualTo(1), "The filelist must be rewritten, or the replacement is not persisted");
+        }
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            Assert.That(GetMetadataBlocksetId(cmd, metadataId), Is.Not.EqualTo(emptyBlocksetId), "The metadata should point at a restorable blockset");
+            Assert.That(
+                cmd.ExecuteScalarInt64(@"SELECT COUNT(*) FROM ""Metadataset"" JOIN ""Blockset"" ON ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID"" WHERE ""Blockset"".""Length"" = 0", -1),
+                Is.EqualTo(0),
+                "No metadata entry may have a length of 0");
+        }
+
+        // The empty file keeps the shared blockset, and both files are still in the backup
+        Assert.That(Directory.GetFiles(this.TARGETFOLDER, "*.dlist.*").Length, Is.EqualTo(dlistsBefore), "The old filelist should have been replaced");
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var files = (await c.ListAsync("*")).Files.Select(x => x.Path).ToArray();
+            Assert.That(files.Count(x => x.EndsWith("a.txt")), Is.EqualTo(1), "The recovered file should still be in the backup");
+            Assert.That(files.Count(x => x.EndsWith("empty.txt")), Is.EqualTo(1), "The empty file should not have been touched");
+
+            TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
+        }
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task PurgeRemovesFileWhenReplacementIsDisabledAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        options["disable-replace-missing-metadata"] = "true";
+
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+            await PointMetadataAtSharedEmptyBlocksetAsync(cmd, "a.txt", GetSharedEmptyBlocksetId(cmd, emptyFileHash));
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var res = await c.PurgeBrokenFilesAsync(null);
+            Assert.That(res.Errors.Count(), Is.EqualTo(0));
+            Assert.That(res.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")), Is.EqualTo(0), "Nothing should have been recovered");
+            Assert.That(res.PurgeResults?.RemovedFileCount, Is.EqualTo(1), "The file should have been removed");
+        }
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var files = (await c.ListAsync("*")).Files.Select(x => x.Path).ToArray();
+            Assert.That(files.Any(x => x.EndsWith("a.txt")), Is.False, "The file should have been removed");
+            Assert.That(files.Count(x => x.EndsWith("empty.txt")), Is.EqualTo(1), "The empty file should not have been touched");
+        }
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task ScopedPurgeDoesNotTouchSharedMetadataAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        // A second version that keeps the unchanged file, and therefore shares its metadata row
+        Thread.Sleep(2000);
+        File.WriteAllText(Path.Combine(this.DATAFOLDER, "b.txt"), "more data");
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+        long metadataId;
+        long emptyBlocksetId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            emptyBlocksetId = GetSharedEmptyBlocksetId(cmd, emptyFileHash);
+            metadataId = await PointMetadataAtSharedEmptyBlocksetAsync(cmd, "a.txt", emptyBlocksetId);
+
+            Assert.That(
+                cmd.SetCommandAndParameters(@"SELECT COUNT(DISTINCT ""FilesetID"") FROM ""FilesetEntry"" JOIN ""FileLookup"" ON ""FileLookup"".""ID"" = ""FilesetEntry"".""FileID"" WHERE ""FileLookup"".""MetadataID"" = @Id")
+                    .SetParameterValue("@Id", metadataId)
+                    .ExecuteScalarInt64(0),
+                Is.EqualTo(2),
+                "Both versions should share the damaged metadata row");
+        }
+
+        // Only version 0 gets a new filelist, so repointing the shared row would leave version 1
+        // referencing the old metadata, and a later recreate would reintroduce the damage
+        var scopedOptions = new Dictionary<string, string>(options) { ["version"] = "0" };
+        using (var c = new Controller("file://" + this.TARGETFOLDER, scopedOptions, null))
+        {
+            var res = await c.PurgeBrokenFilesAsync(null);
+            Assert.That(res.Errors.Count(), Is.EqualTo(0));
+            Assert.That(res.Warnings.Count(x => x.Contains("ReplaceableMetadataOutsideSelection")), Is.EqualTo(1), "The skipped replacement should be reported");
+            Assert.That(res.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")), Is.EqualTo(0), "Nothing should have been recovered");
+
+            // Without the replacement there is nothing to recover the file with, so it is removed from
+            // the selected version, which is what the warning says happens
+            Assert.That(res.PurgeResults?.RemovedFileCount, Is.EqualTo(1), "The affected file should have been removed from the selected version");
+        }
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+            Assert.That(GetMetadataBlocksetId(cmd, metadataId), Is.EqualTo(emptyBlocksetId), "The shared metadata row must not have been repointed");
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, scopedOptions, null))
+        {
+            var newest = (await c.ListAsync("*")).Files.Select(x => x.Path).ToArray();
+            Assert.That(newest.Any(x => x.EndsWith("a.txt")), Is.False, "The affected file should be gone from the purged version");
+        }
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, new Dictionary<string, string>(options) { ["version"] = "1" }, null))
+        {
+            var older = (await c.ListAsync("*")).Files.Select(x => x.Path).ToArray();
+            Assert.That(older.Count(x => x.EndsWith("a.txt")), Is.EqualTo(1), "The unselected version should be untouched");
         }
     }
 }


### PR DESCRIPTION
Detects files with unrestorable metadata in `list-broken-files`, and then lets `purge-broken-files` recover them instead of deleting if they are only missing metadata.