### PR TITLE
Fix HyperV and MSSQL with native

### DIFF
--- a/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/HyperVOptions.cs
@@ -193,7 +193,14 @@ namespace Duplicati.Library.Modules.Builtin
                 Logging.Log.WriteWarningMessage(LOGTAG, "HyperVOnServerOnly", null, "This is client version of Windows. Hyper-V VSS writer is present only on Server version. Backup will continue, but will be crash consistent only in opposite to application consistent in Server version");
 
             Logging.Log.WriteInformationMessage(LOGTAG, "StartingHyperVQuery", "Starting to gather Hyper-V information");
-            var provider = Utility.Utility.ParseEnumOption(changedOptions.AsReadOnly(), "snapshot-provider", WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);
+            var provider = Utility.Utility.ParseEnumOption(commandlineOptions, "snapshot-provider", WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);
+            if (provider == WindowsSnapshotProvider.Wmi)
+            {
+                provider = WindowsSnapshotProvider.Native;
+                changedOptions["snapshot-provider"] = provider.ToString();
+                Logging.Log.WriteWarningMessage(LOGTAG, "WmiNotSupportedForHyperV", null, $"The {WindowsSnapshotProvider.Wmi} cannot be used for HyperV backups, switching to {provider}");
+            }
+
             hypervUtility.QueryHyperVGuestsInfo(provider, true);
 
             if (hypervUtility.Guests == null || hypervUtility.Guests.Count == 0)

--- a/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
+++ b/Duplicati/Library/Modules/Builtin/MSSQLOptions.cs
@@ -229,7 +229,14 @@ namespace Duplicati.Library.Modules.Builtin
             }
 
             Logging.Log.WriteInformationMessage(LOGTAG, "StartingMsSqlQuery", "Starting to gather Microsoft SQL Server information", Logging.LogMessageType.Information);
-            var provider = Utility.Utility.ParseEnumOption(changedOptions.AsReadOnly(), "snapshot-provider", WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);
+            var provider = Utility.Utility.ParseEnumOption(commandlineOptions, "snapshot-provider", WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);
+            if (provider == WindowsSnapshotProvider.Wmi)
+            {
+                provider = WindowsSnapshotProvider.Native;
+                changedOptions["snapshot-provider"] = provider.ToString();
+                Logging.Log.WriteWarningMessage(LOGTAG, "WmiNotSupportedForMSSQL", null, $"The {WindowsSnapshotProvider.Wmi} cannot be used for MSSQL backups, switching to {provider}");
+            }
+
             mssqlUtility.QueryDBsInfo(provider);
             Logging.Log.WriteInformationMessage(LOGTAG, "MsSqlDatabaseCount", "Found {0} databases on Microsoft SQL Server", mssqlUtility.DBs.Count);
 

--- a/Duplicati/Library/Snapshots/Windows/SnapshotManager.cs
+++ b/Duplicati/Library/Snapshots/Windows/SnapshotManager.cs
@@ -88,14 +88,7 @@ namespace Duplicati.Library.Snapshots.Windows
             if (excludedWriters != null && excludedWriters.Length > 0)
                 _snapshotProvider.DisableWriterClasses(excludedWriters);
 
-            try
-            {
-                _snapshotProvider.GatherWriterMetadata();
-            }
-            finally
-            {
-                _snapshotProvider.FreeWriterMetadata();
-            }
+            _snapshotProvider.GatherWriterMetadata();
 
             if (includedWriters == null)
             {
@@ -166,6 +159,11 @@ namespace Duplicati.Library.Snapshots.Windows
         /// <param name="sources">The soruces to include</param>
         public void InitShadowVolumes(IEnumerable<string> sources)
         {
+            // The writer metadata is no longer needed once writers have been
+            // verified, and GatherWriterMetadata can only be called once per
+            // backup components object, so free it before creating snapshots
+            _snapshotProvider.FreeWriterMetadata();
+
             _snapshotProvider.StartSnapshotSet();
 
             CheckAndAddSupportedVolumes(sources);
@@ -229,6 +227,15 @@ namespace Duplicati.Library.Snapshots.Windows
             catch (Exception ex)
             {
                 Logging.Log.WriteVerboseMessage(LOGTAG, "MappedDriveCleanupError", ex, "Failed during VSS mapped drive unmapping");
+            }
+
+            try
+            {
+                _snapshotProvider?.FreeWriterMetadata();
+            }
+            catch (Exception ex)
+            {
+                Logging.Log.WriteVerboseMessage(LOGTAG, "VSSFreeMetadataError", ex, "Failed to free VSS writer metadata");
             }
 
             try

--- a/Duplicati/Library/Snapshots/WindowsSnapshot.cs
+++ b/Duplicati/Library/Snapshots/WindowsSnapshot.cs
@@ -49,8 +49,7 @@ namespace Duplicati.Library.Snapshots
         /// <summary>
         /// The default snapshot query provider
         /// </summary>
-        public static readonly WindowsSnapshotProvider DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER =
-            WindowsSnapshotProvider.AlphaVSS;
+        public static readonly WindowsSnapshotProvider DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER = WindowsSnapshotProvider.Native;
 
         /// <summary>
         /// The snapshot providers that require VC Redist to be installed

--- a/Duplicati/Library/WindowsModules/NativeVssBackup.cs
+++ b/Duplicati/Library/WindowsModules/NativeVssBackup.cs
@@ -360,11 +360,12 @@ public class NativeVssBackup : ISnapshotProvider
                         VssInteropUtility.ThrowIfFailed(component.GetComponentInfo(out infoPtr), nameof(VssWMComponentWrapper.GetComponentInfo));
                         var info = Marshal.PtrToStructure<VSS_COMPONENTINFO>(infoPtr);
                         var logicalPath = info.bstrLogicalPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(info.bstrLogicalPath) ?? string.Empty;
+                        var componentName = info.bstrComponentName == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(info.bstrComponentName) ?? string.Empty;
 
                         results.Add(new WriterMetaData
                         {
                             Guid = writerId,
-                            Name = writerName ?? string.Empty,
+                            Name = componentName,
                             LogicalPath = logicalPath,
                             Paths = GetPathsFromComponent(component, info.cFileCount)
                         });

--- a/Duplicati/Library/WindowsModules/VanaraVssBackup.cs
+++ b/Duplicati/Library/WindowsModules/VanaraVssBackup.cs
@@ -240,7 +240,7 @@ public class VanaraVssBackup : ISnapshotProvider
                     yield return new WriterMetaData
                     {
                         Guid = writerId,
-                        Name = writerName ?? string.Empty,
+                        Name = ci.bstrComponentName ?? string.Empty,
                         LogicalPath = ci.bstrLogicalPath ?? string.Empty,
                         Paths = GetPathsFromComponent(comp)
                     };

--- a/Duplicati/WebserverCore/Endpoints/V1/Filesystem.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/Filesystem.cs
@@ -34,8 +34,8 @@ public class Filesystem : IEndpointV1
     private record FilesystemInput(string path);
     public static void Map(RouteGroupBuilder group)
     {
-        group.MapPost("/filesystem", ([FromQuery] bool? onlyFolders, [FromQuery] bool? showHidden, [FromBody] FilesystemInput input)
-            => Execute(input.path, onlyFolders ?? false, showHidden ?? false))
+        group.MapPost("/filesystem", ([FromServices] Server.Database.Connection connection, [FromQuery] bool? onlyFolders, [FromQuery] bool? showHidden, [FromBody] FilesystemInput input)
+            => Execute(connection, input.path, onlyFolders ?? false, showHidden ?? false))
             .RequireAuthorization();
 
         group.MapPost("/filesystem/validate", ([FromBody] FilesystemInput input)
@@ -72,7 +72,10 @@ public class Filesystem : IEndpointV1
         throw new NotFoundException("The path does not exist");
     }
 
-    private static IEnumerable<Dto.TreeNodeDto> Execute(string path, bool onlyFolders, bool showHidden)
+    private static IReadOnlyDictionary<string, string?> GetApplicationSettings(Server.Database.Connection connection)
+        => connection.Settings.GroupBy(x => x.Name.StartsWith("--") ? x.Name.Substring(2) : x.Name, x => x.Value).ToDictionary(x => x.Key, x=> x.FirstOrDefault());
+
+    private static IEnumerable<Dto.TreeNodeDto> Execute(Server.Database.Connection connection, string path, bool onlyFolders, bool showHidden)
     {
         if (string.IsNullOrEmpty(path))
             throw new BadRequestException("No path was found");
@@ -121,7 +124,7 @@ public class Filesystem : IEndpointV1
             }
             else if (pluginkey != null)
             {
-                var plugin = FilesystemPlugins.KnownPlugins.GetPlugins().FirstOrDefault(x => x.RootName == pluginkey);
+                var plugin = FilesystemPlugins.KnownPlugins.GetPlugins(GetApplicationSettings(connection)).FirstOrDefault(x => x.RootName == pluginkey);
                 if (plugin == null)
                 {
                     Library.Logging.Log.WriteWarningMessage(LOGTAG, "NonExistingPlugin", null, $"Requested plugin key {pluginkey} which is not supported");
@@ -158,7 +161,7 @@ public class Filesystem : IEndpointV1
 
                     })
                     // Add plugins for Hyper-V and MSSQL
-                    .Concat(FilesystemPlugins.KnownPlugins.GetPlugins()
+                    .Concat(FilesystemPlugins.KnownPlugins.GetPlugins(GetApplicationSettings(connection))
                         .SelectMany(plugin => plugin.GetEntries(Array.Empty<string>())))
                     .Concat(res);
             }

--- a/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/HyperV.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/HyperV.cs
@@ -20,11 +20,9 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Security.Principal;
-using Duplicati.Library.Common.IO;
 using Duplicati.Library.Snapshots;
 using Duplicati.Library.Snapshots.Windows;
 using Duplicati.WebserverCore.Dto;
-using Duplicati.WebserverCore.Exceptions;
 
 namespace Duplicati.WebserverCore.Endpoints.V1.FilesystemPlugins;
 
@@ -32,6 +30,11 @@ public class Hyperv : IFilesystemPlugin
 {
     private static readonly string LOGTAG = Duplicati.Library.Logging.Log.LogTagFromType<Hyperv>();
     public string RootName => "%HYPERV%";
+
+    private readonly IReadOnlyDictionary<string, string?> _options;
+
+    public Hyperv(IReadOnlyDictionary<string, string?> options)
+        => _options = options;
 
     public IEnumerable<Dto.TreeNodeDto> GetEntries(string[] pathSegments)
     {
@@ -46,7 +49,7 @@ public class Hyperv : IFilesystemPlugin
 
             if (pathSegments.Length == 0)
             {
-                hypervUtility.QueryHyperVGuestsInfo(WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);
+                hypervUtility.QueryHyperVGuestsInfo(Library.Utility.Utility.ParseEnumOption(_options, "snapshot-provider", WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER));
                 if (!hypervUtility.Guests.Any())
                     return [];
                 return

--- a/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/IFilesystemPlugin.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/IFilesystemPlugin.cs
@@ -46,9 +46,9 @@ public static class KnownPlugins
     /// Gets all filesystem plugins.
     /// </summary>
     /// <returns>An enumerable of <see cref="IFilesystemPlugin"/> instances.</returns>
-    public static IEnumerable<IFilesystemPlugin> GetPlugins()
+    public static IEnumerable<IFilesystemPlugin> GetPlugins(IReadOnlyDictionary<string, string?> options)
     {
-        yield return new Hyperv();
-        yield return new MSSQL();
+        yield return new Hyperv(options);
+        yield return new MSSQL(options);
     }
 }

--- a/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/MSSQL.cs
+++ b/Duplicati/WebserverCore/Endpoints/V1/FilesystemPlugins/MSSQL.cs
@@ -31,6 +31,11 @@ public class MSSQL : IFilesystemPlugin
     private static readonly string LOGTAG = Duplicati.Library.Logging.Log.LogTagFromType<MSSQL>();
     public string RootName => "%MSSQL%";
 
+    private readonly IReadOnlyDictionary<string, string?> _options;
+
+    public MSSQL(IReadOnlyDictionary<string, string?> options)
+        => _options = options;
+
     public IEnumerable<Dto.TreeNodeDto> GetEntries(string[] pathSegments)
     {
         if (!OperatingSystem.IsWindows())
@@ -42,7 +47,7 @@ public class MSSQL : IFilesystemPlugin
             if (!mssqlUtility.IsMSSQLInstalled || !new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
                 return [];
 
-            mssqlUtility.QueryDBsInfo(WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER);
+            mssqlUtility.QueryDBsInfo(Library.Utility.Utility.ParseEnumOption(_options, "snapshot-provider", WindowsSnapshot.DEFAULT_WINDOWS_SNAPSHOT_QUERY_PROVIDER));
 
             // Tier 1: Root Node Selection (%MSSQL%)
             if (pathSegments.Length == 0)
@@ -145,10 +150,10 @@ public class MSSQL : IFilesystemPlugin
                 {
                     text = x,
                     id = Util.AppendDirSeparator(string.Join(Path.DirectorySeparatorChar, pathSegments.Append(x))),
-                    cls = "file",
+                    cls = "folder",
                     iconCls = "x-tree-icon-mssqldb",
                     check = false,
-                    leaf = true,
+                    leaf = false,
                     hidden = false,
                     systemFile = false,
                     temporary = false,


### PR DESCRIPTION
This fixes some issues with the Native VSS provider and HyperV/MSSQL.

It also allows overriding the VSS provider via the global advanced options, such that another provider can be used for enumerating MSSQL and HyperV entries.

The WMI provider cannot make HyperV or MSSQL backups, so the backups will revert to "native" if that combination is selected.