### PR TITLE
Fix broken GCS

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -241,7 +241,14 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
             await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, async ct
                 =>
             {
-                using var resp = await m_oauth.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
+                try
+                {
+                    using var resp = await m_oauth.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
+                }
+                catch (HttpRequestException hrex) when (hrex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    throw new FileMissingException($"File '{remotename}' not found.");
+                }
             }).ConfigureAwait(false);
         }
 

--- a/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleCloudStorage.cs
@@ -236,7 +236,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         }
         public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
         {
-            using var req = await m_oauth.CreateRequestAsync(WebApi.GoogleCloudStorage.DeleteUrl(m_bucket, Library.Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename)), HttpMethod.Delete, cancelToken);
+            using var req = await m_oauth.CreateRequestAsync(WebApi.GoogleCloudStorage.DeleteUrl(m_bucket, m_prefix + remotename), HttpMethod.Delete, cancelToken);
 
             await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, async ct
                 =>
@@ -254,7 +254,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task<DateTime?> GetObjectLockUntilAsync(string remotename, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename));
+            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, m_prefix + remotename);
 
             try
             {
@@ -276,7 +276,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task SetObjectLockUntilAsync(string remotename, DateTime lockUntilUtc, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename));
+            var url = WebApi.GoogleCloudStorage.MetadataUrl(m_bucket, m_prefix + remotename);
 
             var metadata = new ObjectMetadata
             {
@@ -393,7 +393,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
         {
             try
             {
-                var url = WebApi.GoogleCloudStorage.GetUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + remotename));
+                var url = WebApi.GoogleCloudStorage.GetUrl(m_bucket, m_prefix + remotename);
                 using var req = await m_oauth.CreateRequestAsync(url, HttpMethod.Get, cancelToken);
                 using var resp = await Library.Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, ct => m_oauth.GetResponseAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)).ConfigureAwait(false);
                 using var source = await Library.Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken, ct => resp.Content.ReadAsStreamAsync(cancelToken)).ConfigureAwait(false);
@@ -411,7 +411,7 @@ namespace Duplicati.Library.Backend.GoogleCloudStorage
 
         public async Task RenameAsync(string oldname, string newname, CancellationToken cancellationToken)
         {
-            var url = WebApi.GoogleCloudStorage.RewriteUrl(m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + oldname), m_bucket, Utility.UrlEncoding.UrlPathEncode(m_prefix + newname));
+            var url = WebApi.GoogleCloudStorage.RewriteUrl(m_bucket, m_prefix + oldname, m_bucket, m_prefix + newname);
 
             // Perform rewrite (copy)
             await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancellationToken, async ct =>

--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -413,7 +413,7 @@ namespace Duplicati.Library.Backend.GoogleDrive
 
                 foreach (var fileid in entries.Select(x => x.id).WhereNotNullOrWhiteSpace())
                 {
-                    var url = WebApi.GoogleDrive.DeleteUrl(Library.Utility.UrlEncoding.UrlPathEncode(fileid), m_teamDriveID);
+                    var url = WebApi.GoogleDrive.DeleteUrl(fileid, m_teamDriveID);
                     await Utility.Utility.WithTimeout(m_timeouts.ShortTimeout, cancelToken,
                         async ct =>
                         {

--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -174,7 +174,7 @@ namespace Duplicati.Library.Backend.WebApi
             });
 
         public static string DeleteUrl(string fileId, string? teamDriveId)
-            => FileQueryUrl(Utility.UrlEncoding.UrlPathEncode(fileId), AddTeamDriveParam(teamDriveId));
+            => FileQueryUrl(fileId, AddTeamDriveParam(teamDriveId));
 
         public static string PutUrl(string? fileId, bool useTeamDrive)
         {
@@ -188,7 +188,7 @@ namespace Duplicati.Library.Backend.WebApi
             }
 
             return !string.IsNullOrWhiteSpace(fileId) ?
-                FileUploadUrl(Utility.UrlEncoding.UrlPathEncode(fileId), queryParams) :
+                FileUploadUrl(fileId, queryParams) :
                       FileUploadUrl(queryParams);
         }
 
@@ -255,10 +255,10 @@ namespace Duplicati.Library.Backend.WebApi
             => Utility.RelaxedUri.UriBuilder(Url.DRIVE, Path.File, values, false);
 
         private static string FileQueryUrl(string fileId, NameValueCollection? values = null)
-            => Utility.RelaxedUri.UriBuilder(Url.DRIVE, UrlPath.Create(Path.File).Append(fileId).ToString(), values, false);
+            => Utility.RelaxedUri.UriBuilderWithEncodedPath(Url.DRIVE, UrlPath.Create(Path.File).Append(Utility.UrlEncoding.UrlPathEncode(fileId)).ToString(), values, false);
 
         private static string FileUploadUrl(string fileId, NameValueCollection? values)
-            => Utility.RelaxedUri.UriBuilder(Url.UPLOAD, UrlPath.Create(Path.File).Append(fileId).ToString(), values, false);
+            => Utility.RelaxedUri.UriBuilderWithEncodedPath(Url.UPLOAD, UrlPath.Create(Path.File).Append(Utility.UrlEncoding.UrlPathEncode(fileId)).ToString(), values, false);
 
         private static string FileUploadUrl(NameValueCollection values)
             => Utility.RelaxedUri.UriBuilder(Url.UPLOAD, Path.File, values, false);

--- a/Duplicati/Library/Backend/GoogleServices/WebApi.cs
+++ b/Duplicati/Library/Backend/GoogleServices/WebApi.cs
@@ -61,7 +61,7 @@ namespace Duplicati.Library.Backend.WebApi
         {
             var path = BucketObjectPath(bucketId, objectId);
 
-            return Utility.RelaxedUri.UriBuilder(Url.API, path);
+            return Utility.RelaxedUri.UriBuilderWithEncodedPath(Url.API, path, null, false);
         }
 
         public static string CreateFolderUrl(string projectId)
@@ -75,13 +75,13 @@ namespace Duplicati.Library.Backend.WebApi
         }
 
         public static string RenameUrl(string bucketId, string objectId)
-            => Utility.RelaxedUri.UriBuilder(Url.API, BucketObjectPath(bucketId, objectId));
+            => Utility.RelaxedUri.UriBuilderWithEncodedPath(Url.API, BucketObjectPath(bucketId, objectId), null, false);
 
         public static string RewriteUrl(string sourceBucket, string sourceObject, string destBucket, string destObject)
         {
-            var path = UrlPath.Create(Path.Bucket).Append(sourceBucket).Append(Path.Object).Append(sourceObject)
-                .Append("rewriteTo").Append(Path.Bucket).Append(destBucket).Append(Path.Object).Append(destObject).ToString();
-            return Utility.RelaxedUri.UriBuilder(Url.API, path);
+            var path = UrlPath.Create(Path.Bucket).Append(sourceBucket).Append(Path.Object).Append(Utility.UrlEncoding.UrlPathEncode(sourceObject))
+                .Append("rewriteTo").Append(Path.Bucket).Append(destBucket).Append(Path.Object).Append(Utility.UrlEncoding.UrlPathEncode(destObject)).ToString();
+            return Utility.RelaxedUri.UriBuilderWithEncodedPath(Url.API, path, null, false);
         }
 
         public static string ListUrl(string bucketId, string prefix)
@@ -120,13 +120,13 @@ namespace Duplicati.Library.Backend.WebApi
                 };
             var path = BucketObjectPath(bucketId, objectId);
 
-            return Utility.RelaxedUri.UriBuilder(Url.API, path, queryParams, false);
+            return Utility.RelaxedUri.UriBuilderWithEncodedPath(Url.API, path, queryParams, false);
         }
 
         public static string MetadataUrl(string bucketId, string objectId)
         {
             var path = BucketObjectPath(bucketId, objectId);
-            return Utility.RelaxedUri.UriBuilder(Url.API, path);
+            return Utility.RelaxedUri.UriBuilderWithEncodedPath(Url.API, path, null, false);
         }
 
         private static class Url
@@ -160,7 +160,7 @@ namespace Duplicati.Library.Backend.WebApi
             => UrlPath.Create(Path.Bucket)
                 .Append(bucketId)
                 .Append(Path.Object)
-                .Append(objectId).ToString();
+                .Append(objectId == null ? null : Utility.UrlEncoding.UrlPathEncode(objectId)).ToString();
     }
 
     public static class GoogleDrive

--- a/Duplicati/Library/Utility/RelaxedUri.cs
+++ b/Duplicati/Library/Utility/RelaxedUri.cs
@@ -101,6 +101,12 @@ namespace Duplicati.Library.Utility
         public readonly string? Password;
 
         /// <summary>
+        /// Whether the <see cref="Path"/> is already percent-encoded and must be
+        /// emitted verbatim rather than encoded again during serialization.
+        /// </summary>
+        public readonly bool PathIsEncoded = false;
+
+        /// <summary>
         /// The original URI.
         /// </summary>
         public readonly string OriginalUri;
@@ -294,17 +300,19 @@ namespace Duplicati.Library.Utility
         /// <param name="username">The username</param>
         /// <param name="password">The password</param>
         /// <param name="port">The port</param>
-        public RelaxedUri(string scheme, string? host, string? path = null, string? query = null, string? username = null, string? password = null, int port = -1)
+        /// <param name="pathIsEncoded">Whether the path is already percent-encoded</param>
+        public RelaxedUri(string scheme, string? host, string? path = null, string? query = null, string? username = null, string? password = null, int port = -1, bool pathIsEncoded = false)
         {
             m_queryParams = null;
             Scheme = scheme;
             Host = host;
             Path = path ?? "";
+            PathIsEncoded = pathIsEncoded;
             Query = query;
             Username = username;
             Password = password;
             Port = port;
-            OriginalUri = AsString(scheme, host, path, query, username, password, port);
+            OriginalUri = AsString(scheme, host, path, query, username, password, port, pathIsEncoded);
         }
 
         /// <summary>
@@ -313,7 +321,7 @@ namespace Duplicati.Library.Utility
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="Duplicati.Library.Utility.RelaxedUri"/>.</returns>
         public override string ToString()
         {
-            return AsString(Scheme, Host, Path, Query, Username, Password, Port);
+            return AsString(Scheme, Host, Path, Query, Username, Password, Port, PathIsEncoded);
         }
 
         /// <summary>
@@ -336,7 +344,8 @@ namespace Duplicati.Library.Utility
         /// <param name="username">The username</param>
         /// <param name="password">The password</param>
         /// <param name="port">The port</param>
-        private static string AsString(string scheme, string? host, string? path, string? query, string? username, string? password, int port)
+        /// <param name="pathIsEncoded">Whether the path is already percent-encoded</param>
+        private static string AsString(string scheme, string? host, string? path, string? query, string? username, string? password, int port, bool pathIsEncoded)
         {
             var s = scheme + "://";
             if (!string.IsNullOrEmpty(username) || !string.IsNullOrEmpty(password))
@@ -365,7 +374,9 @@ namespace Duplicati.Library.Utility
                 if (!string.IsNullOrEmpty(host) || (WINDOWS_PATH.IsMatch(path) && !path.StartsWith("/")))
                     s += "/";
 
-                s += string.Join('/', path.Split('/').Select(x => UrlEncoding.UrlPathEncode(x)));
+                s += pathIsEncoded
+                    ? path
+                    : string.Join('/', path.Split('/').Select(x => UrlEncoding.UrlPathEncode(x)));
             }
             if (!string.IsNullOrEmpty(query))
                 s += "?" + query;
@@ -380,7 +391,7 @@ namespace Duplicati.Library.Utility
         /// <param name="scheme">The new scheme to use</param>
         public RelaxedUri SetScheme(string scheme)
         {
-            return new RelaxedUri(scheme, Host, Path, Query, Username, Password, Port);
+            return new RelaxedUri(scheme, Host, Path, Query, Username, Password, Port, PathIsEncoded);
         }
 
         /// <summary>
@@ -394,13 +405,24 @@ namespace Duplicati.Library.Utility
         }
 
         /// <summary>
+        /// Creates a new instance with another path whose segments are already
+        /// percent-encoded, so the path is emitted verbatim during serialization.
+        /// </summary>
+        /// <returns>A new instance</returns>
+        /// <param name="encodedPath">The new pre-encoded path to use</param>
+        public RelaxedUri SetEncodedPath(string? encodedPath)
+        {
+            return new RelaxedUri(Scheme, Host, encodedPath, Query, Username, Password, Port, pathIsEncoded: true);
+        }
+
+        /// <summary>
         /// Creates a new instance with another query
         /// </summary>
         /// <returns>A new instance</returns>
         /// <param name="query">The new query to use</param>
         public RelaxedUri SetQuery(string? query)
         {
-            return new RelaxedUri(Scheme, Host, Path, query, Username, Password, Port);
+            return new RelaxedUri(Scheme, Host, Path, query, Username, Password, Port, PathIsEncoded);
         }
 
         /// <summary>
@@ -411,7 +433,7 @@ namespace Duplicati.Library.Utility
         /// <param name="password">The new password to use</param>
         public RelaxedUri SetCredentials(string? username, string? password)
         {
-            return new RelaxedUri(Scheme, Host, Path, Query, username, password, Port);
+            return new RelaxedUri(Scheme, Host, Path, Query, username, password, Port, PathIsEncoded);
         }
 
         /// <summary>
@@ -437,6 +459,29 @@ namespace Duplicati.Library.Utility
             return uri
                 .SetPath(newPath)
                 .SetQuery(query != null ? EscapeUriQuery(UrlEncoding.BuildUriQuery(query, preEncoded)) : null)
+                .ToString();
+        }
+
+        /// <summary>
+        /// Builds a URL together using a base URL and a pre-encoded path.
+        /// The path segments are assumed to already be percent-encoded (e.g. an object
+        /// name whose '/' is encoded as %2F), so they are emitted verbatim rather than
+        /// encoded again. The base URL's own path is still treated as decoded.
+        /// </summary>
+        /// <returns>The built together URL.</returns>
+        /// <param name="url">Base URL, containing schema, host, port.</param>
+        /// <param name="encodedPath">The pre-encoded path to append.</param>
+        /// <param name="query">A collection of name value pairs to be translated into a query string.</param>
+        /// <param name="preEncodedQuery">A value indicating if the query contains pre-encoded values</param>
+        public static string UriBuilderWithEncodedPath(string url, string encodedPath, NameValueCollection? query, bool preEncodedQuery)
+        {
+            var uri = new RelaxedUri(url);
+            var newPath = new UrlPath(uri.Path).Append(encodedPath).ToString();
+            if (!string.IsNullOrEmpty(uri.Host) || string.IsNullOrEmpty(uri.Path))
+                newPath = newPath.TrimStart('/');
+            return uri
+                .SetEncodedPath(newPath)
+                .SetQuery(query != null ? EscapeUriQuery(UrlEncoding.BuildUriQuery(query, preEncodedQuery)) : null)
                 .ToString();
         }
 

--- a/Duplicati/UnitTest/UriUtilityTests.cs
+++ b/Duplicati/UnitTest/UriUtilityTests.cs
@@ -29,6 +29,53 @@ namespace Duplicati.UnitTest
     {
         [Test]
         [Category("UriUtility")]
+        public static void TestUrlBuilderWithEncodedPath()
+        {
+            // A pre-encoded path must be emitted verbatim by UriBuilderWithEncodedPath,
+            // so an object name whose '/' is encoded as %2F is not double-encoded into
+            // %252F (which is what broke reading back files on GCS). The GCS object url
+            // is /o/{object} where the object name is a single path parameter.
+            const string baseUrl = "https://www.googleapis.com/storage/v1";
+
+            // The object name "test-tool/duplicati-access-privileges-test.txt" encodes
+            // its '/' once; the base path (/storage/v1) is preserved.
+            Assert.AreEqual(
+                baseUrl + "/b/bucket/o/test-tool%2Fduplicati-access-privileges-test.txt?alt=media",
+                Library.Utility.RelaxedUri.UriBuilderWithEncodedPath(
+                    baseUrl,
+                    "b/bucket/o/" + Library.Utility.UrlEncoding.UrlPathEncode("test-tool/duplicati-access-privileges-test.txt"),
+                    new NameValueCollection { { "alt", "media" } }, false));
+
+            // A name that itself contains a percent-escape sequence encodes the '%' once
+            Assert.AreEqual(
+                baseUrl + "/b/bucket/o/test-tool%2Ftest%252f%25abc.txt",
+                Library.Utility.RelaxedUri.UriBuilderWithEncodedPath(
+                    baseUrl,
+                    "b/bucket/o/" + Library.Utility.UrlEncoding.UrlPathEncode("test-tool/test%2f%abc.txt"),
+                    null, false));
+
+            // A space encodes once, not twice
+            Assert.AreEqual(
+                baseUrl + "/b/bucket/o/test-tool%2Fa%20b.txt",
+                Library.Utility.RelaxedUri.UriBuilderWithEncodedPath(
+                    baseUrl,
+                    "b/bucket/o/" + Library.Utility.UrlEncoding.UrlPathEncode("test-tool/a b.txt"),
+                    null, false));
+        }
+
+        [Test]
+        [Category("UriUtility")]
+        public static void TestSetEncodedPathEmitsVerbatim()
+        {
+            // The regular SetPath re-encodes the path, while SetEncodedPath keeps it as-is
+            var uri = new Library.Utility.RelaxedUri("https://www.googleapis.com/storage/v1");
+            Assert.AreEqual(
+                "https://www.googleapis.com/storage/v1/b/bucket/o/test-tool%2Ffile.txt",
+                uri.SetEncodedPath("storage/v1/b/bucket/o/test-tool%2Ffile.txt").ToString());
+        }
+
+        [Test]
+        [Category("UriUtility")]
         public static void TestUrlBuilder()
         {
             var baseUrl = "http://localhost";


### PR DESCRIPTION
This updates the code to not double-encode the paths sent to GCS.

The issue is that paths to GCS needs to be encoded so `folder/file` must be sent as `folder%2Ffile`. This failed due to logic fixes to the RelaxedUri class where it would re-encode the paths segments, causing the path to become `folder%252Ffile` which would be read with a literal `%2F` in the path.

To avoid breaking too much there is now a separate method on `RelaxedUri` that can handle these pre-encoded paths, where the caller is responsible for correct encoding.

For future proofing, the Google Drive also handles the encoding.

A fix to get GCS to return "not found" when attempting to delete a non-existing file is also included.