### PR TITLE
Take a source given as a bare drive to be the root of it

### DIFF
--- a/Duplicati/Library/Common/IO/Util.cs
+++ b/Duplicati/Library/Common/IO/Util.cs
@@ -172,6 +172,23 @@ namespace Duplicati.Library.Common.IO
             return !path.EndsWith(separator, StringComparison.Ordinal) ? path + separator : path;
         }
 
+        /// <summary>
+        /// Expands a bare Windows drive specification ("C:") to the root of that drive ("C:\").
+        /// A bare drive specification is drive-relative, so Path.GetFullPath answers with the
+        /// process' current directory on that drive rather than with the root of it.
+        /// </summary>
+        /// <param name="path">The path to expand</param>
+        /// <returns>The root of the drive when the path is a bare drive specification, otherwise the path unchanged</returns>
+        public static string ExpandBareDriveRoot(string path)
+        {
+            if (!OperatingSystem.IsWindows() || string.IsNullOrEmpty(path))
+                return path;
+
+            return path.Length == 2 && path[1] == ':' && char.IsLetter(path[0])
+                ? path + DirectorySeparatorString
+                : path;
+        }
+
 
         /// <summary>
         /// Guesses the directory separator from the path

--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -1302,7 +1302,7 @@ namespace Duplicati.Library.Main
         /// <param name="filter">The filter.</param>
         /// <param name="options">The options.</param>
         /// <returns>The expanded and filtered sources.</returns>
-        private static (string[] Sources, IFilter Filter) ExpandInputSources(string[] inputsources, IFilter filter, Options options)
+        internal static (string[] Sources, IFilter Filter) ExpandInputSources(string[] inputsources, IFilter filter, Options options)
         {
             if (inputsources == null || inputsources.Length == 0)
                 throw new UserInformationException(Strings.Controller.NoSourceFoldersError, "NoSourceFolders");
@@ -1395,8 +1395,9 @@ namespace Duplicati.Library.Main
 
                     try
                     {
-                        // TODO: This expands "C:" to CWD, but not C:\
-                        source = Path.GetFullPath(expandedSource);
+                        // A bare drive is drive-relative, so GetFullPath would answer with
+                        // the current directory on that drive instead of the root of it
+                        source = Path.GetFullPath(Util.ExpandBareDriveRoot(expandedSource));
                     }
                     catch (Exception ex)
                     {

--- a/Duplicati/UnitTest/SourcePathExpansionTests.cs
+++ b/Duplicati/UnitTest/SourcePathExpansionTests.cs
@@ -1,0 +1,210 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Duplicati.Library.Common.IO;
+using Duplicati.Library.Main;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A bare drive specification such as "C:" is drive-relative on Windows, so
+/// Path.GetFullPath answers with the process' current directory on that drive
+/// instead of the root of it. A source given that way was silently replaced by
+/// whatever directory the process happened to be in, and the drive wildcard
+/// "*:" builds that shape itself: 'C' + ":" is what it hands on.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class SourcePathExpansionTests
+{
+    /// <summary>
+    /// The drive of the given path as a bare specification ("C:"), or null when
+    /// the path does not sit on a lettered drive
+    /// </summary>
+    /// <param name="path">The path to read the drive from</param>
+    /// <returns>The bare drive specification, or null</returns>
+    private static string? DriveSpecificationOf(string path)
+    {
+        var root = Path.GetPathRoot(path);
+        if (root == null || root.Length != 3 || root[1] != ':' || !char.IsLetter(root[0]))
+            return null;
+
+        return root.Substring(0, 2);
+    }
+
+    /// <summary>
+    /// Runs the expansion from a known current directory, because the fault is
+    /// that the current directory is what a bare drive resolves to
+    /// </summary>
+    /// <param name="inputsource">The source to expand</param>
+    /// <param name="from">The directory to stand in while expanding</param>
+    /// <returns>The expanded sources</returns>
+    private static string[] ExpandFrom(string inputsource, string from)
+    {
+        var previous = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(from);
+        try
+        {
+            return Controller.ExpandInputSources([inputsource], null, new Options(new Dictionary<string, string?>())).Sources;
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(previous);
+        }
+    }
+
+    [Test]
+    [Category("Controller")]
+    public void ABareDriveMeansTheRootOfIt()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("A drive specification is only one on Windows.");
+            return;
+        }
+
+        Assert.AreEqual(@"C:\", Util.ExpandBareDriveRoot("C:"));
+        Assert.AreEqual(@"c:\", Util.ExpandBareDriveRoot("c:"));
+    }
+
+    [Test]
+    [Category("Controller")]
+    public void APathThatAlreadySaysWhereItStartsIsLeftAlone()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("A drive specification is only one on Windows.");
+            return;
+        }
+
+        Assert.AreEqual(@"C:\", Util.ExpandBareDriveRoot(@"C:\"));
+        Assert.AreEqual(@"C:\Users", Util.ExpandBareDriveRoot(@"C:\Users"));
+        Assert.AreEqual(@"\\server\share", Util.ExpandBareDriveRoot(@"\\server\share"));
+    }
+
+    /// <summary>
+    /// "C:foo" is drive-relative as well, but it is also a plausible thing to
+    /// mean, so it is left as it is
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public void APathWithSomethingAfterTheDriveIsLeftAlone()
+    {
+        Assert.AreEqual("C:foo", Util.ExpandBareDriveRoot("C:foo"));
+        Assert.AreEqual("foo", Util.ExpandBareDriveRoot("foo"));
+        Assert.AreEqual("", Util.ExpandBareDriveRoot(""));
+    }
+
+    [Test]
+    [Category("Controller")]
+    public void ElsewhereADriveSpecificationIsAnOrdinaryName()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("This is about the platforms where a colon is an ordinary character.");
+            return;
+        }
+
+        Assert.AreEqual("C:", Util.ExpandBareDriveRoot("C:"));
+    }
+
+    /// <summary>
+    /// What all of the above is for: a source given as a bare drive has to reach
+    /// the backup as the root of that drive, not as wherever the process stands
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public void ASourceGivenAsABareDriveExpandsToTheDriveRoot()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("A drive specification is only one on Windows.");
+            return;
+        }
+
+        var standIn = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var drive = DriveSpecificationOf(standIn);
+        if (drive == null)
+        {
+            Assert.Ignore("The temporary folder is not on a lettered drive.");
+            return;
+        }
+
+        Directory.CreateDirectory(standIn);
+        try
+        {
+            var sources = ExpandFrom(drive, standIn);
+
+            Assert.AreEqual(1, sources.Length);
+            Assert.AreEqual(drive + Path.DirectorySeparatorChar, sources[0]);
+        }
+        finally
+        {
+            Directory.Delete(standIn, true);
+        }
+    }
+
+    /// <summary>
+    /// Green before and after: the ordinary spellings were never affected, so a
+    /// failure here would mean the change reached further than the fault did
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public void TheOrdinarySpellingsAreUnchanged()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("A drive specification is only one on Windows.");
+            return;
+        }
+
+        var standIn = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var drive = DriveSpecificationOf(standIn);
+        if (drive == null)
+        {
+            Assert.Ignore("The temporary folder is not on a lettered drive.");
+            return;
+        }
+
+        Directory.CreateDirectory(standIn);
+        try
+        {
+            var root = drive + Path.DirectorySeparatorChar;
+            Assert.AreEqual(root, ExpandFrom(root, standIn).Single());
+
+            var named = Util.AppendDirSeparator(standIn);
+            Assert.AreEqual(named, ExpandFrom(named, standIn).Single());
+            Assert.AreEqual(named, ExpandFrom(standIn, standIn).Single());
+        }
+        finally
+        {
+            Directory.Delete(standIn, true);
+        }
+    }
+}


### PR DESCRIPTION
A source given as a bare drive is silently replaced by whatever directory the process happens to be standing in.

On Windows `C:` is *drive-relative*, not the root of C:. `Path.GetFullPath` resolves it against the process' current directory on that drive, and [`ExpandInputSources`](https://github.com/duplicati/duplicati/blob/330774f039d62bd0eff0aec62cf2be31df834fec/Duplicati/Library/Main/Controller.cs#L1398-L1399) took the answer as given:

```csharp
// TODO: This expands "C:" to CWD, but not C:\
source = Path.GetFullPath(expandedSource);
```

The directory it lands on exists, so `foundAnyPaths` is set and it goes into the sources. **No warning is raised.** The backup runs and stores a different tree than the one that was asked for.

Measured on .NET 10, standing in `C:\Users\...\duplicati`:

| input | `IsPathFullyQualified` | `GetFullPath` |
|---|---|---|
| `C:` | False | `C:\Users\...\duplicati` |
| `c:` | False | same |
| `C:\` | True | `C:\` |
| `D:` | False | `D:\` |

`C:` and `D:` give different *kinds* of answer, and that is the shape of the fault: only a drive the process has a current directory on can go wrong.

## The drive wildcard builds this shape itself

This is not only about what someone types. [The `*:` expansion](https://github.com/duplicati/duplicati/blob/330774f039d62bd0eff0aec62cf2be31df834fec/Duplicati/Library/Main/Controller.cs#L1326-L1329) produces the bare form:

```csharp
string sourcePath = inputsource.Substring(1);          // "*:" -> ":"
string expandedSource = drive.Name[0] + sourcePath;    // 'C' + ":" = "C:"
```

So `--source=*:` is wrong for exactly one drive — the one the process is running from.

The volume-GUID route a few lines below can end the same way: `Win32_Volume.DriveLetter` is a bare `C:`, so `\\?\Volume{...}` with nothing after it becomes `C:` too. I have not measured that one — the fix covers it either way.

## Why not `SystemIO.PathGetFullPath`

It does not help. `AddExtendedDevicePathPrefix` only prefixes a path that `IsPathFullyQualified` accepts, and `C:` is not fully qualified, so it passes through untouched and lands on the same `Path.GetFullPath("C:")`. The normalisation has to happen before the call.

## Changes

**`Duplicati/Library/Common/IO/Util.cs`** — a new `ExpandBareDriveRoot`, next to `AppendDirSeparator`. It expands `X:` to `X:\`, returns everything else unchanged, and is the identity outside Windows, where a colon is an ordinary character in a name.

The test for a bare drive is the one this repository already uses: [`Utility.GetParent`](https://github.com/duplicati/duplicati/blob/330774f039d62bd0eff0aec62cf2be31df834fec/Duplicati/Library/Utility/Utility.cs#L453) appends a separator under the same condition.

**`Duplicati/Library/Main/Controller.cs`** — the call goes through the helper, and the TODO is gone.

`C:foo` is left alone. It is drive-relative too, but it is also a plausible thing to mean, and nothing here needs it.

The wildcard at line 1329 is unchanged: one place is enough to cover both routes, and the log line above it should keep showing what was asked for.

## Tests

`Duplicati/UnitTest/SourcePathExpansionTests.cs`. The helper is covered directly, and the point of the change is covered through `ExpandInputSources` itself.

With the helper call taken back out of `Controller.cs`, exactly one test fails, and it fails with the symptom:

```
Expected: "C:\"
But was:  "C:\Users\...\AppData\Local\Temp\jf1p0job.23l\"
```

That is the directory the test was standing in. `Failed: 1, Passed: 4, Skipped: 1`; with the call back in, `Failed: 0, Passed: 5, Skipped: 1`.

`TheOrdinarySpellingsAreUnchanged` is green in both states on purpose — a drive root, and a named folder with and without a trailing separator, all come through as before. Only the failing path moved.

The test sets the current directory to a fresh temp folder and restores it, rather than reading the ambient one. **Without that it could pass without the fix**: the runner's workspace is on `D:`, and a drive the process has never set a current directory on answers with its own root — as `D:` does in the table above. The fixture is `[NonParallelizable]` because it moves the process' current directory.

The Windows-only cases report as skipped on Linux and macOS.

The solution builds with 0 errors and the same 3 warnings as master (all CS0618 in the DBus codegen).

## What is not measured

I have not reproduced this against an installed Windows service or through the UI. The evidence is the measurement above, the code path, and the TODO that was already sitting on the line.

## The one thing that widened

`ExpandInputSources` went from `private` to `internal`, which is what lets the test drive the real function instead of a hand-fed helper. Nothing else was needed — `Duplicati.Library.Main` already carries `InternalsVisibleTo("Duplicati.UnitTest")`, from `Database/Local/LocalDatabase.cs`.

If you would rather it stayed private, the alternative is to keep only the helper tests and drop the two that call `ExpandInputSources`; say so and I will cut it back.
