### PR TITLE
Change test filename

### DIFF
--- a/Duplicati/Library/Utility/BackendExtensions.cs
+++ b/Duplicati/Library/Utility/BackendExtensions.cs
@@ -44,7 +44,7 @@ public static class BackendExtensions
     /// <summary>
     /// The test file name used to test access permissions
     /// </summary>
-    public const string TEST_FILE_NAME = "duplicati-access-privileges-test.tmp";
+    public const string TEST_FILE_NAME = "duplicati-access-privileges-test.txt";
 
     /// <summary>
     /// The test file content used to test access permissions


### PR DESCRIPTION
This changes the access privilege test filename to use a `.txt` extension.

This fixes #7195