### PR TITLE
Drop the two readme badges that report on services the build no longer uses

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -4,8 +4,7 @@
 
 暗号化したバックアップを、クラウドストレージサービスで安全に保管しましょう！
 
-[![Open Collectiveでのサポーター](https://opencollective.com/duplicati/backers/badge.svg)](#backers) [![Open Collectiveでのスポンサー](https://opencollective.com/duplicati/sponsors/badge.svg)](#sponsors) [![Travis-CIでのビルドの状況](https://travis-ci.org/duplicati/duplicati.svg?branch=master)](https://travis-ci.org/duplicati/duplicati)
-[![カバレッジの状況](https://coveralls.io/repos/github/duplicati/duplicati/badge.svg?branch=HEAD)](https://coveralls.io/github/duplicati/duplicati?branch=HEAD)
+[![Open Collectiveでのサポーター](https://opencollective.com/duplicati/backers/badge.svg)](#backers) [![Open Collectiveでのスポンサー](https://opencollective.com/duplicati/sponsors/badge.svg)](#sponsors)
 [![ライセンス](https://img.shields.io/github/license/duplicati/duplicati.svg)](https://github.com/duplicati/duplicati/blob/master/LICENSE)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Duplicati%20Guru-006BFF)](https://gurubase.io/g/duplicati)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 Store securely encrypted backups on cloud storage services!
 
-[![Backers on Open Collective](https://opencollective.com/duplicati/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/duplicati/sponsors/badge.svg)](#sponsors) [![Build Status on Travis-CI](https://travis-ci.org/duplicati/duplicati.svg?branch=master)](https://travis-ci.org/duplicati/duplicati)
-[![Coverage Status](https://coveralls.io/repos/github/duplicati/duplicati/badge.svg?branch=HEAD)](https://coveralls.io/github/duplicati/duplicati?branch=HEAD)
+[![Backers on Open Collective](https://opencollective.com/duplicati/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/duplicati/sponsors/badge.svg)](#sponsors)
 [![License](https://img.shields.io/github/license/duplicati/duplicati.svg)](https://github.com/duplicati/duplicati/blob/master/LICENSE)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Duplicati%20Guru-006BFF)](https://gurubase.io/g/duplicati)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,8 +6,7 @@
 
 在云存储服务上安全地存储加密备份！
 
-[![Open Collective 上的支持者](https://opencollective.com/duplicati/backers/badge.svg)](#backers) [![Open Collective 上的赞助商](https://opencollective.com/duplicati/sponsors/badge.svg)](#sponsors) [![Travis-CI 上的构建状态](https://travis-ci.org/duplicati/duplicati.svg?branch=master)](https://travis-ci.org/duplicati/duplicati)
-[![覆盖率状态](https://coveralls.io/repos/github/duplicati/duplicati/badge.svg?branch=HEAD)](https://coveralls.io/github/duplicati/duplicati?branch=HEAD)
+[![Open Collective 上的支持者](https://opencollective.com/duplicati/backers/badge.svg)](#backers) [![Open Collective 上的赞助商](https://opencollective.com/duplicati/sponsors/badge.svg)](#sponsors)
 [![许可](https://img.shields.io/github/license/duplicati/duplicati.svg)](https://github.com/duplicati/duplicati/blob/master/LICENSE)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Duplicati%20Guru-006BFF)](https://gurubase.io/g/duplicati)
 


### PR DESCRIPTION
Two of the badges at the top of the readme report on services this repository does not use, and one of them has been showing a wrong number for it.

## The coverage badge

```markdown
[![Coverage Status](https://coveralls.io/repos/github/duplicati/duplicati/badge.svg?branch=HEAD)](...)
```

It reads **0%**, and there is nothing behind it. `coveralls` appears in exactly three places in the tree — this line, and the same line in the Japanese and Chinese readmes. No workflow, no config, nothing uploads to it. The number is not a measurement, it is the absence of one.

Coverage *is* still collected. `tests.yml` runs

```
dotnet test ... --collect:"XPlat Code Coverage" --results-directory "$GITHUB_WORKSPACE/TestResults/unit" ...
```

for both the unit and the integration job. `TestResults` appears on those two lines and nowhere else in the file; the two `upload-artifact` steps belong to the Playwright job and take its report and the server log. So the coverage files are written and then thrown away with the runner. Nothing replaced coveralls — this PR only stops the readme claiming otherwise, and leaves the collection alone.

## The Travis badge

```markdown
[![Build Status on Travis-CI](https://travis-ci.org/duplicati/duplicati.svg?branch=master)](...)
```

There is no `.travis.yml` in the tree and no mention of Travis under `.github`. The CI is GitHub Actions.

**A GitHub Actions badge cannot stand in for it as things are.** Every workflow is triggered the same way:

| workflow | `on:` |
|---|---|
| `tests.yml` | `[pull_request, workflow_dispatch]` |
| `build-packages.yml` | `[pull_request, workflow_dispatch]` |
| `backendtests.yml` | `[pull_request, workflow_dispatch]` |
| `secretprovidertests.yml` | `[pull_request, workflow_dispatch]` |
| `stale.yml` | `schedule` |

Nothing runs on a push to `master`, and an Actions badge reports the most recent run on the default branch. Asking the API for `tests.yml` runs on `master` returns **two**, both `pull_request` events from September 2025, and both failed:

```
pull_request  failure  2025-09-19  Minor updates to docs and comments
pull_request  failure  2025-09-11  fix(S3): validate endpoint does not contain path
```

A badge added today would sit on that, showing a year-old failure as the current state — worse than showing nothing.

Adding `push: branches: [master]` to a workflow would make a badge work, but that is a change to when the CI runs, not to the readme: it would put the unit tests, three platforms at 35 to 45 minutes each, and the integration tests on every merge. That belongs to whoever owns the CI budget, so this PR does not touch it.

## Changes

The two badges come out of `README.md`, `README.ja-JP.md` and `README.zh-CN.md`. The backers, sponsors, license and Gurubase badges are untouched, and no other line in any of the three files changes.

## Noticed while reading, not changed here

`build-packages.yml` and `tests.yml` are both named `Tests`. That is already ambiguous in a pull request's check list, and it would make a badge ambiguous too if one were ever added.
