### PR TITLE
Remove redundant distinct

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
@@ -207,10 +207,10 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExecuteNonQueryAsync(@"
                     DELETE FROM ""Blockset""
                     WHERE ""ID"" NOT IN (
-                        SELECT DISTINCT ""BlocksetID""
+                        SELECT ""BlocksetID""
                         FROM ""FileLookup""
                         UNION
-                            SELECT DISTINCT ""BlocksetID""
+                            SELECT ""BlocksetID""
                             FROM ""Metadataset""
                     )
                 ", token)
@@ -247,10 +247,10 @@ namespace Duplicati.Library.Main.Database.Local
                         ""VolumeID""
                     FROM ""Block""
                     WHERE ""ID"" NOT IN (
-                        SELECT DISTINCT ""BlockID"" AS ""BlockID""
+                        SELECT ""BlockID"" AS ""BlockID""
                         FROM ""BlocksetEntry""
                         UNION
-                            SELECT DISTINCT ""ID""
+                            SELECT ""ID""
                             FROM
                                 ""Block"",
                                 ""BlocklistHash""
@@ -262,10 +262,10 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExecuteNonQueryAsync(@"
                     DELETE FROM ""Block""
                     WHERE ""ID"" NOT IN (
-                        SELECT DISTINCT ""BlockID""
+                        SELECT ""BlockID""
                         FROM ""BlocksetEntry""
                         UNION
-                            SELECT DISTINCT ""ID""
+                            SELECT ""ID""
                             FROM
                                 ""Block"",
                                 ""BlocklistHash""

--- a/Duplicati/Library/Main/Database/Local/LocalPurgeDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalPurgeDatabase.cs
@@ -402,7 +402,7 @@ namespace Duplicati.Library.Main.Database.Local
                 {
                     RemovedFileSize = await cmd.SetCommandAndParameters($@"
                         SELECT COALESCE(SUM(""Size""), 0) FROM (
-                            SELECT DISTINCT ""D"".""ID"", ""D"".""Size""
+                            SELECT ""D"".""ID"", ""D"".""Size""
                             FROM
                                 ""{m_tablename}"" ""A""
                                 INNER JOIN ""FileLookup"" ""B"" ON ""A"".""FileID"" = ""B"".""ID""
@@ -419,7 +419,7 @@ namespace Duplicati.Library.Main.Database.Local
 
                             UNION
 
-                            SELECT DISTINCT ""D"".""ID"", ""D"".""Size""
+                            SELECT ""D"".""ID"", ""D"".""Size""
                             FROM
                                 ""{m_tablename}"" ""A""
                                 INNER JOIN ""FileLookup"" ""B"" ON ""A"".""FileID"" = ""B"".""ID""


### PR DESCRIPTION
This is a follow up to the issue discovered in #7180.

When using "UNION" in an SQL statement, it guarantees uniqueness. The SQL queries were calling "DISTINCT" on the subtables prior to "UNION" which is measured to not be optimized away by SQLite.

This PR removes the "DISTINCT" calls for some (marginal) query speedup.