### PR TITLE
Re-read the Drime file list when a delete gets no answer

### DIFF
--- a/Duplicati/Library/Backend/DrimeCloud/DrimeBackend.cs
+++ b/Duplicati/Library/Backend/DrimeCloud/DrimeBackend.cs
@@ -31,6 +31,8 @@ using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using FileEntry = Duplicati.Library.Common.IO.FileEntry;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend.DrimeCloud;
 
 /// <summary>
@@ -217,6 +219,26 @@ public class DrimeBackend : IBackend, IStreamingBackend //, IRenameEnabledBacken
 
         // Parse soft delete option
         _softDelete = Utility.Utility.ParseBoolOption(options, SOFT_DELETE_OPTION);
+    }
+
+    /// <summary>
+    /// Constructor that takes a preconfigured message handler, used for testing
+    /// </summary>
+    /// <param name="url">Backend URL</param>
+    /// <param name="options">Options dictionary</param>
+    /// <param name="handler">The message handler to send requests through</param>
+    internal DrimeBackend(string url, Dictionary<string, string?> options, HttpMessageHandler handler)
+        : this(url, options)
+    {
+        _httpClient = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+            BaseAddress = new System.Uri(_apiUrl.TrimEnd('/') + "/")
+        };
+
+        // GetClientAsync hands back a client that already carries an authorization
+        // header, so setting one here keeps the login round-trip out of the tests
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
     }
 
     /// <inheritdoc/>
@@ -437,10 +459,23 @@ public class DrimeBackend : IBackend, IStreamingBackend //, IRenameEnabledBacken
         };
         request.Headers.Add("Accept", "application/json");
 
-        var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
-            ct => client.SendAsync(request, ct)).ConfigureAwait(false);
+        try
+        {
+            var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken,
+                ct => client.SendAsync(request, ct)).ConfigureAwait(false);
 
-        await EnsureSuccessStatusCodeAsync(response).ConfigureAwait(false);
+            await EnsureSuccessStatusCodeAsync(response).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The request may have reached Drime even though the answer did not reach
+            // us, which leaves the cache holding an id that no longer resolves. Drop
+            // the whole cache rather than the one name, because an upload asks the
+            // cache whether the name is taken and would otherwise skip the delete it
+            // has to make before it can reuse the name.
+            _fileCache = null;
+            throw;
+        }
 
         // Remove from cache
         _fileCache?.TryRemove(remotename, out var _);
@@ -734,9 +769,10 @@ public class DrimeBackend : IBackend, IStreamingBackend //, IRenameEnabledBacken
 
         // Try to parse JSON error response, but handle non-JSON responses gracefully
         string? errorMessage = null;
+        ErrorResponse? result = null;
         try
         {
-            var result = JsonSerializer.Deserialize<ErrorResponse>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            result = JsonSerializer.Deserialize<ErrorResponse>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             errorMessage = result?.Message;
         }
         catch (JsonException)
@@ -745,6 +781,14 @@ public class DrimeBackend : IBackend, IStreamingBackend //, IRenameEnabledBacken
             if (!string.IsNullOrWhiteSpace(body))
                 errorMessage = body.Trim();
         }
+
+        // Deleting an entry that is no longer there is reported as a validation
+        // failure on the ids rather than as a 404, and entryIds is only ever sent
+        // by DeleteAsync. BackendManager confirms this against a listing before it
+        // accepts the delete, so report it as the file being missing rather than
+        // deciding here that the delete succeeded.
+        if (result?.Errors?.ContainsKey("entryIds") == true)
+            throw new FileMissingException();
 
         if (!string.IsNullOrWhiteSpace(errorMessage))
             throw new InvalidOperationException($"Request failed: {errorMessage}");

--- a/Duplicati/Library/Backend/DrimeCloud/Model/FileEntry.cs
+++ b/Duplicati/Library/Backend/DrimeCloud/Model/FileEntry.cs
@@ -173,5 +173,5 @@ public class ErrorResponse
     /// <summary>
     /// Validation errors by field
     /// </summary>
-    public Dictionary<string, string>? Errors { get; set; }
+    public Dictionary<string, string[]>? Errors { get; set; }
 }

--- a/Duplicati/UnitTest/DrimeDeleteRetryTests.cs
+++ b/Duplicati/UnitTest/DrimeDeleteRetryTests.cs
@@ -1,0 +1,263 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.DrimeCloud;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A delete that reaches Drime but whose response does not reach us leaves the
+/// entry id in the file cache. The lookup hands that id back without asking the
+/// server, so every retry deletes something that is already gone, and the run
+/// fails for a file that was removed on the first attempt.
+/// </summary>
+[TestFixture]
+public class DrimeDeleteRetryTests
+{
+    /// <summary>
+    /// An empty path puts the backend at the drive root, which needs no folder lookup
+    /// </summary>
+    private const string Url = "drimecloud://";
+
+    /// <summary>
+    /// The name the tests delete
+    /// </summary>
+    private const string RemoteName = "duplicati-b0123456789.dblock.zip.aes";
+
+    /// <summary>
+    /// A second name, used to tell a cache that lost one entry from a cache that
+    /// was thrown away whole
+    /// </summary>
+    private const string OtherName = "duplicati-b9876543210.dblock.zip.aes";
+
+    /// <summary>
+    /// The id the listing reports for the first name it holds
+    /// </summary>
+    private const long EntryId = 4711;
+
+    /// <summary>
+    /// What Drime answers when the entry ids do not resolve, taken verbatim from
+    /// the backend test run on https://github.com/duplicati/duplicati/pull/7192
+    /// </summary>
+    private const string EntryIdsInvalidBody =
+        "{\"message\":\"The selected entry ids is invalid.\"," +
+        "\"errors\":{\"entryIds\":[\"The selected entry ids is invalid.\"]}}";
+
+    /// <summary>
+    /// Serves a listing and a delete endpoint, and records what was asked of it
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        /// <summary>
+        /// The names the listing reports, changed by the tests to model the server
+        /// state after a delete that the client never saw the answer to
+        /// </summary>
+        public List<string> Listed { get; } = new() { RemoteName };
+
+        /// <summary>
+        /// Runs for each delete request, and decides what that request answers
+        /// </summary>
+        public Func<int, HttpResponseMessage>? DeleteResponse { get; set; }
+
+        /// <summary>
+        /// The number of listing requests received
+        /// </summary>
+        public int Listings { get; private set; }
+
+        /// <summary>
+        /// The body of every delete request received, in order
+        /// </summary>
+        public List<string> DeleteBodies { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path.EndsWith("/file-entries/delete", StringComparison.Ordinal))
+            {
+                DeleteBodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+                return DeleteResponse?.Invoke(DeleteBodies.Count) ?? Json(HttpStatusCode.OK, "{\"status\":\"success\"}");
+            }
+
+            if (path.EndsWith("/drive/file-entries", StringComparison.Ordinal))
+            {
+                Listings++;
+                var entries = Listed.Select((x, i) =>
+                    $"{{\"id\":{EntryId + i},\"name\":\"{x}\",\"type\":\"file\",\"hash\":\"h{EntryId + i}\",\"file_size\":17}}");
+                return Json(HttpStatusCode.OK,
+                    $"{{\"data\":[{string.Join(",", entries)}],\"current_page\":1,\"last_page\":1,\"per_page\":100}}");
+            }
+
+            if (path.EndsWith("/uploads", StringComparison.Ordinal))
+                return Json(HttpStatusCode.OK,
+                    $"{{\"status\":\"success\",\"fileEntry\":{{\"id\":{EntryId + 1},\"name\":\"{RemoteName}\",\"type\":\"file\",\"hash\":\"h{EntryId + 1}\",\"file_size\":17}}}}");
+
+            return Json(HttpStatusCode.NotFound, "{\"message\":\"unexpected request\"}");
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body)
+            => new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static DrimeBackend CreateBackend(StubHandler handler)
+        => new(Url, new Dictionary<string, string?> { ["api-token"] = "test-token" }, handler);
+
+    /// <summary>
+    /// Models the retry the caller performs: the first delete throws, the file is
+    /// gone on the server, and the second attempt has to find that out.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task RetryAfterFailedDeleteRelistsInsteadOfResendingTheStaleId()
+    {
+        using var handler = new StubHandler
+        {
+            // The request reaches Drime, the answer does not reach us
+            DeleteResponse = attempt => attempt == 1 ? throw new TimeoutException("The operation has timed out.") : null!
+        };
+        using var backend = CreateBackend(handler);
+
+        Assert.CatchAsync<TimeoutException>(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+
+        Assert.AreEqual(1, handler.DeleteBodies.Count);
+        Assert.IsTrue(handler.DeleteBodies[0].Contains($"\"entryIds\":[{EntryId}]"), handler.DeleteBodies[0]);
+
+        // The first attempt removed it, so the server no longer reports it
+        handler.Listed.Clear();
+        var listingsBeforeRetry = handler.Listings;
+
+        await backend.DeleteAsync(RemoteName, CancellationToken.None);
+
+        Assert.Greater(handler.Listings, listingsBeforeRetry, "the retry has to ask the server again");
+        Assert.AreEqual(1, handler.DeleteBodies.Count, "the retry must not delete an entry id that is gone");
+    }
+
+    /// <summary>
+    /// Deleting an entry that is already gone is reported as a validation failure
+    /// on entryIds rather than as a 404, and BackendManager only runs its
+    /// list-and-confirm recovery for a FileMissingException.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public void EntryIdValidationErrorIsReportedAsFileMissing()
+    {
+        using var handler = new StubHandler
+        {
+            DeleteResponse = _ => new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+            {
+                Content = new StringContent(EntryIdsInvalidBody, Encoding.UTF8, "application/json")
+            }
+        };
+        using var backend = CreateBackend(handler);
+
+        Assert.CatchAsync<FileMissingException>(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// The error model declares the validation errors as plain strings, but Drime
+    /// sends an array of strings for each field, so parsing the body throws and
+    /// the raw json ends up as the message the user is shown.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public void ValidationErrorMessageIsReadable()
+    {
+        using var handler = new StubHandler
+        {
+            DeleteResponse = _ => new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+            {
+                // A validation error on a field that carries no other meaning
+                Content = new StringContent(
+                    "{\"message\":\"The given data was invalid.\",\"errors\":{\"deleteForever\":[\"must be a boolean\"]}}",
+                    Encoding.UTF8, "application/json")
+            }
+        };
+        using var backend = CreateBackend(handler);
+
+        var ex = Assert.CatchAsync<InvalidOperationException>(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+
+        Assert.AreEqual("Request failed: The given data was invalid.", ex!.Message);
+    }
+
+    /// <summary>
+    /// Throwing the cache away is for the failure path only, so a delete that the
+    /// server answered has to leave the other names in place
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task SuccessfulDeleteKeepsTheRestOfTheCache()
+    {
+        using var handler = new StubHandler();
+        handler.Listed.Add(OtherName);
+        using var backend = CreateBackend(handler);
+
+        await backend.DeleteAsync(RemoteName, CancellationToken.None);
+        var listings = handler.Listings;
+
+        await backend.DeleteAsync(OtherName, CancellationToken.None);
+
+        Assert.AreEqual(listings, handler.Listings, "the second name was still cached");
+        Assert.AreEqual(2, handler.DeleteBodies.Count);
+        Assert.IsTrue(handler.DeleteBodies[1].Contains($"\"entryIds\":[{EntryId + 1}]"), handler.DeleteBodies[1]);
+    }
+
+    /// <summary>
+    /// Drime has no overwrite, so an upload deletes first. Removing just the one
+    /// name from the cache would leave the upload believing the file is not there,
+    /// and Drime would end up holding the name twice.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task UploadStillDeletesBeforeOverwriteAfterAFailedDelete()
+    {
+        using var handler = new StubHandler
+        {
+            DeleteResponse = attempt => attempt == 1 ? throw new TimeoutException("The operation has timed out.") : null!
+        };
+        using var backend = CreateBackend(handler);
+
+        Assert.CatchAsync<TimeoutException>(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+
+        // The delete never landed, so the name is still taken
+        using var source = new MemoryStream(Encoding.UTF8.GetBytes("some file content"));
+        await backend.PutAsync(RemoteName, source, CancellationToken.None);
+
+        Assert.AreEqual(2, handler.DeleteBodies.Count, "the upload has to clear the name it is about to take");
+    }
+}


### PR DESCRIPTION
A delete that reaches Drime but whose answer does not reach us leaves that file permanently undeletable, and the name permanently unusable for an upload.

## What happens

`FindFileEntryAsync` hands back a cached entry without asking the server:

```csharp
if (_fileCache != null && _fileCache.TryGetValue(name, out var cached))
    return cached;
```

and `DeleteAsync` only clears the cache after the request came back:

```csharp
await EnsureSuccessStatusCodeAsync(response).ConfigureAwait(false);

// Remove from cache
_fileCache?.TryRemove(remotename, out var _);
```

So when the request throws, the dead entry id stays cached and every retry deletes it again. Drime answers those with a validation error on `entryIds` instead of a 404, so it does not arrive as a `FileMissingException` and [`BackendManager.DeleteOperation`](https://github.com/duplicati/duplicati/blob/479dbcf890b4bb7cf82b41607838e389126fe63e/Duplicati/Library/Main/Backend/BackendManager.DeleteOperation.cs#L166-L192) never runs the listing that would confirm the delete had in fact worked.

Uploads are caught by the same thing. Drime has no overwrite, so `PutAsync` deletes the name before it takes it.

## Where this came from

The backend tests. From the [`Drime Tests (windows-latest)` job](https://github.com/duplicati/duplicati/actions/runs/32565921938/job/97023691767) on [`a42a94c`](https://github.com/duplicati/duplicati/commit/a42a94c26300c1260e079bf675086aa9ab80c7b6) — two timeouts, and then a definite answer:

```
[12:28:24 008] Deleting file 17
[12:28:55 010] Operation failed with exception, 2 retries left     <- 31 s
[12:29:25 011] Operation failed with exception, 1 retries left     <- 30 s
[12:29:39 799] *** Failed to delete file 6_-NRCea...,
   System.InvalidOperationException: Request failed:
   {"message":"The selected entry ids is invalid.","errors":{"entryIds":[...]}}
```

The first delete had already removed it. Backblaze B2 hits the identical sequence in [a run of its own](https://github.com/duplicati/duplicati/actions/runs/32855648854/job/97851786100) — delete, 30 s timeout, retry, `FileMissingException` — and comes out of it correctly, because the exception is one `DeleteOperation` knows how to check.

## Changes

- `DeleteAsync` drops the file cache when the request fails, so the next lookup asks the server. It drops the whole cache rather than the one name because `PutAsync` asks the cache whether the name is taken; removing only that key would make the upload skip the delete it has to do first, and Drime would hold the name twice.
- `EnsureSuccessStatusCodeAsync` reports a validation failure on `entryIds` as a `FileMissingException`. `entryIds` is only ever sent by `DeleteAsync`. It throws rather than treating the delete as done, so `BackendManager` still confirms against a listing — the ids could be invalid for some other reason.
- `ErrorResponse.Errors` was `Dictionary<string, string>?`, but Drime sends an array of messages per field. Deserializing therefore always threw, the fallback used the raw body, and every Drime validation error was shown to the user as raw json — visible in the log line above.

## Tests

`Duplicati/UnitTest/DrimeDeleteRetryTests.cs`, following `TahoeDeleteStatusTests`. The stub serves the listing and the delete endpoint and records the body of every delete, so what is asserted is the request that goes out.

| test | before |
|---|---|
| `RetryAfterFailedDeleteRelistsInsteadOfResendingTheStaleId` | resent `"entryIds":[4711]` instead of re-reading the listing |
| `EntryIdValidationErrorIsReportedAsFileMissing` | `InvalidOperationException` |
| `ValidationErrorMessageIsReadable` | the message was the raw json |
| `SuccessfulDeleteKeepsTheRestOfTheCache` | green, holds the success path still |
| `UploadStillDeletesBeforeOverwriteAfterAFailedDelete` | green, holds the whole-cache decision |

The first red carried the CI text exactly: `System.InvalidOperationException: Request failed: {"message":"The selected entry ids is invalid.",...}` out of `DrimeBackend.DeleteAsync`.

I have no Drime credentials, so the live test is for CI to run.

## Not in this PR

`GetAsync` reads the same cache and can download against a hash that no longer exists. And the BackendTester fails a run on `FileMissingException` from a delete even though `DeleteListedFileAsync` next to it accepts one, and its start-of-run emptiness check aborts with no retry where the end-of-run check retries — which is what the pCloud and CloudStack reds in the same set are. Separately.
