### PR TITLE
Stop the redundant DISTINCT from blocking the IN index lookup

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDeleteDatabase.cs
@@ -189,7 +189,7 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExecuteNonQueryAsync(@"
                     DELETE FROM ""FileLookup""
                     WHERE ""ID"" NOT IN (
-                        SELECT DISTINCT ""FileID""
+                        SELECT ""FileID""
                         FROM ""FilesetEntry""
                     )
                 ", token)
@@ -198,7 +198,7 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExecuteNonQueryAsync(@"
                     DELETE FROM ""Metadataset""
                     WHERE ""ID"" NOT IN (
-                        SELECT DISTINCT ""MetadataID""
+                        SELECT ""MetadataID""
                         FROM ""FileLookup""
                     )
                 ", token)
@@ -219,7 +219,7 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExecuteNonQueryAsync(@"
                     DELETE FROM ""BlocksetEntry""
                     WHERE ""BlocksetID"" NOT IN (
-                        SELECT DISTINCT ""ID""
+                        SELECT ""ID""
                         FROM ""Blockset""
                     )
                 ", token)
@@ -228,7 +228,7 @@ namespace Duplicati.Library.Main.Database.Local
             await cmd.ExecuteNonQueryAsync(@"
                     DELETE FROM ""BlocklistHash""
                     WHERE ""BlocksetID"" NOT IN (
-                        SELECT DISTINCT ""ID""
+                        SELECT ""ID""
                         FROM ""Blockset""
                     )
                 ", token)

--- a/Duplicati/Library/Main/Database/Local/LocalPurgeDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalPurgeDatabase.cs
@@ -130,7 +130,7 @@ namespace Duplicati.Library.Main.Database.Local
                 SELECT COUNT(*)
                 FROM ""FileLookup""
                 WHERE ""ID"" NOT IN (
-                    SELECT DISTINCT ""FileID""
+                    SELECT ""FileID""
                     FROM ""FilesetEntry""
                 )
             ");

--- a/Duplicati/UnitTest/UnreferencedRowCleanupTests.cs
+++ b/Duplicati/UnitTest/UnreferencedRowCleanupTests.cs
@@ -1,0 +1,230 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Main.Database.Local;
+using Duplicati.Library.SQLiteHelper;
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The cleanup that follows a fileset being dropped decides what to keep by asking
+    /// which rows are still referenced. These tests pin that decision down: a row another
+    /// fileset still uses has to survive, and a row nothing points at any more has to go.
+    ///
+    /// They exist because the queries behind it are rewritten from time to time for speed
+    /// (see #7180 and #7247), and a rewrite that changes what the query means would
+    /// otherwise be silent - it deletes backup history, and nothing complains.
+    /// </summary>
+    [TestFixture]
+    public class UnreferencedRowCleanupTests
+    {
+        /// <summary>The timestamp of the fileset that the tests drop</summary>
+        private const long DroppedFilesetTime = 1000;
+        /// <summary>The timestamp of the fileset that the tests keep</summary>
+        private const long KeptFilesetTime = 2000;
+
+        /// <summary>
+        /// Builds a database with two filesets. One file, its metadata and their blocks are
+        /// shared by both; a second file is used only by the fileset that gets dropped.
+        /// </summary>
+        /// <returns>The database file, which the caller owns</returns>
+        private static async Task<TempFile> CreateTwoFilesetDatabaseAsync()
+        {
+            var dbfile = new TempFile();
+            try
+            {
+                using (var db = await SQLiteLoader.LoadConnectionAsync(dbfile))
+                {
+                    DatabaseUpgrader.UpgradeDatabase(db, dbfile, typeof(DatabaseSchemaMarker));
+                    using var cmd = db.CreateCommand();
+
+                    foreach (var sql in new[]
+                    {
+                        @"INSERT INTO ""Operation"" (""ID"", ""Description"", ""Timestamp"") VALUES (1, 'Test', 0)",
+
+                        // One fileset volume per fileset, plus the volume the blocks live in
+                        @"INSERT INTO ""Remotevolume"" (""ID"", ""OperationID"", ""Name"", ""Type"", ""Size"", ""State"", ""VerificationCount"", ""DeleteGraceTime"", ""ArchiveTime"", ""LockExpirationTime"")
+                          VALUES (1, 1, 'dropped.dlist.zip', 'Files', 10, 'Verified', 0, 0, 0, 0)",
+                        @"INSERT INTO ""Remotevolume"" (""ID"", ""OperationID"", ""Name"", ""Type"", ""Size"", ""State"", ""VerificationCount"", ""DeleteGraceTime"", ""ArchiveTime"", ""LockExpirationTime"")
+                          VALUES (2, 1, 'kept.dlist.zip', 'Files', 20, 'Verified', 0, 0, 0, 0)",
+                        @"INSERT INTO ""Remotevolume"" (""ID"", ""OperationID"", ""Name"", ""Type"", ""Size"", ""State"", ""VerificationCount"", ""DeleteGraceTime"", ""ArchiveTime"", ""LockExpirationTime"")
+                          VALUES (3, 1, 'blocks.dblock.zip', 'Blocks', 30, 'Verified', 0, 0, 0, 0)",
+
+                        $@"INSERT INTO ""Fileset"" (""ID"", ""OperationID"", ""VolumeID"", ""IsFullBackup"", ""Timestamp"") VALUES (1, 1, 1, 1, {DroppedFilesetTime})",
+                        $@"INSERT INTO ""Fileset"" (""ID"", ""OperationID"", ""VolumeID"", ""IsFullBackup"", ""Timestamp"") VALUES (2, 1, 2, 1, {KeptFilesetTime})",
+
+                        // Blocksets 10 and 30 belong to the shared file, 20 and 40 to the one
+                        // that only the dropped fileset uses
+                        @"INSERT INTO ""Blockset"" (""ID"", ""Length"", ""FullHash"") VALUES (10, 1, 'shared-content')",
+                        @"INSERT INTO ""Blockset"" (""ID"", ""Length"", ""FullHash"") VALUES (20, 1, 'lonely-content')",
+                        @"INSERT INTO ""Blockset"" (""ID"", ""Length"", ""FullHash"") VALUES (30, 1, 'shared-metadata')",
+                        @"INSERT INTO ""Blockset"" (""ID"", ""Length"", ""FullHash"") VALUES (40, 1, 'lonely-metadata')",
+
+                        @"INSERT INTO ""Block"" (""ID"", ""Hash"", ""Size"", ""VolumeID"") VALUES (10, 'shared-content', 1, 3)",
+                        @"INSERT INTO ""Block"" (""ID"", ""Hash"", ""Size"", ""VolumeID"") VALUES (20, 'lonely-content', 1, 3)",
+                        @"INSERT INTO ""Block"" (""ID"", ""Hash"", ""Size"", ""VolumeID"") VALUES (30, 'shared-metadata', 1, 3)",
+                        @"INSERT INTO ""Block"" (""ID"", ""Hash"", ""Size"", ""VolumeID"") VALUES (40, 'lonely-metadata', 1, 3)",
+
+                        @"INSERT INTO ""BlocksetEntry"" (""BlocksetID"", ""Index"", ""BlockID"") VALUES (10, 0, 10)",
+                        @"INSERT INTO ""BlocksetEntry"" (""BlocksetID"", ""Index"", ""BlockID"") VALUES (20, 0, 20)",
+                        @"INSERT INTO ""BlocksetEntry"" (""BlocksetID"", ""Index"", ""BlockID"") VALUES (30, 0, 30)",
+                        @"INSERT INTO ""BlocksetEntry"" (""BlocksetID"", ""Index"", ""BlockID"") VALUES (40, 0, 40)",
+
+                        @"INSERT INTO ""BlocklistHash"" (""BlocksetID"", ""Index"", ""Hash"") VALUES (10, 0, 'shared-blocklist')",
+                        @"INSERT INTO ""BlocklistHash"" (""BlocksetID"", ""Index"", ""Hash"") VALUES (20, 0, 'lonely-blocklist')",
+
+                        @"INSERT INTO ""Metadataset"" (""ID"", ""BlocksetID"") VALUES (100, 30)",
+                        @"INSERT INTO ""Metadataset"" (""ID"", ""BlocksetID"") VALUES (200, 40)",
+
+                        @"INSERT INTO ""PathPrefix"" (""ID"", ""Prefix"") VALUES (1, '/')",
+                        @"INSERT INTO ""FileLookup"" (""ID"", ""PrefixID"", ""Path"", ""BlocksetID"", ""MetadataID"") VALUES (1000, 1, 'shared.txt', 10, 100)",
+                        @"INSERT INTO ""FileLookup"" (""ID"", ""PrefixID"", ""Path"", ""BlocksetID"", ""MetadataID"") VALUES (2000, 1, 'lonely.txt', 20, 200)",
+
+                        // The shared file is in both filesets, the lonely one only in the dropped fileset
+                        @"INSERT INTO ""FilesetEntry"" (""FilesetID"", ""FileID"", ""Lastmodified"") VALUES (1, 1000, 0)",
+                        @"INSERT INTO ""FilesetEntry"" (""FilesetID"", ""FileID"", ""Lastmodified"") VALUES (2, 1000, 0)",
+                        @"INSERT INTO ""FilesetEntry"" (""FilesetID"", ""FileID"", ""Lastmodified"") VALUES (1, 2000, 0)",
+                    })
+                    {
+                        cmd.CommandText = sql;
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+
+                    await db.CloseAsync();
+                }
+
+                return dbfile;
+            }
+            catch
+            {
+                dbfile.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Drops the fileset at <see cref="DroppedFilesetTime"/> and commits.
+        /// </summary>
+        /// <param name="dbfile">The database to work on</param>
+        private static async Task DropTheFirstFilesetAsync(string dbfile)
+        {
+            await using var db = await LocalDeleteDatabase.CreateAsync(dbfile, "Test", null, CancellationToken.None);
+
+            var removed = new List<KeyValuePair<string, long>>();
+            await foreach (var v in db.DropFilesetsFromTableAsync(
+                [new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(DroppedFilesetTime)],
+                CancellationToken.None))
+                removed.Add(v);
+
+            Assert.AreEqual(1, removed.Count, "exactly the volume of the dropped fileset is up for removal");
+            Assert.AreEqual("dropped.dlist.zip", removed[0].Key);
+
+            await db.CommitAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Counts the rows of a table whose ID is in the given set.
+        /// </summary>
+        /// <param name="dbfile">The database to read</param>
+        /// <param name="table">The table to count in</param>
+        /// <param name="column">The column to match on</param>
+        /// <param name="ids">The values to look for</param>
+        /// <returns>The number of matching rows</returns>
+        private static async Task<long> CountAsync(string dbfile, string table, string column, params long[] ids)
+        {
+            using var db = await SQLiteLoader.LoadConnectionAsync(dbfile);
+            using var cmd = db.CreateCommand();
+            cmd.CommandText = $@"SELECT COUNT(*) FROM ""{table}"" WHERE ""{column}"" IN ({string.Join(",", ids)})";
+            return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+        }
+
+        [Test]
+        [Category("Database")]
+        public async Task DroppingAFilesetKeepsRowsThatAnotherFilesetStillUses()
+        {
+            using var dbfile = await CreateTwoFilesetDatabaseAsync();
+            await DropTheFirstFilesetAsync(dbfile);
+
+            Assert.AreEqual(1, await CountAsync(dbfile, "FileLookup", "ID", 1000), "the file the kept fileset still lists");
+            Assert.AreEqual(1, await CountAsync(dbfile, "Metadataset", "ID", 100), "its metadata");
+            Assert.AreEqual(2, await CountAsync(dbfile, "Blockset", "ID", 10, 30), "the blocksets of both");
+            Assert.AreEqual(2, await CountAsync(dbfile, "BlocksetEntry", "BlocksetID", 10, 30), "and their entries");
+            Assert.AreEqual(1, await CountAsync(dbfile, "BlocklistHash", "BlocksetID", 10), "and its blocklist hash");
+            Assert.AreEqual(1, await CountAsync(dbfile, "FilesetEntry", "FilesetID", 2), "the kept fileset keeps its entry");
+        }
+
+        [Test]
+        [Category("Database")]
+        public async Task DroppingTheLastFilesetToUseARowRemovesIt()
+        {
+            using var dbfile = await CreateTwoFilesetDatabaseAsync();
+            await DropTheFirstFilesetAsync(dbfile);
+
+            Assert.AreEqual(0, await CountAsync(dbfile, "FileLookup", "ID", 2000), "the file nothing lists any more");
+            Assert.AreEqual(0, await CountAsync(dbfile, "Metadataset", "ID", 200), "its metadata");
+            Assert.AreEqual(0, await CountAsync(dbfile, "Blockset", "ID", 20, 40), "the blocksets of both");
+            Assert.AreEqual(0, await CountAsync(dbfile, "BlocksetEntry", "BlocksetID", 20, 40), "and their entries");
+            Assert.AreEqual(0, await CountAsync(dbfile, "BlocklistHash", "BlocksetID", 20), "and its blocklist hash");
+            Assert.AreEqual(0, await CountAsync(dbfile, "FilesetEntry", "FilesetID", 1), "the dropped fileset keeps nothing");
+            Assert.AreEqual(0, await CountAsync(dbfile, "Fileset", "ID", 1), "and is gone itself");
+        }
+
+        [Test]
+        [Category("Database")]
+        public async Task AFileNoFilesetListsIsCountedAsAnOrphan()
+        {
+            using var dbfile = await CreateTwoFilesetDatabaseAsync();
+
+            // Take the lonely file out of the only fileset that listed it, without
+            // running the cleanup, which is the state the count is there to find
+            using (var raw = await SQLiteLoader.LoadConnectionAsync(dbfile))
+            {
+                using var cmd = raw.CreateCommand();
+                cmd.CommandText = @"DELETE FROM ""FilesetEntry"" WHERE ""FileID"" = 2000";
+                await cmd.ExecuteNonQueryAsync();
+                await raw.CloseAsync();
+            }
+
+            await using var db = await LocalPurgeDatabase.CreateAsync(dbfile, null, CancellationToken.None);
+            Assert.AreEqual(1, await db.CountOrphanFilesAsync(CancellationToken.None));
+        }
+
+        [Test]
+        [Category("Database")]
+        public async Task AFileAFilesetStillListsIsNotAnOrphan()
+        {
+            using var dbfile = await CreateTwoFilesetDatabaseAsync();
+
+            await using var db = await LocalPurgeDatabase.CreateAsync(dbfile, null, CancellationToken.None);
+            Assert.AreEqual(0, await db.CountOrphanFilesAsync(CancellationToken.None),
+                "every file here is listed by at least one fileset");
+        }
+    }
+}


### PR DESCRIPTION
`x IN (SELECT DISTINCT c FROM t)` means the same as `x IN (SELECT c FROM t)` — membership does not care about duplicates, and `DISTINCT` keeps one NULL rather than removing it, so `NOT IN` behaves identically too.

SQLite does not treat them the same. The `DISTINCT` **stops it using an index for the `IN` operator**, and it materialises the subquery instead:

```
FileLookup."ID" NOT IN (SELECT DISTINCT "FileID" FROM "FilesetEntry")
  with:     SCAN FileLookup / LIST SUBQUERY 1
            SCAN FilesetEntry USING COVERING INDEX FilesetentryFileIdIndex / CREATE BLOOM FILTER
  without:  SCAN FileLookup / USING INDEX FilesetentryFileIdIndex FOR IN-OPERATOR
```

This is a follow-up to [#7180](https://github.com/duplicati/duplicati/pull/7180) and [#7247](https://github.com/duplicati/duplicati/pull/7247), but a **different shape**: those removed `DISTINCT` from the branches of a `UNION`, and neither touched an `IN` subquery.

## Measured, per site

I found 15 places that spell `IN (SELECT DISTINCT …)` and timed the ones I could put a realistic shape to, against the real schema (SQLite 3.50.4, 200k files, 15 filesets, 2.7M `FilesetEntry` rows, 400k blocks; best of 5).

| query | with | without | |
|---|---:|---:|---|
| `DELETE FROM FileLookup … NOT IN (FilesetEntry.FileID)` | 234.7 ms | 79.8 ms | **2.9×** |
| `DELETE FROM Metadataset … NOT IN (FileLookup.MetadataID)` | 129.2 ms | 59.5 ms | **2.2×** |
| `DELETE FROM BlocksetEntry … NOT IN (Blockset.ID)` | 187.5 ms | 34.6 ms | **5.4×** |
| `DELETE FROM BlocklistHash … NOT IN (Blockset.ID)` | 135.1 ms | 19.8 ms | **6.8×** |
| `CountOrphanFiles` (same shape as the first) | 225.7 ms | 79.9 ms | **2.8×** |

Row counts were identical in every pair.

The last two are the clearest case: `Blockset.ID` is `INTEGER PRIMARY KEY`, so the subquery cannot return a duplicate at all and the `DISTINCT` was only ever cost.

## Two places where I measured it and left the `DISTINCT` alone

**This is not a keyword to sweep out of the codebase.** Two of the sites I looked at do not want the change:

- **`LocalDatabase.RemoveRemoteVolumesAsync`** — removing both `DISTINCT`s made it **slower**, 49.6 ms → 215.4 ms. The outer table there is `Fileset` (tens of rows) while the subqueries are large and heavily duplicated, so deduplicating once beats probing per row.
- **`LocalRecreateDatabase.CleanupMissingVolumesAsync`** — the outer tables are small enough that the whole statement runs in single-digit milliseconds either way (5.7 ms vs 5.3 ms). Not worth the churn.

Also left alone, as different shapes that need their own measurement: `LocalPurgeDatabase.PostFilterChecks` (the subquery is a three-table join), the three in `LocalListDatabase` (they read the `File` view), and the outer `DISTINCT` over a `UNION` in `LocalListBrokenFilesDatabase`.

**One of those looks like this change but must not get it.** `LocalListBrokenFilesDatabase` line 320 has `SELECT DISTINCT "ID" FROM ( … UNION … )`, and the subquery yields `(ID, BlocksetID, IsMetadata)` while the outer takes only `ID` — so the same `ID` legitimately appears twice, once per `IsMetadata` value. That `DISTINCT` is load-bearing.

## Changes

Five `DISTINCT` keywords, in two methods:

- `LocalDeleteDatabase.DropFilesetsFromTableAsync` — the cascade that deletes rows nothing references any more, 4 of them
- `LocalPurgeDatabase.CountOrphanFilesAsync` — 1

Nothing else in those statements moved.

## Tests

`Duplicati/UnitTest/UnreferencedRowCleanupTests.cs`, 4 tests, following the harness in [`LocalDatabaseRemoveRemoteVolumesTests`](https://github.com/duplicati/duplicati/blob/5d8deaace31a4ef7888efbbf2b2c8ecf18afe288/Duplicati/UnitTest/LocalDatabaseRemoveRemoteVolumesTests.cs#L131): build the real schema with `DatabaseUpgrader`, insert the rows by hand, then drive the real method. No backup is run, so the whole file takes about two seconds.

Two filesets share one file, its metadata and their blocksets; a second file belongs only to the fileset that gets dropped. The tests assert that the shared rows survive and the lonely ones do not.

**There is no red-to-green here, and I am not going to pretend otherwise** — the change does not alter what the queries mean, so the tests pass before it as well. What they are for is the next rewrite. To show they can actually catch one, I broke each changed statement in turn and ran them:

| deliberate error | tests that failed |
|---|---|
| `FileLookup … NOT IN` → `IN` | 2 |
| `Metadataset … SELECT "MetadataID"` → `SELECT "BlocksetID"` | 1 |
| `BlocksetEntry … NOT IN` → `IN` | 2 |
| `BlocklistHash … NOT IN` → `IN` | 2 |
| `CountOrphanFiles … NOT IN` → `IN` | 1 |

Every changed statement is covered by at least one test that fails when it is wrong.

I did not assert on `EXPLAIN QUERY PLAN` in a test. It would pin the suite to one planner and break the day the bundled SQLite is upgraded, which is a worse trade than leaving the speed claim to the measurements above.

## What is not measured

The numbers come from synthetic data built on the real schema, not from a captured backup database. The shapes and the indexes are the real ones; the row counts are my choice, and a different mix could move the ratios.

`UnreferencedRowCleanupTests` (4), `LocalDatabaseRemoveRemoteVolumesTests` (4) and `SharedMetadataRemoveRemoteVolumesTests` (2) all pass — 10 of 10. The solution builds with 0 errors and the same 3 warnings as master.
