### PR TITLE
Let an interrupted backup say what it did when the version count is wrong

### DIFF
--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -1158,12 +1158,18 @@ namespace Duplicati.UnitTest
                 return false;
             };
 
+            // What each interrupted run did is what the count at the end is made of, and
+            // those runs throw, so none of it reaches the assertion on its own
+            var interruptedRuns = new List<string>();
             for (var i = 0; i < runs; i++)
             {
                 if (modifyInBetween)
                     ModifySourceFiles();
 
+                var sink = new InterruptedRunSink();
                 using (var c = new Controller(failtarget, testopts, null))
+                {
+                    await c.AppendSinkAsync(sink);
                     try
                     {
                         await c.BackupAsync(new string[] { DATAFOLDER });
@@ -1171,6 +1177,9 @@ namespace Duplicati.UnitTest
                     catch (DeterministicErrorBackend.DeterministicErrorBackendException)
                     {
                     }
+                }
+
+                interruptedRuns.Add($"#{i} {sink}");
 
                 // Prevent clashes in timestamps
                 Thread.Sleep(3000);
@@ -1189,7 +1198,8 @@ namespace Duplicati.UnitTest
                     $"The last backup reported {backupResults.AddedFiles} added and "
                     + $"{backupResults.ModifiedFiles} modified file(s), "
                     + $"{backupResults.AddedFolders} added and {backupResults.ModifiedFolders} modified folder(s). "
-                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}");
+                    + $"Versions present: {DescribeFilesets(listResults.Filesets)}. "
+                    + $"Interrupted runs: {string.Join("; ", interruptedRuns)}");
             }
 
             // Verify that all is in order
@@ -1230,6 +1240,52 @@ namespace Duplicati.UnitTest
                 .OrderBy(x => x.Version)
                 .Select(x => $"#{x.Version} {(x.IsFullBackup == 1 ? "full" : "partial")}"
                     + $" at {x.Time.ToUniversalTime():HH:mm:ss}Z with {x.FileCount} file(s)"));
+
+        /// <summary>
+        /// Records what one interrupted run did. A run with an unchanged source and a
+        /// complete backup behind it has nothing to upload, so it never reaches the error
+        /// backend at all; a run that does send a filelist is the one the version count at
+        /// the end disagrees about, and whether it also uploaded a filelist for an earlier
+        /// run says which term of the decision in UploadRealFilelist made it do so.
+        /// </summary>
+        private class InterruptedRunSink : IMessageSink
+        {
+            /// <summary>
+            /// The filelists the run started sending
+            /// </summary>
+            public List<string> StartedFilelists { get; } = new List<string>();
+
+            /// <summary>
+            /// Whether the run uploaded a filelist for an earlier interrupted run
+            /// </summary>
+            public bool UploadedSyntheticFilelist { get; private set; }
+
+            public void BackendEvent(BackendActionType action, BackendEventType type, string path, long size)
+            {
+                if (action == BackendActionType.Put && type == BackendEventType.Started && path.Contains(".dlist."))
+                    this.StartedFilelists.Add(path);
+            }
+
+            public void WriteMessage(LogEntry entry)
+            {
+                if (string.Equals(entry.Id, "PreviousBackupFilelistUpload", StringComparison.Ordinal))
+                    this.UploadedSyntheticFilelist = true;
+            }
+
+            public void SetBackendProgress(IBackendProgress progress)
+            {
+            }
+
+            public void SetOperationProgress(IOperationProgress progress)
+            {
+            }
+
+            public override string ToString()
+                => this.StartedFilelists.Count == 0
+                    ? "sent nothing"
+                    : $"sent {this.StartedFilelists.Count} filelist(s)"
+                        + (this.UploadedSyntheticFilelist ? ", one of them for an earlier run" : ", none for an earlier run");
+        }
 
         private class LogSink : IMessageSink
         {


### PR DESCRIPTION
`DisruptionTests.TestMultiExceptionOnDlistAsync` fails occasionally, and the log from the job it fails in still cannot say why.

[#7177](https://github.com/duplicati/duplicati/pull/7177) fixed half of that. The assertion used to print two numbers; it now names the versions with their timestamps, says whether each is partial, and gives the last backup's added and modified counts. That half paid off on 2026-08-27: the failure on [#7221](https://github.com/duplicati/duplicati/pull/7221) arrived carrying

```
The last backup reported 0 added and 0 modified file(s), 0 added and 0 modified folder(s).
Versions present: #0 full at 14:31:31Z with 3 file(s), #1 partial at 14:31:25Z with 3 file(s),
                  #2 full at 14:31:21Z with 3 file(s)
```

which is enough to place the fault. The last backup thought nothing had changed, so it wrote a version only because a partial one was there — `lastWasPartial` in `UploadRealFilelist`, which is correct behaviour. The partial came from a synthetic filelist, which is uploaded for a run that was interrupted. **So whatever goes wrong, goes wrong in one of the three interrupted runs, before the backup being asserted on.**

Those runs throw, and nothing they did survives to the assertion. That is the half still missing.

## What this adds

Each interrupted run gets a sink that records two things:

- **the filelists it started sending.** A run with an unchanged source and a complete backup behind it has nothing to upload, so it never reaches the error backend at all. A run that does send one is the run the version count disagrees about.
- **whether it uploaded a filelist for an earlier run.** `UploadSyntheticFilelist` logs `PreviousBackupFilelistUpload` when it does. That distinguishes the two remaining terms of

  ```csharp
  var doUpload = options.UploadUnchangedBackups || changeCount > 0 || lastWasPartial;
  ```

  since `upload-unchanged-backups` is off by default: either something looked changed, or the previous backup looked partial.

Both go in the assertion message, which is the only part of this that reaches an ordinary job's log.

```
... Versions present: #0 full at 14:48:07Z with 3 file(s).
    Interrupted runs: #0 sent nothing; #1 sent nothing; #2 sent nothing
```

That is the passing shape. When it fails, one of them will name itself and say which of the two reasons it had.

## This fixes nothing

It makes the next occurrence say what happened. The failure cannot be summoned — 663 iterations on a fork produced eight occurrences and none in the last 312 — so waiting for it to happen in an ordinary job, with the log carrying the answer, is cheaper than more repetition.

## Verified

- The eight cases still pass, unchanged (8/8 locally).
- **The message was seen rendering.** A diagnostic that only appears on failure has to be watched appearing, so the expected count was deliberately set wrong, the case run, and the output above is what came back. The expectation is restored in this branch.
- Whole solution builds with 0 errors and the same 3 warnings as master.

`IMessageSink` and `Controller.AppendSinkAsync` are both already used this way by `LogSink` in the same file.

## Not in this PR

Only `TestMultiExceptionOnDlistAsync` gets this. The other two tests #7177 touched interrupt exactly one run, so "which run" is not a question there.

Worth noting separately: the failure is **not macOS-only**, which is how it has been described so far. The 2026-08-27 occurrence was **ubuntu**, on a branch touching nothing but `Duplicati/Library/Backend/DrimeCloud/`, while windows and macOS passed in the same run.
