### PR TITLE
Use VSS for fulldisk backup

### DIFF
--- a/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
+++ b/Duplicati/Library/DynamicLoader/SourceProviderLoader.cs
@@ -169,14 +169,13 @@ namespace Duplicati.Library.DynamicLoader
         }
 
         /// <summary>
-        /// Instanciates a specific SourceProvider, given the url and options
+        /// Creates a specific SourceProvider without initializing it, given the url and options
         /// </summary>
         /// <param name="url">The url to create the instance for</param>
         /// <param name="mountPoint">The mount point to use</param>
         /// <param name="options">The options to pass to the instance constructor</param>
-        /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>The instanciated SourceProvider or null if the url is not supported</returns>
-        public static async Task<ISourceProviderModule> GetSourceProvider(string url, string mountPoint, Dictionary<string, string> options, CancellationToken cancellationToken)
+        /// <returns>The created SourceProvider or null if the url is not supported</returns>
+        public static ISourceProviderModule CreateSourceProvider(string url, string mountPoint, Dictionary<string, string> options)
         {
             // Source providers are preferred over backends
             var provider = _SourceProviderLoader.GetSourceProvider(url, mountPoint, options);
@@ -189,6 +188,21 @@ namespace Duplicati.Library.DynamicLoader
                 else
                     backend?.Dispose();
             }
+
+            return provider;
+        }
+
+        /// <summary>
+        /// Instanciates a specific SourceProvider, given the url and options
+        /// </summary>
+        /// <param name="url">The url to create the instance for</param>
+        /// <param name="mountPoint">The mount point to use</param>
+        /// <param name="options">The options to pass to the instance constructor</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The instanciated SourceProvider or null if the url is not supported</returns>
+        public static async Task<ISourceProviderModule> GetSourceProvider(string url, string mountPoint, Dictionary<string, string> options, CancellationToken cancellationToken)
+        {
+            var provider = CreateSourceProvider(url, mountPoint, options);
 
             if (provider == null)
                 return null;

--- a/Duplicati/Library/Interface/ISnapshotAwareModule.cs
+++ b/Duplicati/Library/Interface/ISnapshotAwareModule.cs
@@ -1,0 +1,55 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Duplicati.Library.Interface;
+
+/// <summary>
+/// Interface for source provider modules that can participate in snapshot operations.
+/// When a snapshot is created for the backup (e.g., VSS on Windows), modules implementing
+/// this interface will be asked to contribute paths to the snapshot and will receive
+/// the snapshot service for use during backup operations.
+/// </summary>
+public interface ISnapshotAwareModule
+{
+    /// <summary>
+    /// Gets the paths that should be included in the snapshot.
+    /// This is called before the snapshot is created, so the paths can be included
+    /// in the snapshot set.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The paths to include in the snapshot, or an empty collection if none.</returns>
+    Task<IEnumerable<string>> GetSnapshotPathsAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets the snapshot service for the module to use.
+    /// This is called after the snapshot has been created (or after snapshot creation
+    /// has been skipped/failed). The module should use the snapshot service for
+    /// subsequent operations.
+    /// </summary>
+    /// <param name="snapshotService">The snapshot service, or null if no snapshot was created.</param>
+    void SetSnapshotService(ISnapshotService? snapshotService);
+}

--- a/Duplicati/Library/Main/Operation/Common/SourceProviderFactory.cs
+++ b/Duplicati/Library/Main/Operation/Common/SourceProviderFactory.cs
@@ -207,14 +207,22 @@ namespace Duplicati.Library.Main.Operation.Common
             // To avoid leaking snapshot instances, we create all instances first and then dispose them if an exception occurs
             // The number of instances is expected to be low, so the memory overhead is acceptable
             var results = new List<ISourceProvider>();
+            var uninitializedProviders = new List<ISourceProviderModule>();
+            var snapshotAwareProviders = new List<ISnapshotAwareModule>();
+            var fileSources = new List<string>();
+
             try
             {
                 foreach (var entry in sourceTypes)
                 {
                     if ("file".Equals(entry.Key, StringComparison.OrdinalIgnoreCase))
-                        results.Add(new LocalFileSource(GetFileSnapshotService(entry, options)));
+                    {
+                        fileSources.AddRange(entry);
+                    }
                     else if ("vss".Equals(entry.Key, StringComparison.OrdinalIgnoreCase) || "lvm".Equals(entry.Key, StringComparison.OrdinalIgnoreCase))
+                    {
                         results.Add(new LocalFileSource(SnapshotUtility.CreateSnapshot(entry, options.RawOptions, options.SymlinkPolicy == Options.SymlinkStrategy.Follow)));
+                    }
                     else if ("@".Equals(entry.Key, StringComparison.OrdinalIgnoreCase))
                     {
                         foreach (var url in entry)
@@ -233,10 +241,11 @@ namespace Duplicati.Library.Main.Operation.Common
                                 var normalizedMountpoint = Duplicati.Library.Common.IO.Util.AppendDirSeparator(mountpoint);
                                 var backendurl = remoteSource.Url;
 
-                                ISourceProvider provider;
+                                ISourceProviderModule provider;
                                 try
                                 {
-                                    provider = await SourceProviderLoader.GetSourceProvider(backendurl, Path.GetFullPath(normalizedMountpoint), options.RawOptions, cancellationToken).ConfigureAwait(false);
+                                    provider = SourceProviderLoader.CreateSourceProvider(backendurl, Path.GetFullPath(normalizedMountpoint), options.RawOptions)
+                                        ?? throw new UserInformationException($"The source \"{sanitizedUrl}\" is not supported", "SourceNotSupported");
                                 }
                                 catch (Exception ex)
                                 {
@@ -251,8 +260,10 @@ namespace Duplicati.Library.Main.Operation.Common
                                     }
                                 }
 
-                                // Don't accept missing providers
-                                results.Add(provider ?? throw new UserInformationException($"The source \"{sanitizedUrl}\" is not supported", "SourceNotSupported"));
+                                uninitializedProviders.Add(provider);
+
+                                if (provider is ISnapshotAwareModule snapshotAware)
+                                    snapshotAwareProviders.Add(snapshotAware);
                             }
                             else
                                 throw new UserInformationException($"The source \"{sanitizedUrl}\" is not a supported format", "SourceFormatNotSupported");
@@ -261,10 +272,59 @@ namespace Duplicati.Library.Main.Operation.Common
                     else
                         throw new UserInformationException($"The source type \"{entry.Key}\" is not supported", "SourceTypeNotSupported");
                 }
+
+                // Collect snapshot paths from file sources and snapshot-aware providers
+                var snapshotPaths = new List<string>(fileSources);
+                foreach (var snapshotAware in snapshotAwareProviders)
+                {
+                    var paths = await snapshotAware.GetSnapshotPathsAsync(cancellationToken).ConfigureAwait(false);
+                    if (paths != null)
+                        snapshotPaths.AddRange(paths);
+                }
+
+                // Create the snapshot service if we have any paths that need it
+                ISnapshotService? fileSnapshot = null;
+                if (snapshotPaths.Count > 0)
+                {
+                    fileSnapshot = GetFileSnapshotService(snapshotPaths, options);
+
+                    // Give the snapshot to snapshot-aware providers before initializing them
+                    foreach (var snapshotAware in snapshotAwareProviders)
+                        snapshotAware.SetSnapshotService(fileSnapshot);
+                }
+
+                // Create the file source with the snapshot
+                if (fileSources.Count > 0)
+                    results.Add(new LocalFileSource(fileSnapshot ?? GetFileSnapshotService(fileSources, options)));
+
+                // Initialize the remote providers (now with snapshot available)
+                foreach (var provider in uninitializedProviders)
+                {
+                    try
+                    {
+                        await provider.InitializeAsync(cancellationToken).ConfigureAwait(false);
+                        results.Add(provider);
+                    }
+                    catch (Exception ex)
+                    {
+                        var sanitizedUrl = provider.MountedPath ?? "unknown";
+                        if (options.AbortIfSourceMissing)
+                            throw new UserInformationException($"Failed to initialize source provider for \"{sanitizedUrl}\": {ex.Message}", "SourceProviderFailed", ex);
+                        else if (options.AllowMissingSource)
+                            continue;
+                        else
+                        {
+                            Log.WriteWarningMessage(LOGTAG, "SourceProviderFailed", ex, "Failed to initialize source provider for \"{0}\"", sanitizedUrl);
+                            continue;
+                        }
+                    }
+                }
             }
             catch
             {
                 foreach (var provider in results)
+                    (provider as IDisposable)?.Dispose();
+                foreach (var provider in uninitializedProviders)
                     (provider as IDisposable)?.Dispose();
 
                 throw;

--- a/proprietary/DiskImage/Disk/VssDiskWrapper.cs
+++ b/proprietary/DiskImage/Disk/VssDiskWrapper.cs
@@ -329,7 +329,7 @@ internal sealed class VssDiskWrapper : IRawDisk
 
         var script = $@"
 Get-Partition -DiskNumber {diskNumber} -ErrorAction SilentlyContinue |
-Where-Object {{ $_.DriveLetter -ne $null }} |
+Where-Object {{ $_.DriveLetter -ne $null -and $_.DriveLetter -ne [char]0 -and $_.DriveLetter -ne '' }} |
 ForEach-Object {{
     [pscustomobject]@{{
         DriveLetter = $_.DriveLetter.ToString()

--- a/proprietary/DiskImage/Disk/VssDiskWrapper.cs
+++ b/proprietary/DiskImage/Disk/VssDiskWrapper.cs
@@ -1,0 +1,377 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Proprietary.DiskImage.Disk;
+using Duplicati.Proprietary.DiskImage.General;
+using Vanara.PInvoke;
+using static Vanara.PInvoke.Kernel32;
+
+namespace Duplicati.Proprietary.DiskImage.Disk;
+
+/// <summary>
+/// A wrapper around a raw disk that redirects reads to VSS snapshot devices for snapshotted volumes.
+/// This ensures that data read from snapshotted volumes is crash-consistent, while data outside
+/// snapshotted volumes (partition table, unallocated space) is read from the raw disk.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class VssDiskWrapper : IRawDisk
+{
+    private static readonly string LOGTAG = Duplicati.Library.Logging.Log.LogTagFromType<VssDiskWrapper>();
+
+    /// <summary>
+    /// The underlying raw disk.
+    /// </summary>
+    private readonly IRawDisk _rawDisk;
+
+    /// <summary>
+    /// Mapping from partition offset ranges to snapshot device handles.
+    /// Key is the start offset of the partition, value is a tuple of (endOffset, snapshotHandle).
+    /// </summary>
+    private readonly List<(long StartOffset, long EndOffset, SafeHFILE Handle)> _snapshotVolumes = [];
+
+    /// <summary>
+    /// Indicates whether the wrapper has been disposed.
+    /// </summary>
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VssDiskWrapper"/> class.
+    /// </summary>
+    /// <param name="rawDisk">The raw disk to wrap.</param>
+    private VssDiskWrapper(IRawDisk rawDisk)
+    {
+        _rawDisk = rawDisk ?? throw new ArgumentNullException(nameof(rawDisk));
+    }
+
+    /// <inheritdoc />
+    public static string Prefix => Windows.Prefix;
+
+    /// <inheritdoc />
+    public string DevicePath => _rawDisk.DevicePath;
+
+    /// <inheritdoc />
+    public long Size => _rawDisk.Size;
+
+    /// <inheritdoc />
+    public int SectorSize => _rawDisk.SectorSize;
+
+    /// <inheritdoc />
+    public int Sectors => _rawDisk.Sectors;
+
+    /// <inheritdoc />
+    public bool IsWriteable => false; // VSS snapshots are read-only
+
+    /// <summary>
+    /// Creates a new VSS disk wrapper for the specified disk.
+    /// </summary>
+    /// <param name="rawDisk">The raw disk to wrap.</param>
+    /// <param name="snapshotService">The snapshot service that provides snapshot device paths.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A new VSS disk wrapper, or null if VSS is not available or no volumes were found.</returns>
+    public static async Task<VssDiskWrapper?> CreateAsync(IRawDisk rawDisk, ISnapshotService snapshotService, CancellationToken cancellationToken)
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        // Get the volumes on this disk
+        var volumes = await GetVolumesOnDiskAsync(rawDisk.DevicePath, cancellationToken).ConfigureAwait(false);
+        if (volumes.Count == 0)
+        {
+            Duplicati.Library.Logging.Log.WriteInformationMessage(LOGTAG, "NoVolumesFound", "No volumes found on disk {0}, skipping VSS", rawDisk.DevicePath);
+            return null;
+        }
+
+        Duplicati.Library.Logging.Log.WriteInformationMessage(LOGTAG, "CreatingVssSnapshot", "Creating VSS disk wrapper for disk {0} with volumes: {1}", rawDisk.DevicePath, string.Join(", ", volumes.Select(v => v.DriveLetter)));
+
+        var wrapper = new VssDiskWrapper(rawDisk);
+        var openedAny = false;
+
+        foreach (var volume in volumes)
+        {
+            var driveLetter = volume.DriveLetter + ":\\";
+            string snapshotPath;
+            try
+            {
+                snapshotPath = snapshotService.ConvertToSnapshotPath(driveLetter);
+            }
+            catch (Exception ex)
+            {
+                Duplicati.Library.Logging.Log.WriteVerboseMessage(LOGTAG, "SnapshotPathFailed", ex, "Failed to get snapshot path for volume {0}", driveLetter);
+                continue;
+            }
+
+            // Check if the snapshot path is a real VSS snapshot device
+            if (!snapshotPath.Contains("HarddiskVolumeShadowCopy", StringComparison.OrdinalIgnoreCase))
+            {
+                Duplicati.Library.Logging.Log.WriteVerboseMessage(LOGTAG, "NoSnapshotForVolume", "No VSS snapshot available for volume {0}", driveLetter);
+                continue;
+            }
+
+            // Remove the trailing backslash to get the device path
+            var devicePath = snapshotPath.TrimEnd('\\');
+
+            var handle = CreateFile(
+                devicePath,
+                Kernel32.FileAccess.GENERIC_READ,
+                FILE_SHARE.FILE_SHARE_READ | FILE_SHARE.FILE_SHARE_WRITE,
+                null,
+                CreationOption.OPEN_EXISTING,
+                FileFlagsAndAttributes.FILE_FLAG_NO_BUFFERING,
+                IntPtr.Zero);
+
+            if (handle.IsInvalid)
+            {
+                var error = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                Duplicati.Library.Logging.Log.WriteWarningMessage(LOGTAG, "SnapshotOpenFailed", null, "Failed to open snapshot device {0}: Win32 Error Code {1}", devicePath, error);
+                continue;
+            }
+
+            wrapper._snapshotVolumes.Add((volume.Offset, volume.Offset + volume.Size, handle));
+            openedAny = true;
+            Duplicati.Library.Logging.Log.WriteVerboseMessage(LOGTAG, "SnapshotOpened", "Opened snapshot device {0} for partition at offset {1}", devicePath, volume.Offset);
+        }
+
+        if (!openedAny)
+        {
+            Duplicati.Library.Logging.Log.WriteWarningMessage(LOGTAG, "NoSnapshotsOpened", null, "Failed to open any snapshot devices, falling back to raw disk");
+            return null;
+        }
+
+        return wrapper;
+    }
+
+    /// <inheritdoc />
+    public Task<string?> InitializeAsync(CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null); // Already initialized via CreateAsync
+
+    /// <inheritdoc />
+    public Task<string?> InitializeAsync(bool enableWrite, CancellationToken cancellationToken)
+        => Task.FromResult<string?>(enableWrite ? "VSS snapshots are read-only" : null);
+
+    /// <inheritdoc />
+    public Task<bool> AutoUnmountAsync(CancellationToken cancellationToken)
+        => _rawDisk.AutoUnmountAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task<bool> FinalizeAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream> ReadSectorsAsync(long startSector, int sectorCount, CancellationToken cancellationToken)
+    {
+        long offset = startSector * SectorSize;
+        int length = sectorCount * SectorSize;
+        return await ReadBytesAsync(offset, length, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream> ReadBytesAsync(long offset, int length, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[length];
+        var bytesRead = await ReadBytesAsync(offset, buffer, cancellationToken).ConfigureAwait(false);
+        return new MemoryStream(buffer, 0, bytesRead);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ReadBytesAsync(long offset, Memory<byte> destination, CancellationToken cancellationToken)
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(VssDiskWrapper));
+
+        if (offset + destination.Length > Size)
+            throw new InvalidOperationException($"The requested read would read beyond disk size: {offset} + {destination.Length} > {Size}");
+
+        // Find the snapshot volume that contains this offset
+        foreach (var (startOffset, endOffset, handle) in _snapshotVolumes)
+        {
+            if (offset >= startOffset && offset < endOffset)
+            {
+                // Calculate how much we can read from this snapshot
+                var bytesAvailable = (int)Math.Min(destination.Length, endOffset - offset);
+                var snapshotOffset = offset - startOffset;
+
+                // Read from the snapshot device
+                var bytesRead = await ReadFromSnapshotAsync(handle, snapshotOffset, destination.Slice(0, bytesAvailable), cancellationToken).ConfigureAwait(false);
+
+                // If we read everything requested, we're done
+                if (bytesRead >= destination.Length)
+                    return bytesRead;
+
+                // If there's more to read, continue reading from the raw disk for the remainder
+                if (bytesRead < destination.Length)
+                {
+                    var remainingBytes = await _rawDisk.ReadBytesAsync(offset + bytesRead, destination.Slice(bytesRead), cancellationToken).ConfigureAwait(false);
+                    return bytesRead + remainingBytes;
+                }
+
+                return bytesRead;
+            }
+        }
+
+        // Not in a snapshotted volume, read from the raw disk
+        return await _rawDisk.ReadBytesAsync(offset, destination, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads data from a snapshot device handle.
+    /// </summary>
+    /// <param name="handle">The snapshot device handle.</param>
+    /// <param name="offset">The offset within the snapshot to read from.</param>
+    /// <param name="destination">The buffer to read into.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of bytes read.</returns>
+    private static async Task<int> ReadFromSnapshotAsync(SafeHFILE handle, long offset, Memory<byte> destination, CancellationToken cancellationToken)
+    {
+        // Calculate aligned offset and length for unbuffered I/O (FILE_FLAG_NO_BUFFERING)
+        var sectorSize = 512; // VSS snapshot devices use 512-byte sectors
+        long alignedOffset = (offset / sectorSize) * sectorSize;
+        long offsetDelta = offset - alignedOffset;
+        long alignedLength = ((offsetDelta + destination.Length + sectorSize - 1) / sectorSize) * sectorSize;
+
+        // Allocate aligned buffer
+        var buffer = new byte[alignedLength];
+        int totalBytesRead = 0;
+
+        await Task.Run(() =>
+        {
+            var seeked = SetFilePointerEx(handle, alignedOffset, out _, SeekOrigin.Begin);
+            if (!seeked)
+            {
+                var error = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                throw new IOException($"Failed to seek to offset {alignedOffset} in snapshot. Win32 Error Code: {error}");
+            }
+
+            unsafe
+            {
+                fixed (byte* ptr = buffer)
+                {
+                    var result = ReadFile(handle, (IntPtr)ptr, (uint)alignedLength, out uint bytesRead, IntPtr.Zero);
+                    if (!result)
+                    {
+                        var error = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                        throw new IOException($"Failed to read from snapshot at offset {alignedOffset}. Win32 Error Code: {error}");
+                    }
+                    totalBytesRead = (int)bytesRead;
+                }
+            }
+        }, cancellationToken).ConfigureAwait(false);
+
+        // Copy the requested portion from the aligned buffer
+        int bytesToCopy = Math.Min(destination.Length, totalBytesRead - (int)offsetDelta);
+        if (bytesToCopy > 0)
+            buffer.AsSpan((int)offsetDelta, bytesToCopy).CopyTo(destination.Span);
+
+        return Math.Max(0, bytesToCopy);
+    }
+
+    /// <inheritdoc />
+    public Task<int> WriteSectorsAsync(long startSector, byte[] data, CancellationToken cancellationToken)
+        => throw new InvalidOperationException("Write operations are not supported on VSS snapshots.");
+
+    /// <inheritdoc />
+    public Task<int> WriteBytesAsync(long offset, byte[] data, CancellationToken cancellationToken)
+        => throw new InvalidOperationException("Write operations are not supported on VSS snapshots.");
+
+    /// <inheritdoc />
+    public Task<int> WriteBytesAsync(long offset, ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+        => throw new InvalidOperationException("Write operations are not supported on VSS snapshots.");
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        foreach (var (_, _, handle) in _snapshotVolumes)
+        {
+            try
+            {
+                handle?.Dispose();
+            }
+            catch
+            {
+                // Ignore disposal errors
+            }
+        }
+        _snapshotVolumes.Clear();
+
+        _rawDisk?.Dispose();
+        _disposed = true;
+    }
+
+    /// <inheritdoc />
+    public static IAsyncEnumerable<PhysicalDriveInfo> ListPhysicalDrivesAsync(CancellationToken cancellationToken)
+        => Windows.ListPhysicalDrivesAsync(cancellationToken);
+
+    /// <summary>
+    /// Gets the volumes on the specified disk.
+    /// </summary>
+    /// <param name="devicePath">The disk device path (e.g., "\\.\PhysicalDrive0").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of volumes on the disk with their offsets and sizes.</returns>
+    internal static async Task<List<VolumeInfo>> GetVolumesOnDiskAsync(string devicePath, CancellationToken cancellationToken)
+    {
+        // Extract disk number from device path (e.g., "\\.\PhysicalDrive0" -> 0)
+        var trimmed = devicePath.TrimEnd('\\', '/');
+        if (!int.TryParse(trimmed[^1..], out var diskNumber))
+            return [];
+
+        var script = $@"
+Get-Partition -DiskNumber {diskNumber} -ErrorAction SilentlyContinue |
+Where-Object {{ $_.DriveLetter -ne $null }} |
+ForEach-Object {{
+    [pscustomobject]@{{
+        DriveLetter = $_.DriveLetter.ToString()
+        Offset      = [long]$_.Offset
+        Size        = [long]$_.Size
+    }}
+}} | ConvertTo-Json -Depth 4
+";
+
+        var output = await Windows.RunPowerShellAsync(script, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(output))
+            return [];
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                var volumes = JsonSerializer.Deserialize<VolumeInfo[]>(output);
+                return volumes?.ToList() ?? [];
+            }
+            else if (doc.RootElement.ValueKind == JsonValueKind.Object)
+            {
+                var volume = JsonSerializer.Deserialize<VolumeInfo>(output);
+                return volume != null ? [volume] : [];
+            }
+        }
+        catch (JsonException ex)
+        {
+            Duplicati.Library.Logging.Log.WriteWarningMessage(LOGTAG, "FailedVolumeParsing", ex, "Failed to parse volume output");
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Information about a volume on a disk.
+    /// </summary>
+    internal sealed class VolumeInfo
+    {
+        public string DriveLetter { get; set; } = "";
+        public long Offset { get; set; }
+        public long Size { get; set; }
+    }
+}

--- a/proprietary/DiskImage/Disk/Windows.cs
+++ b/proprietary/DiskImage/Disk/Windows.cs
@@ -460,7 +460,7 @@ namespace Duplicati.Proprietary.DiskImage.Disk
         /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
         /// <returns>The standard output of the PowerShell script.</returns>
         /// <exception cref="IOException">Thrown if the PowerShell script fails.</exception>
-        private static async Task<string> RunPowerShellAsync(string script, CancellationToken cancellationToken)
+        internal static async Task<string> RunPowerShellAsync(string script, CancellationToken cancellationToken)
         {
             var program = "powershell.exe";
             var args = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"{script.Replace("\"", "\\\"")}\"";

--- a/proprietary/DiskImage/Duplicati.Proprietary.DiskImage.csproj
+++ b/proprietary/DiskImage/Duplicati.Proprietary.DiskImage.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\Duplicati\Library\Utility\Duplicati.Library.Utility.csproj" />
     <ProjectReference Include="..\..\Duplicati\Library\Localization\Duplicati.Library.Localization.csproj" />
     <ProjectReference Include="..\..\Duplicati\Library\Logging\Duplicati.Library.Logging.csproj" />
+    <ProjectReference Include="..\..\Duplicati\Library\Snapshots\Duplicati.Library.Snapshots.csproj" />
   </ItemGroup>
 
   <!-- Native libraries -->

--- a/proprietary/DiskImage/SourceProvider.cs
+++ b/proprietary/DiskImage/SourceProvider.cs
@@ -155,6 +155,9 @@ public sealed class SourceProvider : ISourceProviderModule, ISnapshotAwareModule
         if (OperatingSystem.IsWindows())
         {
             var disk = new Windows(physicalDrivePath.TrimEnd(Path.DirectorySeparatorChar));
+            var msg = await disk.InitializeAsync(cancellationToken);
+            if (!string.IsNullOrWhiteSpace(msg))
+                throw new UserInformationException($"Failed to initialize disk: {physicalDrivePath}, {msg}", "DiskInitializeFailed");
 
             // Wrap with VSS if a snapshot service is available
             if (_snapshotService != null)
@@ -163,10 +166,6 @@ public sealed class SourceProvider : ISourceProviderModule, ISnapshotAwareModule
                 if (vssDisk != null)
                     return vssDisk;
             }
-
-            var msg = await disk.InitializeAsync(cancellationToken);
-            if (!string.IsNullOrWhiteSpace(msg))
-                throw new UserInformationException($"Failed to initialize disk: {physicalDrivePath}, {msg}", "DiskInitializeFailed");
 
             return disk;
         }

--- a/proprietary/DiskImage/SourceProvider.cs
+++ b/proprietary/DiskImage/SourceProvider.cs
@@ -20,7 +20,7 @@ namespace Duplicati.Proprietary.DiskImage;
 /// Source provider for disk images. Provides access to disk, partition, and filesystem structures
 /// as a virtual folder hierarchy for backup operations.
 /// </summary>
-public sealed class SourceProvider : ISourceProviderModule, IDisposable
+public sealed class SourceProvider : ISourceProviderModule, ISnapshotAwareModule, IDisposable
 {
     /// <summary>
     /// The path to the disk device.
@@ -54,6 +54,11 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
     /// Indicates whether to treat filesystems as unknown (force raw block-based backup).
     /// </summary>
     private readonly bool _treatFilesystemAsUnknown;
+
+    /// <summary>
+    /// The snapshot service to use for VSS-enabled backups.
+    /// </summary>
+    private ISnapshotService? _snapshotService;
 
     /// <summary>
     /// The subpath within the disk hierarchy that the device URL points to
@@ -112,6 +117,23 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
     internal bool TreatFilesystemAsUnknown => _treatFilesystemAsUnknown;
 
     /// <inheritdoc />
+    public async Task<IEnumerable<string>> GetSnapshotPathsAsync(CancellationToken cancellationToken)
+    {
+        if (!OperatingSystem.IsWindows() || string.IsNullOrEmpty(_devicePath))
+            return Enumerable.Empty<string>();
+
+        // Query volumes on the disk to include them in the snapshot
+        var (physicalDrivePath, _) = SplitDeviceAndSubpath(_devicePath);
+        var volumes = await VssDiskWrapper.GetVolumesOnDiskAsync(physicalDrivePath, cancellationToken).ConfigureAwait(false);
+        return volumes.Select(v => OperatingSystem.IsWindows() ? $"{v.DriveLetter}:\\" : throw new InvalidOperationException("Should not get here"));
+    }
+    /// <inheritdoc />
+    public void SetSnapshotService(ISnapshotService? snapshotService)
+    {
+        _snapshotService = snapshotService;
+    }
+
+    /// <inheritdoc />
     public async Task InitializeAsync(CancellationToken cancellationToken)
     {
         // TODO: Should we redesign this? 
@@ -122,6 +144,9 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
         _disk = (IRawDisk)await GetDiskAsync(_devicePath, cancellationToken).ConfigureAwait(false);
     }
 
+    // Note: The return type is object instead of IRawDisk because IRawDisk contains
+    // static abstract members, which prevents it from being used as a generic type
+    // argument (e.g., Task<IRawDisk>), triggering CS8920.
     private async Task<object> GetDiskAsync(string path, CancellationToken cancellationToken)
     {
         var (physicalDrivePath, subpath) = SplitDeviceAndSubpath(path);
@@ -130,6 +155,15 @@ public sealed class SourceProvider : ISourceProviderModule, IDisposable
         if (OperatingSystem.IsWindows())
         {
             var disk = new Windows(physicalDrivePath.TrimEnd(Path.DirectorySeparatorChar));
+
+            // Wrap with VSS if a snapshot service is available
+            if (_snapshotService != null)
+            {
+                var vssDisk = await VssDiskWrapper.CreateAsync(disk, _snapshotService, cancellationToken).ConfigureAwait(false);
+                if (vssDisk != null)
+                    return vssDisk;
+            }
+
             var msg = await disk.InitializeAsync(cancellationToken);
             if (!string.IsNullOrWhiteSpace(msg))
                 throw new UserInformationException($"Failed to initialize disk: {physicalDrivePath}, {msg}", "DiskInitializeFailed");


### PR DESCRIPTION
When creating a full-disk backup of a live disk, there is a risk that the backup will be inconsistent if the disk is written during the backup.

This PR adds support for using an active VSS snapshot during the backup when making a full-disk backup.

No configuration is needed, if the VSS provider is active the full-disk provider will read the disk through it, guaranteeing a disk-consistent snapshot.