### PR TITLE
Ensure empty metadata exists

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -3369,7 +3369,7 @@ namespace Duplicati.Library.Main.Database.Local
         /// SQL fragment listing the ids of the volumes that can currently supply blocks: volumes that are
         /// block volumes and are not on their way out of the backup.
         /// </summary>
-        private static readonly string LIVE_BLOCK_VOLUME_IDS = @$"
+        protected static readonly string LIVE_BLOCK_VOLUME_IDS = @$"
             SELECT ""ID""
             FROM ""RemoteVolume""
             WHERE

--- a/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
@@ -36,6 +36,11 @@ namespace Duplicati.Library.Main.Database.Local
     internal class LocalListBrokenFilesDatabase : LocalDatabase
     {
         /// <summary>
+        /// The tag used for logging.
+        /// </summary>
+        private static readonly string LOGTAG = Logging.Log.LogTagFromType(typeof(LocalListBrokenFilesDatabase));
+
+        /// <summary>
         /// SQL query to get the IDs of all block volumes.
         /// </summary>
         private static readonly string BLOCK_VOLUME_IDS = $@"
@@ -622,6 +627,366 @@ namespace Duplicati.Library.Main.Database.Local
                     .ConfigureAwait(false);
             }
             catch { /* Ignore, will be deleted on close anyway. */ }
+        }
+
+        /// <summary>
+        /// Finds the id of an available block with the given hash and size.
+        /// </summary>
+        /// <remarks>
+        /// A block can be stored without any blockset pointing at it, so this is not the same question as
+        /// <see cref="FindExactMetadataBlocksetIdAsync"/>: the block may be present at the destination while
+        /// the blockset that used to reference it has been damaged or removed.
+        /// </remarks>
+        /// <param name="hash">The block hash to look for.</param>
+        /// <param name="size">The block size to look for.</param>
+        /// <param name="blockVolumeIds">The ids of the volumes to treat as unavailable.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the id of the block, or -1 if it is not available.</returns>
+        public async Task<long> FindAvailableBlockIdAsync(string hash, long size, IEnumerable<long> blockVolumeIds, CancellationToken token)
+        {
+            await using var tmptable = await TemporaryDbValueList.CreateAsync(this, blockVolumeIds, token)
+                .ConfigureAwait(false);
+
+            await using var cmd = Connection.CreateCommand(@$"
+                SELECT ""Block"".""ID""
+                FROM ""Block""
+                WHERE
+                    ""Block"".""Hash"" = @Hash
+                    AND ""Block"".""Size"" = @Size
+                    AND ""Block"".""VolumeID"" NOT IN (@BlockVolumeIds)
+                    AND ""Block"".""VolumeID"" IN ({LIVE_BLOCK_VOLUME_IDS})
+                LIMIT 1
+            ")
+                .SetTransaction(m_rtr)
+                .SetParameterValue("@Hash", hash)
+                .SetParameterValue("@Size", size);
+
+            await cmd.ExpandInClauseParameterMssqliteAsync("@BlockVolumeIds", tmptable, token)
+                .ConfigureAwait(false);
+
+            return await cmd.ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Describes a <c>Block</c> row that was pointed at a volume by <see cref="RegisterBlockAsync"/>,
+        /// with what is needed to undo it again.
+        /// </summary>
+        /// <param name="BlockId">The id of the block row.</param>
+        /// <param name="Hash">The hash of the block.</param>
+        /// <param name="Size">The size of the block.</param>
+        /// <param name="VolumeId">The volume the block was pointed at.</param>
+        /// <param name="PreviousVolumeId">The volume the block was pointed at before, if that could be read.</param>
+        /// <param name="Created">Whether the row was created, as opposed to being repointed.</param>
+        public sealed record BlockRegistration(long BlockId, string Hash, long Size, long VolumeId, long? PreviousVolumeId, bool Created);
+
+        /// <summary>
+        /// Records that the block with the given hash and size is stored in the given volume, creating the
+        /// <c>Block</c> row if it does not exist yet.
+        /// </summary>
+        /// <remarks>
+        /// The registration has to be committed before the upload of the volume starts, so it can be visible
+        /// before the volume actually exists at the destination. Keep the returned value and hand it to
+        /// <see cref="RollbackBlockRegistrationAsync"/> if the volume never arrives, or a block that is
+        /// perfectly restorable from its old volume is left looking unrestorable.
+        /// </remarks>
+        /// <param name="hash">The block hash.</param>
+        /// <param name="size">The block size.</param>
+        /// <param name="volumeId">The id of the volume the block is stored in.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the registration.</returns>
+        public async Task<BlockRegistration> RegisterBlockAsync(string hash, long size, long volumeId, CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            cmd.SetCommandAndParameters(@"
+                SELECT
+                    ""ID"",
+                    ""VolumeID""
+                FROM ""Block""
+                WHERE
+                    ""Hash"" = @Hash
+                    AND ""Size"" = @Size
+            ")
+                .SetParameterValue("@Hash", hash)
+                .SetParameterValue("@Size", size);
+
+            var existingId = -1L;
+            long? previousVolumeId = null;
+            await using (var rd = await cmd.ExecuteReaderAsync(writeLog: false, token).ConfigureAwait(false))
+                if (await rd.ReadAsync(token).ConfigureAwait(false))
+                {
+                    existingId = rd.ConvertValueToInt64(0, -1);
+                    // Only record a previous volume if one could actually be read. Guessing one and writing
+                    // it back on rollback would point the block at a volume that never held it.
+                    if (!await rd.IsDBNullAsync(1, token).ConfigureAwait(false))
+                        previousVolumeId = rd.ConvertValueToInt64(1);
+                }
+
+            if (existingId >= 0)
+            {
+                await cmd.SetCommandAndParameters(@"
+                    UPDATE ""Block""
+                    SET ""VolumeID"" = @VolumeId
+                    WHERE ""ID"" = @Id
+                ")
+                    .SetParameterValue("@VolumeId", volumeId)
+                    .SetParameterValue("@Id", existingId)
+                    .ExecuteNonQueryAsync(true, token)
+                    .ConfigureAwait(false);
+
+                return new BlockRegistration(existingId, hash, size, volumeId, previousVolumeId, false);
+            }
+
+            var newId = await cmd.SetCommandAndParameters(@"
+                INSERT INTO ""Block"" (
+                    ""Hash"",
+                    ""Size"",
+                    ""VolumeID""
+                )
+                VALUES (
+                    @Hash,
+                    @Size,
+                    @VolumeId
+                );
+                SELECT last_insert_rowid();
+            ")
+                .SetParameterValue("@Hash", hash)
+                .SetParameterValue("@Size", size)
+                .SetParameterValue("@VolumeId", volumeId)
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+
+            if (newId < 0)
+                throw new InvalidOperationException($"Failed to register the block {hash} in volume {volumeId}.");
+
+            return new BlockRegistration(newId, hash, size, volumeId, null, true);
+        }
+
+        /// <summary>
+        /// Undoes a registration made by <see cref="RegisterBlockAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// The row is only touched while it still points at the volume from the registration, so a
+        /// registration made by something else in the meantime is left alone. If the row was repointed and
+        /// the previous volume is not known, the row is left as it is and a warning is written: writing a
+        /// guessed volume id would be worse than leaving the block where the failed upload put it.
+        /// </remarks>
+        /// <param name="registration">The registration to undo.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that completes when the rollback has been attempted.</returns>
+        public async Task RollbackBlockRegistrationAsync(BlockRegistration registration, CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            if (registration.Created)
+            {
+                await cmd.SetCommandAndParameters(@"
+                    DELETE FROM ""Block""
+                    WHERE
+                        ""ID"" = @Id
+                        AND ""VolumeID"" = @VolumeId
+                ")
+                    .SetParameterValue("@Id", registration.BlockId)
+                    .SetParameterValue("@VolumeId", registration.VolumeId)
+                    .ExecuteNonQueryAsync(true, token)
+                    .ConfigureAwait(false);
+
+                return;
+            }
+
+            if (!registration.PreviousVolumeId.HasValue)
+            {
+                Logging.Log.WriteWarningMessage(LOGTAG, "BlockRegistrationNotRolledBack", null, "The block {0} was pointed at volume {1}, but the volume it was in before is not known, so it is left as it is. Run repair to restore the block mapping.", registration.Hash, registration.VolumeId);
+                return;
+            }
+
+            await cmd.SetCommandAndParameters(@"
+                UPDATE ""Block""
+                SET ""VolumeID"" = @PreviousVolumeId
+                WHERE
+                    ""ID"" = @Id
+                    AND ""VolumeID"" = @VolumeId
+            ")
+                .SetParameterValue("@PreviousVolumeId", registration.PreviousVolumeId.Value)
+                .SetParameterValue("@Id", registration.BlockId)
+                .SetParameterValue("@VolumeId", registration.VolumeId)
+                .ExecuteNonQueryAsync(true, token)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates, or repairs, the blockset with the given hash and length, made up of the given blocks.
+        /// </summary>
+        /// <remarks>
+        /// An existing <c>Blockset</c> row for the hash and length is reused - it is unique on those two
+        /// columns - but its <c>BlocksetEntry</c> and <c>BlocklistHash</c> rows are rebuilt, so a stale row
+        /// cannot keep pointing at the wrong blocks.
+        /// </remarks>
+        /// <param name="fullHash">The file hash of the metadata blob.</param>
+        /// <param name="size">The length of the metadata blob.</param>
+        /// <param name="blockIds">The ids of the blocks making up the blockset, in order.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the id of the blockset.</returns>
+        public async Task<long> CreateMetadataBlocksetAsync(string fullHash, long size, IEnumerable<long> blockIds, CancellationToken token)
+        {
+            var ids = blockIds?.ToList() ?? [];
+
+            // A zero-length metadata blockset can never be restored, and is shared with every empty file in
+            // the backup, see FindExactMetadataBlocksetIdAsync
+            if (size <= 0)
+                throw new ArgumentOutOfRangeException(nameof(size), "A metadata blockset must have contents.");
+            if (ids.Count == 0)
+                throw new ArgumentException("A metadata blockset must have at least one block.", nameof(blockIds));
+            // More than one block needs blocklist hashes, and those are blocks in their own right, which
+            // would have to be stored at the destination as well
+            if (ids.Count > 1)
+                throw new ArgumentException("A metadata blockset of more than one block is not supported here.", nameof(blockIds));
+
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            var blocksetId = await cmd.SetCommandAndParameters(@"
+                SELECT ""ID""
+                FROM ""Blockset""
+                WHERE
+                    ""FullHash"" = @FullHash
+                    AND ""Length"" = @Length
+            ")
+                .SetParameterValue("@FullHash", fullHash)
+                .SetParameterValue("@Length", size)
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+
+            if (blocksetId < 0)
+            {
+                blocksetId = await cmd.SetCommandAndParameters(@"
+                    INSERT INTO ""Blockset"" (
+                        ""Length"",
+                        ""FullHash""
+                    )
+                    VALUES (
+                        @Length,
+                        @FullHash
+                    );
+                    SELECT last_insert_rowid();
+                ")
+                    .SetParameterValue("@Length", size)
+                    .SetParameterValue("@FullHash", fullHash)
+                    .ExecuteScalarInt64Async(-1, token)
+                    .ConfigureAwait(false);
+
+                if (blocksetId < 0)
+                    throw new InvalidOperationException($"Failed to create a metadata blockset for {fullHash}.");
+            }
+            else
+            {
+                await cmd.SetCommandAndParameters(@"
+                    DELETE FROM ""BlocksetEntry""
+                    WHERE ""BlocksetID"" = @BlocksetId
+                ")
+                    .SetParameterValue("@BlocksetId", blocksetId)
+                    .ExecuteNonQueryAsync(true, token)
+                    .ConfigureAwait(false);
+
+                await cmd.SetCommandAndParameters(@"
+                    DELETE FROM ""BlocklistHash""
+                    WHERE ""BlocksetID"" = @BlocksetId
+                ")
+                    .SetParameterValue("@BlocksetId", blocksetId)
+                    .ExecuteNonQueryAsync(true, token)
+                    .ConfigureAwait(false);
+            }
+
+            cmd.SetCommandAndParameters(@"
+                INSERT INTO ""BlocksetEntry"" (
+                    ""BlocksetID"",
+                    ""Index"",
+                    ""BlockID""
+                )
+                VALUES (
+                    @BlocksetId,
+                    @Index,
+                    @BlockId
+                )
+            ");
+
+            for (var i = 0; i < ids.Count; i++)
+                await cmd
+                    .SetParameterValue("@BlocksetId", blocksetId)
+                    .SetParameterValue("@Index", i)
+                    .SetParameterValue("@BlockId", ids[i])
+                    .ExecuteNonQueryAsync(true, token)
+                    .ConfigureAwait(false);
+
+            // Refuse to hand out a blockset that does not add up, as that is exactly the damage this is
+            // meant to repair
+            var calculatedLength = await cmd.SetCommandAndParameters(@"
+                SELECT IFNULL(SUM(""Block"".""Size""), 0)
+                FROM ""BlocksetEntry""
+                JOIN ""Block""
+                    ON ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
+                WHERE ""BlocksetEntry"".""BlocksetID"" = @BlocksetId
+            ")
+                .SetParameterValue("@BlocksetId", blocksetId)
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+
+            if (calculatedLength != size)
+                throw new InvalidOperationException($"The metadata blockset {blocksetId} has a recorded length of {size}, but its blocks add up to {calculatedLength}.");
+
+            return blocksetId;
+        }
+
+        /// <summary>
+        /// Returns the id of a <c>Metadataset</c> row for the given blockset, creating one if there is none.
+        /// </summary>
+        /// <remarks>
+        /// A freshly created metadata blockset is referenced by nothing until the damaged metadata is
+        /// repointed at it, and an unreferenced blockset is removed by the next cleanup. The row also makes
+        /// the blockset visible to <see cref="FindSmallestUsableMetadataBlocksetIdAsync"/>, which only
+        /// considers blocksets that are already used as metadata.
+        /// </remarks>
+        /// <param name="blocksetId">The blockset to point the metadata entry at.</param>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that when awaited contains the id of the metadata entry.</returns>
+        public async Task<long> GetOrCreateMetadatasetIdAsync(long blocksetId, CancellationToken token)
+        {
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            var metadataId = await cmd.SetCommandAndParameters(@"
+                SELECT ""ID""
+                FROM ""Metadataset""
+                WHERE ""BlocksetID"" = @BlocksetId
+                LIMIT 1
+            ")
+                .SetParameterValue("@BlocksetId", blocksetId)
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+
+            if (metadataId >= 0)
+                return metadataId;
+
+            metadataId = await cmd.SetCommandAndParameters(@"
+                INSERT INTO ""Metadataset"" (
+                    ""BlocksetID""
+                )
+                VALUES (
+                    @BlocksetId
+                );
+                SELECT last_insert_rowid();
+            ")
+                .SetParameterValue("@BlocksetId", blocksetId)
+                .ExecuteScalarInt64Async(-1, token)
+                .ConfigureAwait(false);
+
+            if (metadataId < 0)
+                throw new InvalidOperationException($"Failed to create a metadata entry for blockset {blocksetId}.");
+
+            return metadataId;
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Main.Database.Local;
+using Duplicati.Library.Utility;
 
 namespace Duplicati.Library.Main.Operation
 {
@@ -111,36 +112,17 @@ namespace Duplicati.Library.Main.Operation
                     }
                 }
 
+                var emptymetadata = Utility.WrapMetadata(new Dictionary<string, string>(), m_options);
+                // The volumes that are missing cannot supply blocks, so a blockset that depends on them
+                // is no more restorable than the metadata we are replacing.
+                var unavailableVolumeIds = (missing ?? []).Select(x => x.ID).ToArray();
+
                 if (replaceMetadata)
                 {
-                    var emptymetadata = Utility.WrapMetadata(new Dictionary<string, string>(), m_options);
-                    // The volumes that are missing cannot supply blocks, so a blockset that depends on them
-                    // is no more restorable than the metadata we are replacing.
-                    var unavailableVolumeIds = (missing ?? []).Select(x => x.ID).ToArray();
-
-                    replacementMetadataBlocksetId = await db
-                        .FindExactMetadataBlocksetIdAsync(
-                            unavailableVolumeIds,
-                            emptymetadata.FileHash,
-                            emptymetadata.Blob.Length,
-                            m_result.TaskControl.ProgressToken
-                        )
-                        .ConfigureAwait(false);
-
-                    if (replacementMetadataBlocksetId < 0)
-                    {
-                        // The canonical empty metadata blob is not stored in this backup, so fall back to
-                        // the smallest metadata that is actually restorable. Its contents do not describe
-                        // the files it gets assigned to, so they lose their permissions and timestamps.
-                        replacementMetadataBlocksetId = await db
-                            .FindSmallestUsableMetadataBlocksetIdAsync(unavailableVolumeIds, m_result.TaskControl.ProgressToken)
-                            .ConfigureAwait(false);
-
-                        if (replacementMetadataBlocksetId >= 0)
-                            Logging.Log.WriteInformationMessage(LOGTAG, "ReplacementMetadataIsNotEmpty", "The empty metadata entry is not present in the backup, using the smallest available metadata as replacement. The affected files will lose their original permissions and timestamps.");
-                    }
-
-                    if (replacementMetadataBlocksetId < 0)
+                    // Only ask whether a replacement can be obtained here. Obtaining it may mean uploading a
+                    // new block volume, and that must not happen until it is known that something needs
+                    // replacing, nor during a dry-run.
+                    if (!await CanProvideReplacementMetadataAsync(db, emptymetadata, unavailableVolumeIds).ConfigureAwait(false))
                         throw new UserInformationException($"Failed to locate an empty metadata blockset to replace missing metadata. Set the option --disable-replace-missing-metadata=true to ignore this and drop files with missing metadata.", "FailedToLocateEmptyMetadataBlockset");
                 }
 
@@ -160,10 +142,6 @@ namespace Duplicati.Library.Main.Operation
                         recoveredFileCounts[set.FilesetID] = set.RemoveCount - remaining;
                         brokenCounts[set.FilesetID] = remaining;
                     }
-
-                    var recovered = recoveredFileCounts.Values.Sum();
-                    if (recovered > 0)
-                        Logging.Log.WriteWarningMessage(LOGTAG, "MetadataReplacedWithEmpty", null, "Recovering {0} file(s) by replacing metadata that cannot be restored. The affected files keep their contents, but lose their original permissions and timestamps. Use {1} to remove them instead.", recovered, "--disable-replace-missing-metadata");
                 }
 
                 var compare_list = sets.Select(async x => new
@@ -182,6 +160,15 @@ namespace Duplicati.Library.Main.Operation
 
                 var fully_emptied = compare_list.Where(x => x.RemoveCount == x.SetCount).ToArray();
                 var to_purge = compare_list.Where(x => x.RemoveCount != x.SetCount).ToArray();
+
+                // Only a fileset that gets a new filelist can carry the replacement to the destination, and a
+                // fileset that is removed entirely does not need one. If none of the filesets being rewritten
+                // recovers anything, there is nothing to replace, and nothing to store.
+                var filesToRecover = to_purge.Sum(x => x.RecoverCount);
+                if (filesToRecover <= 0)
+                    replaceMetadata = false;
+                else
+                    Logging.Log.WriteWarningMessage(LOGTAG, "MetadataReplacedWithEmpty", null, "Recovering {0} file(s) by replacing metadata that cannot be restored. The affected files keep their contents, but lose their original permissions and timestamps. Use {1} to remove them instead.", filesToRecover, "--disable-replace-missing-metadata");
 
                 if (fully_emptied.Length == await db.FilesetTimesAsync(m_result.TaskControl.ProgressToken).CountAsync(cancellationToken: m_result.TaskControl.ProgressToken).ConfigureAwait(false))
                     throw new UserInformationException("All filesets are fully broken and needs to be removed. To avoid unexpected deletions, you must manually remove the remote files and delete the database.", "AllFilesetsBroken");
@@ -216,6 +203,20 @@ namespace Duplicati.Library.Main.Operation
 
                     pgoffset += (pgspan * fully_emptied.Length);
                     m_result.OperationProgressUpdater.UpdateProgress(pgoffset);
+                }
+
+                if (replaceMetadata)
+                {
+                    // Obtain the replacement only now: the delete above removes filesets, and everything that
+                    // is no longer referenced with them, which would take a freshly created blockset with it.
+                    replacementMetadataBlocksetId = await EnsureReplacementMetadataBlocksetAsync(backendManager, db, emptymetadata, unavailableVolumeIds)
+                        .ConfigureAwait(false);
+
+                    // The probe above said a replacement could be obtained, so this means an upload failed
+                    // and there was nothing left to fall back to. Stop rather than fall back to removing the
+                    // files, which would silently do something the projected counts no longer describe.
+                    if (replacementMetadataBlocksetId < 0)
+                        throw new UserInformationException($"Failed to obtain replacement metadata for the files that cannot be restored. Set the option --disable-replace-missing-metadata=true to remove those files instead.", "FailedToLocateEmptyMetadataBlockset");
                 }
 
                 if (to_purge.Length > 0)
@@ -293,6 +294,260 @@ namespace Duplicati.Library.Main.Operation
             }
 
             m_result.OperationProgressUpdater.UpdateProgress(1.0f);
+        }
+
+        /// <summary>
+        /// Computes the block hash of the given data.
+        /// </summary>
+        /// <remarks>
+        /// A blockset records the <em>file</em> hash of its contents in <c>Blockset.FullHash</c>, while the
+        /// blocks it is made of are identified by their <em>block</em> hash. For a blob that fits in a single
+        /// block these are two different hashes of the same bytes.
+        /// </remarks>
+        /// <param name="data">The data to hash.</param>
+        /// <returns>The base64 encoded block hash.</returns>
+        private string CalculateBlockHash(byte[] data)
+        {
+            using var blockhasher = Library.Utility.HashFactory.CreateHasher(m_options.BlockHashAlgorithm);
+            if (blockhasher == null)
+                throw new UserInformationException(Strings.Common.InvalidHashAlgorithm(m_options.BlockHashAlgorithm), "BlockHashAlgorithmNotSupported");
+
+            return Convert.ToBase64String(blockhasher.ComputeHash(data));
+        }
+
+        /// <summary>
+        /// Answers, without changing anything, whether replacement metadata can be obtained.
+        /// </summary>
+        /// <remarks>
+        /// This must follow the same chain as <see cref="EnsureReplacementMetadataBlocksetAsync"/>, including
+        /// the dry-run rule, or a dry-run projects a recovery that the real run would not perform, and the
+        /// other way around.
+        /// </remarks>
+        /// <param name="db">The database to query.</param>
+        /// <param name="emptymetadata">The canonical empty metadata blob.</param>
+        /// <param name="unavailableVolumeIds">The ids of the volumes that cannot supply blocks.</param>
+        /// <returns>A task that when awaited is <c>true</c> if a replacement can be obtained.</returns>
+        private async Task<bool> CanProvideReplacementMetadataAsync(LocalListBrokenFilesDatabase db, IMetahash emptymetadata, long[] unavailableVolumeIds)
+        {
+            var token = m_result.TaskControl.ProgressToken;
+
+            if (await db.FindExactMetadataBlocksetIdAsync(unavailableVolumeIds, emptymetadata.FileHash, emptymetadata.Blob.Length, token).ConfigureAwait(false) >= 0)
+                return true;
+
+            if (await db.FindAvailableBlockIdAsync(CalculateBlockHash(emptymetadata.Blob), emptymetadata.Blob.Length, unavailableVolumeIds, token).ConfigureAwait(false) >= 0)
+                return true;
+
+            // We can store it ourselves, unless it would not fit in a single block, or this is a dry-run
+            if (!m_options.Dryrun && emptymetadata.Blob.Length <= m_options.Blocksize)
+                return true;
+
+            return await db.FindSmallestUsableMetadataBlocksetIdAsync(unavailableVolumeIds, token).ConfigureAwait(false) >= 0;
+        }
+
+        /// <summary>
+        /// Returns the id of a blockset holding the canonical empty metadata blob, storing it at the
+        /// destination if it is not there yet, and falling back to another file's metadata if it cannot be
+        /// stored.
+        /// </summary>
+        /// <remarks>
+        /// Storing the blob matters because the replacement is recorded in the filelists at the destination.
+        /// If nothing at the destination backs the blockset the filelists point at, a database recreate
+        /// reintroduces exactly the damage this is repairing.
+        /// </remarks>
+        /// <param name="backendManager">The backend manager to upload with.</param>
+        /// <param name="db">The database to record the blockset in.</param>
+        /// <param name="emptymetadata">The canonical empty metadata blob.</param>
+        /// <param name="unavailableVolumeIds">The ids of the volumes that cannot supply blocks.</param>
+        /// <returns>A task that when awaited contains the id of the blockset, or -1 if none could be obtained.</returns>
+        private async Task<long> EnsureReplacementMetadataBlocksetAsync(IBackendManager backendManager, LocalListBrokenFilesDatabase db, IMetahash emptymetadata, long[] unavailableVolumeIds)
+        {
+            var token = m_result.TaskControl.ProgressToken;
+
+            // 1. The blob is already stored, and a blockset already describes it
+            var blocksetId = await db
+                .FindExactMetadataBlocksetIdAsync(unavailableVolumeIds, emptymetadata.FileHash, emptymetadata.Blob.Length, token)
+                .ConfigureAwait(false);
+            if (blocksetId >= 0)
+                return blocksetId;
+
+            // 2. The block is stored, but no usable blockset points at it
+            var blockHash = CalculateBlockHash(emptymetadata.Blob);
+            var blockId = await db
+                .FindAvailableBlockIdAsync(blockHash, emptymetadata.Blob.Length, unavailableVolumeIds, token)
+                .ConfigureAwait(false);
+            if (blockId >= 0)
+            {
+                Logging.Log.WriteInformationMessage(LOGTAG, "ReusingStoredReplacementMetadata", "The empty metadata block is already stored, registering it as replacement metadata");
+                blocksetId = await db
+                    .CreateMetadataBlocksetAsync(emptymetadata.FileHash, emptymetadata.Blob.Length, [blockId], token)
+                    .ConfigureAwait(false);
+                await db.GetOrCreateMetadatasetIdAsync(blocksetId, token).ConfigureAwait(false);
+                if (!m_options.Dryrun)
+                    await db.Transaction.CommitAsync("RegisteredReplacementMetadata", true, token).ConfigureAwait(false);
+
+                return blocksetId;
+            }
+
+            // 3. Store it, so the replacement survives a database recreate
+            if (emptymetadata.Blob.Length > m_options.Blocksize)
+            {
+                Logging.Log.WriteWarningMessage(LOGTAG, "ReplacementMetadataTooLarge", null, "The empty metadata entry is {0} bytes, which does not fit in a single block of {1} bytes, so it cannot be stored as replacement metadata.", emptymetadata.Blob.Length, m_options.Blocksize);
+            }
+            else if (m_options.Dryrun)
+            {
+                Logging.Log.WriteDryrunMessage(LOGTAG, "WouldUploadReplacementMetadata", "Would upload a new block volume with the empty metadata entry to use as replacement metadata");
+            }
+            else
+            {
+                try
+                {
+                    return await UploadReplacementMetadataAsync(backendManager, db, emptymetadata, blockHash)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    if (ex.IsAbortOrCancelException())
+                        throw;
+
+                    Logging.Log.WriteWarningMessage(LOGTAG, "ReplacementMetadataUploadFailed", ex, "Failed to store the empty metadata entry: {0}", ex.Message);
+                }
+            }
+
+            // 4. Fall back to another file's metadata, which is restorable but describes the wrong file
+            blocksetId = await db
+                .FindSmallestUsableMetadataBlocksetIdAsync(unavailableVolumeIds, token)
+                .ConfigureAwait(false);
+
+            if (blocksetId >= 0)
+                Logging.Log.WriteInformationMessage(LOGTAG, "ReplacementMetadataIsNotEmpty", "The empty metadata entry is not stored in the backup, using the smallest available metadata as replacement. The affected files will lose their original permissions and timestamps.");
+
+            return blocksetId;
+        }
+
+        /// <summary>
+        /// Uploads a new block volume holding the empty metadata blob, and records the resulting blockset.
+        /// </summary>
+        /// <param name="backendManager">The backend manager to upload with.</param>
+        /// <param name="db">The database to record the volume, block and blockset in.</param>
+        /// <param name="emptymetadata">The canonical empty metadata blob.</param>
+        /// <param name="blockHash">The block hash of the blob.</param>
+        /// <returns>A task that when awaited contains the id of the blockset.</returns>
+        private async Task<long> UploadReplacementMetadataAsync(IBackendManager backendManager, LocalListBrokenFilesDatabase db, IMetahash emptymetadata, string blockHash)
+        {
+            var token = m_result.TaskControl.ProgressToken;
+            Volumes.BlockVolumeWriter? blockVolume = null;
+            Volumes.IndexVolumeWriter? indexVolume = null;
+            LocalListBrokenFilesDatabase.BlockRegistration? registration = null;
+
+            // Record that an upload is in progress before anything is registered. If the process is killed
+            // between the commit below and the end of the upload, the volume is left in Uploading state with
+            // the block pointing at it, and this flag is what lets the next run clean that up: without it
+            // the next operation verifies in strict mode and refuses to continue instead.
+            await db.TerminatedWithActiveUploadsAsync(token, true).ConfigureAwait(false);
+
+            try
+            {
+                blockVolume = new Volumes.BlockVolumeWriter(m_options);
+                blockVolume.VolumeID = await db
+                    .RegisterRemoteVolumeAsync(blockVolume.RemoteFilename, RemoteVolumeType.Blocks, RemoteVolumeState.Temporary, token)
+                    .ConfigureAwait(false);
+
+                // This has to be recorded before the upload starts, and is therefore visible before the
+                // volume exists at the destination. It is undone below if the volume never arrives.
+                registration = await db
+                    .RegisterBlockAsync(blockHash, emptymetadata.Blob.Length, blockVolume.VolumeID, token)
+                    .ConfigureAwait(false);
+
+                await blockVolume
+                    .AddBlockAsync(blockHash, emptymetadata.Blob, 0, emptymetadata.Blob.Length, CompressionHint.Compressible)
+                    .ConfigureAwait(false);
+
+                await db
+                    .UpdateRemoteVolumeAsync(blockVolume.RemoteFilename, RemoteVolumeState.Uploading, -1, null, token)
+                    .ConfigureAwait(false);
+
+                if (m_options.IndexfilePolicy != Options.IndexFileStrategy.None)
+                {
+                    indexVolume = new Volumes.IndexVolumeWriter(m_options);
+                    indexVolume.VolumeID = await db
+                        .RegisterRemoteVolumeAsync(indexVolume.RemoteFilename, RemoteVolumeType.Index, RemoteVolumeState.Temporary, token)
+                        .ConfigureAwait(false);
+                    indexVolume.StartVolume(blockVolume.RemoteFilename);
+                    indexVolume.AddBlock(blockHash, emptymetadata.Blob.Length);
+                    await db.AddIndexBlockLinkAsync(indexVolume.VolumeID, blockVolume.VolumeID, token)
+                        .ConfigureAwait(false);
+
+                    // No blocklists to write, even for IndexFileStrategy.Full: the blockset is a single
+                    // block, so it has no blocklist hashes.
+                }
+
+                await backendManager.FlushPendingMessagesAsync(db, token).ConfigureAwait(false);
+                await db.Transaction.CommitAsync("PreUploadReplacementMetadata", true, token).ConfigureAwait(false);
+
+                // waitForComplete, so the volume is known to be at the destination before anything is pointed
+                // at it, and so the temp files are no longer needed once this returns or throws
+                await backendManager.PutAsync(blockVolume, indexVolume, null, true, null, token).ConfigureAwait(false);
+                await backendManager.WaitForEmptyAsync(db, token).ConfigureAwait(false);
+
+                var blocksetId = await db
+                    .CreateMetadataBlocksetAsync(emptymetadata.FileHash, emptymetadata.Blob.Length, [registration.BlockId], token)
+                    .ConfigureAwait(false);
+                await db.GetOrCreateMetadatasetIdAsync(blocksetId, token).ConfigureAwait(false);
+                await db.Transaction.CommitAsync("StoredReplacementMetadata", true, token).ConfigureAwait(false);
+
+                // Nothing is in flight any more. The flag is deliberately left set when this throws, so the
+                // next run cleans up whatever the failure left behind.
+                await db.TerminatedWithActiveUploadsAsync(token, false).ConfigureAwait(false);
+
+                Logging.Log.WriteInformationMessage(LOGTAG, "StoredReplacementMetadata", "Stored the empty metadata entry in {0} to use as replacement metadata", blockVolume.RemoteFilename);
+                return blocksetId;
+            }
+            catch
+            {
+                if (registration != null)
+                    await db.RollbackBlockRegistrationAsync(registration, token).ConfigureAwait(false);
+
+                foreach (var name in new[] { blockVolume?.RemoteFilename, indexVolume?.RemoteFilename })
+                    if (!string.IsNullOrWhiteSpace(name))
+                        try
+                        {
+                            await db.RemoveRemoteVolumeAsync(name, token).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logging.Log.WriteWarningMessage(LOGTAG, "ReplacementMetadataCleanupFailed", ex, "Failed to remove the registration of {0}: {1}. If the file reached the destination, run repair to clean it up.", name, ex.Message);
+                        }
+
+                await db.Transaction.CommitAsync("RolledBackReplacementMetadata", true, token).ConfigureAwait(false);
+                throw;
+            }
+            finally
+            {
+                // With waitForComplete the backend is done with the temp files by the time PutAsync returns
+                // or throws, so disposing here neither leaks a temp file when an exception is raised before
+                // ownership transfers, nor deletes a file the backend still needs.
+                DisposeVolumeWriter(indexVolume);
+                DisposeVolumeWriter(blockVolume);
+            }
+        }
+
+        /// <summary>
+        /// Disposes a volume writer without letting the disposal hide whatever went wrong before it.
+        /// </summary>
+        /// <param name="writer">The writer to dispose, if any.</param>
+        private static void DisposeVolumeWriter(Volumes.VolumeWriterBase? writer)
+        {
+            if (writer == null)
+                return;
+
+            // An index volume refuses to be disposed while a volume is still being written, which is the
+            // state it is left in when something fails between StartVolume and the upload
+            if (writer is Volumes.IndexVolumeWriter indexVolume)
+                try { indexVolume.FinishVolume(null, 0); }
+                catch (Exception ex) { Logging.Log.WriteVerboseMessage(LOGTAG, "FinishVolumeFailed", ex, "Failed to finish {0}: {1}", writer.RemoteFilename, ex.Message); }
+
+            try { writer.Dispose(); }
+            catch (Exception ex) { Logging.Log.WriteVerboseMessage(LOGTAG, "DisposeVolumeFailed", ex, "Failed to dispose a volume writer: {0}", ex.Message); }
         }
     }
 }

--- a/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
+++ b/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -45,14 +46,35 @@ namespace Duplicati.UnitTest;
 public class ZeroLengthMetadataTests : BasicSetupHelper
 {
     /// <summary>
+    /// Writes a file into the data folder and gives it a distinct modification time.
+    /// </summary>
+    /// <remarks>
+    /// Metadata is deduplicated on the hash of its contents, and the contents include
+    /// <c>CoreLastWritetime</c> and <c>CoreCreatetime</c> as read from the filesystem. Two files written
+    /// back to back can therefore land on the same timestamp and end up sharing a single
+    /// <c>Metadataset</c> row, which makes "one file's metadata" belong to two files. Whether that happens
+    /// depends on the clock granularity of the platform, so leaving it to chance makes these tests pass on
+    /// macOS and fail on Linux and Windows. An explicit, distinct modification time removes the ambiguity.
+    /// </remarks>
+    /// <param name="name">The file name to write.</param>
+    /// <param name="contents">The contents to write.</param>
+    /// <param name="dayOffset">A per-file offset that keeps the modification times apart.</param>
+    private void WriteFileWithDistinctMetadata(string name, string contents, int dayOffset)
+    {
+        var path = Path.Combine(this.DATAFOLDER, name);
+        File.WriteAllText(path, contents);
+        File.SetLastWriteTimeUtc(path, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(dayOffset));
+    }
+
+    /// <summary>
     /// Creates a backup containing a regular file and an empty file, so that the shared empty-file
     /// blockset exists, and returns the options used.
     /// </summary>
     private async Task<Dictionary<string, string>> BackupWithEmptyFileAsync()
     {
         var options = new Dictionary<string, string>(this.TestOptions);
-        File.WriteAllText(Path.Combine(this.DATAFOLDER, "a.txt"), "some data");
-        File.WriteAllText(Path.Combine(this.DATAFOLDER, "empty.txt"), string.Empty);
+        WriteFileWithDistinctMetadata("a.txt", "some data", 1);
+        WriteFileWithDistinctMetadata("empty.txt", string.Empty, 2);
 
         using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
@@ -97,6 +119,15 @@ public class ZeroLengthMetadataTests : BasicSetupHelper
             .ExecuteScalarInt64(-1);
 
         Assert.That(metadataId, Is.GreaterThanOrEqualTo(0), $"No metadata found for {path}");
+
+        // Repointing a shared metadata row would break every file using it, and the counts the tests assert
+        // on would silently describe something else. See WriteFileWithDistinctMetadata.
+        var sharingFiles = cmd
+            .SetCommandAndParameters(@"SELECT COUNT(*) FROM ""FileLookup"" WHERE ""MetadataID"" = @Id")
+            .SetParameterValue("@Id", metadataId)
+            .ExecuteScalarInt64(0);
+
+        Assert.That(sharingFiles, Is.EqualTo(1), $"The metadata of {path} is shared with {sharingFiles - 1} other entrie(s), so breaking it would not affect a single file");
 
         var updated = await cmd
             .SetCommandAndParameters(@"UPDATE ""Metadataset"" SET ""BlocksetID"" = @BlocksetId WHERE ""ID"" = @Id")
@@ -475,7 +506,7 @@ public class ZeroLengthMetadataTests : BasicSetupHelper
 
         // A second version that keeps the unchanged file, and therefore shares its metadata row
         Thread.Sleep(2000);
-        File.WriteAllText(Path.Combine(this.DATAFOLDER, "b.txt"), "more data");
+        WriteFileWithDistinctMetadata("b.txt", "more data", 3);
         using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
 
@@ -595,7 +626,7 @@ public class ZeroLengthMetadataTests : BasicSetupHelper
 
         // A second version that keeps the unchanged file, and therefore shares its metadata row
         Thread.Sleep(2000);
-        File.WriteAllText(Path.Combine(this.DATAFOLDER, "b.txt"), "more data");
+        WriteFileWithDistinctMetadata("b.txt", "more data", 3);
         using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
 

--- a/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
+++ b/Duplicati/UnitTest/ZeroLengthMetadataTests.cs
@@ -109,6 +109,49 @@ public class ZeroLengthMetadataTests : BasicSetupHelper
     }
 
     /// <summary>
+    /// Counts the metadata entries that cannot be restored because their blockset has a length of 0.
+    /// </summary>
+    private static long CountZeroLengthMetadata(SqliteCommand cmd)
+        => cmd.ExecuteScalarInt64(@"
+            SELECT COUNT(*)
+            FROM ""Metadataset""
+            JOIN ""Blockset"" ON ""Metadataset"".""BlocksetID"" = ""Blockset"".""ID""
+            WHERE ""Blockset"".""Length"" = 0
+        ", -1);
+
+    /// <summary>
+    /// Returns the id of the blockset holding the given metadata blob, and asserts that it is backed by
+    /// blocks in a live block volume, which is what makes the replacement survive a database recreate.
+    /// </summary>
+    private static long GetStoredMetadataBlocksetId(SqliteCommand cmd, IMetahash metadata)
+    {
+        var blocksetId = cmd
+            .SetCommandAndParameters(@"SELECT ""ID"" FROM ""Blockset"" WHERE ""FullHash"" = @Hash AND ""Length"" = @Length")
+            .SetParameterValue("@Hash", metadata.FileHash)
+            .SetParameterValue("@Length", metadata.Blob.Length)
+            .ExecuteScalarInt64(-1);
+
+        Assert.That(blocksetId, Is.GreaterThanOrEqualTo(0), "The empty metadata blockset is not registered");
+
+        var blocksInLiveVolumes = cmd
+            .SetCommandAndParameters(@"
+                SELECT COUNT(*)
+                FROM ""BlocksetEntry""
+                JOIN ""Block"" ON ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
+                JOIN ""RemoteVolume"" ON ""RemoteVolume"".""ID"" = ""Block"".""VolumeID""
+                WHERE
+                    ""BlocksetEntry"".""BlocksetID"" = @Id
+                    AND ""RemoteVolume"".""Type"" = 'Blocks'
+                    AND ""RemoteVolume"".""State"" NOT IN ('Deleted', 'Deleting', 'Temporary')
+            ")
+            .SetParameterValue("@Id", blocksetId)
+            .ExecuteScalarInt64(0);
+
+        Assert.That(blocksInLiveVolumes, Is.EqualTo(1), "The empty metadata blockset must be backed by a stored block");
+        return blocksetId;
+    }
+
+    /// <summary>
     /// Returns the blockset the given metadata entry points at.
     /// </summary>
     private static long GetMetadataBlocksetId(SqliteCommand cmd, long metadataId)
@@ -482,5 +525,156 @@ public class ZeroLengthMetadataTests : BasicSetupHelper
             var older = (await c.ListAsync("*")).Files.Select(x => x.Path).ToArray();
             Assert.That(older.Count(x => x.EndsWith("a.txt")), Is.EqualTo(1), "The unselected version should be untouched");
         }
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task PurgeStoresReplacementMetadataAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+        var emptyMetadata = Duplicati.Library.Main.Utility.WrapMetadata(new Dictionary<string, string>(), opts);
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+            await PointMetadataAtSharedEmptyBlocksetAsync(cmd, "a.txt", GetSharedEmptyBlocksetId(cmd, emptyFileHash));
+
+        var dblocksBefore = Directory.GetFiles(this.TARGETFOLDER, "*.dblock.*").Length;
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var res = await c.PurgeBrokenFilesAsync(null);
+            TestUtils.AssertResults(res, "MetadataReplacedWithEmpty");
+            Assert.That(res.PurgeResults?.RewrittenFileLists, Is.EqualTo(1));
+        }
+
+        // The empty metadata blob is not part of a normal backup, so it has to be stored now
+        Assert.That(Directory.GetFiles(this.TARGETFOLDER, "*.dblock.*").Length, Is.EqualTo(dblocksBefore + 1), "The empty metadata blob should have been stored in a new block volume");
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            GetStoredMetadataBlocksetId(cmd, emptyMetadata);
+            Assert.That(CountZeroLengthMetadata(cmd), Is.EqualTo(0), "No metadata entry may have a length of 0");
+        }
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
+
+        // The replacement is only real if it is recorded at the destination: recreating the database from
+        // the remote files must not bring the damage back
+        File.Delete(this.DBFILE);
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.RepairAsync());
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            Assert.That(CountZeroLengthMetadata(cmd), Is.EqualTo(0), "The recreated database must not have zero-length metadata");
+            GetStoredMetadataBlocksetId(cmd, emptyMetadata);
+        }
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
+
+            var files = (await c.ListAsync("*")).Files.Select(x => x.Path).ToArray();
+            Assert.That(files.Count(x => x.EndsWith("a.txt")), Is.EqualTo(1), "The recovered file should still be in the backup");
+        }
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task PurgeRewritesEveryAffectedFilelistAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+        var emptyMetadata = Duplicati.Library.Main.Utility.WrapMetadata(new Dictionary<string, string>(), opts);
+
+        // A second version that keeps the unchanged file, and therefore shares its metadata row
+        Thread.Sleep(2000);
+        File.WriteAllText(Path.Combine(this.DATAFOLDER, "b.txt"), "more data");
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.BackupAsync(new[] { this.DATAFOLDER }));
+
+        long metadataId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            metadataId = await PointMetadataAtSharedEmptyBlocksetAsync(cmd, "a.txt", GetSharedEmptyBlocksetId(cmd, emptyFileHash));
+
+            Assert.That(
+                cmd.SetCommandAndParameters(@"SELECT COUNT(DISTINCT ""FilesetID"") FROM ""FilesetEntry"" JOIN ""FileLookup"" ON ""FileLookup"".""ID"" = ""FilesetEntry"".""FileID"" WHERE ""FileLookup"".""MetadataID"" = @Id")
+                    .SetParameterValue("@Id", metadataId)
+                    .ExecuteScalarInt64(0),
+                Is.EqualTo(2),
+                "Both versions should share the damaged metadata row");
+        }
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var res = await c.PurgeBrokenFilesAsync(null);
+            TestUtils.AssertResults(res, "MetadataReplacedWithEmpty");
+
+            // Leaving one filelist behind is what makes the damage come back on the next recreate
+            Assert.That(res.PurgeResults?.RewrittenFileLists, Is.EqualTo(2), "Every affected filelist must be rewritten");
+            Assert.That(res.PurgeResults?.RemovedFileCount, Is.EqualTo(0), "No file should have been removed");
+        }
+
+        File.Delete(this.DBFILE);
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.RepairAsync());
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            Assert.That(CountZeroLengthMetadata(cmd), Is.EqualTo(0), "The recreated database must not have zero-length metadata");
+            GetStoredMetadataBlocksetId(cmd, emptyMetadata);
+        }
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.TestAsync(int.MaxValue));
+    }
+
+    [Test]
+    [Category("Targeted")]
+    public async Task DryrunPurgeDoesNotChangeAnythingAsync()
+    {
+        var options = await BackupWithEmptyFileAsync();
+        var opts = new Options(options);
+        var emptyFileHash = Duplicati.Library.Main.Utility.CalculateEmptyFileHash(opts);
+
+        long metadataId;
+        long emptyBlocksetId;
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+        {
+            emptyBlocksetId = GetSharedEmptyBlocksetId(cmd, emptyFileHash);
+            metadataId = await PointMetadataAtSharedEmptyBlocksetAsync(cmd, "a.txt", emptyBlocksetId);
+        }
+
+        var remoteBefore = Directory.GetFiles(this.TARGETFOLDER).OrderBy(x => x).ToArray();
+        var databaseBefore = File.ReadAllBytes(this.DBFILE);
+
+        var dryrunOptions = new Dictionary<string, string>(options) { ["dry-run"] = "true" };
+        using (var c = new Controller("file://" + this.TARGETFOLDER, dryrunOptions, null))
+        {
+            var res = await c.PurgeBrokenFilesAsync(null);
+            Assert.That(res.Warnings.Count(x => x.Contains("MetadataReplacedWithEmpty")), Is.EqualTo(1), "The dry-run should report what it would recover");
+            // Nothing was repaired, so the closing consistency check still finds the damage. A real run
+            // does not report this, because by then the metadata has been replaced.
+            Assert.That(res.Warnings.Count(x => x.Contains("ZeroLengthMetadata")), Is.EqualTo(1), "The dry-run should still report the unrestorable metadata");
+            TestUtils.AssertResults(res, "MetadataReplacedWithEmpty", "ZeroLengthMetadata");
+        }
+
+        // A dry-run must not store the replacement, and must not rewrite any filelist
+        Assert.That(Directory.GetFiles(this.TARGETFOLDER).OrderBy(x => x).ToArray(), Is.EqualTo(remoteBefore), "A dry-run must not change the destination");
+        Assert.That(File.ReadAllBytes(this.DBFILE), Is.EqualTo(databaseBefore), "A dry-run must not change the database");
+
+        using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        using (var cmd = con.CreateCommand())
+            Assert.That(GetMetadataBlocksetId(cmd, metadataId), Is.EqualTo(emptyBlocksetId), "A dry-run must not repoint the metadata");
     }
 }


### PR DESCRIPTION
This PR ensures that an empty metadata set always exists in remote volumes.

Newer backups will automatically emit the empty metadata (5 bytes) into the first volume, precisely to ensure we have something "safe" to use for metadata in the case that we need to repair later.

With this PR the purge-broken-files will now detect if that empty block is missing, either due to an older backup, or due to damage to the volume that has the empty metadata block.

In this case, instead of assigning random metadata, it will now upload a very small `dblock` with just the empty metadata. This small block can later be picked up by compact.