### PR TITLE
Report an OpenStack delete of a missing object as missing

### DIFF
--- a/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
+++ b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs
@@ -31,6 +31,8 @@ using Duplicati.Library.Utility;
 using Duplicati.Library.Utility.Options;
 using Exception = System.Exception;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend.OpenStack;
 
 public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
@@ -161,6 +163,20 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
 
         m_httpClient = HttpClientHelper.CreateClient();
         m_httpClient.Timeout = Timeout.InfiniteTimeSpan;
+        m_helper = new OpenStackWebHelper(this, m_httpClient);
+    }
+
+    /// <summary>
+    /// Builds a backend that talks to the given transport, so the responses of the
+    /// object store can be decided by a test.
+    /// </summary>
+    /// <param name="url">The backend url</param>
+    /// <param name="options">The options to use</param>
+    /// <param name="handler">The transport to send requests through</param>
+    internal OpenStackStorage(string url, Dictionary<string, string?> options, HttpMessageHandler handler)
+        : this(url, options)
+    {
+        m_httpClient = new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
         m_helper = new OpenStackWebHelper(this, m_httpClient);
     }
 
@@ -439,9 +455,22 @@ public class OpenStackStorage : IStreamingBackend, IRenameEnabledBackend
     public async Task DeleteAsync(string remotename, CancellationToken cancelToken)
     {
         var url = JoinUrls(await GetSimpleStorageEndPoint(cancelToken).ConfigureAwait(false), m_container, UrlEncoding.UrlPathEncode(m_prefix + remotename));
-        using var req = m_helper.CreateRequest(url, "DELETE");
-        using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, ct => m_helper.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, ct)).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+
+        try
+        {
+            using var req = m_helper.CreateRequest(url, "DELETE");
+            using var response = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, ct => m_helper.GetResponseAsync(req, HttpCompletionOption.ResponseContentRead, ct)).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (HttpRequestException wex)
+        {
+            // The API answers the delete of an object that is not there with 404,
+            // and the callers look for FileMissingException to tell that apart from
+            // a destination that does not work. GetAsync already reports it that way.
+            if (wex.StatusCode == HttpStatusCode.NotFound)
+                throw new FileMissingException();
+            throw;
+        }
     }
 
     /// <inheritdoc />

--- a/Duplicati/UnitTest/OpenStackDeleteTests.cs
+++ b/Duplicati/UnitTest/OpenStackDeleteTests.cs
@@ -1,0 +1,178 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.OpenStack;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// The Object Storage API answers the delete of an object that is not there with
+/// 404, and this backend already knows that: GetAsync reports such a 404 as a
+/// FileMissingException. DeleteAsync did not, so the destination self-test could
+/// not tell "the probe file is already gone" from a destination that does not work.
+/// </summary>
+[TestFixture]
+public class OpenStackDeleteTests
+{
+    /// <summary>The container the backend is pointed at</summary>
+    private const string Container = "duplicati-container";
+
+    /// <summary>The name the tests delete</summary>
+    private const string RemoteName = "duplicati-b0123456789.dblock.zip.aes";
+
+    /// <summary>Where the catalog says the object store lives</summary>
+    private const string StorageEndpoint = "https://swift.invalid/v1/AUTH_test";
+
+    /// <summary>The v2 authentication endpoint the tests point the backend at</summary>
+    private const string AuthUri = "https://keystone.invalid/v2.0";
+
+    /// <summary>
+    /// Answers the keystone request with a catalog, and lets the test decide what
+    /// the object store says. Records every request it is given.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        /// <summary>
+        /// Runs for each request that is not the authentication call
+        /// </summary>
+        public Func<HttpRequestMessage, HttpResponseMessage> OnStorageRequest { get; set; }
+            = _ => new HttpResponseMessage(HttpStatusCode.NoContent);
+
+        /// <summary>
+        /// The requests the object store was given, in order
+        /// </summary>
+        public List<(HttpMethod Method, string Url)> StorageRequests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+
+            if (url.StartsWith(AuthUri, StringComparison.Ordinal))
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"access\":{\"token\":{\"id\":\"test-token\"}," +
+                        "\"serviceCatalog\":[{\"type\":\"object-store\",\"endpoints\":[{\"publicURL\":\"" + StorageEndpoint + "\"}]}]}}",
+                        Encoding.UTF8, "application/json")
+                });
+
+            StorageRequests.Add((request.Method, url));
+            return Task.FromResult(OnStorageRequest(request));
+        }
+    }
+
+    private static (OpenStackStorage Backend, StubHandler Handler) Create(
+        Func<HttpRequestMessage, HttpResponseMessage>? onStorageRequest = null)
+    {
+        var handler = new StubHandler();
+        if (onStorageRequest != null)
+            handler.OnStorageRequest = onStorageRequest;
+
+        var options = new Dictionary<string, string?>
+        {
+            ["auth-username"] = "user",
+            ["auth-password"] = "pass",
+            ["openstack-tenant-name"] = "tenant",
+            ["openstack-authuri"] = AuthUri
+        };
+
+        return (new OpenStackStorage($"openstack://{Container}", options, handler), handler);
+    }
+
+    private static HttpResponseMessage Status(HttpStatusCode code)
+        => new(code) { Content = new StringContent("", Encoding.UTF8, "text/plain") };
+
+    /// <summary>
+    /// The point of the change: an object that is not there has to arrive as a
+    /// FileMissingException, which is what the callers look for
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public void ADeleteOfAFileThatIsGoneIsReportedAsMissing()
+    {
+        var (backend, _) = Create(_ => Status(HttpStatusCode.NotFound));
+        using var _b = backend;
+
+        Assert.CatchAsync<FileMissingException>(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Green before and after: only the 404 changed meaning, everything else still
+    /// comes out as the transport error it is
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public void ADeleteThatFailsForAnotherReasonIsNotReportedAsMissing()
+    {
+        var (backend, _) = Create(_ => Status(HttpStatusCode.InternalServerError));
+        using var _b = backend;
+
+        var ex = Assert.CatchAsync(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+
+        Assert.IsNotInstanceOf<FileMissingException>(ex);
+    }
+
+    /// <summary>
+    /// Green before and after: a delete the store accepted stays quiet
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public void ASuccessfulDeleteDoesNotThrow()
+    {
+        var (backend, _) = Create(_ => Status(HttpStatusCode.NoContent));
+        using var _b = backend;
+
+        Assert.DoesNotThrowAsync(async () =>
+            await backend.DeleteAsync(RemoteName, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Green before and after, and the reason the rest of this measures anything:
+    /// the request that goes out is the delete of that object in that container
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task TheDeleteGoesToTheObjectStoreEndpoint()
+    {
+        var (backend, handler) = Create(_ => Status(HttpStatusCode.NoContent));
+        using var _b = backend;
+
+        await backend.DeleteAsync(RemoteName, CancellationToken.None);
+
+        Assert.AreEqual(1, handler.StorageRequests.Count);
+        Assert.AreEqual(HttpMethod.Delete, handler.StorageRequests[0].Method);
+        Assert.AreEqual($"{StorageEndpoint}/{Container}/{RemoteName}", handler.StorageRequests[0].Url);
+    }
+}


### PR DESCRIPTION
Deleting an object that is not there answers 404, and this backend already knows it. [`GetAsync`](https://github.com/duplicati/duplicati/blob/acf58e7852aa744f73ec87432588f2f59d44116b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs#L356-L361) says so:

```csharp
catch (HttpRequestException wex)
{
    if (wex.StatusCode == HttpStatusCode.NotFound)
        throw new FileMissingException();
    throw;
}
```

[`DeleteAsync`](https://github.com/duplicati/duplicati/blob/acf58e7852aa744f73ec87432588f2f59d44116b/Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs#L439-L445), three methods down, does not. `OpenStackWebHelper` does not override `AttemptParseAndThrowExceptionAsync` — the base returns `Task.CompletedTask` — so the 404 comes out as a bare `HttpRequestException`.

The mapping in this file is deliberate, not incidental: `HandleListExceptions` turns a 404 on a
listing into a `FolderMissingException` instead, because there a 404 means the container is
missing. Only the delete was left without an answer.

The [Object Storage API reference](https://docs.openstack.org/api-ref/object-store/index.html) gives delete-object `Normal response codes: 204` and `Error response codes: 404`, so this is the documented answer, not an edge case.

## What it costs, and what it does not

**Backups and compact are not affected.** [`BackendManager.DeleteOperation`](https://github.com/duplicati/duplicati/blob/acf58e7852aa744f73ec87432588f2f59d44116b/Duplicati/Library/Main/Backend/BackendManager.DeleteOperation.cs#L169) checks for a bare 404 as well as the exception type, and recovers by listing:

```csharp
var isHttpFileMissingException = ex is HttpRequestException && (ex as HttpRequestException)?.StatusCode == HttpStatusCode.NotFound;
```

What is affected is the **destination self-test**. [`TestReadWritePermissionsAsync`](https://github.com/duplicati/duplicati/blob/acf58e7852aa744f73ec87432588f2f59d44116b/Duplicati/Library/Utility/BackendExtensions.cs#L91) catches `FileMissingException` and nothing else, both when clearing an old probe file and when cleaning up after itself, so a bare 404 becomes a `TestAfterConnectException` — "Test connection" and `BackendTester` report the destination as broken because a file they wanted gone was already gone.

That is the same failure GCS was showing in the backend test runs, and the same mapping [#7249](https://github.com/duplicati/duplicati/pull/7249) added there a few days ago.

## Changes

`Duplicati/Library/Backend/OpenStack/OpenStackStorage.cs` only. The `catch` is copied from `GetAsync` in the same file rather than written fresh, so the two now read alike.

## Tests

`Duplicati/UnitTest/OpenStackDeleteTests.cs`. The stub answers the keystone v2 request with a catalog and lets each test decide what the object store says.

Before the change, one test fails, and it fails with the symptom:

```
Expected: instance of <Duplicati.Library.Interface.FileMissingException>
But was:  <System.Net.Http.HttpRequestException: Response status code does not indicate success: 404 (Not Found).
   at HttpResponseMessage.EnsureSuccessStatusCode()
   at JsonWebHelperHttpClient.GetResponseAsync(...)
   at OpenStackStorage.DeleteAsync(...)
```

`Failed: 1, Passed: 3` before; `Failed: 0, Passed: 4` after.

The other three are green in both states on purpose:

| test | what it holds down |
|---|---|
| `ADeleteThatFailsForAnotherReasonIsNotReportedAsMissing` | a 500 still comes out as the transport error — only the 404 changed meaning |
| `ASuccessfulDeleteDoesNotThrow` | 204 stays quiet |
| `TheDeleteGoesToTheObjectStoreEndpoint` | the request that goes out is a `DELETE` to `endpoint/container/name` |

The last one is there because a seam fed hand-written values proves nothing on its own; it checks the request actually sent.

`DrimeDeleteRetryTests` still passes — 9 of 9 together. The solution builds with 0 errors and 0 warnings, which is also what master gives now that [#7248](https://github.com/duplicati/duplicati/pull/7248) has regenerated the DBus bindings.

## What is not measured

**I have not run this against a real Swift endpoint** — there are no OpenStack credentials here, and that job is gated on secrets in CI, so it would be skipped there too. The evidence is the API reference, the fact that `GetAsync` in this same file already treats a 404 that way, and the tests above.

## The seam

`Duplicati.Library.Backend.OpenStack` gains `InternalsVisibleTo("Duplicati.UnitTest")` — the first for this assembly, though fourteen others already carry it — and an `internal` constructor taking an `HttpMessageHandler`, chaining to the real one so the option parsing is not duplicated. It is the same shape as `DrimeBackend`, `Filejump` and `FilenClient`.

If that is more than you want here, the alternative is the `catch` on its own with no tests; say so and I will cut it back.

## Noticed, not changed

`DeleteAsync` ends with `response.EnsureSuccessStatusCode()`, which cannot fire — `m_helper.GetResponseAsync` has already called it and thrown. Left alone as unrelated.
