### PR TITLE
Fix MS365 group classifications

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -947,7 +947,7 @@ namespace Duplicati.Library.Main
                 }
             }
 
-            ValidateOptions();
+            ValidateOptions(paths);
 
             return (paths, filter);
         }
@@ -1003,7 +1003,8 @@ namespace Duplicati.Library.Main
         /// This function will examine all options passed on the commandline, and test for unsupported or deprecated values.
         /// Any errors will be logged into the statistics module.
         /// </summary>
-        private void ValidateOptions()
+        /// <param name="paths">The source paths, used to determine the options supported by source providers; null for operations without sources.</param>
+        private void ValidateOptions(string[] paths)
         {
             // Check if only one of the retention options is set
             var selectedRetentionOptions = new List<String>();
@@ -1086,20 +1087,103 @@ namespace Duplicati.Library.Main
                     }
             }
 
+            //Figure out what options are supported by the source providers of the current sources
+            var sourceProviderOptions = new List<ICommandLineArgument>();
+            var sourceProviderSchemes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var path in paths ?? [])
+            {
+                var remoteSource = SourceProviderFactory.ParseRemoteSource(path);
+                if (remoteSource == null)
+                    continue;
+
+                try
+                {
+                    var sourceUri = new Library.Utility.RelaxedUri(remoteSource.Url);
+
+                    // Throw url-encoded options into the mix
+                    //TODO: This can hide values if both commandline and url-parameters supply the same key
+                    foreach (var k in sourceUri.QueryParameters.AllKeys)
+                        ropts[k] = sourceUri.QueryParameters[k];
+
+                    // Each source provider scheme contributes its options once,
+                    // even if multiple sources use the same scheme
+                    if (!sourceProviderSchemes.Add(sourceUri.Scheme))
+                        continue;
+
+                    var sourcecommands = DynamicLoader.SourceProviderLoader.GetSupportedCommands(remoteSource.Url);
+                    if (sourcecommands != null)
+                        sourceProviderOptions.AddRange(sourcecommands);
+                }
+                catch
+                {
+                    // Invalid source urls are reported when the source provider is loaded
+                    continue;
+                }
+            }
+
+            //Figure out what options are supported by the restore destination provider, if the restore target is remote
+            var restoreDestinationOptions = new List<ICommandLineArgument>();
+            var restorepath = m_options.Restorepath;
+            if (!string.IsNullOrEmpty(restorepath) && restorepath.StartsWith("@"))
+            {
+                try
+                {
+                    var restoreUri = new Library.Utility.RelaxedUri(restorepath.Substring(1));
+
+                    // Throw url-encoded options into the mix
+                    foreach (var k in restoreUri.QueryParameters.AllKeys)
+                        ropts[k] = restoreUri.QueryParameters[k];
+
+                    var restorecommands = DynamicLoader.RestoreDestinationProviderLoader.GetSupportedCommands(restorepath.Substring(1));
+                    if (restorecommands != null)
+                        restoreDestinationOptions.AddRange(restorecommands);
+                }
+                catch
+                {
+                    // Invalid restore destination urls are reported when the restore destination provider is loaded
+                }
+            }
+
             // Throw url-encoded options into the mix
             //TODO: This can hide values if both commandline and url-parameters supply the same key
             var ext = new Library.Utility.RelaxedUri(m_backendUrl).QueryParameters;
             foreach (var k in ext.AllKeys)
                 ropts[k] = ext[k];
 
+            var backendCommands = DynamicLoader.BackendLoader.GetSupportedCommands(m_backendUrl);
+            var encryptionCommands = m_options.NoEncryption ? [] : DynamicLoader.EncryptionLoader.GetSupportedCommands(m_options.EncryptionModule);
+            var compressionCommands = DynamicLoader.CompressionLoader.GetSupportedCommands(m_options.CompressionModule);
+            var parityCommands = string.IsNullOrEmpty(m_options.ParityModule) ? [] : DynamicLoader.ParityLoader.GetSupportedCommands(m_options.ParityModule);
+
+            // The same module can legitimately contribute its options more than once, e.g. when
+            // the target backend is also used as a source, or a provider is used as both the
+            // source and the restore destination. Silently drop such identical re-declarations,
+            // while keeping re-declarations with a differing definition, so the duplicate check
+            // below still reports those.
+            var declaredOptions = new Dictionary<string, ICommandLineArgument>(StringComparer.OrdinalIgnoreCase);
+            foreach (var l in new IEnumerable<ICommandLineArgument>[] { m_options.SupportedCommands, backendCommands, encryptionCommands, moduleOptions, compressionCommands, parityCommands })
+                if (l != null)
+                    foreach (var a in l)
+                    {
+                        declaredOptions.TryAdd(a.Name, a);
+                        if (a.Aliases != null)
+                            foreach (var s in a.Aliases)
+                                declaredOptions.TryAdd(s, a);
+                    }
+
+            sourceProviderOptions = FilterIdenticalRedeclarations(sourceProviderOptions, declaredOptions);
+            restoreDestinationOptions = FilterIdenticalRedeclarations(restoreDestinationOptions, declaredOptions);
+
             //Now run through all supported options, and look for deprecated options
             foreach (var l in new IEnumerable<ICommandLineArgument>[] {
                 m_options.SupportedCommands,
-                DynamicLoader.BackendLoader.GetSupportedCommands(m_backendUrl),
-                m_options.NoEncryption ? null : DynamicLoader.EncryptionLoader.GetSupportedCommands(m_options.EncryptionModule),
+                backendCommands,
+                encryptionCommands,
                 moduleOptions,
-                DynamicLoader.CompressionLoader.GetSupportedCommands(m_options.CompressionModule),
-                string.IsNullOrEmpty(m_options.ParityModule) ? null : DynamicLoader.ParityLoader.GetSupportedCommands(m_options.ParityModule) })
+                sourceProviderOptions,
+                restoreDestinationOptions,
+                compressionCommands,
+                parityCommands })
             {
                 if (l != null)
                     foreach (ICommandLineArgument a in l)
@@ -1162,7 +1246,7 @@ namespace Duplicati.Library.Main
             }
 
             var scheme = Library.Utility.Utility.GuessScheme(m_backendUrl);
-            if (DynamicLoader.BackendLoader.GetSupportedCommands(m_backendUrl) == null && !string.Equals(m_backendUrl, "dummy://", StringComparison.OrdinalIgnoreCase))
+            if (backendCommands == null && !string.Equals(m_backendUrl, "dummy://", StringComparison.OrdinalIgnoreCase))
             {
                 // If the backend is HTTP or HTTPS, give a custom error message
                 if (string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) || string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase))
@@ -1180,6 +1264,34 @@ namespace Duplicati.Library.Main
                 Logging.Log.WriteWarningMessage(LOGTAG, "ExperimentalDiskImageFilesystemParsed", null, "The option 'diskimage-filesystem-parsed' is experimental and should be used with caution.");
 
             //TODO: Based on the action, see if all options are relevant
+        }
+
+        /// <summary>
+        /// Removes commands that are identical re-declarations of an already declared option,
+        /// and registers the remaining commands as declared, so that later lists are filtered
+        /// against them as well.
+        /// </summary>
+        /// <param name="commands">The commands to filter</param>
+        /// <param name="declaredOptions">The options declared so far, keyed by name and alias</param>
+        /// <returns>The commands that are not identical re-declarations</returns>
+        private static List<ICommandLineArgument> FilterIdenticalRedeclarations(List<ICommandLineArgument> commands, Dictionary<string, ICommandLineArgument> declaredOptions)
+        {
+            var result = new List<ICommandLineArgument>(commands.Count);
+            foreach (var c in commands)
+            {
+                if (declaredOptions.TryGetValue(c.Name, out var existing)
+                    && existing.Type == c.Type
+                    && existing.DefaultValue == c.DefaultValue)
+                    continue;
+
+                result.Add(c);
+                declaredOptions.TryAdd(c.Name, c);
+                if (c.Aliases != null)
+                    foreach (var s in c.Aliases)
+                        declaredOptions.TryAdd(s, c);
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Operation/Common/SourceProviderFactory.cs
+++ b/Duplicati/Library/Main/Operation/Common/SourceProviderFactory.cs
@@ -38,6 +38,13 @@ using Duplicati.Library.Utility;
 namespace Duplicati.Library.Main.Operation.Common
 {
     /// <summary>
+    /// A remote source given on the form "@mountpoint|url", split into its parts
+    /// </summary>
+    /// <param name="Mountpoint">The mountpoint where the remote source is logically mounted</param>
+    /// <param name="Url">The url of the remote source</param>
+    public sealed record RemoteSource(string Mountpoint, string Url);
+
+    /// <summary>
     /// Factory for creating source providers from a list of source paths.
     /// This logic is shared between backup and sync operations to ensure
     /// consistent source enumeration behavior.
@@ -53,6 +60,20 @@ namespace Duplicati.Library.Main.Operation.Common
         /// The option that enables storing metadata content in the database
         /// </summary>
         public const string StoreMetadataContentInDatabaseOption = "store-metadata-content-in-database";
+
+        /// <summary>
+        /// Splits a remote source on the form "@mountpoint|url" into its parts
+        /// </summary>
+        /// <param name="source">The source to split</param>
+        /// <returns>The remote source, or null if the source is not a remote source</returns>
+        public static RemoteSource? ParseRemoteSource(string source)
+        {
+            // Remote sources are given on the form "@mountpoint|url"
+            var match = Regex.Match(source, @"^@(?<mountpoint>[^|]+)\|(?<url>.+)$", RegexOptions.IgnoreCase);
+            return match.Success
+                ? new RemoteSource(match.Groups["mountpoint"].Value, match.Groups["url"].Value)
+                : null;
+        }
 
         /// <summary>
         /// Enables the "store-metadata-content-in-database" option if any of the sources
@@ -77,15 +98,14 @@ namespace Duplicati.Library.Main.Operation.Common
 
             foreach (var source in sources)
             {
-                // Remote sources are given on the form "@mountpoint|url"
-                var match = Regex.Match(source, @"^@(?<mountpoint>[^|]+)\|(?<url>.+)$", RegexOptions.IgnoreCase);
-                if (!match.Success)
+                var remoteSource = ParseRemoteSource(source);
+                if (remoteSource == null)
                     continue;
 
                 string scheme;
                 try
                 {
-                    scheme = new Duplicati.Library.Utility.RelaxedUri(match.Groups["url"].Value).Scheme;
+                    scheme = new Duplicati.Library.Utility.RelaxedUri(remoteSource.Url).Scheme;
                 }
                 catch
                 {
@@ -195,10 +215,10 @@ namespace Duplicati.Library.Main.Operation.Common
                         foreach (var url in entry)
                         {
                             var sanitizedUrl = Duplicati.Library.Utility.Utility.GetUrlWithoutCredentials(url);
-                            var m = Regex.Match(url, @"^@(?<mountpoint>[^|]+)\|(?<url>.+)$", RegexOptions.IgnoreCase);
-                            if (m.Success)
+                            var remoteSource = ParseRemoteSource(url);
+                            if (remoteSource != null)
                             {
-                                var mountpoint = m.Groups["mountpoint"].Value;
+                                var mountpoint = remoteSource.Mountpoint;
 
                                 if (mountpoint.Any(x => Path.GetInvalidPathChars().Contains(x)))
                                     throw new UserInformationException(string.Format("The mountpoint \"{0}\" contains invalid characters", mountpoint), "InvalidMountpoint");
@@ -206,7 +226,7 @@ namespace Duplicati.Library.Main.Operation.Common
                                     throw new UserInformationException(string.Format("The mountpoint \"{0}\" is not a valid rooted mountpoint", mountpoint), "InvalidMountpoint");
 
                                 var normalizedMountpoint = Duplicati.Library.Common.IO.Util.AppendDirSeparator(mountpoint);
-                                var backendurl = m.Groups["url"].Value;
+                                var backendurl = remoteSource.Url;
 
                                 ISourceProvider provider;
                                 try

--- a/Duplicati/UnitTest/SourceProviderOptionValidationTests.cs
+++ b/Duplicati/UnitTest/SourceProviderOptionValidationTests.cs
@@ -1,0 +1,444 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Logging;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Tests that options belonging to a source provider are covered by the option
+/// validation performed by <see cref="Controller"/>, so that an unknown option or an
+/// invalid value produces a warning instead of being silently ignored.
+/// </summary>
+[TestFixture]
+public class SourceProviderOptionValidationTests : BasicSetupHelper
+{
+    private sealed class LogSink : ILogDestination
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public void WriteMessage(LogEntry entry)
+        {
+            Entries.Add(entry);
+        }
+    }
+
+    private sealed class TestProviderEntry : ISourceProviderEntry
+    {
+        public bool IsFolder { get; set; }
+        public bool IsMetaEntry => false;
+        public bool IsRootEntry { get; set; }
+        public DateTime CreatedUtc => new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public DateTime LastModificationUtc => new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public string Path { get; set; } = string.Empty;
+        public long Size { get; set; }
+        public bool IsSymlink => false;
+        public string? SymlinkTarget => null;
+        public FileAttributes Attributes => IsFolder ? FileAttributes.Directory : FileAttributes.Normal;
+        public bool IsBlockDevice => false;
+        public bool IsCharacterDevice => false;
+        public bool IsAlternateStream => false;
+        public string? HardlinkTargetId => null;
+        public byte[]? Content { get; set; }
+        public ISourceProviderEntry? Child { get; set; }
+
+        public Task<Stream> OpenRead(CancellationToken cancellationToken)
+            => Task.FromResult<Stream>(new MemoryStream(Content ?? []));
+
+        public Task<Dictionary<string, string?>> GetMinorMetadata(CancellationToken cancellationToken)
+            => Task.FromResult(new Dictionary<string, string?>());
+
+        public Task<bool> FileExists(string filename, CancellationToken cancellationToken)
+            => Task.FromResult(false);
+
+        public async IAsyncEnumerable<ISourceProviderEntry> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            if (Child != null)
+                yield return Child;
+        }
+    }
+
+    /// <summary>
+    /// A source provider that advertises a flags option with a fixed set of valid values
+    /// </summary>
+    private sealed class FlagsOptionSourceProvider : ISourceProviderModule
+    {
+        /// <summary>
+        /// The flags option advertised by this provider
+        /// </summary>
+        public const string FlagsOptionName = "test-provider-flags";
+
+        private readonly string _mountPoint;
+
+        /// <summary>
+        /// Constructor used by the dynamic loader for module metadata
+        /// </summary>
+        public FlagsOptionSourceProvider()
+        {
+            _mountPoint = string.Empty;
+        }
+
+        /// <summary>
+        /// Constructor used when instantiating the provider for an operation
+        /// </summary>
+        public FlagsOptionSourceProvider(string url, string mountPoint, Dictionary<string, string?> options)
+        {
+            _mountPoint = mountPoint;
+        }
+
+        public string Key => "test-flags-option";
+        public string DisplayName => "Test flags option provider";
+        public string Description => "Test provider that advertises a flags option";
+        public IList<ICommandLineArgument> SupportedCommands =>
+        [
+            new CommandLineArgument(FlagsOptionName, CommandLineArgument.ArgumentType.Flags, "Test flags.", "Test flags.", null, null, ["Alpha", "Beta"])
+        ];
+        public string MountedPath => _mountPoint;
+        public bool NeedsStoredMetadata => false;
+
+        public Task InitializeAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task TestAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public async IAsyncEnumerable<ISourceProviderEntry> EnumerateAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            var content = "data"u8.ToArray();
+            yield return new TestProviderEntry
+            {
+                Path = _mountPoint,
+                IsFolder = true,
+                IsRootEntry = true,
+                Child = new TestProviderEntry
+                {
+                    Path = _mountPoint + "file.txt",
+                    IsFolder = false,
+                    Size = content.Length,
+                    Content = content
+                }
+            };
+        }
+
+        public Task<ISourceProviderEntry?> GetEntryAsync(string path, bool isFolder, CancellationToken cancellationToken)
+            => Task.FromResult<ISourceProviderEntry?>(null);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// A restore destination provider that advertises a flags option with a fixed set of
+    /// valid values, delegating the actual restore work to the local file system
+    /// </summary>
+    private sealed class FlagsOptionRestoreDestinationProvider : IRestoreDestinationProviderModule
+    {
+        /// <summary>
+        /// The flags option advertised by this provider
+        /// </summary>
+        public const string FlagsOptionName = "test-restore-flags";
+
+        /// <summary>
+        /// The folder the provider restores to, set by the test before the restore starts
+        /// </summary>
+        public static string? TargetFolder { get; set; }
+
+        private readonly IRestoreDestinationProvider? _inner;
+
+        /// <summary>
+        /// Constructor used by the dynamic loader for module metadata
+        /// </summary>
+        public FlagsOptionRestoreDestinationProvider()
+        {
+        }
+
+        /// <summary>
+        /// Constructor used when instantiating the provider for an operation
+        /// </summary>
+        public FlagsOptionRestoreDestinationProvider(string url, Dictionary<string, string> options)
+            => _inner = new Library.SourceProvider.FileRestoreDestinationProvider(TargetFolder ?? string.Empty, true);
+
+        public string Key => "test-restore-destination";
+        public string DisplayName => "Test restore destination provider";
+        public string Description => "Test provider that advertises a flags option";
+        public IList<ICommandLineArgument> SupportedCommands =>
+        [
+            // Shared with FlagsOptionSourceProvider, mimicking providers that work in both roles
+            new CommandLineArgument(FlagsOptionSourceProvider.FlagsOptionName, CommandLineArgument.ArgumentType.Flags, "Test flags.", "Test flags.", null, null, ["Alpha", "Beta"]),
+            new CommandLineArgument(FlagsOptionName, CommandLineArgument.ArgumentType.Flags, "Test flags.", "Test flags.", null, null, ["Alpha", "Beta"])
+        ];
+
+        private IRestoreDestinationProvider Inner
+            => _inner ?? throw new InvalidOperationException("The module metadata instance does not perform restore operations");
+
+        public string TargetDestination => Inner.TargetDestination;
+        public Task Initialize(CancellationToken cancel) => Inner.Initialize(cancel);
+        public Task Finalize(Action<double>? progressCallback, CancellationToken cancel) => Inner.Finalize(progressCallback, cancel);
+        public Task Test(CancellationToken cancellationToken) => Inner.Test(cancellationToken);
+        public Task<bool> CreateFolderIfNotExists(string path, CancellationToken cancel) => Inner.CreateFolderIfNotExists(path, cancel);
+        public Task<bool> FileExists(string path, CancellationToken cancel) => Inner.FileExists(path, cancel);
+        public Task<Stream> OpenWrite(string path, CancellationToken cancel) => Inner.OpenWrite(path, cancel);
+        public Task<Stream> OpenRead(string path, CancellationToken cancel) => Inner.OpenRead(path, cancel);
+        public Task<Stream> OpenReadWrite(string path, CancellationToken cancel) => Inner.OpenReadWrite(path, cancel);
+        public Task<long> GetFileLength(string path, CancellationToken cancel) => Inner.GetFileLength(path, cancel);
+        public Task<bool> HasReadOnlyAttribute(string path, CancellationToken cancel) => Inner.HasReadOnlyAttribute(path, cancel);
+        public Task ClearReadOnlyAttribute(string path, CancellationToken cancel) => Inner.ClearReadOnlyAttribute(path, cancel);
+        public Task<bool> WriteMetadata(string path, Dictionary<string, string?> metadata, bool restoreSymlinkMetadata, bool restorePermissions, CancellationToken cancel) => Inner.WriteMetadata(path, metadata, restoreSymlinkMetadata, restorePermissions, cancel);
+        public Task DeleteFolder(string path, CancellationToken cancel) => Inner.DeleteFolder(path, cancel);
+        public Task DeleteFile(string path, CancellationToken cancel) => Inner.DeleteFile(path, cancel);
+        public IList<string> GetPriorityFiles() => Inner.GetPriorityFiles();
+        public void Dispose() => _inner?.Dispose();
+    }
+
+    [Test]
+    public async Task Backup_WarnsOnInvalidSourceProviderOptionValue()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new FlagsOptionSourceProvider());
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true",
+            [FlagsOptionSourceProvider.FlagsOptionName] = "Typo"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var results = await c.BackupAsync(["@/testremote|test-flags-option://source"]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Backup should succeed despite the invalid option value");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "OptionValidationError" && (x.Message?.Contains(FlagsOptionSourceProvider.FlagsOptionName) ?? false)), Is.True,
+            "An invalid source provider option value should produce a validation warning");
+    }
+
+    [Test]
+    public async Task Backup_DoesNotWarnOnValidSourceProviderOption()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new FlagsOptionSourceProvider());
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true",
+            [FlagsOptionSourceProvider.FlagsOptionName] = "Alpha,Beta"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var results = await c.BackupAsync(["@/testremote|test-flags-option://source"]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Backup should succeed");
+            Assert.That(results.Warnings.Count(), Is.EqualTo(0), "Backup should not produce warnings");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "UnsupportedOption" && (x.Message?.Contains(FlagsOptionSourceProvider.FlagsOptionName) ?? false)), Is.False,
+            "A known source provider option should not be reported as unsupported");
+        Assert.That(logSink.Entries.Any(x => x.Id == "OptionValidationError" && (x.Message?.Contains(FlagsOptionSourceProvider.FlagsOptionName) ?? false)), Is.False,
+            "A valid source provider option value should not produce a validation warning");
+    }
+
+    [Test]
+    public async Task Backup_MultipleSourcesWithSameProvider_DoesNotWarnOnDuplicateOptions()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new FlagsOptionSourceProvider());
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true",
+            [FlagsOptionSourceProvider.FlagsOptionName] = "Alpha"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var results = await c.BackupAsync(["@/remotea|test-flags-option://one", "@/remoteb|test-flags-option://two"]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Backup should succeed");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "DuplicateOption" && (x.Message?.Contains(FlagsOptionSourceProvider.FlagsOptionName) ?? false)), Is.False,
+            "Options from a source provider used by multiple sources should not be reported as duplicates");
+        Assert.That(logSink.Entries.Any(x => x.Id == "UnsupportedOption" && (x.Message?.Contains(FlagsOptionSourceProvider.FlagsOptionName) ?? false)), Is.False,
+            "A known source provider option should not be reported as unsupported");
+    }
+
+    [Test]
+    public async Task Backup_WarnsOnUnsupportedOptionInSourceUrl()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new FlagsOptionSourceProvider());
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var results = await c.BackupAsync(["@/testremote|test-flags-option://source?unsupported-option=1"]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Backup should succeed despite the unsupported option");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "UnsupportedOption" && (x.Message?.Contains("unsupported-option") ?? false)), Is.True,
+            "An unsupported option in the source url should produce a validation warning");
+    }
+
+    [Test]
+    public async Task Backup_WarnsOnInvalidOptionValueInSourceUrl()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new FlagsOptionSourceProvider());
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var results = await c.BackupAsync(["@/testremote|test-flags-option://source?" + FlagsOptionSourceProvider.FlagsOptionName + "=Typo"]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Backup should succeed despite the invalid option value");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "OptionValidationError" && (x.Message?.Contains(FlagsOptionSourceProvider.FlagsOptionName) ?? false)), Is.True,
+            "An invalid option value in the source url should produce a validation warning");
+    }
+
+    [Test]
+    public async Task Restore_WarnsOnInvalidRestoreDestinationProviderOptions()
+    {
+        Library.DynamicLoader.RestoreDestinationProviderLoader.AddSourceProvider(new FlagsOptionRestoreDestinationProvider());
+        FlagsOptionRestoreDestinationProvider.TargetFolder = this.RESTOREFOLDER;
+
+        File.WriteAllText(Path.Combine(this.DATAFOLDER, "file.txt"), "data");
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, new Dictionary<string, string>(this.TestOptions) { ["no-encryption"] = "true" }, null))
+            await c.BackupAsync([this.DATAFOLDER]);
+
+        var restoreOptions = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true",
+            ["restore-path"] = "@test-restore-destination://target?unsupported-option=1",
+            [FlagsOptionRestoreDestinationProvider.FlagsOptionName] = "Typo"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, restoreOptions, null))
+        {
+            var results = await c.RestoreAsync(["*"]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Restore should succeed despite the invalid option value");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "OptionValidationError" && (x.Message?.Contains(FlagsOptionRestoreDestinationProvider.FlagsOptionName) ?? false)), Is.True,
+            "An invalid restore destination option value should produce a validation warning");
+        Assert.That(logSink.Entries.Any(x => x.Id == "UnsupportedOption" && (x.Message?.Contains("unsupported-option") ?? false)), Is.True,
+            "An unsupported option in the restore destination url should produce a validation warning");
+    }
+
+    [Test]
+    public async Task Backup_SourceBackendSameAsTargetBackend_DoesNotWarnOnDuplicateOptions()
+    {
+        File.WriteAllText(Path.Combine(this.DATAFOLDER, "file.txt"), "data");
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var results = await c.BackupAsync(["@/mplocal|file://" + this.DATAFOLDER]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Backup should succeed");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "DuplicateOption"), Is.False,
+            "Options from the target backend that is also used as a source should not be reported as duplicates");
+    }
+
+    [Test]
+    public async Task Backup_SourceAndRestoreDestinationSharingOptions_DoesNotWarnOnDuplicateOptions()
+    {
+        Library.DynamicLoader.SourceProviderLoader.AddSourceProvider(new FlagsOptionSourceProvider());
+        Library.DynamicLoader.RestoreDestinationProviderLoader.AddSourceProvider(new FlagsOptionRestoreDestinationProvider());
+        FlagsOptionRestoreDestinationProvider.TargetFolder = this.RESTOREFOLDER;
+
+        var options = new Dictionary<string, string>(this.TestOptions)
+        {
+            ["no-encryption"] = "true",
+            ["restore-path"] = "@test-restore-destination://target",
+            [FlagsOptionSourceProvider.FlagsOptionName] = "Alpha",
+            [FlagsOptionRestoreDestinationProvider.FlagsOptionName] = "Beta"
+        };
+
+        var logSink = new LogSink();
+        using var isolatingScope = Log.StartIsolatingScope(true);
+        using var log = Log.StartScope(logSink, LogMessageType.Warning);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var results = await c.BackupAsync(["@/testremote|test-flags-option://source"]);
+            Assert.That(results.Errors.Count(), Is.EqualTo(0), "Backup should succeed");
+        }
+
+        Assert.That(logSink.Entries.Any(x => x.Id == "DuplicateOption"), Is.False,
+            "An option shared by the source and restore destination providers should not be reported as duplicate");
+        Assert.That(logSink.Entries.Any(x => x.Id == "UnsupportedOption"), Is.False,
+            "Options from the source and restore destination providers should be supported");
+        Assert.That(logSink.Entries.Any(x => x.Id == "OptionValidationError"), Is.False,
+            "Valid option values should not produce validation warnings");
+    }
+}

--- a/proprietary/DiskImage/General/OptionsHelper.cs
+++ b/proprietary/DiskImage/General/OptionsHelper.cs
@@ -24,9 +24,9 @@ internal static class OptionsHelper
     internal const string DISK_RESTORE_SKIP_PARTITION_TABLE_OPTION = "diskimage-restore-skip-partition-table";
 
     /// <summary>
-    /// Option to validate target disk size before restoring.
+    /// Option to skip validation of the target disk size before restoring.
     /// </summary>
-    internal const string DISK_RESTORE_VALIDATE_SIZE_OPTION = "diskimage-restore-validate-size";
+    internal const string DISK_RESTORE_SKIP_SIZE_VALIDATION_OPTION = "diskimage-restore-skip-size-validation";
 
     /// <summary>
     /// Option to treat filesystem as unknown (force raw block-based backup).
@@ -45,7 +45,7 @@ internal static class OptionsHelper
     [
         new CommandLineArgument(DISK_RESTORE_AUTO_UNMOUNT_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskRestoreAutoUnmountShort, Strings.DiskRestoreAutoUnmountLong, "false"),
         new CommandLineArgument(DISK_RESTORE_SKIP_PARTITION_TABLE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskRestoreSkipPartitionTableShort, Strings.DiskRestoreSkipPartitionTableLong, "false"),
-        new CommandLineArgument(DISK_RESTORE_VALIDATE_SIZE_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskRestoreValidateSizeShort, Strings.DiskRestoreValidateSizeLong, "true"),
+        new CommandLineArgument(DISK_RESTORE_SKIP_SIZE_VALIDATION_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskRestoreSkipSizeValidationShort, Strings.DiskRestoreSkipSizeValidationLong, "false"),
         //new CommandLineArgument(DISK_IMAGE_FILESYSTEM_UNKNOWN_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskImageFilesystemUnknownShort, Strings.DiskImageFilesystemUnknownLong, "false"),
         new CommandLineArgument(DISK_IMAGE_FILESYSTEM_PARSED_OPTION, CommandLineArgument.ArgumentType.Boolean, Strings.DiskImageFilesystemParsedShort, Strings.DiskImageFilesystemParsedLong, "false"),
     ];

--- a/proprietary/DiskImage/General/Strings.cs
+++ b/proprietary/DiskImage/General/Strings.cs
@@ -52,14 +52,14 @@ internal static class Strings
     public static string DiskRestoreSkipPartitionTableLong => LC.L("If set, the partition table (MBR/GPT) will not be restored, only the data within partitions.");
 
     /// <summary>
-    /// Short description for the validate size option.
+    /// Short description for the skip size validation option.
     /// </summary>
-    public static string DiskRestoreValidateSizeShort => LC.L("Validate target size.");
+    public static string DiskRestoreSkipSizeValidationShort => LC.L("Skip target size validation.");
 
     /// <summary>
-    /// Long description for the validate size option.
+    /// Long description for the skip size validation option.
     /// </summary>
-    public static string DiskRestoreValidateSizeLong => LC.L("If set, the target disk size will be validated against the source size before restoring.");
+    public static string DiskRestoreSkipSizeValidationLong => LC.L("If set, the target disk size will not be validated against the source size before restoring.");
 
     /// <summary>
     /// Error message for when platform is not supported.

--- a/proprietary/DiskImage/RestoreProvider.cs
+++ b/proprietary/DiskImage/RestoreProvider.cs
@@ -181,7 +181,7 @@ public sealed class RestoreProvider : IRestoreDestinationProviderModule, IDispos
         (_devicePath, _subpath) = SourceProvider.SplitDeviceAndSubpath(uri.HostAndPath);
 
         _skipPartitionTable = Utility.ParseBoolOption(options, OptionsHelper.DISK_RESTORE_SKIP_PARTITION_TABLE_OPTION);
-        _validateSize = Utility.ParseBoolOption(options, OptionsHelper.DISK_RESTORE_VALIDATE_SIZE_OPTION);
+        _validateSize = !Utility.ParseBoolOption(options, OptionsHelper.DISK_RESTORE_SKIP_SIZE_VALIDATION_OPTION);
         _autoUnmount = Utility.ParseBoolOption(options, OptionsHelper.DISK_RESTORE_AUTO_UNMOUNT_OPTION);
         _hasSetOverwriteOption = Utility.ParseBoolOption(options, "overwrite");
     }

--- a/proprietary/Office365/SourceItems/Office365Classifications.cs
+++ b/proprietary/Office365/SourceItems/Office365Classifications.cs
@@ -40,10 +40,6 @@ internal enum Office365SiteClassification
 {
     /// <summary>A Microsoft 365 group-connected team site.</summary>
     Group = 1,
-    /// <summary>A classic (non-group) team site.</summary>
-    Classic = 2,
-    /// <summary>A modern communication site.</summary>
-    Communication = 4,
     /// <summary>
     /// A personal (OneDrive for Business) site owned by a licensed user account, or one whose
     /// owner could not be determined.

--- a/proprietary/Office365/SourceProvider/SourceProvider.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.cs
@@ -422,10 +422,6 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     {
         /// <summary>A Microsoft 365 group-connected team site.</summary>
         Group,
-        /// <summary>A classic (non-group) team site.</summary>
-        Classic,
-        /// <summary>A modern communication site.</summary>
-        Communication,
         /// <summary>
         /// A personal (OneDrive for Business) site whose owner holds a Microsoft 365 license,
         /// or could not be determined.
@@ -467,8 +463,6 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
         => category switch
         {
             SiteCategory.Group => Office365SiteClassification.Group,
-            SiteCategory.Classic => Office365SiteClassification.Classic,
-            SiteCategory.Communication => Office365SiteClassification.Communication,
             SiteCategory.PersonalLicensedUser => Office365SiteClassification.PersonalLicensedUser,
             SiteCategory.PersonalUnlicensedUser => Office365SiteClassification.PersonalUnlicensedUser,
             _ => Office365SiteClassification.Other
@@ -657,8 +651,8 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     /// Classifies a SharePoint site into one of the <see cref="SiteCategory"/> buckets,
     /// on a best-effort basis using only the Microsoft Graph <c>site</c> object.
     /// Personal (OneDrive) sites are detected reliably. The Graph <c>site</c> object does
-    /// not expose the SharePoint web template, so group, classic and communication sites
-    /// cannot be reliably distinguished from Graph alone and are reported as
+    /// not expose the SharePoint web template, so group-connected team sites cannot be
+    /// reliably distinguished from other sites from Graph alone and are reported as
     /// <see cref="SiteCategory.Other"/>.
     /// </summary>
     /// <param name="site">The site to classify.</param>
@@ -687,8 +681,8 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
                 || site.WebUrl.Contains("/personal/", StringComparison.OrdinalIgnoreCase)))
             return SiteCategory.PersonalLicensedUser;
 
-        // The Graph site object does not expose the web template, so group/classic/
-        // communication cannot be distinguished reliably from Graph alone.
+        // The Graph site object does not expose the web template, so group-connected
+        // team sites cannot be distinguished reliably from Graph alone.
         return SiteCategory.Other;
     }
 

--- a/proprietary/Office365/Strings.cs
+++ b/proprietary/Office365/Strings.cs
@@ -78,7 +78,7 @@ internal static class Strings
     public static string OfficeIncludedGroupClassificationsLong => LC.L("The group classifications to include in the backup: Unified (Microsoft 365 groups), NotUnified (security groups and distribution lists). Defaults to all.");
 
     public static string OfficeIncludedSiteClassificationsShort => LC.L("Included site classifications.");
-    public static string OfficeIncludedSiteClassificationsLong => LC.L("The site classifications to include in the backup: Group, Classic, Communication, PersonalLicensedUser, PersonalUnlicensedUser, Other. Defaults to all. Personal is accepted as a shorthand for both PersonalLicensedUser and PersonalUnlicensedUser.");
+    public static string OfficeIncludedSiteClassificationsLong => LC.L("The site classifications to include in the backup: Group, PersonalLicensedUser, PersonalUnlicensedUser, Other. Defaults to all. Personal is accepted as a shorthand for both PersonalLicensedUser and PersonalUnlicensedUser.");
 
     public static string UnlicensedUserLookupFailed => LC.L("Failed to list the user accounts in the tenant. Personal sites belonging to a user without an assigned Microsoft 365 license cannot be identified and will consume a license seat. Reading this requires the User.Read.All application permission.");
 

--- a/proprietary/Office365/WebModule/WebModule.cs
+++ b/proprietary/Office365/WebModule/WebModule.cs
@@ -263,12 +263,6 @@ public class WebModule : IWebModule
                 case SourceProvider.SiteCategory.Group:
                     result.Sites.Group++;
                     break;
-                case SourceProvider.SiteCategory.Classic:
-                    result.Sites.Classic++;
-                    break;
-                case SourceProvider.SiteCategory.Communication:
-                    result.Sites.Communication++;
-                    break;
                 case SourceProvider.SiteCategory.PersonalLicensedUser:
                     result.Sites.PersonalLicensedUser++;
                     break;
@@ -374,12 +368,6 @@ public class WebModule : IWebModule
 
         [System.Text.Json.Serialization.JsonPropertyName("group")]
         public int Group { get; set; }
-
-        [System.Text.Json.Serialization.JsonPropertyName("classic")]
-        public int Classic { get; set; }
-
-        [System.Text.Json.Serialization.JsonPropertyName("communication")]
-        public int Communication { get; set; }
 
         [System.Text.Json.Serialization.JsonPropertyName("personal")]
         public int Personal => PersonalLicensedUser + PersonalUnlicensedUser;


### PR DESCRIPTION
As mentioned in issue #7081 the MS365 provider had additional classifications of groups which was never mapped in the code.

This could be confusing if the user chose these types, as they would not classify, and instead show up as "other". If "other" was not in the list, they would simply be omitted.

This PR handles this by removing the inactive groups in MS365.

During this, I discovered that source and destination provider options were never validated. This means the user would never be aware that the options applied have no effect.

Due to this, this PR also adds support for validating the source and destination url parameters.

This fixes #7081