### PR TITLE
Support path in Azure Blob Storage

### DIFF
--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobBackend.cs
@@ -113,6 +113,12 @@ namespace Duplicati.Library.Backend.AzureBlob
 
             var containerName = (uri.Host ?? "").ToLowerInvariant();
 
+            // The URL path is used as a blob name prefix, so that
+            // azure://container/some/folder stores all blobs under "some/folder/".
+            var prefix = (uri.Path ?? "").Trim('/');
+            if (prefix.Length != 0)
+                prefix = prefix + "/";
+
             var auth = AuthOptionsHelper.ParseWithAlias(options, uri.Username, uri.Password, AZURE_ACCOUNT_NAME_OPTION, AZURE_ACCESS_KEY_OPTION);
             var timeouts = TimeoutOptionsHelper.Parse(options);
 
@@ -133,7 +139,7 @@ namespace Duplicati.Library.Backend.AzureBlob
 
             _immutabilityPolicyMode = Utility.Utility.ParseEnumOption(options, AZURE_BLOB_IMMUTABILITY_POLICY_MODE_OPTION, DEFAULT_IMMUTABILITY_MODE);
 
-            _azureBlob = new AzureBlobWrapper(auth.Username!, auth.Password, sasToken, containerName, accessTier, archiveClasses, timeouts, internalRetries);
+            _azureBlob = new AzureBlobWrapper(auth.Username!, auth.Password, sasToken, containerName, prefix, accessTier, archiveClasses, timeouts, internalRetries);
         }
 
         /// <summary>

--- a/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
+++ b/Duplicati/Library/Backend/AzureBlob/AzureBlobWrapper.cs
@@ -42,6 +42,13 @@ namespace Duplicati.Library.Backend.AzureBlob
         private readonly AccessTier? _accessTier;
 
         /// <summary>
+        /// The blob name prefix from the backend URL path, ending with a '/' when
+        /// non-empty. All blob names are prefixed with this value so a backend URL
+        /// of azure://container/some/folder stores blobs under "some/folder/".
+        /// </summary>
+        private readonly string _prefix;
+
+        /// <summary>
         /// Gets an array of DNS names associated with the blob container.
         /// </summary>
         /// <returns>An array of DNS hostnames for the primary and secondary URIs of the container.</returns>
@@ -62,11 +69,12 @@ namespace Duplicati.Library.Backend.AzureBlob
         /// <param name="accessKey">The access key for the storage account.</param>
         /// <param name="sasToken">The Shared Access Signature (SAS) token for authentication.</param>
         /// <param name="containerName">The name of the blob container.</param>
+        /// <param name="prefix">The blob name prefix from the URL path; empty or ending with '/'.</param>
         /// <param name="accessTier">The access tier assigned to blobs on upload.</param>
         /// <param name="archiveClasses">The storage classes that are considered archive classes.</param>
         /// <param name="timeouts">The timeout options.</param>
         /// <param name="maxRetries">The maximum number of retries for Azure operations.</param>
-        public AzureBlobWrapper(string accountName, string? accessKey, string? sasToken, string containerName, AccessTier? accessTier, IReadOnlySet<AccessTier> archiveClasses, TimeoutOptionsHelper.Timeouts timeouts, int maxRetries)
+        public AzureBlobWrapper(string accountName, string? accessKey, string? sasToken, string containerName, string prefix, AccessTier? accessTier, IReadOnlySet<AccessTier> archiveClasses, TimeoutOptionsHelper.Timeouts timeouts, int maxRetries)
         {
             BlobServiceClient blobServiceClient;
             var maxTicks = timeouts.ReadWriteTimeout.Ticks - TimeSpan.FromSeconds(1).Ticks;
@@ -106,6 +114,7 @@ namespace Duplicati.Library.Backend.AzureBlob
             _accessTier = accessTier;
             _archiveClasses = archiveClasses;
             _container = blobServiceClient.GetBlobContainerClient(containerName);
+            _prefix = prefix ?? "";
             _timeouts = timeouts;
         }
 
@@ -131,7 +140,7 @@ namespace Duplicati.Library.Backend.AzureBlob
         /// <returns>A task that represents the asynchronous download operation.</returns>
         public async Task GetFileStreamAsync(string keyName, Stream target, CancellationToken cancellationToken)
         {
-            var blobClient = _container.GetBlobClient(keyName);
+            var blobClient = _container.GetBlobClient(_prefix + keyName);
             using var timeoutStream = target.ObserveWriteTimeout(_timeouts.ReadWriteTimeout, false);
             await blobClient.DownloadToAsync(target, cancellationToken).ConfigureAwait(false);
         }
@@ -145,7 +154,7 @@ namespace Duplicati.Library.Backend.AzureBlob
         /// <returns>A task that represents the asynchronous upload operation.</returns>
         public async Task AddFileStream(string keyName, Stream source, CancellationToken cancelToken)
         {
-            var blobClient = _container.GetBlobClient(keyName);
+            var blobClient = _container.GetBlobClient(_prefix + keyName);
             using var timeoutStream = source.ObserveReadTimeout(_timeouts.ReadWriteTimeout, false);
             var options = new BlobUploadOptions()
             {
@@ -163,7 +172,7 @@ namespace Duplicati.Library.Backend.AzureBlob
         /// <param name="cancelToken">A token to monitor for cancellation requests.</param>
         public async Task DeleteObjectAsync(string keyName, CancellationToken cancelToken)
         {
-            var blobClient = _container.GetBlobClient(keyName);
+            var blobClient = _container.GetBlobClient(_prefix + keyName);
             await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, async ct =>
                 await blobClient.DeleteIfExistsAsync(cancellationToken: ct).ConfigureAwait(false)
             ).ConfigureAwait(false);
@@ -178,8 +187,8 @@ namespace Duplicati.Library.Backend.AzureBlob
         /// <returns>A task that represents the asynchronous copy operation.</returns>
         public async Task CopyFileAsync(string sourceKeyName, string destinationKeyName, CancellationToken cancelToken)
         {
-            var sourceBlobClient = _container.GetBlobClient(sourceKeyName);
-            var destinationBlobClient = _container.GetBlobClient(destinationKeyName);
+            var sourceBlobClient = _container.GetBlobClient(_prefix + sourceKeyName);
+            var destinationBlobClient = _container.GetBlobClient(_prefix + destinationKeyName);
 
             // Start the copy operation
             var operation = await Utility.Utility.WithTimeout(_timeouts.ShortTimeout, cancelToken, async ct =>
@@ -198,7 +207,9 @@ namespace Duplicati.Library.Backend.AzureBlob
         /// <exception cref="FolderMissingException">Thrown when the container is not found</exception>
         public virtual async IAsyncEnumerable<IFileEntry> ListContainerEntriesAsync([EnumeratorCancellation] CancellationToken cancelToken)
         {
-            await using var blobEnumerator = _container.GetBlobsAsync().GetAsyncEnumerator(cancelToken);
+            // Only list blobs below the prefix (if any), and strip the prefix from the
+            // returned names so callers see names relative to the bound URL path.
+            await using var blobEnumerator = _container.GetBlobsAsync(BlobTraits.None, BlobStates.None, string.IsNullOrEmpty(_prefix) ? null : _prefix, cancelToken).GetAsyncEnumerator(cancelToken);
 
             while (true)
             {
@@ -221,7 +232,18 @@ namespace Duplicati.Library.Backend.AzureBlob
 
                 if (blobEnumerator.Current is { } blob)
                 {
-                    var blobName = Uri.UnescapeDataString(blob.Name.Replace("+", "%2B"));
+                    // Match and strip the prefix on the raw name, which is the
+                    // representation the server-side prefix filter operates on.
+                    // Decoding before comparing could drop blobs when the prefix
+                    // contains characters affected by the unescape step below.
+                    var rawName = blob.Name;
+                    if (!string.IsNullOrEmpty(_prefix))
+                    {
+                        if (!rawName.StartsWith(_prefix, StringComparison.Ordinal))
+                            continue;
+                        rawName = rawName.Substring(_prefix.Length);
+                    }
+                    var blobName = Uri.UnescapeDataString(rawName.Replace("+", "%2B"));
                     var lastModified = blob.Properties.LastModified?.UtcDateTime ?? DateTime.UtcNow;
                     var isArchive = blob.Properties.AccessTier.HasValue && _archiveClasses.Contains(blob.Properties.AccessTier.Value);
 
@@ -241,7 +263,7 @@ namespace Duplicati.Library.Backend.AzureBlob
 
         public async Task<DateTime?> GetObjectLockUntilAsync(string keyName, CancellationToken cancellationToken)
         {
-            var blobClient = _container.GetBlobClient(keyName);
+            var blobClient = _container.GetBlobClient(_prefix + keyName);
 
             try
             {
@@ -267,7 +289,7 @@ namespace Duplicati.Library.Backend.AzureBlob
 
         public async Task SetObjectLockUntilAsync(string keyName, DateTime lockUntilUtc, BlobImmutabilityPolicyMode policyMode, CancellationToken cancellationToken)
         {
-            var blobClient = _container.GetBlobClient(keyName);
+            var blobClient = _container.GetBlobClient(_prefix + keyName);
             var policy = new BlobImmutabilityPolicy
             {
                 ExpiresOn = new DateTimeOffset(lockUntilUtc.ToUniversalTime(), TimeSpan.Zero),

--- a/Duplicati/Library/Backend/AzureBlob/Strings.cs
+++ b/Duplicati/Library/Backend/AzureBlob/Strings.cs
@@ -25,7 +25,7 @@ namespace Duplicati.Library.Backend.AzureBlob.Strings;
 
 internal static class AzureBlobBackend
 {
-    public static string DescriptionV2 => LC.L(@"This backend can read and write data to Azure blob storage. Allowed format is ""azure://bucketname"".");
+    public static string DescriptionV2 => LC.L(@"This backend can read and write data to Azure blob storage. Allowed format is ""azure://bucketname/folder"".");
     public static string DisplayName => LC.L(@"Azure blob");
     public static string ContainerNameDescriptionLong => LC.L(@"All files will be written to the container specified.");
     public static string ContainerNameDescriptionShort => LC.L(@"The name of the storage container");


### PR DESCRIPTION
For some reason, the Azure blob-storage backend has been ignoring the path part of the url, always storing the data in the root of the backend.

This PR updates the logic to treat a path as a prefix.

This is related to #7271