### PR TITLE
Clear the Filen file cache when the write did not come back

### DIFF
--- a/Duplicati/Library/Backend/Filen/FilenClient.cs
+++ b/Duplicati/Library/Backend/Filen/FilenClient.cs
@@ -25,6 +25,8 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Duplicati.Library.Interface;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend.Filen;
 
 /// <summary>
@@ -175,6 +177,23 @@ public class FilenClient : IDisposable
         _baseUrl = baseUrl;
         _validUntil = DateTime.Now + TimeSpan.FromMinutes(50);
     }
+
+    /// <summary>
+    /// Builds a client around a transport and a key, without logging in, so that the
+    /// caching can be exercised. The listing decrypts names with the account keys, so
+    /// a test has to hold the same key to write a listing the client will read.
+    /// </summary>
+    /// <param name="httpClient">The client to send requests with</param>
+    /// <param name="baseUrl">The base url to send them to</param>
+    /// <param name="masterKey">The key the listing is encrypted with</param>
+    /// <returns>A client that talks to the given transport</returns>
+    internal static FilenClient CreateForTesting(HttpClient httpClient, string baseUrl, DerivedKey masterKey)
+        => new(httpClient, new FilenAuthResult
+        {
+            ApiKey = "test-api-key",
+            AccountMasterKey = masterKey,
+            MasterKeys = [masterKey]
+        }, baseUrl);
 
     /// <summary>
     /// The time the client is valid
@@ -476,8 +495,20 @@ public class FilenClient : IDisposable
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _authResult.ApiKey);
         request.Content = JsonContent.Create(new { uuid = fileUuid });
 
-        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        await ExtractDataFromResponse<string?>(response, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            await ExtractDataFromResponse<string?>(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The request may have reached the server even though the answer did not
+            // reach us, and then the cache holds a uuid that no longer resolves. Which
+            // entry went stale cannot be told from here, so the table goes.
+            _cachedFiles.Clear();
+            throw;
+        }
+
         var key = _cachedFiles.FirstOrDefault(kv => kv.Value.Uuid == fileUuid).Key;
         if (string.IsNullOrWhiteSpace(key))
             _cachedFiles.Clear();
@@ -787,8 +818,18 @@ public class FilenClient : IDisposable
             metadata
         });
 
-        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        await ExtractDataFromResponse<string?>(response, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            await ExtractDataFromResponse<string?>(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // As with the delete: the rename may have landed, and then the name the
+            // cache still answers with is the one that is gone
+            _cachedFiles.Clear();
+            throw;
+        }
 
         // Update cache
         var key = _cachedFiles.FirstOrDefault(kv => kv.Value.Uuid == fileEntry.Uuid).Key;

--- a/Duplicati/UnitTest/FilenCacheInvalidationTests.cs
+++ b/Duplicati/UnitTest/FilenCacheInvalidationTests.cs
@@ -1,0 +1,217 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.Filen;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// The file cache is only tidied once the request has come back. A delete or a
+/// rename that reaches the server but whose answer does not reach us therefore
+/// leaves the old entry in place, and the lookup answers from it without asking
+/// the server again. The sibling backends had the same shape - see
+/// https://github.com/duplicati/duplicati/pull/7221.
+/// </summary>
+[TestFixture]
+public class FilenCacheInvalidationTests
+{
+    private const string BaseUrl = "https://gateway.invalid";
+    private const string FolderUuid = "11111111-1111-1111-1111-111111111111";
+    private const string FileUuid = "22222222-2222-2222-2222-222222222222";
+    private const string RemoteName = "duplicati-b0123456789.dblock.zip.aes";
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Serves the folder listing and the delete and rename endpoints, and counts
+    /// how often the folder was read
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly DerivedKey _key;
+
+        public StubHandler(DerivedKey key)
+            => _key = key;
+
+        /// <summary>
+        /// The number of folder listings served
+        /// </summary>
+        public int Listings { get; private set; }
+
+        /// <summary>
+        /// The number of delete or rename requests received
+        /// </summary>
+        public int Writes { get; private set; }
+
+        /// <summary>
+        /// Runs for each delete or rename, and decides what it answers
+        /// </summary>
+        public Func<int, HttpResponseMessage>? WriteResponse { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path.EndsWith("/dir/content", StringComparison.Ordinal))
+            {
+                Listings++;
+
+                // The client decrypts the metadata with the account key, so the
+                // listing has to be written with the same one
+                var metadata = _key.EncryptMetadata(JsonSerializer.Serialize(new
+                {
+                    name = RemoteName,
+                    size = 17,
+                    mime = "application/octet-stream",
+                    key = "0123456789abcdef0123456789abcdef",
+                    lastModified = 1700000000000L,
+                    creation = 1700000000000L
+                }));
+
+                var file = JsonSerializer.Serialize(new
+                {
+                    uuid = FileUuid,
+                    metadata,
+                    rm = "rm",
+                    chunks = 1,
+                    size = 17,
+                    bucket = "bucket",
+                    region = "region",
+                    parent = FolderUuid,
+                    version = 2
+                });
+
+                return Task.FromResult(Json($"{{\"status\":true,\"data\":{{\"folders\":[],\"uploads\":[{file}]}}}}"));
+            }
+
+            Writes++;
+            return Task.FromResult(WriteResponse?.Invoke(Writes) ?? Json("{\"status\":true,\"data\":null}"));
+        }
+
+        private static HttpResponseMessage Json(string body)
+            => new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static (FilenClient Client, StubHandler Handler) Create(Func<int, HttpResponseMessage>? onWrite = null)
+    {
+        var key = DerivedKey.Create("0123456789abcdef0123456789abcdef");
+        var handler = new StubHandler(key) { WriteResponse = onWrite };
+        var client = FilenClient.CreateForTesting(new HttpClient(handler), BaseUrl, key);
+        return (client, handler);
+    }
+
+    /// <summary>
+    /// The lookup has to be answered from the listing at least once, or none of
+    /// the rest of this is testing what it says it is
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task TheListingPopulatesTheCache()
+    {
+        var (client, handler) = Create();
+        using var _ = client;
+
+        var first = await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+        Assert.IsNotNull(first);
+        Assert.AreEqual(FileUuid, first!.Uuid);
+        Assert.AreEqual(1, handler.Listings);
+
+        await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+        Assert.AreEqual(1, handler.Listings, "the second lookup came from the cache");
+    }
+
+    /// <summary>
+    /// The delete may have landed even though the answer did not arrive, so the
+    /// uuid the cache holds cannot be trusted afterwards
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task ARetryAfterAFailedDeleteAsksTheServerAgain()
+    {
+        var (client, handler) = Create(attempt =>
+            attempt == 1 ? throw new TimeoutException("The operation has timed out.") : null!);
+        using var _ = client;
+
+        await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+        Assert.AreEqual(1, handler.Listings);
+
+        Assert.CatchAsync<TimeoutException>(async () =>
+            await client.DeleteFileAsync(FileUuid, true, CancellationToken.None));
+
+        await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+
+        Assert.AreEqual(2, handler.Listings, "the lookup after a failed delete has to ask the server");
+    }
+
+    /// <summary>
+    /// Throwing the cache away is for the failure path; a delete that was answered
+    /// still just forgets the one name
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task ASuccessfulDeleteStillForgetsTheName()
+    {
+        var (client, handler) = Create();
+        using var _ = client;
+
+        await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+        await client.DeleteFileAsync(FileUuid, true, CancellationToken.None);
+
+        await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+
+        Assert.AreEqual(2, handler.Listings, "the deleted name must not be answered from the cache");
+    }
+
+    /// <summary>
+    /// A rename that landed leaves the cache answering with the name that is gone
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task AFailedRenameDoesNotLeaveTheOldNameCached()
+    {
+        var (client, handler) = Create(attempt =>
+            attempt == 1 ? throw new TimeoutException("The operation has timed out.") : null!);
+        using var _ = client;
+
+        var entry = await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+        Assert.IsNotNull(entry);
+        Assert.AreEqual(1, handler.Listings);
+
+        Assert.CatchAsync<TimeoutException>(async () =>
+            await client.RenameFileAsync(entry!, "duplicati-b9999999999.dblock.zip.aes", CancellationToken.None));
+
+        await client.GetFileEntryAsync(FolderUuid, RemoteName, Timeout, CancellationToken.None);
+
+        Assert.AreEqual(2, handler.Listings, "the lookup after a failed rename has to ask the server");
+    }
+}


### PR DESCRIPTION
`FilenClient` tidies its file cache only once the request has come back, so a delete or a rename that reaches the server but whose answer does not reach us leaves the old entry in place. The lookup then answers from it without asking the server:

```csharp
var f = _cachedFiles.GetValueOrDefault($"{folderUuid}:{filename}");
if (f is not null)
    return f;
```

Both write paths have the same shape — the cleanup sits after the call that throws:

```csharp
await ExtractDataFromResponse<string?>(response, cancellationToken);   // throws here
var key = _cachedFiles.FirstOrDefault(kv => kv.Value.Uuid == fileUuid).Key;
...
```

`ExtractDataFromResponse` throws twice over: `EnsureSuccessStatusCode()` for the transport, and a `UserInformationException` when the envelope reports `status: false`. Neither reaches the cleanup.

So a delete that timed out on the way out leaves a uuid behind that no longer resolves, and every retry sends it again. A rename that landed leaves the cache answering with the name that is gone.

## This is the last of them

I read every backend that keeps a name-to-id cache:

| backend | on a failed write |
|---|---|
| `BoxBackend` | `catch { _fileCache.Clear(); throw; }` |
| `GoogleDrive` | `catch { m_filecache.Clear(); throw; }` |
| `MegaBackend` | `catch { m_filecache = null; throw; }` |
| `DrimeBackend` | added by [#7221](https://github.com/duplicati/duplicati/pull/7221) |
| `Filejump` | added by [#7240](https://github.com/duplicati/duplicati/pull/7240) |
| **`FilenClient`** | **nothing** |

## Changes

`Duplicati/Library/Backend/Filen/FilenClient.cs` only.

- `DeleteFileAsync` and `RenameFileAsync` clear the cache when the request fails. The existing cleanup on the success path is untouched.
- `Clear()` rather than removing the one key: the table is keyed by `folderUuid:name` and the entry is found by scanning the values for a uuid, so after a failure there is nothing reliable to key on. Box, GoogleDrive and Mega all clear for the same reason.

## What is not in this

**No mapping of the API's error to `FileMissingException`.** For Drime the exact body was in a CI log, so #7221 could key on it. Filen's is not measured, and guessing at it would be a change I cannot check.

**Filen's own live tests have not failed.** That is not evidence of correctness: the Filen job is gated on secrets and skipped in the runs I looked at, so this would not be caught there either. What is measured is the Drime side, where the whole sequence — two 30-second timeouts and then a definite answer that the id was invalid — is in the log.

## The seam is bigger here, and why

The other two backends only needed a constructor taking an `HttpMessageHandler`. That is not enough here: the listing decrypts names with the account keys, so replacing the transport alone cannot fill the cache, and the cache is the thing under test.

So `FilenClient` gains an `internal static CreateForTesting(HttpClient, string, DerivedKey)` that builds the client without logging in, and the assembly gains `InternalsVisibleTo("Duplicati.UnitTest")`. `DerivedKey.Create` and `DerivedKey.EncryptMetadata` are already public, so the test writes its listing with the same key and the same encryption the client will read it with — nothing about the decryption is faked.

If that is more than you want in the product for a test's sake, the alternative is the same two `catch` blocks with no test at all; say so and I will cut it back.

## Tests

`Duplicati/UnitTest/FilenCacheInvalidationTests.cs`. The stub serves `/v3/dir/content` and the delete and rename endpoints, and counts the listings.

| test | with the guards taken out |
|---|---|
| `ARetryAfterAFailedDeleteAsksTheServerAgain` | **red** — one listing, so the stale uuid was served from the cache |
| `AFailedRenameDoesNotLeaveTheOldNameCached` | **red** — same |
| `TheListingPopulatesTheCache` | green — the cache still works, this is not a change that disables it |
| `ASuccessfulDeleteStillForgetsTheName` | green — the success path is untouched |

The two greens are the point of taking the guards out again to watch the red: only the failure path moved.

The solution builds with 0 errors and the same 3 warnings as master.
