### PR TITLE
Say that --synchronous-upload no longer does anything

### DIFF
--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -445,7 +445,7 @@ namespace Duplicati.Library.Main
             new CommandLineArgument("retry-delay", CommandLineArgument.ArgumentType.Timespan, Strings.Options.RetrydelayShort, Strings.Options.RetrydelayLong, DEFAULT_RETRY_DELAY),
             new CommandLineArgument("retry-with-exponential-backoff", CommandLineArgument.ArgumentType.Boolean, Strings.Options.RetrywithexponentialbackoffShort, Strings.Options.RetrywithexponentialbackoffLong, "false"),
 
-            new CommandLineArgument("synchronous-upload", CommandLineArgument.ArgumentType.Boolean, Strings.Options.SynchronousuploadShort, Strings.Options.SynchronousuploadLong, "false"),
+            new CommandLineArgument("synchronous-upload", CommandLineArgument.ArgumentType.Boolean, Strings.Options.SynchronousuploadShort, Strings.Options.SynchronousuploadLong, "false", null, null, Strings.Options.SynchronousuploadDeprecated("asynchronous-upload-limit")),
             new CommandLineArgument("asynchronous-upload-limit", CommandLineArgument.ArgumentType.Integer, Strings.Options.AsynchronousconcurrentuploadlimitShort, Strings.Options.AsynchronousconcurrentuploadlimitLong, DEFAULT_ASYNCHRONOUS_UPLOAD_LIMIT.ToString(), ["asynchronous-concurrent-upload-limit"]),
             new CommandLineArgument("asynchronous-upload-folder", CommandLineArgument.ArgumentType.Path, Strings.Options.AsynchronousuploadfolderShort, Strings.Options.AsynchronousuploadfolderLong, System.IO.Path.GetTempPath()),
 
@@ -932,11 +932,6 @@ namespace Duplicati.Library.Main
         /// Gets the number of time to retry transmission if it fails
         /// </summary>
         public int NumberOfRetries => Math.Max(0, GetInt("number-of-retries", DEFAULT_NUMBER_OF_RETRIES));
-
-        /// <summary>
-        /// A value indicating if backups are transmitted on a separate thread
-        /// </summary>
-        public bool SynchronousUpload => GetBool("synchronous-upload");
 
         /// <summary>
         /// A value indicating if system is allowed to enter sleep power states during backup/restore

--- a/Duplicati/Library/Main/Strings.cs
+++ b/Duplicati/Library/Main/Strings.cs
@@ -163,6 +163,7 @@ namespace Duplicati.Library.Main.Strings
         public static string ListverifyuploadsShort { get { return LC.L(@"Verify uploads by listing contents"); } }
         public static string SynchronousuploadLong { get { return LC.L(@"Disables uploading multiple files concurrently to preserve bandwith. This will have the same effect as setting --asynchronous-upload-limit=1 but additionally wait for related uploads. The volume that is being created is not counted in the upload limit."); } }
         public static string SynchronousuploadShort { get { return LC.L(@"Upload files synchronously"); } }
+        public static string SynchronousuploadDeprecated(string alternativeOptionName) { return LC.L(@"The option --{0} is no longer used and has been deprecated. To limit how many uploads run at once, set the option --{1}.", "synchronous-upload", alternativeOptionName); }
         public static string NoconnectionreuseLong { get { return LC.L(@"Duplicati will attempt to perform multiple operations on a single connection, as this avoids repeated login attempts, and thus speeds up the process. Use this option to ensure that each operation is performed on a seperate connection."); } }
         public static string NoconnectionreuseShort { get { return LC.L(@"Do not re-use connections"); } }
         public static string DebugretryerrorsLong { get { return LC.L(@"When an error occurs, Duplicati will silently retry, and only report the number of retries. Enable this option to have the error messages displayed when a retry is performed."); } }

--- a/Duplicati/UnitTest/CompactBlockVolumeIdConstraintTests.cs
+++ b/Duplicati/UnitTest/CompactBlockVolumeIdConstraintTests.cs
@@ -46,8 +46,7 @@ namespace Duplicati.UnitTest
                 ["backup-test-samples"] = "0",
                 ["number-of-retries"] = "0",
                 ["dblock-size"] = "10KB",
-                ["blocksize"] = "1KB",
-                ["synchronous-upload"] = "true"
+                ["blocksize"] = "1KB"
             };
 
             string target = "file://" + TARGETFOLDER;
@@ -103,7 +102,6 @@ namespace Duplicati.UnitTest
                 ["number-of-retries"] = "0",
                 ["dblock-size"] = "10KB",
                 ["blocksize"] = "1KB",
-                ["synchronous-upload"] = "true",
                 ["no-auto-compact"] = "true"
             };
 

--- a/Duplicati/UnitTest/DeprecatedUploadOptionTests.cs
+++ b/Duplicati/UnitTest/DeprecatedUploadOptionTests.cs
@@ -1,0 +1,96 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Nothing reads --synchronous-upload. It is still offered in the help and
+    /// still accepted, so setting it looked like it did something, and the only
+    /// way to find out otherwise was to read Options.cs.
+    /// </summary>
+    public class DeprecatedUploadOptionTests : BasicSetupHelper
+    {
+        private async Task<IBackupResults> BackupWith(Dictionary<string, string> extra)
+        {
+            File.WriteAllBytes(Path.Combine(this.DATAFOLDER, "file"), new byte[] { 0, 1, 2 });
+
+            var options = new Dictionary<string, string>(this.TestOptions);
+            foreach (var (key, value) in extra)
+                options[key] = value;
+
+            using var c = new Controller("file://" + this.TARGETFOLDER, options, null);
+            return await c.BackupAsync(new[] { this.DATAFOLDER });
+        }
+
+        [Test]
+        [Category("Options")]
+        public async Task SettingSynchronousUploadSaysItDoesNothingAsync()
+        {
+            var results = await BackupWith(new Dictionary<string, string> { ["synchronous-upload"] = "true" });
+
+            Assert.AreEqual(0, results.Errors.Count());
+
+            var warnings = results.Warnings.Where(x => x.Contains("synchronous-upload")).ToList();
+            Assert.AreEqual(1, warnings.Count, string.Join("; ", results.Warnings));
+            Assert.IsTrue(warnings[0].Contains("no longer used"), warnings[0]);
+        }
+
+        [Test]
+        [Category("Options")]
+        public async Task TheOptionIsStillAcceptedAsync()
+        {
+            // Removing it outright would fail every existing configuration that
+            // sets it, so it stays offered and stays valid
+            var supported = new Options(new Dictionary<string, string?>()).SupportedCommands;
+            var argument = supported.FirstOrDefault(x => x.Name == "synchronous-upload");
+
+            Assert.IsNotNull(argument, "the option must remain, so old configurations still load");
+            Assert.IsTrue(argument!.Deprecated);
+
+            var results = await BackupWith(new Dictionary<string, string> { ["synchronous-upload"] = "true" });
+            Assert.AreEqual(0, results.Errors.Count());
+        }
+
+        [Test]
+        [Category("Options")]
+        public async Task AnOptionThatStillWorksIsNotWarnedAboutAsync()
+        {
+            // asynchronous-upload-limit reads the same way and is still used, by
+            // BackendManager.Handler, so it must not be caught by this
+            var results = await BackupWith(new Dictionary<string, string> { ["asynchronous-upload-limit"] = "2" });
+
+            Assert.AreEqual(0, results.Errors.Count());
+            Assert.AreEqual(0, results.Warnings.Count(x => x.Contains("no longer used")),
+                string.Join("; ", results.Warnings));
+        }
+    }
+}


### PR DESCRIPTION
`--synchronous-upload` is offered in the help, accepted from a configuration, and does nothing.

Its name appears in the tree four times, and that is all:

| where | |
|---|---|
| `Options.cs:448` | the line that advertises it |
| `Options.cs:939` | `public bool SynchronousUpload => GetBool("synchronous-upload");` |
| `CompactBlockVolumeIdConstraintTests.cs:50, 106` | two lines that set it to `true` |

`Options.SynchronousUpload` has no reader anywhere in the tree. Deleting it compiles, which is a better proof of that than any grep.

So a user who sets this to serialise their uploads gets concurrent uploads, and the only way to discover that is to read `Options.cs`.

## Deprecated, not removed

Removing it would fail every existing configuration that sets it. Marking it deprecated keeps it accepted and gets [`Controller`](https://github.com/duplicati/duplicati/blob/43f27b13706107b1676ef643e61c066be8f87d68/Duplicati/Library/Main/Controller.cs#L1204-L1220) to warn that it has no effect — which is where the user finds out. That is what `verbose`, `file-read-buffer-size`, `disable-filepath-cache` and four others already do here.

The property goes, because none of those seven keeps one.

The message names `--asynchronous-upload-limit`. That option **is** still read, by `BackendManager.Handler`, and `--synchronous-upload`'s own description already offers it as the near equivalent:

> This will have the same effect as setting --asynchronous-upload-limit=1 but additionally wait for related uploads.

## The unit test believed it worked

`CompactBlockVolumeIdConstraintTests` set `synchronous-upload = true` in two configurations. Removing those lines changes nothing about what the test does — that is the point — but leaving them would now log a deprecation warning and would keep the next reader believing what the author believed.

## Tests

`Duplicati/UnitTest/DeprecatedUploadOptionTests.cs`, following `ControllerTests`: one three-byte file, one backup, read `Warnings`.

| test | before |
|---|---|
| `SettingSynchronousUploadSaysItDoesNothingAsync` | **red** — no warning at all, the option was accepted in silence |
| `TheOptionIsStillAcceptedAsync` | **red** — `Deprecated` was false. Also pins that the option is still offered, so old configurations keep loading |
| `AnOptionThatStillWorksIsNotWarnedAboutAsync` | green before and after — `--asynchronous-upload-limit` must not get caught by this |

That third one is there for a reason. While looking for other options in this state I decided `--asynchronous-upload-limit` was dead too, from an automated sweep that had derived the property name wrong — it is `AsynchronousConcurrentUploadLimit`, and `BackendManager.Handler.cs:194` reads it. The sweep was discarded and this PR covers only what was verified by hand. The test keeps the mistake from being made again in code.

31 tests green across the new file, `OptionsTests` and `CompactBlockVolumeIdConstraintTests`. The solution builds with 0 errors and the same 3 warnings as master.
