### PR TITLE
Fix copying in `ijwhost.dll` on Windows

### DIFF
--- a/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
+++ b/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
@@ -26,4 +26,16 @@
   <ItemGroup>
     <ProjectReference Include="..\Interface\Duplicati.Library.Interface.csproj" />
   </ItemGroup>
+
+  <Target Name="IncludeIjwhostForVanara" BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <_Ijwhost Include="$(NetCoreTargetingPackRoot)\Microsoft.NETCore.App.Host.win-x64\$([System.String]::Copy('$(TargetFrameworkVersion)').TrimStart('v')).*\runtimes\win-x64\native\ijwhost.dll" />
+      <None Include="@(_Ijwhost)">
+        <Link>ijwhost.dll</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <PublishState>Included</PublishState>
+        <Visible>false</Visible>
+      </None>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/ReleaseBuilder/Build/Command.Compile.Verify.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Verify.cs
@@ -46,11 +46,15 @@ public static partial class Command
 
             string[] extras = target.OS switch
             {
-                OSType.Windows => ["Vanara.PInvoke.Kernel32.dll", "Vanara.PInvoke.VssApi.dll", "Duplicati.Library.WindowsModules.dll", "ijwhost.dll"],
+                OSType.Windows => ["Vanara.PInvoke.Kernel32.dll", "Vanara.PInvoke.VssApi.dll", "Duplicati.Library.WindowsModules.dll"],
                 OSType.MacOS => [],
                 OSType.Linux => [],
                 _ => throw new Exception($"Not supported OS: {target.OS}")
             };
+
+            // For now, Vanara is not supported on ARM
+            if (target.OS == OSType.Windows && target.Arch != ArchType.Arm64 && target.Arch != ArchType.Arm7)
+                extras = extras.Append("ijwhost.dll").ToArray();
 
             // Random sample of files we expect
             string[] probeFiles = [

--- a/ReleaseBuilder/Build/Command.Compile.Verify.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Verify.cs
@@ -46,7 +46,7 @@ public static partial class Command
 
             string[] extras = target.OS switch
             {
-                OSType.Windows => ["Vanara.PInvoke.Kernel32.dll", "Vanara.PInvoke.VssApi.dll", "Duplicati.Library.WindowsModules.dll"],
+                OSType.Windows => ["Vanara.PInvoke.Kernel32.dll", "Vanara.PInvoke.VssApi.dll", "Duplicati.Library.WindowsModules.dll", "ijwhost.dll"],
                 OSType.MacOS => [],
                 OSType.Linux => [],
                 _ => throw new Exception($"Not supported OS: {target.OS}")


### PR DESCRIPTION
This fixes an issue where `ijwhost.dll` is not copied to the run folder when debugging on Windows.

Without this file, some VSS related operations can fail with "Module not found" or "File not found".

It has no effect on release builds because they copy in the modules in different ways, but a check was added to ensure we do not ship without it.