### PR TITLE
Add the workflow check offered in #7224

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,35 @@
+name: Plumber
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: getplumber/plumber@e815e0bff47f9170e8e0a056df0a851124634ae2 # v0.4.51
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,23 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the testcontainers
+      # cloud action this repo already uses, pinned by commit hash.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - atomicjar/testcontainers-cloud-setup-action
+
+    # The baseline also expects release/* branches to be protected.
+    # Here they are one frozen branch per shipped release, kept for
+    # history. The requirement stays on master, where development and
+    # releases actually happen.
+    branchMustBeProtected:
+      defaultMustBeProtected: true
+      namePatterns:
+        - master

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Store securely encrypted backups on cloud storage services!
 [![Backers on Open Collective](https://opencollective.com/duplicati/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/duplicati/sponsors/badge.svg)](#sponsors)
 [![License](https://img.shields.io/github/license/duplicati/duplicati.svg)](https://github.com/duplicati/duplicati/blob/master/LICENSE)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Duplicati%20Guru-006BFF)](https://gurubase.io/g/duplicati)
+[![Plumber Score](https://score.getplumber.io/github.com/duplicati/duplicati.svg)](https://score.getplumber.io/github.com/duplicati/duplicati)
 
 Duplicati is a free, open-source backup client that securely stores encrypted, incremental, and compressed backups on cloud storage services and remote file servers. It supports:
 


### PR DESCRIPTION
Follows up on #7224 and on the offer in the comments there, so here it is as a PR rather than an example config.

A small workflow runs the [Plumber](https://github.com/getplumber/plumber) CLI on pushes to master and on pull requests. It watches for the kind of drift #7224 closed, a new floating ref or a widened token sneaking in, and gates at 85 points so one small finding never blocks a PR. The `.plumber.yaml` next to it keeps the branch protection requirement on master, your release branches are frozen history and stay out of it.

The badge works like Scorecard's published results: every run publishes the score, the badge shows master, a failed publish never fails your CI, no token or secret involved. Gray UNKNOWN until the first run on master. Check without badge: remove the `score-push` line, that is the whole opt-out.

As said in the thread, I work on Plumber. If you would rather stop at the pin, close this with no hard feelings, #7224 stands on its own.
