### PR TITLE
Re-read the Filejump file list when a delete gets no answer

### DIFF
--- a/Duplicati/Library/Backend/Filejump/Filejump.cs
+++ b/Duplicati/Library/Backend/Filejump/Filejump.cs
@@ -155,6 +155,27 @@ namespace Duplicati.Library.Backend
             m_client.BaseAddress = new System.Uri(DEFAULT_API_URL);
         }
 
+        /// <summary>
+        /// Constructor that takes a preconfigured message handler, used for testing
+        /// </summary>
+        /// <param name="url">The backend url</param>
+        /// <param name="options">The options to use</param>
+        /// <param name="handler">The message handler to send requests through</param>
+        internal Filejump(string url, Dictionary<string, string?> options, HttpMessageHandler handler)
+            : this(url, options)
+        {
+            m_client?.Dispose();
+            m_client = new HttpClient(handler)
+            {
+                Timeout = Timeout.InfiniteTimeSpan,
+                BaseAddress = new System.Uri(m_apiUrl)
+            };
+
+            // GetClient hands back the client it has while the token is still good, so
+            // dating the token forward keeps the login round-trip out of the tests
+            m_tokenExpiration = DateTime.UtcNow.Add(TOKEN_EXPIRATION);
+        }
+
         ///<inheritdoc/>
         public string ProtocolKey => "filejump";
         ///<inheritdoc/>
@@ -479,8 +500,23 @@ namespace Duplicati.Library.Backend
             using var request = new HttpRequestMessage(HttpMethod.Post, "file-entries/delete") { Content = json };
             request.Headers.Add("Accept", "application/json");
 
-            var response = await Utility.Utility.WithTimeout(m_timeoutOptions.ShortTimeout, token, ct => client.SendAsync(request, ct));
-            await EnsureSuccessStatusCode(response);
+            try
+            {
+                var response = await Utility.Utility.WithTimeout(m_timeoutOptions.ShortTimeout, token, ct => client.SendAsync(request, ct));
+                await EnsureSuccessStatusCode(response);
+            }
+            catch
+            {
+                // The request may have reached the server even though the answer did not
+                // reach us, which leaves the cache holding an id that no longer resolves.
+                // Drop the whole table rather than the one name, because an upload takes
+                // the table itself from GetCacheTable and would keep reading the old one.
+                m_fileEntryIdCache = null;
+                throw;
+            }
+
+            // The entry is gone, so the id must not be handed out again
+            m_fileEntryIdCache?.Remove(remotename);
         }
 
         ///<inheritdoc/>
@@ -576,13 +612,23 @@ namespace Duplicati.Library.Backend
             // The body is not always the shape this backend expects; a gateway in
             // front of the API answers with html, and some errors carry no message
             string? message = null;
+            ResponseEnvelope? envelope = null;
             try
             {
-                message = JsonSerializer.Deserialize<ResponseEnvelope>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })?.Message;
+                envelope = JsonSerializer.Deserialize<ResponseEnvelope>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                message = envelope?.Message;
             }
             catch (JsonException)
             {
             }
+
+            // Deleting an entry that is no longer there is reported as a validation
+            // failure on the ids rather than as a 404, and entryIds is only ever sent
+            // by DeleteAsync. BackendManager confirms this against a listing before it
+            // accepts the delete, so report the file as missing rather than deciding
+            // here that the delete succeeded.
+            if (envelope?.Errors?.ContainsKey("entryIds") == true)
+                throw new FileMissingException();
 
             if (!string.IsNullOrWhiteSpace(message))
                 throw new InvalidOperationException($"Request failed: {message}");
@@ -677,6 +723,10 @@ namespace Duplicati.Library.Backend
             /// The status of the response.
             /// </summary>
             public string? Status { get; set; }
+            /// <summary>
+            /// The validation errors, one list of messages per field.
+            /// </summary>
+            public Dictionary<string, string[]>? Errors { get; set; }
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/FilejumpDeleteRetryTests.cs
+++ b/Duplicati/UnitTest/FilejumpDeleteRetryTests.cs
@@ -1,0 +1,227 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A delete that reaches Filejump but whose answer does not reach us leaves the
+/// entry id in the file cache, and the lookup hands that id back without asking
+/// the server, so every retry deletes something that is already gone. This is the
+/// same defect that was fixed for the sibling backend in
+/// https://github.com/duplicati/duplicati/pull/7221 - the two speak the same API.
+/// </summary>
+[TestFixture]
+public class FilejumpDeleteRetryTests
+{
+    /// <summary>
+    /// An empty path puts the backend at the drive root, which needs no folder lookup
+    /// </summary>
+    private const string Url = "filejump://";
+
+    /// <summary>
+    /// The name the tests delete
+    /// </summary>
+    private const string RemoteName = "duplicati-b0123456789.dblock.zip.aes";
+
+    /// <summary>
+    /// A second name, used to tell a cache that lost one entry from a cache that
+    /// was thrown away whole
+    /// </summary>
+    private const string OtherName = "duplicati-b9876543210.dblock.zip.aes";
+
+    /// <summary>
+    /// The id the listing reports for the first name it holds
+    /// </summary>
+    private const long EntryId = 4711;
+
+    /// <summary>
+    /// What the API answers when the entry ids do not resolve. The shape is the one
+    /// the sibling backend was measured returning for the same endpoint.
+    /// </summary>
+    private const string EntryIdsInvalidBody =
+        "{\"message\":\"The selected entry ids is invalid.\"," +
+        "\"errors\":{\"entryIds\":[\"The selected entry ids is invalid.\"]}}";
+
+    /// <summary>
+    /// Serves a listing and a delete endpoint, and records what was asked of it
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        /// <summary>
+        /// The names the listing reports, changed by the tests to model the server
+        /// state after a delete that the client never saw the answer to
+        /// </summary>
+        public List<string> Listed { get; } = new() { RemoteName };
+
+        /// <summary>
+        /// Runs for each delete request, and decides what that request answers
+        /// </summary>
+        public Func<int, HttpResponseMessage>? DeleteResponse { get; set; }
+
+        /// <summary>
+        /// The number of listing requests received
+        /// </summary>
+        public int Listings { get; private set; }
+
+        /// <summary>
+        /// The body of every delete request received, in order
+        /// </summary>
+        public List<string> DeleteBodies { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path.EndsWith("/file-entries/delete", StringComparison.Ordinal))
+            {
+                DeleteBodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+                return DeleteResponse?.Invoke(DeleteBodies.Count) ?? Json(HttpStatusCode.OK, "{\"status\":\"success\"}");
+            }
+
+            if (path.EndsWith("/drive/file-entries", StringComparison.Ordinal))
+            {
+                Listings++;
+                var entries = Listed.Select((x, i) =>
+                    $"{{\"id\":{EntryId + i},\"name\":\"{x}\",\"type\":\"file\",\"url\":\"files/{EntryId + i}\",\"file_size\":17}}");
+                return Json(HttpStatusCode.OK,
+                    $"{{\"data\":[{string.Join(",", entries)}],\"current_page\":1,\"per_page\":100,\"next_page\":null}}");
+            }
+
+            return Json(HttpStatusCode.NotFound, "{\"message\":\"unexpected request\"}");
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body)
+            => new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static Filejump CreateBackend(StubHandler handler)
+        => new(Url, new Dictionary<string, string?> { ["api-token"] = "test-token" }, handler);
+
+    /// <summary>
+    /// Models the retry the caller performs: the first delete throws, the file is
+    /// gone on the server, and the second attempt has to find that out.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task RetryAfterFailedDeleteRelistsInsteadOfResendingTheStaleId()
+    {
+        using var handler = new StubHandler
+        {
+            // The request reaches the server, the answer does not reach us
+            DeleteResponse = attempt => attempt == 1 ? throw new TimeoutException("The operation has timed out.") : null!
+        };
+        using var backend = CreateBackend(handler);
+
+        Assert.CatchAsync<TimeoutException>(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+
+        Assert.AreEqual(1, handler.DeleteBodies.Count);
+        Assert.IsTrue(handler.DeleteBodies[0].Contains($"\"entryIds\":[{EntryId}]"), handler.DeleteBodies[0]);
+
+        // The first attempt removed it, so the server no longer reports it
+        handler.Listed.Clear();
+        var listingsBeforeRetry = handler.Listings;
+
+        await backend.DeleteAsync(RemoteName, CancellationToken.None);
+
+        Assert.Greater(handler.Listings, listingsBeforeRetry, "the retry has to ask the server again");
+        Assert.AreEqual(1, handler.DeleteBodies.Count, "the retry must not delete an entry id that is gone");
+    }
+
+    /// <summary>
+    /// Deleting an entry that is already gone is reported as a validation failure on
+    /// entryIds rather than as a 404, and BackendManager only runs its
+    /// list-and-confirm recovery for a FileMissingException.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public void EntryIdValidationErrorIsReportedAsFileMissing()
+    {
+        using var handler = new StubHandler
+        {
+            DeleteResponse = _ => new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+            {
+                Content = new StringContent(EntryIdsInvalidBody, Encoding.UTF8, "application/json")
+            }
+        };
+        using var backend = CreateBackend(handler);
+
+        Assert.CatchAsync<FileMissingException>(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A delete that the server answered has to leave the id behind, or the next
+    /// operation on that name asks for something that is no longer there.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task ASuccessfulDeleteForgetsThatName()
+    {
+        using var handler = new StubHandler();
+        using var backend = CreateBackend(handler);
+
+        await backend.DeleteAsync(RemoteName, CancellationToken.None);
+
+        // The server no longer holds it, and the name must not be served from the cache
+        handler.Listed.Clear();
+        await backend.DeleteAsync(RemoteName, CancellationToken.None);
+
+        Assert.AreEqual(1, handler.DeleteBodies.Count, "the id must not be sent a second time");
+    }
+
+    /// <summary>
+    /// Throwing the cache away is for the failure path only, so a delete that the
+    /// server answered has to leave the other names in place
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task SuccessfulDeleteKeepsTheRestOfTheCache()
+    {
+        using var handler = new StubHandler();
+        handler.Listed.Add(OtherName);
+        using var backend = CreateBackend(handler);
+
+        await backend.DeleteAsync(RemoteName, CancellationToken.None);
+        var listings = handler.Listings;
+
+        await backend.DeleteAsync(OtherName, CancellationToken.None);
+
+        Assert.AreEqual(listings, handler.Listings, "the second name was still cached");
+        Assert.AreEqual(2, handler.DeleteBodies.Count);
+        Assert.IsTrue(handler.DeleteBodies[1].Contains($"\"entryIds\":[{EntryId + 1}]"), handler.DeleteBodies[1]);
+    }
+}


### PR DESCRIPTION
A delete that reaches Filejump but whose answer does not reach us leaves that file permanently undeletable, and the name permanently unusable for an upload.

This is [#7221](https://github.com/duplicati/duplicati/pull/7221) again, in the sibling backend. The two speak the same API — `file-entries/delete`, `entryIds`, `deleteForever`, an envelope with `message` — and Filejump was left in the state Drime was in before that PR, minus one guard it did have.

## What happens

`FindFileEntryIdAsync` hands back a cached entry without asking the server:

```csharp
if (m_fileEntryIdCache != null && m_fileEntryIdCache.TryGetValue(name, out var entry))
    return entry;
```

and `DeleteAsync` never touches the cache at all — not on failure, and not on success either:

```csharp
var response = await Utility.Utility.WithTimeout(m_timeoutOptions.ShortTimeout, token, ct => client.SendAsync(request, ct));
await EnsureSuccessStatusCode(response);
```

So a request that throws leaves the dead id cached and every retry deletes it again. The API answers that with a validation error on `entryIds` rather than a 404, so it does not arrive as a `FileMissingException` and [`BackendManager.DeleteOperation`](https://github.com/duplicati/duplicati/blob/2b59903326b31d105a51fc1072e842710e6915e3/Duplicati/Library/Main/Backend/BackendManager.DeleteOperation.cs#L166-L192) never runs the listing that would confirm the delete had worked.

Uploads are caught by it too: `PutAsync` deletes the name before it takes it.

## Every other backend with this cache already guards it

| backend | on a failed delete |
|---|---|
| `BoxBackend` | `catch { _fileCache.Clear(); throw; }` |
| `GoogleDrive` | `catch { m_filecache.Clear(); throw; }` |
| `MegaBackend` | `catch { m_filecache = null; throw; }` |
| `DrimeBackend` | added by #7221 |
| **`Filejump`** | **nothing** |

## Changes

- `DeleteAsync` drops the cache when the request fails, and forgets the name when it succeeds. It drops the whole table rather than the one key because `PutAsync` takes the table itself from `GetCacheTable` and would go on reading the old one — the same reasoning as #7221.
- `EnsureSuccessStatusCode` reports a validation failure on `entryIds` as a `FileMissingException`. `entryIds` is only ever sent by `DeleteAsync`, so there is no ambiguity. It throws rather than treating the delete as done, so `BackendManager` still confirms against a listing.
- `ResponseEnvelope` gains `Errors`, as `Dictionary<string, string[]>?`. It had only `message` and `status`, so the per-field errors were never read.

## How this was found, and what is not measured

By reading, after #7221 — not from a failure. **Filejump's own live tests have not failed**, but that is not evidence of correctness: the Filejump and Drime jobs are gated on secrets and are skipped in the runs I looked at, so the bug would not be caught there.

What is measured is the Drime side. Its CI log carried the whole sequence — two 30-second timeouts and then a definite answer from the server:

```
[12:28:24 008] Deleting file 17
[12:28:55 010] Operation failed with exception, 2 retries left     <- 31 s
[12:29:25 011] Operation failed with exception, 1 retries left     <- 30 s
[12:29:39 799] {"message":"The selected entry ids is invalid.", ...}
```

The error body above is Drime's, on the same endpoint with the same payload. If Filejump words it differently, the `FileMissingException` mapping simply will not fire there — the cache fix, which is the substantive half, does not depend on it.

## Tests

`Duplicati/UnitTest/FilejumpDeleteRetryTests.cs`, following `DrimeDeleteRetryTests`. The stub serves the listing and the delete endpoint and records the body of every delete, so what is asserted is the request that goes out.

| test | before |
|---|---|
| `RetryAfterFailedDeleteRelistsInsteadOfResendingTheStaleId` | **red** — no second listing, the stale id went out again |
| `ASuccessfulDeleteForgetsThatName` | **red** — the id was sent twice |
| `EntryIdValidationErrorIsReportedAsFileMissing` | **red** — `InvalidOperationException` |
| `SuccessfulDeleteKeepsTheRestOfTheCache` | green before and after — a guard, so the failure path does not spread to the success path |

The two cache tests were confirmed red by putting only the cache change back and re-running: the `entryIds` test stayed green, which separates the two halves.

`DrimeDeleteRetryTests` still passes, unchanged. The solution builds with 0 errors and the same 3 warnings as master.

## Noticed, not changed

`PutAsync` has `cache.TryGetValue(remotename, out var _);` and discards the result — it looks like the remains of the `if (cache.ContainsKey(...))` guard Drime has around its delete-before-upload. It is harmless today, because `DeleteAsync` returns early when the name is absent.

The same cache is read by `GetAsync`, which can therefore download against a stale id. That is a separate change.
