### PR TITLE
Exclude system volume information

### DIFF
--- a/Duplicati/Library/Main/Operation/Backup/FileEnumerationProcess.cs
+++ b/Duplicati/Library/Main/Operation/Backup/FileEnumerationProcess.cs
@@ -487,6 +487,15 @@ namespace Duplicati.Library.Main.Operation.Backup
                 return false;
             }
 
+            // Exclude the "System Volume Information" folder,
+            // which contains system internal data that should not be backed up,
+            // even if the process holds the backup privilege that allows reading it
+            if (OperatingSystem.IsWindows() && entry.IsFolder && IsSystemVolumeInformationFolder(entry))
+            {
+                Logging.Log.WriteVerboseMessage(FILTER_LOGTAG, "ExcludingSystemVolumeInformationFolder", "Excluding System Volume Information folder: {0}", entry.Path);
+                return false;
+            }
+
             // Exclude block devices
             try
             {
@@ -518,6 +527,32 @@ namespace Duplicati.Library.Main.Operation.Backup
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Checks if the given entry is a "System Volume Information" folder,
+        /// based on the name, location, and attributes of the folder.
+        /// This method is not inlined to prevent loading the snapshot types on non-Windows platforms.
+        /// </summary>
+        /// <param name="entry">The entry to evaluate.</param>
+        /// <returns>True if the entry is a "System Volume Information" folder, false otherwise.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        private static bool IsSystemVolumeInformationFolder(ISourceProviderEntry entry)
+        {
+            // If we cannot read the attributes, we cannot verify the folder
+            FileAttributes attributes;
+            try
+            {
+                attributes = entry.Attributes;
+            }
+            catch (Exception ex)
+            {
+                LogExceptionHelper.LogCommonWarning(ex, FILTER_LOGTAG, "PathProcessingErrorAttributes", entry.Path);
+                return false;
+            }
+
+            return Duplicati.Library.Snapshots.WindowsSnapshot.IsSystemVolumeInformationFolder(entry.Path, attributes);
         }
 
         /// <summary>

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -68,6 +68,11 @@ namespace Duplicati.Library.Snapshots
         private static readonly ISystemIO IO_WIN = SystemIO.IO_OS;
 
         /// <summary>
+        /// The name of the special system folder that is excluded from backups
+        /// </summary>
+        private const string SYSTEM_VOLUME_INFORMATION_FOLDER = "System Volume Information";
+
+        /// <summary>
         /// The main reference to the backup controller
         /// </summary>
         private readonly SnapshotManager _snapshotManager;
@@ -138,6 +143,37 @@ namespace Duplicati.Library.Snapshots
 
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Checks if a given path is a "System Volume Information" folder.
+        /// The folder is identified by being located at the root of a volume,
+        /// having the expected name, and having the hidden and system attributes set.
+        /// </summary>
+        /// <param name="path">The path to check</param>
+        /// <param name="attributes">The attributes of the path</param>
+        /// <returns>True if the path is a "System Volume Information" folder, false otherwise</returns>
+        public static bool IsSystemVolumeInformationFolder(string path, FileAttributes attributes)
+        {
+            // The folder must be marked as both hidden and system,
+            // which is the case for the real "System Volume Information" folder,
+            // but unlikely for a user-created folder
+            if (!attributes.HasFlag(FileAttributes.Directory)
+                || !attributes.HasFlag(FileAttributes.Hidden)
+                || !attributes.HasFlag(FileAttributes.System))
+                return false;
+
+            // The folder must be located at the root of a volume
+            var root = Path.GetPathRoot(path.TrimEnd(Path.DirectorySeparatorChar));
+            if (string.IsNullOrEmpty(root))
+                return false;
+
+            // The name of the folder must be exactly "System Volume Information"
+            // and the only component after the root.
+            // Note that the root does not always end with a separator,
+            // such as for UNC paths, so we trim any leading separators
+            var relative = path.TrimEnd(Path.DirectorySeparatorChar).Substring(root.Length).TrimStart(Path.DirectorySeparatorChar);
+            return string.Equals(relative, SYSTEM_VOLUME_INFORMATION_FOLDER, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
On Windows, the "System Volume Information" folder does not contain content that can be meaningfully backed up or restored. For most cases, attempting to read the folder will result in various errors.

For that reason, the folder is now excluded automatically, making it simpler to choose a drive root for backup.