### PR TITLE
Reduce query time for `purge-broken-files`

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalListBrokenFilesDatabase.cs
@@ -140,23 +140,132 @@ namespace Duplicati.Library.Main.Database.Local
         ";
 
         /// <summary>
-        /// Returns the SQL query for the ids of the blocksets that cannot be restored.
+        /// The name of the temporary table holding the materialized classification, or <c>null</c> if the
+        /// classification is not materialized.
+        /// </summary>
+        private string? m_invalidBlocksetIdsTable;
+
+        /// <summary>
+        /// How many times the classification has been requested since it was last invalidated.
+        /// </summary>
+        private long m_invalidBlocksetIdsRequests;
+
+        /// <summary>
+        /// Returns the SQL query for the ids of the blocksets that cannot be restored, materializing the
+        /// classification into a temporary table from the second request onwards.
         /// </summary>
         /// <remarks>
-        /// This currently just hands out a constant, and is asynchronous only so that it can be changed into
-        /// a lookup that materializes the classification into a temporary table when it is requested more
-        /// than once. The classification aggregates over every row of <c>BlocksetEntry</c> joined to
-        /// <c>Block</c>, and the broken-file query is evaluated once per fileset, so evaluating it inline
-        /// every time is a full scan per fileset.
+        /// The classification aggregates over every row of <c>BlocksetEntry</c> joined to <c>Block</c>, and
+        /// the broken-file query is evaluated once per fileset, so evaluating it inline every time is a full
+        /// scan per fileset. Materializing it unconditionally would be worse for the recreate path, which
+        /// needs the classification exactly once and would then pay for a full scan at the end of every
+        /// recreate. Waiting for the second request gives both callers what they need.
         /// <para>
-        /// Callers must resolve it once per query they build, and pass the string down, or a single query
-        /// build will look like several requests to the caching version.
+        /// Callers must resolve this once per query they build, and pass the string down, or a single query
+        /// build counts as several requests and materializes on the very first build.
         /// </para>
         /// </remarks>
         /// <param name="token">A cancellation token to cancel the operation.</param>
         /// <returns>A task that when awaited contains the SQL query.</returns>
-        private Task<string> InvalidBlocksetIdsQueryAsync(CancellationToken token)
-            => Task.FromResult(INVALID_BLOCKSET_IDS);
+        private async Task<string> InvalidBlocksetIdsQueryAsync(CancellationToken token)
+        {
+            m_invalidBlocksetIdsRequests++;
+            if (m_invalidBlocksetIdsRequests <= 1)
+                return INVALID_BLOCKSET_IDS;
+
+            await using var cmd = m_connection.CreateCommand()
+                .SetTransaction(m_rtr);
+
+            // SQLite rolls back temporary table DDL, so a rollback of the transaction the table was created
+            // in drops it while this field still names it, and the next query fails with "no such table".
+            if (m_invalidBlocksetIdsTable != null)
+            {
+                var exists = await cmd.SetCommandAndParameters(@"
+                    SELECT COUNT(*)
+                    FROM ""sqlite_temp_master""
+                    WHERE
+                        ""type"" = 'table'
+                        AND ""name"" = @Name
+                ")
+                    .SetParameterValue("@Name", m_invalidBlocksetIdsTable)
+                    .ExecuteScalarInt64Async(0, token)
+                    .ConfigureAwait(false);
+
+                if (exists == 0)
+                    m_invalidBlocksetIdsTable = null;
+            }
+
+            if (m_invalidBlocksetIdsTable == null)
+            {
+                var tablename = $"InvalidBlocksets-{Library.Utility.Utility.GetHexGuid()}";
+
+                await cmd.ExecuteNonQueryAsync($@"
+                    CREATE TEMPORARY TABLE ""{tablename}"" AS
+                    {INVALID_BLOCKSET_IDS}
+                ", token)
+                    .ConfigureAwait(false);
+
+                await cmd.ExecuteNonQueryAsync($@"
+                    CREATE UNIQUE INDEX ""{tablename}-Ix""
+                    ON ""{tablename}"" (""BlocksetID"")
+                ", token)
+                    .ConfigureAwait(false);
+
+                m_invalidBlocksetIdsTable = tablename;
+            }
+
+            return $@"
+                SELECT ""BlocksetID""
+                FROM ""{m_invalidBlocksetIdsTable}""
+            ";
+        }
+
+        /// <summary>
+        /// Drops the materialized classification, so the next request recomputes it.
+        /// </summary>
+        /// <remarks>
+        /// This must be called after anything that changes blocks, blocksets or blocklist hashes, as those
+        /// are what the classification is derived from. Note that <see cref="ReplaceMetadataAsync"/> does not
+        /// need it: repointing <c>Metadataset.BlocksetID</c> changes which blockset a metadata entry uses, not
+        /// which blocksets are restorable.
+        /// </remarks>
+        /// <param name="token">A cancellation token to cancel the operation.</param>
+        /// <returns>A task that completes when the classification has been dropped.</returns>
+        public async Task InvalidateBrokenFileCacheAsync(CancellationToken token)
+        {
+            if (m_invalidBlocksetIdsTable != null)
+            {
+                try
+                {
+                    await using var cmd = m_connection.CreateCommand()
+                        .SetTransaction(m_rtr);
+
+                    await cmd.ExecuteNonQueryAsync($@"DROP TABLE IF EXISTS ""{m_invalidBlocksetIdsTable}""", token)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Logging.Log.WriteVerboseMessage(LOGTAG, "FailedToDropInvalidBlocksetsTable", ex, "Failed to drop the temporary table {0}: {1}", m_invalidBlocksetIdsTable, ex.Message);
+                }
+
+                m_invalidBlocksetIdsTable = null;
+            }
+
+            // Clamp to 1 rather than 0: the classification has already been asked for, so the next request
+            // should get a table instead of repeating the inline scan.
+            m_invalidBlocksetIdsRequests = Math.Min(m_invalidBlocksetIdsRequests, 1);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask DisposeAsync()
+        {
+            // The connection can outlive this wrapper, as it does when the database was created around an
+            // existing one, so the temporary table has to be dropped rather than left to the connection.
+            if (!IsDisposed)
+                await InvalidateBrokenFileCacheAsync(default).ConfigureAwait(false);
+
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
 
         /// <summary>
         /// Builds the SQL query for the blocksets that can hold restorable metadata.
@@ -497,6 +606,11 @@ namespace Duplicati.Library.Main.Database.Local
         /// recovery count: the first fileset repairs rows that later filesets also use, and those would then
         /// report zero.
         /// </para>
+        /// <para>
+        /// This deliberately does not call <see cref="InvalidateBrokenFileCacheAsync"/>: repointing
+        /// <c>Metadataset.BlocksetID</c> changes which blockset a metadata entry uses, not which blocksets are
+        /// restorable, so the classification is still valid afterwards.
+        /// </para>
         /// </remarks>
         /// <param name="filesetId">The filesetId to target.</param>
         /// <param name="replacementBlocksetId">The blockset ID to point the damaged metadata at.</param>
@@ -627,6 +741,9 @@ namespace Duplicati.Library.Main.Database.Local
                     .ConfigureAwait(false);
             }
             catch { /* Ignore, will be deleted on close anyway. */ }
+
+            // Blocks, blocksets and blocklist hashes have changed, so the classification is stale
+            await InvalidateBrokenFileCacheAsync(token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -838,6 +955,11 @@ namespace Duplicati.Library.Main.Database.Local
         /// <returns>A task that when awaited contains the registration.</returns>
         public async Task<BlockRegistration> RegisterBlockAsync(string hash, long size, long volumeId, CancellationToken token)
         {
+            // Which volume a block lives in decides whether the blocksets using it are restorable. Dropping
+            // the classification up front is enough, because it is rebuilt on the next request, which can
+            // only happen after this has run.
+            await InvalidateBrokenFileCacheAsync(token).ConfigureAwait(false);
+
             await using var cmd = m_connection.CreateCommand()
                 .SetTransaction(m_rtr);
 
@@ -919,6 +1041,9 @@ namespace Duplicati.Library.Main.Database.Local
         /// <returns>A task that completes when the rollback has been attempted.</returns>
         public async Task RollbackBlockRegistrationAsync(BlockRegistration registration, CancellationToken token)
         {
+            // See RegisterBlockAsync: this puts Block.VolumeID back, which changes the classification again
+            await InvalidateBrokenFileCacheAsync(token).ConfigureAwait(false);
+
             await using var cmd = m_connection.CreateCommand()
                 .SetTransaction(m_rtr);
 
@@ -1077,6 +1202,9 @@ namespace Duplicati.Library.Main.Database.Local
 
             if (calculatedLength != size)
                 throw new InvalidOperationException($"The metadata blockset {blocksetId} has a recorded length of {size}, but its blocks add up to {calculatedLength}.");
+
+            // A new or rebuilt blockset changes the classification
+            await InvalidateBrokenFileCacheAsync(token).ConfigureAwait(false);
 
             return blocksetId;
         }

--- a/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
+++ b/Duplicati/Library/Main/Operation/PurgeBrokenFilesHandler.cs
@@ -201,6 +201,11 @@ namespace Duplicati.Library.Main.Operation
                                 .ConfigureAwait(false);
                     }
 
+                    // The delete removed files, blocksets and blocks, so the classification the broken-file
+                    // queries below rely on is stale. Easy to miss, because the first to_purge fileset is the
+                    // next thing to query it.
+                    await db.InvalidateBrokenFileCacheAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false);
+
                     pgoffset += (pgspan * fully_emptied.Length);
                     m_result.OperationProgressUpdater.UpdateProgress(pgoffset);
                 }
@@ -267,6 +272,9 @@ namespace Duplicati.Library.Main.Operation
                                 return updatedEntries;
                             }).ConfigureAwait(false);
                         }
+
+                        // Purging a fileset removes files, and with them blocksets and blocks
+                        await db.InvalidateBrokenFileCacheAsync(m_result.TaskControl.ProgressToken).ConfigureAwait(false);
 
                         pgoffset += pgspan;
                         m_result.OperationProgressUpdater.UpdateProgress(pgoffset);

--- a/Duplicati/UnitTest/EmptyMetadataTests.cs
+++ b/Duplicati/UnitTest/EmptyMetadataTests.cs
@@ -255,4 +255,78 @@ public class EmptyMetadataTests : BasicSetupHelper
             Assert.That(blocks, Is.GreaterThan(0), "Replacement metadata must have blocks to restore from");
         }
     }
+
+    /// <summary>
+    /// Counts the temporary tables holding a materialized blockset classification.
+    /// </summary>
+    private static long CountMaterializedClassifications(Microsoft.Data.Sqlite.SqliteConnection con)
+    {
+        using var cmd = con.CreateCommand();
+        cmd.CommandText = @"SELECT COUNT(*) FROM ""sqlite_temp_master"" WHERE ""type"" = 'table' AND ""name"" LIKE 'InvalidBlocksets-%'";
+        return Convert.ToInt64(cmd.ExecuteScalar());
+    }
+
+    /// <summary>
+    /// The blockset classification is materialized from the second request onwards, and dropped again when
+    /// it is invalidated. The first request stays inline, so a database recreate - which needs it exactly
+    /// once - does not pay for a temporary table.
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task BlocksetClassificationIsMaterializedOnSecondRequestAsync()
+    {
+        var testopts = TestOptions.Expand(new { no_encryption = true });
+
+        File.WriteAllText(Path.Combine(DATAFOLDER, "file.txt"), "data");
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            TestUtils.AssertResults(await c.BackupAsync(new[] { DATAFOLDER }));
+
+        await using var localDb = await LocalListBrokenFilesDatabase.CreateAsync(DBFILE, null, CancellationToken.None).ConfigureAwait(false);
+        var con = localDb.Connection;
+
+        // Every call requests the classification exactly once
+        await localDb.GetFilesetsWithReplaceableMetadataAsync(CancellationToken.None);
+        Assert.That(CountMaterializedClassifications(con), Is.EqualTo(0), "The first request must be evaluated inline");
+
+        await localDb.GetFilesetsWithReplaceableMetadataAsync(CancellationToken.None);
+        Assert.That(CountMaterializedClassifications(con), Is.EqualTo(1), "The second request should materialize the classification");
+
+        await localDb.GetFilesetsWithReplaceableMetadataAsync(CancellationToken.None);
+        Assert.That(CountMaterializedClassifications(con), Is.EqualTo(1), "The materialized classification should be reused");
+
+        await localDb.InvalidateBrokenFileCacheAsync(CancellationToken.None);
+        Assert.That(CountMaterializedClassifications(con), Is.EqualTo(0), "Invalidating should drop the table");
+
+        // The counter is clamped rather than reset, so the recomputed classification is materialized again on
+        // the next request instead of repeating the inline scan
+        await localDb.GetFilesetsWithReplaceableMetadataAsync(CancellationToken.None);
+        Assert.That(CountMaterializedClassifications(con), Is.EqualTo(1), "The next request should materialize again");
+    }
+
+    /// <summary>
+    /// SQLite rolls back temporary table DDL, so a rollback of the transaction the table was created in
+    /// drops it. The lookup has to notice that instead of handing out a query naming a table that is gone.
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task BlocksetClassificationSurvivesTransactionRollbackAsync()
+    {
+        var testopts = TestOptions.Expand(new { no_encryption = true });
+
+        File.WriteAllText(Path.Combine(DATAFOLDER, "file.txt"), "data");
+        using (var c = new Controller("file://" + TARGETFOLDER, testopts, null))
+            TestUtils.AssertResults(await c.BackupAsync(new[] { DATAFOLDER }));
+
+        await using var localDb = await LocalListBrokenFilesDatabase.CreateAsync(DBFILE, null, CancellationToken.None).ConfigureAwait(false);
+
+        await localDb.GetFilesetsWithReplaceableMetadataAsync(CancellationToken.None);
+        await localDb.GetFilesetsWithReplaceableMetadataAsync(CancellationToken.None);
+        Assert.That(CountMaterializedClassifications(localDb.Connection), Is.EqualTo(1), "The classification should be materialized");
+
+        await localDb.Transaction.RollBackAsync(CancellationToken.None);
+
+        // Must not fail with "no such table"
+        await localDb.GetFilesetsWithReplaceableMetadataAsync(CancellationToken.None);
+        Assert.That(CountMaterializedClassifications(localDb.Connection), Is.EqualTo(1), "The classification should have been rebuilt");
+    }
 }


### PR DESCRIPTION
When running the `purge-broken-files` it may need the table of invalid blocks up to 3 times.

Prior to this PR each request would run the query dutifully on each request.

With this PR, the first call will create the temporary table and then allow all other callers to directly use it. This means we pay the query cost at most once, and then reap the benefits from futher calls.