### PR TITLE
Read the remote folder again before abandoning a test run

### DIFF
--- a/Duplicati/CommandLine/BackendTester/Program.cs
+++ b/Duplicati/CommandLine/BackendTester/Program.cs
@@ -159,6 +159,10 @@ namespace Duplicati.CommandLine.BackendTester
             if (options.ContainsKey("failure-retries"))
                 retries = int.Parse(options["failure-retries"]);
 
+            var verificationRetries = 3;
+            if (options.ContainsKey("verification-retries"))
+                verificationRetries = int.Parse(options["verification-retries"]);
+
             options.TryGetValue("enable-module", out var enabledModulesValue);
             options.TryGetValue("disable-module", out var disabledModulesValue);
             var enabledModules = enabledModulesValue == null ? new string[0] : enabledModulesValue.Trim().ToLower(CultureInfo.InvariantCulture).Split(',');
@@ -199,27 +203,36 @@ namespace Duplicati.CommandLine.BackendTester
                         throw;
                 }
 
-                foreach (Library.Interface.IFileEntry fe in curlist)
-                    if (!fe.IsFolder)
-                    {
-                        if (Library.Utility.Utility.ParseBoolOption(options, "auto-clean") && first)
-                            if (Library.Utility.Utility.ParseBoolOption(options, "force"))
-                            {
-                                Console.WriteLine($"{LogTimeStamp}Auto clean, removing file: {fe.Name}");
-                                DeleteListedFileAsync(backend, fe.Name, retries).Await();
-                                continue;
-                            }
-                            else
-                                Console.WriteLine("Specify the --force flag to actually delete files");
+                var present = curlist.Where(x => !x.IsFolder).Select(x => x.Name).ToList();
 
-                        var fileCount = curlist.Where(x => !x.IsFolder).Count();
-                        var filenames = curlist.Where(x => !x.IsFolder).Select(x => x.Name).Take(10).ToList();
-                        Console.WriteLine($"{LogTimeStamp}*** Remote folder contains {fileCount} file(s), aborting");
+                if (present.Count > 0 && first && Library.Utility.Utility.ParseBoolOption(options, "auto-clean"))
+                {
+                    if (Library.Utility.Utility.ParseBoolOption(options, "force"))
+                        foreach (var name in present)
+                        {
+                            Console.WriteLine($"{LogTimeStamp}Auto clean, removing file: {name}");
+                            DeleteListedFileAsync(backend, name, retries).Await();
+                        }
+                    else
+                        Console.WriteLine("Specify the --force flag to actually delete files");
+                }
+
+                // Testing the destination writes and removes a file of its own, and the
+                // listing can lag behind that, so the folder is read again before the
+                // run is abandoned over what it reported the first time.
+                if (present.Count > 0)
+                {
+                    var leftovers = ListUntilFolderIsEmpty(backend, retries, verificationRetries);
+                    if (leftovers.Count > 0)
+                    {
+                        var filenames = leftovers.Take(10).ToList();
+                        Console.WriteLine($"{LogTimeStamp}*** Remote folder contains {leftovers.Count} file(s), aborting");
                         Console.WriteLine($"{LogTimeStamp}*** First {filenames.Count} file(s): {Environment.NewLine}{string.Join(Environment.NewLine, filenames)}");
-                        if (fileCount > filenames.Count)
-                            Console.WriteLine($"{LogTimeStamp}*** ... and {fileCount - filenames.Count} more file(s)");
+                        if (leftovers.Count > filenames.Count)
+                            Console.WriteLine($"{LogTimeStamp}*** ... and {leftovers.Count - filenames.Count} more file(s)");
                         return false;
                     }
+                }
 
 
                 var number_of_files = 10;
@@ -286,10 +299,6 @@ namespace Duplicati.CommandLine.BackendTester
                     waitAfterUpload = Timeparser.ParseTimeSpan(options["wait-after-upload"]);
                 if (options.ContainsKey("wait-after-delete"))
                     waitAfterDelete = Timeparser.ParseTimeSpan(options["wait-after-delete"]);
-
-                var verificationRetries = 3;
-                if (options.ContainsKey("verification-retries"))
-                    verificationRetries = int.Parse(options["verification-retries"]);
 
                 var rnd = new Random();
                 var sha = System.Security.Cryptography.SHA256.Create();
@@ -446,17 +455,11 @@ namespace Duplicati.CommandLine.BackendTester
 
                     Console.WriteLine($"{LogTimeStamp}Deleting files...");
 
-                    for (int i = 0; i < files.Count; i++)
-                        try
-                        {
-                            Console.WriteLine($"{LogTimeStamp}Deleting file {i}");
-                            Retry(() => backend.DeleteAsync(files[i].remotefilename, CancellationToken.None), retries).Await();
-                        }
-                        catch (Exception ex)
-                        {
-                            failAfterFinished = true;
-                            Console.WriteLine($"{LogTimeStamp}*** Failed to delete file {files[i].remotefilename}, message: {ex}");
-                        }
+                    foreach (var (name, error) in DeleteTestFiles(backend, files.Select(x => x.remotefilename), retries))
+                    {
+                        failAfterFinished = true;
+                        Console.WriteLine($"{LogTimeStamp}*** Failed to delete file {name}, message: {error}");
+                    }
 
                     if (waitAfterDelete > TimeSpan.Zero)
                     {
@@ -465,20 +468,7 @@ namespace Duplicati.CommandLine.BackendTester
                     }
 
                     // As with the upload verification, the listing can lag behind the deletes
-                    List<string> leftovers;
-                    for (var attempt = 0; ; attempt++)
-                    {
-                        curlist = Retry(() => backend.ListAsync(CancellationToken.None).ToBlockingEnumerable().ToList(), retries);
-                        leftovers = curlist.Where(x => !x.IsFolder).Select(x => x.Name).ToList();
-                        if (leftovers.Count == 0 || attempt >= verificationRetries)
-                            break;
-
-                        var delay = Utility.GetRetryDelay(TimeSpan.FromSeconds(1), attempt + 1, true);
-                        Console.WriteLine($"{LogTimeStamp}Remote folder is not empty yet ({leftovers.Count} file(s)), re-checking in {delay.TotalMilliseconds} ms");
-                        Thread.Sleep(delay);
-                    }
-
-                    foreach (var name in leftovers)
+                    foreach (var name in ListUntilFolderIsEmpty(backend, retries, verificationRetries))
                     {
                         failAfterFinished = true;
                         Console.WriteLine($"{LogTimeStamp}*** Remote folder contains {name} after cleanup");
@@ -671,6 +661,62 @@ namespace Duplicati.CommandLine.BackendTester
                     Console.WriteLine($"{LogTimeStamp}File was already gone: {remotename}");
                 }
             }, retries);
+
+        /// <summary>
+        /// Reads the remote folder until it reports no files, or the attempts run out.
+        /// A listing can lag behind the operations that were just performed, so a folder
+        /// that still looks occupied is read again before that is treated as a problem.
+        /// </summary>
+        /// <param name="backend">The backend to read</param>
+        /// <param name="retries">The number of attempts to make per listing</param>
+        /// <param name="verificationRetries">The number of times to read the folder again</param>
+        /// <returns>The names of the files the folder still holds</returns>
+        internal static List<string> ListUntilFolderIsEmpty(IBackend backend, int retries, int verificationRetries)
+        {
+            for (var attempt = 0; ; attempt++)
+            {
+                var leftovers = Retry(() => backend.ListAsync(CancellationToken.None).ToBlockingEnumerable().ToList(), retries)
+                    .Where(x => !x.IsFolder).Select(x => x.Name).ToList();
+
+                if (leftovers.Count == 0 || attempt >= verificationRetries)
+                    return leftovers;
+
+                var delay = Utility.GetRetryDelay(TimeSpan.FromSeconds(1), attempt + 1, true);
+                Console.WriteLine($"{LogTimeStamp}Remote folder is not empty yet ({leftovers.Count} file(s)), re-checking in {delay.TotalMilliseconds} ms");
+                Thread.Sleep(delay);
+            }
+        }
+
+        /// <summary>
+        /// Removes the files the run created, and reports the ones that would not go away
+        /// </summary>
+        /// <param name="backend">The backend to delete from</param>
+        /// <param name="remotenames">The names to remove, in the order they were created</param>
+        /// <param name="retries">The number of attempts to make per file</param>
+        /// <returns>The names that could not be removed, with the reason</returns>
+        internal static List<(string RemoteName, Exception Error)> DeleteTestFiles(IBackend backend, IEnumerable<string> remotenames, int retries)
+        {
+            var failures = new List<(string, Exception)>();
+            var i = 0;
+
+            foreach (var remotename in remotenames)
+            {
+                try
+                {
+                    Console.WriteLine($"{LogTimeStamp}Deleting file {i}");
+                    DeleteListedFileAsync(backend, remotename, retries).Await();
+                }
+                catch (Exception ex)
+                {
+                    // One file that will not go away does not stop the rest from being tried
+                    failures.Add((remotename, ex));
+                }
+
+                i++;
+            }
+
+            return failures;
+        }
 
         private static async Task<T> Retry<T>(Func<Task<T>> action, int retries)
         {

--- a/Duplicati/UnitTest/BackendTesterEmptyFolderTests.cs
+++ b/Duplicati/UnitTest/BackendTesterEmptyFolderTests.cs
@@ -1,0 +1,201 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.CommandLine.BackendTester;
+using Duplicati.Library.Common.IO;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The backend tester requires the remote folder to be empty, and a listing can
+    /// lag behind the deletes that emptied it - the tester writes and removes a file
+    /// of its own on the line above the one that reads the folder. It also has to
+    /// accept a delete that reports the file as missing, because a delete that timed
+    /// out may well have landed.
+    /// </summary>
+    [TestFixture]
+    [Category("BackendTesterVerification")]
+    public class BackendTesterEmptyFolderTests
+    {
+        /// <summary>
+        /// A backend that lists and deletes, with both outcomes under the test's control
+        /// </summary>
+        private sealed class FolderBackend : IBackend
+        {
+            private readonly Func<int, IEnumerable<IFileEntry>> _onList;
+            private readonly Func<string, Exception?>? _onDelete;
+
+            public FolderBackend(Func<int, IEnumerable<IFileEntry>> onList, Func<string, Exception?>? onDelete = null)
+            {
+                _onList = onList;
+                _onDelete = onDelete;
+            }
+
+            /// <summary>
+            /// The number of times the folder was read
+            /// </summary>
+            public int Listings { get; private set; }
+
+            /// <summary>
+            /// The names that were passed to a delete, in order
+            /// </summary>
+            public List<string> Deletes { get; } = new();
+
+            public async IAsyncEnumerable<IFileEntry> ListAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                var entries = _onList(Listings++);
+                foreach (var entry in entries)
+                {
+                    await Task.Yield();
+                    yield return entry;
+                }
+            }
+
+            public Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+            {
+                Deletes.Add(remotename);
+                var error = _onDelete?.Invoke(remotename);
+                if (error != null)
+                    throw error;
+
+                return Task.CompletedTask;
+            }
+
+            public Task PutAsync(string remotename, string filename, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task GetAsync(string remotename, string filename, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task TestAsync(bool alsoWrite, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task CreateFolderAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult(Array.Empty<string>());
+
+            public string DisplayName => "Folder Backend";
+            public string ProtocolKey => "folder";
+            public string Description => "A testing backend that lists and deletes";
+            public IList<ICommandLineArgument> SupportedCommands => new List<ICommandLineArgument>();
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private static IFileEntry File(string name) => new FileEntry(name, 17);
+
+        private static IFileEntry Folder(string name) => new FileEntry(name) { IsFolder = true };
+
+        [Test]
+        public void AFolderThatBecomesEmptyIsAccepted()
+        {
+            // The delete had landed, the listing just had not caught up with it
+            using var backend = new FolderBackend(attempt =>
+                attempt == 0 ? new[] { File("left-over.tmp") } : Enumerable.Empty<IFileEntry>());
+
+            var leftovers = Program.ListUntilFolderIsEmpty(backend, 1, 3);
+
+            Assert.AreEqual(0, leftovers.Count);
+            Assert.AreEqual(2, backend.Listings, "the folder has to be read again before it is given up on");
+        }
+
+        [Test]
+        public void AFolderThatStaysOccupiedIsReported()
+        {
+            // Re-reading is not the same as accepting whatever the folder holds
+            using var backend = new FolderBackend(_ => new[] { File("really-there.tmp") });
+
+            var leftovers = Program.ListUntilFolderIsEmpty(backend, 1, 1);
+
+            Assert.AreEqual(new[] { "really-there.tmp" }, leftovers);
+            Assert.AreEqual(2, backend.Listings, "the attempts have to run out");
+        }
+
+        [Test]
+        public void AnEmptyFolderIsNotReadAgain()
+        {
+            using var backend = new FolderBackend(_ => Enumerable.Empty<IFileEntry>());
+
+            var leftovers = Program.ListUntilFolderIsEmpty(backend, 1, 3);
+
+            Assert.AreEqual(0, leftovers.Count);
+            Assert.AreEqual(1, backend.Listings);
+        }
+
+        [Test]
+        public void FoldersDoNotCountAsFiles()
+        {
+            using var backend = new FolderBackend(_ => new[] { Folder("subfolder") });
+
+            var leftovers = Program.ListUntilFolderIsEmpty(backend, 1, 3);
+
+            Assert.AreEqual(0, leftovers.Count);
+            Assert.AreEqual(1, backend.Listings);
+        }
+
+        [Test]
+        public void ADeleteOfAFileThatIsAlreadyGoneIsNotAFailure()
+        {
+            // A delete that timed out on the way out may still have landed, and the
+            // file being gone is what the delete was for
+            using var backend = new FolderBackend(_ => Enumerable.Empty<IFileEntry>(),
+                _ => new FileMissingException());
+
+            var failures = Program.DeleteTestFiles(backend, new[] { "gone.tmp" }, 1);
+
+            Assert.AreEqual(0, failures.Count, "a file that is already gone is not a failed delete");
+        }
+
+        [Test]
+        public void AFailingDeleteIsReported()
+        {
+            // Anything other than the file being gone is still a real failure
+            using var backend = new FolderBackend(_ => Enumerable.Empty<IFileEntry>(),
+                _ => new IOException("connection reset"));
+
+            var failures = Program.DeleteTestFiles(backend, new[] { "locked.tmp" }, 1);
+
+            Assert.AreEqual(1, failures.Count);
+            Assert.AreEqual("locked.tmp", failures[0].RemoteName);
+            Assert.IsInstanceOf<IOException>(failures[0].Error);
+        }
+
+        [Test]
+        public void EveryFileIsAttemptedAfterOneFails()
+        {
+            using var backend = new FolderBackend(_ => Enumerable.Empty<IFileEntry>(),
+                name => name == "locked.tmp" ? new IOException("connection reset") : null);
+
+            var failures = Program.DeleteTestFiles(backend, new[] { "first.tmp", "locked.tmp", "last.tmp" }, 1);
+
+            Assert.AreEqual(new[] { "first.tmp", "locked.tmp", "last.tmp" }, backend.Deletes);
+            Assert.AreEqual(1, failures.Count);
+            Assert.AreEqual("locked.tmp", failures[0].RemoteName);
+        }
+    }
+}


### PR DESCRIPTION
The backend tester treats two things as failures that the rest of the codebase already treats as normal: a listing that has not caught up yet, and a delete that reports the file as missing.

Both come out of reading the failing `backendtests.yml` runs. Of the ten failed jobs in the last twenty-five runs, **six are this**, across four backends and three operating systems.

## The folder has to be empty, and it is read once

`Run` is called five times, and each call does this:

```csharp
Retry(() => backend.TestAsync(true, CancellationToken.None), retries).Await();
curlist = Retry(() => backend.ListAsync(CancellationToken.None).ToBlockingEnumerable().ToList(), retries);
```

`TestAsync(true)` writes `duplicati-access-privileges-test.tmp` and removes it again. The listing on the next line then aborts the whole run if the removal has not shown up yet. From the [pCloud job](https://github.com/duplicati/duplicati/actions/runs/32853961514/job/97823000014), on the fourth of the five runs:

```
[14:01:05 619] Checking DNS names used by this backend...
[14:01:05 619] Starting run no 3
[14:01:09 809] *** Remote folder contains 1 file(s), aborting
[14:01:09 809] *** First 1 file(s):
 duplicati-access-privileges-test.tmp
```

Four of the six are exactly that, and the leftover is that file every time. A fifth is CloudStack, where a generated file **passed** the end-of-run check and was back in the listing two seconds later.

Meanwhile the same condition is re-read twice elsewhere in the same method — after the uploads, and after the deletes, where the comment says the listing can lag behind. Only the check at the start of a run gives up on the first answer.

## A delete that says the file is gone

```csharp
Retry(() => backend.DeleteAsync(files[i].remotefilename, CancellationToken.None), retries).Await();
}
catch (Exception ex)
{
    failAfterFinished = true;
```

From the [Backblaze B2 job](https://github.com/duplicati/duplicati/actions/runs/32855648854/job/97851786100):

```
[15:06:53 822] Deleting file 1
[15:07:23 866] Operation failed with exception, 2 retries left     <- 30 s
[15:07:25 246] Operation failed with exception, 1 retries left
[15:07:27 352] *** Failed to delete file LqXjopLQ...,
   Duplicati.Library.Interface.FileMissingException: The requested file does not exist
```

The first delete timed out on the way out and had landed. B2 reports that correctly and the run fails anyway. `DeleteListedFileAsync` was added for this in [`1501e13f`](https://github.com/duplicati/duplicati/commit/1501e13f2675d7a20f22ced4bcfe38af51258666) ([#7108](https://github.com/duplicati/duplicati/pull/7108)), and only the auto clean was switched over to it.

`BackendExtensions` takes the same view of its own probe file:

> a file that was just written is not always addressable right away, and the file being gone is what the cleanup is for

## Changes

`Duplicati/CommandLine/BackendTester/Program.cs` only.

- The two re-reading loops become one method, `ListUntilFolderIsEmpty`, and the check at the start of a run calls it too. `verification-retries` had to move up, as it was read after that check.
- The delete loop becomes `DeleteTestFiles` and goes through `DeleteListedFileAsync`.
- Every console message is unchanged, character for character, including `Deleting file {i}`.

**Nothing is hidden by this.** The start of a run still aborts once `verification-retries` is used up, and the end of a run still fails if the files really are still there — that check is what makes accepting a missing delete safe, because a file that did not actually go away is caught there.

The extra listing only happens when the first one reported something, so an empty folder still costs one request.

## Tests

`Duplicati/UnitTest/BackendTesterEmptyFolderTests.cs`, following `BackendTesterCleanupTests`.

| test | |
|---|---|
| `ADeleteOfAFileThatIsAlreadyGoneIsNotAFailure` | **was red** — `FileMissingException` came back as one failure |
| `AFolderThatBecomesEmptyIsAccepted` | occupied, then empty — two listings, nothing reported |
| `AFolderThatStaysOccupiedIsReported` | re-reading is not the same as accepting; the attempts run out |
| `AnEmptyFolderIsNotReadAgain` | one listing |
| `FoldersDoNotCountAsFiles` | |
| `AFailingDeleteIsReported` | an `IOException` still comes back |
| `EveryFileIsAttemptedAfterOneFails` | all three names are tried |

## The rest of the ten

Two are Drime, and are a real backend bug — [#7221](https://github.com/duplicati/duplicati/pull/7221). Two look like the environment: a CloudStack download that read the version before an overwrite, and a Webdav run where `localhost:8090` stopped accepting connections partway through.
