### PR TITLE
Test no longer leave certs

### DIFF
--- a/Duplicati/UnitTest/CertificateTests.cs
+++ b/Duplicati/UnitTest/CertificateTests.cs
@@ -37,6 +37,44 @@ namespace Duplicati.UnitTest;
 [Category("Certificates")]
 public class CertificateTests
 {
+    /// <summary>
+    /// The time the test started, used to scope the certificate cleanup
+    /// </summary>
+    private DateTimeOffset m_testStart;
+
+    /// <summary>
+    /// Records the test start time for certificate cleanup scoping
+    /// </summary>
+    [SetUp]
+    public void SetUp() => m_testStart = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Removes certificates persisted to the OS certificate store by certificate
+    /// generation during the test (on macOS each generated certificate is written
+    /// to the login keychain)
+    /// </summary>
+    [TearDown]
+    public void TearDown() => TestUtils.RemovePersistedGeneratedCertificates(m_testStart);
+
+    /// <summary>
+    /// Verifies that generated certificates do not accumulate in the per-user store,
+    /// and that the cleanup mechanism actually covers certificates persisted by generation
+    /// </summary>
+    [Test]
+    public void GeneratedCertificatesDoNotPersistInStore()
+    {
+        // Certificate generation uses X509KeyStorageFlags.PersistKeySet, which persists
+        // the generated certificate to the per-user store on some platforms (macOS keychain)
+        var caPair = CertificateGenerator.GenerateCACertificate();
+
+        if (OperatingSystem.IsMacOS())
+            Assert.Greater(TestUtils.CountPersistedGeneratedCertificates(m_testStart), 0,
+                "Generated certificate was not found in the per-user store; the cleanup would not cover this platform");
+
+        TestUtils.RemovePersistedGeneratedCertificates(m_testStart);
+        Assert.AreEqual(0, TestUtils.CountPersistedGeneratedCertificates(m_testStart));
+    }
+
     #region CertificateGenerator Tests
 
     [Test]

--- a/Duplicati/UnitTest/HttpsConfigurationTests.cs
+++ b/Duplicati/UnitTest/HttpsConfigurationTests.cs
@@ -50,9 +50,16 @@ public class HttpsConfigurationTests
     private string _databasePath = null!;
     private Connection _connection = null!;
 
+    /// <summary>
+    /// The time the test started, used to scope the certificate cleanup
+    /// </summary>
+    private DateTimeOffset _testStart;
+
     [SetUp]
     public async Task SetUpAsync()
     {
+        _testStart = DateTimeOffset.UtcNow;
+
         // Create a temporary folder for test data
         _tempDataFolder = Path.Combine(Path.GetTempPath(), $"duplicati-test-{Guid.NewGuid()}");
         Directory.CreateDirectory(_tempDataFolder);
@@ -71,6 +78,11 @@ public class HttpsConfigurationTests
     public void TearDown()
     {
         _connection?.Dispose();
+
+        // Remove certificates persisted to the OS certificate store by certificate
+        // generation during the test (on macOS each generated certificate is written
+        // to the login keychain)
+        TestUtils.RemovePersistedGeneratedCertificates(_testStart);
 
         // Clean up temp folder
         if (Directory.Exists(_tempDataFolder))

--- a/Duplicati/UnitTest/SslCertificateValidatorTests.cs
+++ b/Duplicati/UnitTest/SslCertificateValidatorTests.cs
@@ -41,6 +41,25 @@ namespace Duplicati.UnitTest;
 public class SslCertificateValidatorTests
 {
     /// <summary>
+    /// The time the test started, used to scope the certificate cleanup
+    /// </summary>
+    private DateTimeOffset m_testStart;
+
+    /// <summary>
+    /// Records the test start time for certificate cleanup scoping
+    /// </summary>
+    [SetUp]
+    public void SetUp() => m_testStart = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Removes certificates persisted to the OS certificate store by certificate
+    /// generation during the test (on macOS each generated certificate is written
+    /// to the login keychain)
+    /// </summary>
+    [TearDown]
+    public void TearDown() => TestUtils.RemovePersistedGeneratedCertificates(m_testStart);
+
+    /// <summary>
     /// Generates an expired self-signed certificate (notAfter in the past) for testing
     /// the date-validity-first behaviour and its interaction with pinned hashes.
     /// </summary>

--- a/Duplicati/UnitTest/TestUtils.cs
+++ b/Duplicati/UnitTest/TestUtils.cs
@@ -33,11 +33,72 @@ using Duplicati.Library.Interface;
 using System.Data;
 using System.Text;
 using Duplicati.Library.Main.Database;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Duplicati.UnitTest
 {
     public static class TestUtils
     {
+        /// <summary>
+        /// Subject fragments of the certificates created by the certificate generator
+        /// </summary>
+        private static readonly string[] GeneratedCertificateSubjectFragments = ["Duplicati Local CA", "Duplicati Server"];
+
+        /// <summary>
+        /// Counts the Duplicati certificates generated during tests that were persisted to the
+        /// per-user certificate store. Certificate generation uses X509KeyStorageFlags.PersistKeySet,
+        /// which on macOS writes each generated certificate into the user's login keychain.
+        /// </summary>
+        /// <param name="createdAfter">Only certificates with a not-before timestamp after this time are counted, so pre-existing certificates are ignored</param>
+        /// <returns>The number of matching certificates in the store</returns>
+        public static int CountPersistedGeneratedCertificates(DateTimeOffset createdAfter)
+        {
+            try
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
+                // The generator backdates not-before by 5 minutes for clock skew; apply a margin
+                var notBeforeAfter = createdAfter.LocalDateTime.AddMinutes(-10);
+                return store.Certificates.Count(c =>
+                    c.NotBefore >= notBeforeAfter
+                    && GeneratedCertificateSubjectFragments.Any(s => c.Subject.Contains(s, StringComparison.Ordinal)));
+            }
+            catch
+            {
+                // Best effort: the store may not exist or be accessible on all platforms
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Removes Duplicati certificates generated during tests from the per-user certificate
+        /// store. Certificate generation uses X509KeyStorageFlags.PersistKeySet, which on macOS
+        /// writes each generated certificate into the user's login keychain; without cleanup the
+        /// keychain accumulates entries on every test run.
+        /// </summary>
+        /// <param name="createdAfter">Only certificates with a not-before timestamp after this time are removed, so pre-existing certificates are left alone</param>
+        /// <returns>The number of certificates removed</returns>
+        public static int RemovePersistedGeneratedCertificates(DateTimeOffset createdAfter)
+        {
+            try
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadWrite | OpenFlags.OpenExistingOnly);
+                // The generator backdates not-before by 5 minutes for clock skew; apply a margin
+                var notBeforeAfter = createdAfter.LocalDateTime.AddMinutes(-10);
+                var matches = store.Certificates
+                    .Where(c => c.NotBefore >= notBeforeAfter
+                        && GeneratedCertificateSubjectFragments.Any(s => c.Subject.Contains(s, StringComparison.Ordinal)))
+                    .ToList();
+                foreach (var cert in matches)
+                    store.Remove(cert);
+                return matches.Count;
+            }
+            catch
+            {
+                // Best effort: the store may not exist or be writable on all platforms
+                return 0;
+            }
+        }
+
         public static Dictionary<string, string> DefaultOptions
         {
             get


### PR DESCRIPTION
The certificate tests use the local cert store, and running the tests could leave several certificates in the keychain.