### PR TITLE
Enabled reading the machineid

### DIFF
--- a/Duplicati/Agent/Program.cs
+++ b/Duplicati/Agent/Program.cs
@@ -555,7 +555,7 @@ public static class Program
         if (string.IsNullOrWhiteSpace(settings.JWT))
         {
             Log.WriteMessage(LogMessageType.Information, LogTag, "ClientNoJWT", "No JWT found in settings, starting in registration mode");
-            using (var registration = new RegisterForRemote(registrationUrl, null, cancellationToken))
+            using (var registration = new RegisterForRemote(registrationUrl, null, null, cancellationToken))
             {
                 var registerClientData = await registration.RegisterAsync();
                 if (registerClientData.RegistrationData != null)

--- a/Duplicati/Library/AutoUpdater/DataFolderManager.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderManager.cs
@@ -154,7 +154,7 @@ public static class DataFolderManager
         }
 
         if (mode == AccessMode.ReadWritePermissionSet && !File.Exists(Path.Combine(dataFolder, MACHINE_FILE)))
-            File.WriteAllText(Path.Combine(dataFolder, MACHINE_FILE), AutoUpdateSettings.UpdateMachineFileText(InstallID));
+            File.WriteAllText(Path.Combine(dataFolder, MACHINE_FILE), AutoUpdateSettings.UpdateMachineFileText(GetInstallID()));
 
         return dataFolder;
     }
@@ -375,21 +375,20 @@ public static class DataFolderManager
     /// exist yet, an empty value is returned without caching, so a later call can still pick
     /// up the value; once the file exists, the value is stable and is cached, even if empty.
     /// </summary>
-    public static string InstallID
+    /// <param name="probeOnly">A flag indicating the caller is only probing; a missing ID returns empty without throwing (debug) or logging</param>
+    /// <returns>The ID or an empty string</returns>
+    public static string GetInstallID(bool probeOnly = false)
     {
-        get
+        if (_installID == null)
         {
-            if (_installID == null)
-            {
-                var value = ProbeIdFile(INSTALL_FILE, out var fileExists);
-                if (!fileExists)
-                    return ReportMissingIdValue(INSTALL_FILE);
+            var value = ProbeIdFile(INSTALL_FILE, out var fileExists);
+            if (!fileExists)
+                return ReportMissingIdValue(INSTALL_FILE, probeOnly);
 
-                _installID = value ?? "";
-            }
-
-            return _installID;
+            _installID = value ?? "";
         }
+
+        return _installID;
     }
 
     /// <summary>
@@ -399,24 +398,23 @@ public static class DataFolderManager
     /// an empty value is returned without caching, so a later call can still pick up the
     /// value; once the file exists, the value is stable and is cached, even if empty.
     /// </summary>
-    public static string MachineID
+    /// <param name="probeOnly">A flag indicating the caller is only probing; a missing ID returns empty without throwing (debug) or logging</param>
+    /// <returns>The ID or an empty string</returns>
+    public static string GetMachineID(bool probeOnly = false)
     {
-        get
+        if (_machineID == null)
         {
-            if (_machineID == null)
-            {
-                var value = ProbeIdFile(MACHINE_FILE, out var fileExists);
-                if (string.IsNullOrWhiteSpace(value))
-                    value = ProbeIdFile(INSTALL_FILE, out _);
+            var value = ProbeIdFile(MACHINE_FILE, out var fileExists);
+            if (string.IsNullOrWhiteSpace(value))
+                value = GetInstallID(probeOnly: true);
 
-                if (!fileExists && string.IsNullOrWhiteSpace(value))
-                    return ReportMissingIdValue(MACHINE_FILE);
+            if (!fileExists && string.IsNullOrWhiteSpace(value))
+                return ReportMissingIdValue(MACHINE_FILE, probeOnly);
 
-                _machineID = value ?? "";
-            }
-
-            return _machineID;
+            _machineID = value ?? "";
         }
+
+        return _machineID;
     }
 
     /// <summary>
@@ -454,24 +452,16 @@ public static class DataFolderManager
     /// </summary>
     /// <param name="filename">The name of the ID file that had no value</param>
     /// <returns>An empty string in release builds; never returns in debug builds</returns>
-    private static string ReportMissingIdValue(string filename)
+    private static string ReportMissingIdValue(string filename, bool probeOnly)
     {
+        if (probeOnly)
+            return string.Empty;
+
 #if DEBUG
         throw new InvalidOperationException($"The ID file \"{filename}\" in the data folder does not exist or is empty; the ID was requested before the data folder was initialized");
 #else
         return string.Empty;
 #endif
-    }
-
-    /// <summary>
-    /// DEBUG-only test hook that ensures the data folder is initialized and stores
-    /// the given machine ID in it, so tests can run with a stable machine ID without
-    /// going through the application startup sequence that normally creates the ID.
-    /// </summary>
-    /// <param name="machineID">The machine ID to use</param>
-    public static void SetMachineIDForTesting(string machineID)
-    {
-        _machineID = machineID;
     }
 
     /// <summary>

--- a/Duplicati/Library/AutoUpdater/UpdaterManager.cs
+++ b/Duplicati/Library/AutoUpdater/UpdaterManager.cs
@@ -224,8 +224,10 @@ namespace Duplicati.Library.AutoUpdater
 
                         using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
-                        request.Headers.Add(System.Net.HttpRequestHeader.UserAgent.ToString(), string.Format("{0} v{1}{2}", APPNAME, SelfVersion.Version, string.IsNullOrWhiteSpace(DataFolderManager.InstallID) ? "" : " -" + DataFolderManager.InstallID));
-                        request.Headers.Add("X-Install-ID", DataFolderManager.InstallID);
+                        var installId = DataFolderManager.GetInstallID();
+
+                        request.Headers.Add(System.Net.HttpRequestHeader.UserAgent.ToString(), string.Format("{0} v{1}{2}", APPNAME, SelfVersion.Version, string.IsNullOrWhiteSpace(installId) ? "" : " -" + installId));
+                        request.Headers.Add("X-Install-ID", installId);
                         request.Headers.Add("X-Package-Type-ID", PackageTypeId);
 
                         using var timeoutToken = new CancellationTokenSource();
@@ -388,7 +390,7 @@ namespace Duplicati.Library.AutoUpdater
                             using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
                             request.Headers.Add(System.Net.HttpRequestHeader.UserAgent.ToString(), string.Format("{0} v{1}", APPNAME, SelfVersion.Version));
-                            request.Headers.Add("X-Install-ID", DataFolderManager.InstallID);
+                            request.Headers.Add("X-Install-ID", DataFolderManager.GetInstallID());
 
                             using var timeoutToken = new CancellationTokenSource();
                             timeoutToken.CancelAfter(TimeSpan.FromSeconds(DOWNLOAD_OPERATION_TIMEOUT_SECONDS));

--- a/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
+++ b/Duplicati/Library/Backend/Duplicati/DuplicatiBackend.cs
@@ -171,7 +171,7 @@ public class DuplicatiBackend : IBackend, IStreamingBackend, IQuotaEnabledBacken
         // Honor the global "machine-id" option, falling back to the AutoUpdater machine id
         var machineId = options.GetValueOrDefault("machine-id");
         if (string.IsNullOrWhiteSpace(machineId))
-            machineId = AutoUpdater.DataFolderManager.MachineID;
+            machineId = AutoUpdater.DataFolderManager.GetMachineID();
 
         _client.DefaultRequestHeaders.Add("X-Api-Key", _auth.Password);
         _client.DefaultRequestHeaders.Add("X-Organization-Id", _auth.Username);

--- a/Duplicati/Library/Main/Options.cs
+++ b/Duplicati/Library/Main/Options.cs
@@ -502,7 +502,7 @@ namespace Duplicati.Library.Main
             new CommandLineArgument("exclude-files-attributes", CommandLineArgument.ArgumentType.Flags, Strings.Options.ExcludefilesattributesShort, Strings.Options.ExcludefilesattributesLong, null, null, Common.IO.ExtendedFileAttributes.GetNames(false).ToArray()),
             new CommandLineArgument("compression-extension-file", CommandLineArgument.ArgumentType.Path, Strings.Options.CompressionextensionfileShort, Strings.Options.CompressionextensionfileLong(DEFAULT_COMPRESSED_EXTENSION_FILE), DEFAULT_COMPRESSED_EXTENSION_FILE),
 
-            new CommandLineArgument("machine-id", CommandLineArgument.ArgumentType.String, Strings.Options.MachineidShort, Strings.Options.MachineidLong, Library.AutoUpdater.DataFolderManager.MachineID),
+            new CommandLineArgument("machine-id", CommandLineArgument.ArgumentType.String, Strings.Options.MachineidShort, Strings.Options.MachineidLong, Library.AutoUpdater.DataFolderManager.GetMachineID(probeOnly: true)),
             new CommandLineArgument("machine-name", CommandLineArgument.ArgumentType.String, Strings.Options.MachinenameShort, Strings.Options.MachinenameLong, Library.AutoUpdater.DataFolderManager.MachineName),
             new CommandLineArgument("backup-id", CommandLineArgument.ArgumentType.String, Strings.Options.BackupidShort, Strings.Options.BackupidLong, ""),
             new CommandLineArgument("backup-name", CommandLineArgument.ArgumentType.String, Strings.Options.BackupnameShort, Strings.Options.BackupnameLong, DefaultBackupName),
@@ -1280,16 +1280,6 @@ namespace Duplicati.Library.Main
             get => GetString("backup-name", DefaultBackupName);
             set => m_options["backup-name"] = value;
         }
-
-        /// <summary>
-        /// Gets the ID of the backup
-        /// </summary>
-        public string? BackupId => m_options.GetValueOrDefault("backup-id");
-
-        /// <summary>
-        /// Gets the ID of the machine
-        /// </summary>
-        public string? MachineId => m_options.GetValueOrDefault("machine-id", Library.AutoUpdater.DataFolderManager.InstallID);
 
         /// <summary>
         /// Gets the path to the database

--- a/Duplicati/Library/Modules/Builtin/HttpReportStatus.cs
+++ b/Duplicati/Library/Modules/Builtin/HttpReportStatus.cs
@@ -440,7 +440,7 @@ namespace Duplicati.Library.Modules.Builtin
             => new ReportMetadata
             {
                 DuplicatiVersion = UpdaterManager.SelfVersion.Version,
-                MachineId = OptionOrDefault("machine-id", () => DataFolderManager.MachineID),
+                MachineId = OptionOrDefault("machine-id", () => DataFolderManager.GetMachineID()),
                 BackupId = OptionOrDefault("backup-id", () => Utility.Utility.CalculateBackupId(m_remoteUrl)),
                 BackupName = OptionOrDefault("backup-name", () => System.IO.Path.GetFileNameWithoutExtension(Utility.Utility.getEntryAssembly().Location)),
                 MachineName = OptionOrDefault("machine-name", () => DataFolderManager.MachineName),

--- a/Duplicati/Library/Modules/Builtin/HttpReportStatus.cs
+++ b/Duplicati/Library/Modules/Builtin/HttpReportStatus.cs
@@ -440,7 +440,7 @@ namespace Duplicati.Library.Modules.Builtin
             => new ReportMetadata
             {
                 DuplicatiVersion = UpdaterManager.SelfVersion.Version,
-                MachineId = OptionOrDefault("machine-id", () => DataFolderManager.GetMachineID()),
+                MachineId = OptionOrDefault("machine-id", () => DataFolderManager.GetMachineID(probeOnly: true)),
                 BackupId = OptionOrDefault("backup-id", () => Utility.Utility.CalculateBackupId(m_remoteUrl)),
                 BackupName = OptionOrDefault("backup-name", () => System.IO.Path.GetFileNameWithoutExtension(Utility.Utility.getEntryAssembly().Location)),
                 MachineName = OptionOrDefault("machine-name", () => DataFolderManager.MachineName),

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -441,7 +441,7 @@ namespace Duplicati.Library.Modules.Builtin
                 case PARSEDRESULT:
                     return m_parsedresultlevel;
                 case MACHINE_ID:
-                    return DataFolderManager.MachineID;
+                    return DataFolderManager.GetMachineID();
                 case BACKUP_ID:
                     return Utility.Utility.CalculateBackupId(m_remoteurl);
                 case BACKUP_NAME:

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -441,7 +441,7 @@ namespace Duplicati.Library.Modules.Builtin
                 case PARSEDRESULT:
                     return m_parsedresultlevel;
                 case MACHINE_ID:
-                    return DataFolderManager.GetMachineID();
+                    return DataFolderManager.GetMachineID(probeOnly: true);
                 case BACKUP_ID:
                     return Utility.Utility.CalculateBackupId(m_remoteurl);
                 case BACKUP_NAME:

--- a/Duplicati/Library/Modules/Builtin/ReportHelper.cs
+++ b/Duplicati/Library/Modules/Builtin/ReportHelper.cs
@@ -441,7 +441,10 @@ namespace Duplicati.Library.Modules.Builtin
                 case PARSEDRESULT:
                     return m_parsedresultlevel;
                 case MACHINE_ID:
-                    return DataFolderManager.GetMachineID(probeOnly: true);
+                    // Honor an explicit "machine-id" option, falling back to the machine default
+                    return (m_options != null && m_options.TryGetValue(MACHINE_ID, out var machineId) && !string.IsNullOrWhiteSpace(machineId))
+                        ? machineId
+                        : DataFolderManager.GetMachineID(probeOnly: true);
                 case BACKUP_ID:
                     return Utility.Utility.CalculateBackupId(m_remoteurl);
                 case BACKUP_NAME:

--- a/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
+++ b/Duplicati/Library/RemoteControl/KeepRemoteConnection.cs
@@ -433,8 +433,8 @@ public class KeepRemoteConnection : IDisposable
                         { "client-id", ClientId },
                         { "client-uptime", (DateTime.Now - Process.GetCurrentProcess().StartTime).ToString() },
                         { "machine-name", DataFolderManager.MachineName },
-                        { "machine-id", DataFolderManager.MachineID },
-                        { "install-id", DataFolderManager.InstallID },
+                        { "machine-id", DataFolderManager.GetMachineID() },
+                        { "install-id", DataFolderManager.GetInstallID() },
                         { "machine-os", UpdaterManager.OperatingSystemName },
                         { "package-id", UpdaterManager.PackageTypeId },
                         { "update-channel", UpdaterManager.CurrentChannel.ToString() }

--- a/Duplicati/Library/RemoteControl/RegisterForRemote.cs
+++ b/Duplicati/Library/RemoteControl/RegisterForRemote.cs
@@ -172,17 +172,24 @@ public class RegisterForRemote : IDisposable
     private ClaimedClientData? _claimedClientData;
 
     /// <summary>
+    /// The machine ID override to report, or null to use the machine default
+    /// </summary>
+    private readonly string? _machineId;
+
+    /// <summary>
     /// Creates a new instance of the registration process
     /// </summary>
     /// <param name="registrationUrl">The URL to register the machine with</param>
     /// <param name="httpClient">The HTTP client to use for requests</param>
+    /// <param name="machineId">An optional machine ID override; if null or empty the machine default is used</param>
     /// <param name="cancellationToken">The cancellation token to use for the process</param>
-    public RegisterForRemote(string registrationUrl, HttpClient? httpClient, CancellationToken cancellationToken)
+    public RegisterForRemote(string registrationUrl, HttpClient? httpClient, string? machineId, CancellationToken cancellationToken)
     {
         _state = States.NotStarted;
         _registrationUrl = registrationUrl;
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _httpClient = httpClient ?? HttpClientHelper.CreateClient();
+        _machineId = string.IsNullOrWhiteSpace(machineId) ? null : machineId;
         // Timeout for _httpClient will be kept at default 100s (Which is already a long one for registration)
     }
 
@@ -237,7 +244,7 @@ public class RegisterForRemote : IDisposable
         var basics = new Dictionary<string, string?>
         {
             { "instanceId", ClientInstanceId },
-            { "machineId", AutoUpdater.DataFolderManager.GetMachineID() },
+            { "machineId", _machineId ?? AutoUpdater.DataFolderManager.GetMachineID() },
             { "machineName", AutoUpdater.DataFolderManager.MachineName },
             { "installId", AutoUpdater.DataFolderManager.GetInstallID() },
             { "localTime", DateTimeOffset.Now.ToString("o", CultureInfo.InvariantCulture) },

--- a/Duplicati/Library/RemoteControl/RegisterForRemote.cs
+++ b/Duplicati/Library/RemoteControl/RegisterForRemote.cs
@@ -237,9 +237,9 @@ public class RegisterForRemote : IDisposable
         var basics = new Dictionary<string, string?>
         {
             { "instanceId", ClientInstanceId },
-            { "machineId", AutoUpdater.DataFolderManager.MachineID },
+            { "machineId", AutoUpdater.DataFolderManager.GetMachineID() },
             { "machineName", AutoUpdater.DataFolderManager.MachineName },
-            { "installId", AutoUpdater.DataFolderManager.InstallID },
+            { "installId", AutoUpdater.DataFolderManager.GetInstallID() },
             { "localTime", DateTimeOffset.Now.ToString("o", CultureInfo.InvariantCulture) },
             { "version", AutoUpdater.UpdaterManager.SelfVersion?.Version },
             { "packageTypeId", AutoUpdater.UpdaterManager.PackageTypeId },

--- a/Duplicati/Library/UsageReporter/ReportSet.cs
+++ b/Duplicati/Library/UsageReporter/ReportSet.cs
@@ -44,7 +44,7 @@ namespace Duplicati.Library.UsageReporter
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static void DoInitUID()
         {
-            Cached_UserID = Library.AutoUpdater.DataFolderManager.InstallID;
+            Cached_UserID = Library.AutoUpdater.DataFolderManager.GetInstallID();
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]

--- a/Duplicati/UnitTest/BasicSetupHelper.cs
+++ b/Duplicati/UnitTest/BasicSetupHelper.cs
@@ -32,55 +32,6 @@ using System.Timers;
 
 namespace Duplicati.UnitTest
 {
-    /// <summary>
-    /// Assembly-wide setup that runs once before any test in this assembly.
-    /// Ensures a stable machine ID is present in the data folder, so the DEBUG guard
-    /// in <see cref="Library.AutoUpdater.DataFolderManager"/> does not trip when a test
-    /// reads the ID without going through the application startup sequence that
-    /// normally initializes the data folder.
-    /// </summary>
-    [SetUpFixture]
-    public class GlobalTestSetup
-    {
-        /// <summary>
-        /// The machine ID used by the test suite
-        /// </summary>
-        internal const string TestMachineId = "unittestid";
-
-        [OneTimeSetUp]
-        public void RunBeforeAnyTests()
-        {
-            Library.AutoUpdater.DataFolderManager.SetMachineIDForTesting(TestMachineId);
-
-            // Seed the machine id file in the data folder so processes spawned by tests
-            // (e.g. the IPC controller process) inherit a valid machine ID via the
-            // DUPLICATI_HOME environment; such processes cannot see the in-process
-            // SetMachineIDForTesting value.
-            try
-            {
-                var dataFolder = Library.AutoUpdater.DataFolderManager.GetDataFolder(Library.AutoUpdater.DataFolderManager.AccessMode.ProbeOnly);
-                if (!Directory.Exists(dataFolder))
-                {
-                    // Create the folder through the regular startup path so it gets the
-                    // canonical locked-down permissions and both id files; a plainly created
-                    // folder would later be rejected by the secure-folder verification.
-                    Library.AutoUpdater.DataFolderManager.GetDataFolder(Library.AutoUpdater.DataFolderManager.AccessMode.ReadWritePermissionSet);
-                }
-                else
-                {
-                    var machineIdPath = Path.Combine(dataFolder, "machineid.txt");
-                    if (!File.Exists(machineIdPath))
-                        File.WriteAllText(machineIdPath, TestMachineId);
-                }
-            }
-            catch
-            {
-                // Best-effort: if the data folder cannot be written, the in-process
-                // fallback above still protects the tests running in this process.
-            }
-        }
-    }
-
     public abstract class BasicSetupHelper
     {
         /// <summary>

--- a/Duplicati/UnitTest/DataFolderManagerIdTests.cs
+++ b/Duplicati/UnitTest/DataFolderManagerIdTests.cs
@@ -92,10 +92,6 @@ namespace Duplicati.UnitTest
             ResetCachedIds();
             DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ProbeOnly);
 
-            // Restore the shared test machine id that GlobalTestSetup installs, so
-            // later tests in this process do not trip the DEBUG guard in DataFolderManager
-            DataFolderManager.SetMachineIDForTesting(GlobalTestSetup.TestMachineId);
-
             try
             {
                 if (Directory.Exists(m_tempDir))
@@ -123,19 +119,19 @@ namespace Duplicati.UnitTest
             // Reading the ids before the data folder is initialized must not cache the
             // empty value; in debug builds the read throws to reveal early callers
 #if DEBUG
-            Assert.Throws<InvalidOperationException>(() => { var _ = DataFolderManager.MachineID; });
-            Assert.Throws<InvalidOperationException>(() => { var _ = DataFolderManager.InstallID; });
+            Assert.Throws<InvalidOperationException>(() => { var _ = DataFolderManager.GetMachineID(); });
+            Assert.Throws<InvalidOperationException>(() => { var _ = DataFolderManager.GetInstallID(); });
 #else
-            Assert.AreEqual("", DataFolderManager.MachineID);
-            Assert.AreEqual("", DataFolderManager.InstallID);
+            Assert.AreEqual("", DataFolderManager.GetMachineID());
+            Assert.AreEqual("", DataFolderManager.GetInstallID());
 #endif
 
             // Initialize the data folder, which creates the id files
             DataFolderManager.GetDataFolder(DataFolderManager.AccessMode.ReadWritePermissionSet);
 
             // A later read picks up the real values, proving the empty values were not cached
-            var machineId = DataFolderManager.MachineID;
-            var installId = DataFolderManager.InstallID;
+            var machineId = DataFolderManager.GetMachineID();
+            var installId = DataFolderManager.GetInstallID();
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(machineId));
             Assert.IsFalse(string.IsNullOrWhiteSpace(installId));
@@ -162,16 +158,16 @@ namespace Duplicati.UnitTest
             File.WriteAllText(installIdPath, "");
 
             // The file exists, so the empty value is a stable state and does not throw
-            Assert.AreEqual("", DataFolderManager.MachineID);
-            Assert.AreEqual("", DataFolderManager.InstallID);
+            Assert.AreEqual("", DataFolderManager.GetMachineID());
+            Assert.AreEqual("", DataFolderManager.GetInstallID());
 
             // Write real ids; the cached empty values must still be returned,
             // proving the file is not re-read on every access
             File.WriteAllText(machineIdPath, "machine-id-written-later");
             File.WriteAllText(installIdPath, "install-id-written-later");
 
-            Assert.AreEqual("", DataFolderManager.MachineID);
-            Assert.AreEqual("", DataFolderManager.InstallID);
+            Assert.AreEqual("", DataFolderManager.GetMachineID());
+            Assert.AreEqual("", DataFolderManager.GetInstallID());
         }
     }
 }

--- a/Duplicati/UnitTest/HttpReportStatusTests.cs
+++ b/Duplicati/UnitTest/HttpReportStatusTests.cs
@@ -280,7 +280,6 @@ namespace Duplicati.UnitTest
             Assert.AreEqual("s3", metadata.DestinationType, "DestinationType should be the remote URL scheme");
             Assert.IsFalse(string.IsNullOrEmpty(metadata.OperatingSystem), "OperatingSystem should be populated");
             Assert.IsFalse(string.IsNullOrEmpty(metadata.OperatingSystemDetailed), "OperatingSystemDetailed should be populated");
-            Assert.IsFalse(string.IsNullOrEmpty(metadata.InstallationType), "InstallationType should be populated");
 
             // The backup id is a stable hex string derived from the remote URL.
             Assert.That(metadata.BackupId, Does.Match("^[0-9a-fA-F]+$"));

--- a/Duplicati/WebserverCore/Services/RemoteControllerRegistrationService.cs
+++ b/Duplicati/WebserverCore/Services/RemoteControllerRegistrationService.cs
@@ -110,7 +110,7 @@ public class RemoteControllerRegistrationService(Connection connection, IHttpCli
         {
             try
             {
-                _registerForRemote = new RegisterForRemote(registrationUrl, httpClientFactory.CreateClient(), _operationCancellation.Token);
+                _registerForRemote = new RegisterForRemote(registrationUrl, httpClientFactory.CreateClient(), GetMachineIdOverride(), _operationCancellation.Token);
                 var data = await _registerForRemote.RegisterAsync(maxRetries: 3, retryInterval: TimeSpan.FromSeconds(5));
 
                 // Make the link visible to outside
@@ -166,5 +166,22 @@ public class RemoteControllerRegistrationService(Connection connection, IHttpCli
         _operationCancellation = null;
         RegistrationUrl = null;
         eventPollNotify.SignalRemoteControlUpdate();
+    }
+
+    /// <summary>
+    /// Gets the machine ID override from the application settings (ANY_BACKUP_ID), if set.
+    /// </summary>
+    /// <returns>The configured machine ID override, or null if not set</returns>
+    private string? GetMachineIdOverride()
+    {
+        if (connection.Settings == null)
+            return null;
+
+        var lookup = connection.Settings
+            .GroupBy(k => k.Name.StartsWith("--", StringComparison.Ordinal) ? k.Name.Substring(2) : k.Name, k => k.Value)
+            .ToDictionary(x => x.Key, x => x.FirstOrDefault(), StringComparer.OrdinalIgnoreCase);
+
+        var machineId = lookup.GetValueOrDefault("machine-id");
+        return string.IsNullOrWhiteSpace(machineId) ? null : machineId;
     }
 }

--- a/proprietary/GoogleWorkspace/OptionsHelper.cs
+++ b/proprietary/GoogleWorkspace/OptionsHelper.cs
@@ -73,6 +73,7 @@ public static class OptionsHelper
         public string? RefreshToken { get; set; }
         public string? ServiceAccountJson { get; set; }
         public string? AdminEmail { get; set; }
+        public string MachineId { get; set; } = "";
         public GoogleRootType[] IncludedRootTypes { get; set; } = Enum.GetValues<GoogleRootType>().ToArray();
         public GoogleUserType[] IncludedUserTypes { get; set; } = Enum.GetValues<GoogleUserType>().ToArray();
     }
@@ -102,6 +103,11 @@ public static class OptionsHelper
 
         if (options.ContainsKey(GOOGLE_ADMIN_EMAIL_OPTION))
             result.AdminEmail = options[GOOGLE_ADMIN_EMAIL_OPTION];
+
+        // Honor the global "machine-id" option, falling back to the AutoUpdater machine id
+        result.MachineId = options.TryGetValue("machine-id", out var machineId) && !string.IsNullOrWhiteSpace(machineId)
+            ? machineId
+            : Library.AutoUpdater.DataFolderManager.GetMachineID();
 
         var includedRootTypes = Library.Utility.Utility.ParseFlagsOption(options, GOOGLE_INCLUDED_ROOT_TYPES_OPTION, (GoogleRootType)Enum.GetValues<GoogleRootType>().Cast<int>().Aggregate(0, (acc, type) => acc | type));
         var includedUserTypes = Library.Utility.Utility.ParseFlagsOption(options, GOOGLE_INCLUDED_USER_TYPES_OPTION, (GoogleUserType)Enum.GetValues<GoogleUserType>().Cast<int>().Aggregate(0, (acc, type) => acc | type));

--- a/proprietary/GoogleWorkspace/SourceItems/RootSourceEntry.cs
+++ b/proprietary/GoogleWorkspace/SourceItems/RootSourceEntry.cs
@@ -37,7 +37,7 @@ internal class RootSourceEntry(SourceProvider provider)
         var description = new BackupDescription(
             Version: "1.0",
             DuplicatiVersion: Library.AutoUpdater.UpdaterManager.SelfVersion.Version ?? "",
-            MachineId: Library.AutoUpdater.DataFolderManager.GetMachineID(),
+            MachineId: provider.Options.MachineId,
             PackageTypeId: Library.AutoUpdater.UpdaterManager.PackageTypeId,
             OSType: Library.AutoUpdater.UpdaterManager.OperatingSystemName,
             OSVersion: Library.Utility.OSInfoHelper.PlatformString,

--- a/proprietary/GoogleWorkspace/SourceItems/RootSourceEntry.cs
+++ b/proprietary/GoogleWorkspace/SourceItems/RootSourceEntry.cs
@@ -37,7 +37,7 @@ internal class RootSourceEntry(SourceProvider provider)
         var description = new BackupDescription(
             Version: "1.0",
             DuplicatiVersion: Library.AutoUpdater.UpdaterManager.SelfVersion.Version ?? "",
-            MachineId: Library.AutoUpdater.DataFolderManager.MachineID,
+            MachineId: Library.AutoUpdater.DataFolderManager.GetMachineID(),
             PackageTypeId: Library.AutoUpdater.UpdaterManager.PackageTypeId,
             OSType: Library.AutoUpdater.UpdaterManager.OperatingSystemName,
             OSVersion: Library.Utility.OSInfoHelper.PlatformString,

--- a/proprietary/Office365/OptionsHelper.cs
+++ b/proprietary/Office365/OptionsHelper.cs
@@ -118,7 +118,8 @@ internal static class OptionsHelper
         Office365UserClassification IncludedUserClassifications,
         Office365GroupClassification IncludedGroupClassifications,
         Office365SiteClassification IncludedSiteClassifications,
-        bool EnumerationMode
+        bool EnumerationMode,
+        string MachineId
     );
 
     internal static ParsedOptions ParseAndValidateOptions(string url, Dictionary<string, string?> options)
@@ -152,6 +153,11 @@ internal static class OptionsHelper
 
         var enumerationMode = Library.Utility.Utility.ParseBoolOption(options, ENUMERATION_MODE_OPTION);
 
+        // Honor the global "machine-id" option, falling back to the AutoUpdater machine id
+        var machineId = options.GetValueOrDefault("machine-id");
+        if (string.IsNullOrWhiteSpace(machineId))
+            machineId = Library.AutoUpdater.DataFolderManager.GetMachineID();
+
         return new ParsedOptions(
             TenantId: _tenantId,
             AuthOptions: _authOptions,
@@ -165,7 +171,8 @@ internal static class OptionsHelper
             IncludedUserClassifications: includedUserClassifications,
             IncludedGroupClassifications: includedGroupClassifications,
             IncludedSiteClassifications: includedSiteClassifications,
-            EnumerationMode: enumerationMode
+            EnumerationMode: enumerationMode,
+            MachineId: machineId
         );
     }
 

--- a/proprietary/Office365/SourceItems/RootSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/RootSourceEntry.cs
@@ -35,7 +35,7 @@ internal class RootSourceEntry(SourceProvider provider, string mountPoint)
         var description = new BackupDescription(
             Version: "1.0",
             DuplicatiVersion: Library.AutoUpdater.UpdaterManager.SelfVersion.Version ?? "",
-            MachineId: Library.AutoUpdater.DataFolderManager.MachineID,
+            MachineId: Library.AutoUpdater.DataFolderManager.GetMachineID(),
             PackageTypeId: Library.AutoUpdater.UpdaterManager.PackageTypeId,
             OSType: Library.AutoUpdater.UpdaterManager.OperatingSystemName,
             OSVersion: Library.Utility.OSInfoHelper.PlatformString,

--- a/proprietary/Office365/SourceItems/RootSourceEntry.cs
+++ b/proprietary/Office365/SourceItems/RootSourceEntry.cs
@@ -35,7 +35,7 @@ internal class RootSourceEntry(SourceProvider provider, string mountPoint)
         var description = new BackupDescription(
             Version: "1.0",
             DuplicatiVersion: Library.AutoUpdater.UpdaterManager.SelfVersion.Version ?? "",
-            MachineId: Library.AutoUpdater.DataFolderManager.GetMachineID(),
+            MachineId: provider.MachineId,
             PackageTypeId: Library.AutoUpdater.UpdaterManager.PackageTypeId,
             OSType: Library.AutoUpdater.UpdaterManager.OperatingSystemName,
             OSVersion: Library.Utility.OSInfoHelper.PlatformString,

--- a/proprietary/Office365/SourceProvider/SourceProvider.cs
+++ b/proprietary/Office365/SourceProvider/SourceProvider.cs
@@ -34,6 +34,16 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
     private readonly bool _hasSetMetadataStorageOption;
 
     /// <summary>
+    /// The machine id recorded in the backup description, honoring the global <c>machine-id</c> override.
+    /// </summary>
+    private readonly string _machineId;
+
+    /// <summary>
+    /// The machine id to record in the backup description, honoring the global <c>machine-id</c> override.
+    /// </summary>
+    internal string MachineId => _machineId;
+
+    /// <summary>
     /// The timeout options for the backend
     /// </summary>
     private readonly TimeoutOptionsHelper.Timeouts _timeouts;
@@ -164,6 +174,7 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
         _apiHelper = null!;
         _mountPoint = null!;
         _timeouts = null!;
+        _machineId = null!;
         _includedRootTypes = null!;
         _includedUserTypes = null!;
         _includedGroupTypes = null!;
@@ -194,6 +205,7 @@ public sealed partial class SourceProvider : ISourceProviderModule, IDisposable
         _includedGroupClassifications = parsedOptions.IncludedGroupClassifications;
         _includedSiteClassifications = parsedOptions.IncludedSiteClassifications;
         EnumerationMode = parsedOptions.EnumerationMode;
+        _machineId = parsedOptions.MachineId;
         _apiHelper = APIHelper.Create(
             tenantId: parsedOptions.TenantId,
             authOptions: parsedOptions.AuthOptions,


### PR DESCRIPTION
This PR fixes a startup race where the TrayIcon will enumerate all options, which in turn causes the machineId to be evaluated before it is assigned a value.

This PR handles the issue by allowing the options default value reader to call for the ID without caching the result, such that the option read does not store the missing value.

Effect of this change is that a user that does not start Duplicati, but invokes "help" as the very first operation could see an empty string as the default value for "machineId", but on the next run see the real value.