### PR TITLE
Pin the testcontainers cloud action to a commit hash

### DIFF
--- a/.github/workflows/backendtests.yml
+++ b/.github/workflows/backendtests.yml
@@ -283,7 +283,7 @@ jobs:
           dotnet build --no-restore
           LiveTests/Duplicati.Backend.Tests/Duplicati.Backend.Tests.slnx
       - name: Setup Testcontainers Cloud Client
-        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.4.0
         with:
           token: "${{ secrets.TC_CLOUD_TOKEN }}"
       - name: Run FTP tests
@@ -438,7 +438,7 @@ jobs:
           dotnet build --no-restore
           LiveTests/Duplicati.Backend.Tests/Duplicati.Backend.Tests.slnx
       - name: Setup Testcontainers Cloud Client
-        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.4.0
         with:
           token: "${{ secrets.TC_CLOUD_TOKEN }}"
       - name: Run Webdav tests
@@ -514,7 +514,7 @@ jobs:
           dotnet build --no-restore
           LiveTests/Duplicati.Backend.Tests/Duplicati.Backend.Tests.slnx
       - name: Setup Testcontainers Cloud Client
-        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.4.0
         with:
           token: "${{ secrets.TC_CLOUD_TOKEN }}"
       - name: Run SSH tests
@@ -554,7 +554,7 @@ jobs:
           dotnet build --no-restore
           LiveTests/Duplicati.Backend.Tests/Duplicati.Backend.Tests.slnx
       - name: Setup Testcontainers Cloud Client
-        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.4.0
         with:
           token: "${{ secrets.TC_CLOUD_TOKEN }}"
       - name: Run SFTP tests


### PR DESCRIPTION
One small change: the four references to `atomicjar/testcontainers-cloud-setup-action@v1` now point to the full commit hash of the v1.4.0 already in use, with the tag kept in a comment. It is the only floating action ref left in the workflows, everything else is already pinned or first party.

Why it is worth a PR at four lines: a tag is a movable pointer, whoever controls the action repository can repoint it and the next run executes their code. These four sites run inside the backend test jobs, which hold live storage credentials for the provider test suites. The March 2025 tj-actions/changed-files incident (CVE-2025-30066) was exactly this shape, force-moved tags running in every referencing repo with its secrets in reach. A commit hash cannot be repointed, and the change is behavior-identical since the hash is the version the tag points to today.

The rest of the workflow hygiene here is genuinely good, permissions declared everywhere and the release path fully pinned, this closes the last gap. If a hash bump ever feels like churn, a dependabot github-actions config keeps hash pins updated the same way it bumps tags, happy to add that block here or in a follow-up if you want it.

One heads-up: an allowed-actions list using tag patterns (`owner/action@v1`) stops matching SHA refs and fails workflows at startup, the fix is `owner/action@*`.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.