### PR TITLE
Fix `--prefix` with path separator

### DIFF
--- a/Duplicati/Library/Main/Backend/BackendManager.cs
+++ b/Duplicati/Library/Main/Backend/BackendManager.cs
@@ -217,6 +217,11 @@ internal partial class BackendManager : IBackendManager
     /// Applies path translation to a file-oriented operation (put/get/delete) for
     /// backends that do not support folder operations.
     ///
+    /// This is only invoked for operations where the caller explicitly passes a
+    /// relative path that may contain sub-folders (the sync operation). Regular
+    /// backup volume uploads pass an opaque volume name (which may legitimately
+    /// contain '/' from a --prefix value) and must not be split.
+    ///
     /// Backends that implement <see cref="IFolderEnabledBackend"/> accept a relative
     /// path (including sub-folders) directly in their put/get/delete calls, so no
     /// translation is applied and the operation runs against the base backend URL with
@@ -271,6 +276,24 @@ internal partial class BackendManager : IBackendManager
     public async Task DeleteAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken)
     {
         var op = new DeleteOperation(remotename, size, context, waitForComplete, cancelToken);
+        await QueueTaskAsync(op).ConfigureAwait(false);
+        await op.GetResultAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes a remote file, treating the remote name as a relative path that may
+    /// contain sub-folders. For backends without folder support the path is split
+    /// so the delete targets the sub-folder; folder-enabled backends receive the
+    /// path unchanged.
+    /// </summary>
+    /// <param name="remotename">The relative path of the remote file, which may contain sub-folders</param>
+    /// <param name="size">The size of the remote file, for statistics</param>
+    /// <param name="waitForComplete">True if the operation should wait for the file to actually be deleted. If this argument is false, the task will complete once the operation is queued</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>An awaitable task</returns>
+    public async Task DeleteWithPathAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken)
+    {
+        var op = new DeleteOperation(remotename, size, context, waitForComplete, cancelToken);
         ApplyPathTranslation(op);
         await QueueTaskAsync(op).ConfigureAwait(false);
         await op.GetResultAsync().ConfigureAwait(false);
@@ -320,7 +343,6 @@ internal partial class BackendManager : IBackendManager
             Decrypt = true,
             AllowParityRepair = allowParityRepair
         };
-        ApplyPathTranslation(op);
         await QueueTaskAsync(op).ConfigureAwait(false);
         (var file, var _, var _) = await op.GetResultAsync().ConfigureAwait(false);
         return file;
@@ -343,7 +365,6 @@ internal partial class BackendManager : IBackendManager
             Decrypt = false,
             AllowParityRepair = allowParityRepair
         };
-        ApplyPathTranslation(op);
         await QueueTaskAsync(op).ConfigureAwait(false);
         (var file, var _, var _) = await op.GetResultAsync().ConfigureAwait(false);
         return file;
@@ -378,7 +399,6 @@ internal partial class BackendManager : IBackendManager
             Decrypt = true,
             AllowParityRepair = allowParityRepair
         };
-        ApplyPathTranslation(op);
         await QueueTaskAsync(op).ConfigureAwait(false);
         (var file, var downloadHash, var downloadSize) = await op.GetResultAsync().ConfigureAwait(false);
         return (file, downloadHash, downloadSize);
@@ -463,7 +483,6 @@ internal partial class BackendManager : IBackendManager
 
         // Prepare encryption
         op.StartEncryptionAndHashing();
-        ApplyPathTranslation(op);
         await QueueTaskAsync(op).ConfigureAwait(false);
         await op.GetResultAsync().ConfigureAwait(false);
     }
@@ -477,6 +496,38 @@ internal partial class BackendManager : IBackendManager
     /// <returns>An awaitable task</returns>
     public async Task PutFileUnencryptedAsync(string remotename, TempFile tempFile, CancellationToken cancelToken)
     {
+        var op = CreateUnencryptedPutOperation(remotename, tempFile, cancelToken);
+        await QueueTaskAsync(op).ConfigureAwait(false);
+        await op.GetResultAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Uploads a file to the remote location without encryption, treating the
+    /// remote name as a relative path that may contain sub-folders. For backends
+    /// without folder support the path is split so the upload targets the
+    /// sub-folder; folder-enabled backends receive the path unchanged.
+    /// </summary>
+    /// <param name="remotename">The relative path of the remote file, which may contain sub-folders</param>
+    /// <param name="tempFile">The temporary file to upload</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>An awaitable task</returns>
+    public async Task PutFileUnencryptedWithPathAsync(string remotename, TempFile tempFile, CancellationToken cancelToken)
+    {
+        var op = CreateUnencryptedPutOperation(remotename, tempFile, cancelToken);
+        ApplyPathTranslation(op);
+        await QueueTaskAsync(op).ConfigureAwait(false);
+        await op.GetResultAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates a prepared operation for uploading a file without encryption
+    /// </summary>
+    /// <param name="remotename">The name of the remote file</param>
+    /// <param name="tempFile">The temporary file to upload</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>The prepared put operation, ready to be queued</returns>
+    private PutOperation CreateUnencryptedPutOperation(string remotename, TempFile tempFile, CancellationToken cancelToken)
+    {
         var op = new PutOperation(remotename, context, true, cancelToken)
         {
             LocalTempfile = tempFile,
@@ -489,9 +540,7 @@ internal partial class BackendManager : IBackendManager
 
         // Sets the task as already completed
         op.StartEncryptionAndHashing();
-        ApplyPathTranslation(op);
-        await QueueTaskAsync(op).ConfigureAwait(false);
-        await op.GetResultAsync().ConfigureAwait(false);
+        return op;
     }
 
     /// <summary>

--- a/Duplicati/Library/Main/IBackendManager.cs
+++ b/Duplicati/Library/Main/IBackendManager.cs
@@ -60,6 +60,18 @@ internal interface IBackendManager : IDisposable
     Task PutFileUnencryptedAsync(string remotename, TempFile tempFile, CancellationToken cancelToken);
 
     /// <summary>
+    /// Uploads a file to the backend without encryption, treating the remote name
+    /// as a relative path that may contain sub-folders. For backends without folder
+    /// support the path is split so the upload targets the sub-folder; folder-enabled
+    /// backends receive the path unchanged.
+    /// </summary>
+    /// <param name="remotename">The relative path of the file to upload to, which may contain sub-folders</param>
+    /// <param name="tempFile">The file to upload</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>An awaitable task</returns>
+    Task PutFileUnencryptedWithPathAsync(string remotename, TempFile tempFile, CancellationToken cancelToken);
+
+    /// <summary>
     /// Waits for the backend queue to be empty
     /// </summary>
     /// <param name="cancellationToken">The cancellation token</param>
@@ -114,6 +126,19 @@ internal interface IBackendManager : IDisposable
     /// <param name="cancelToken">The cancellation token</param>
     /// <returns>An awaitable task</returns>
     Task DeleteAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken);
+
+    /// <summary>
+    /// Deletes a file on the backend, treating the remote name as a relative path
+    /// that may contain sub-folders. For backends without folder support the path
+    /// is split so the delete targets the sub-folder; folder-enabled backends
+    /// receive the path unchanged.
+    /// </summary>
+    /// <param name="remotename">The relative path of the file to delete, which may contain sub-folders</param>
+    /// <param name="size">The size of the file to delete, or -1 if not known</param>
+    /// <param name="waitForComplete">Whether to wait for the delete to complete</param>
+    /// <param name="cancelToken">The cancellation token</param>
+    /// <returns>An awaitable task</returns>
+    Task DeleteWithPathAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken);
 
     /// <summary>
     /// Applies or updates an object lock on a remote volume.

--- a/Duplicati/Library/Main/Operation/Sync/SyncHandler.cs
+++ b/Duplicati/Library/Main/Operation/Sync/SyncHandler.cs
@@ -802,7 +802,7 @@ internal class SyncHandler
                 // next run if this one crashes before the commit) at the start of the
                 // next run if leftover.
                 await db.UpsertPendingOperationAsync(relPath, SyncOperation.Delete, null, null, ct).ConfigureAwait(false);
-                await backendManager.DeleteAsync(relPath, 0, true, ct).ConfigureAwait(false);
+                await backendManager.DeleteWithPathAsync(relPath, 0, true, ct).ConfigureAwait(false);
                 deletedPaths.Add(relPath);
                 planSummary.Delete++;
                 planSummary.SizeOfDeletedFiles += Math.Max(rc.Size, 0);
@@ -917,7 +917,7 @@ internal class SyncHandler
 
         // The caller has already ensured the destination folder exists, so we put the
         // file directly. No EnsureFolderAsync call here.
-        await backendManager.PutFileUnencryptedAsync(relPath, temp, cancellationToken);
+        await backendManager.PutFileUnencryptedWithPathAsync(relPath, temp, cancellationToken);
 
         // Commit the inventory update and intent clearance atomically so a crash
         // between them cannot leave the inventory and intent journal inconsistent.

--- a/Duplicati/UnitTest/Issue7271Tests.cs
+++ b/Duplicati/UnitTest/Issue7271Tests.cs
@@ -1,0 +1,192 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using NUnit.Framework;
+using FileEntry = Duplicati.Library.Common.IO.FileEntry;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Regression tests for https://github.com/duplicati/duplicati/issues/7271.
+///
+/// A --prefix value containing a '/' (e.g. "myjob/duplicati") produces remote
+/// volume names like "myjob/duplicati-....dlist.zip". The folder part is part of
+/// the opaque volume name and must NOT be split off by the backend manager's
+/// path translation, which exists only for the sync operation's explicit
+/// relative paths. On backends without folder support the split previously
+/// dropped the folder part entirely (the backend was pointed at a sub-folder
+/// URL it could not honour), so the volumes landed at the destination root and
+/// the next list reported them as missing.
+/// </summary>
+[TestFixture]
+[Category("Targeted")]
+public class Issue7271Tests : BasicSetupHelper
+{
+    /// <summary>
+    /// A minimal flat-namespace backend that mimics how Azure Blob Storage (and
+    /// similar object stores) treat names: the name is an opaque key that may
+    /// contain '/' characters, there is a single flat listing per URL, and the
+    /// URL path is ignored (as the pre-fix Azure backend did). The backend does
+    /// NOT implement <see cref="IFolderEnabledBackend"/>, so it exercises the
+    /// backend manager's non-folder code path.
+    /// </summary>
+    private class FlatMemoryBackend : IStreamingBackend
+    {
+        /// <summary>
+        /// The shared per-URL store of (name -> contents). Static so all backend
+        /// instances created for the same URL (e.g. via BackendUrlOverride) share
+        /// the same storage, like a real remote store.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte[]>> stores = new();
+
+        private readonly string urlKey;
+        private readonly ConcurrentDictionary<string, byte[]> store;
+
+        public FlatMemoryBackend()
+        {
+            // Required by the backend loader for option discovery; never used.
+            urlKey = null!;
+            store = null!;
+        }
+
+        public FlatMemoryBackend(string url, Dictionary<string, string?> options)
+        {
+            urlKey = url;
+            store = stores.GetOrAdd(urlKey, _ => new ConcurrentDictionary<string, byte[]>());
+        }
+
+        /// <summary>
+        /// Returns the stored (name -> contents) map for the given URL.
+        /// </summary>
+        public static IReadOnlyDictionary<string, byte[]> GetStore(string url)
+            => stores.GetOrAdd(url, _ => new ConcurrentDictionary<string, byte[]>());
+
+        public string DisplayName => "Flat Memory Backend";
+        public string ProtocolKey => "flatmem";
+        public string Description => "A flat-namespace in-memory test backend";
+        public bool SupportsStreaming => true;
+
+        public IList<ICommandLineArgument> SupportedCommands => [];
+
+        public async IAsyncEnumerable<IFileEntry> ListAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancelToken)
+        {
+            foreach (var kvp in store)
+                yield return new FileEntry(kvp.Key, kvp.Value.Length, DateTime.UtcNow, DateTime.UtcNow);
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        public Task PutAsync(string remotename, string localname, CancellationToken cancelToken)
+        {
+            store[remotename] = File.ReadAllBytes(localname);
+            return Task.CompletedTask;
+        }
+
+        public async Task PutAsync(string remotename, Stream input, CancellationToken cancelToken)
+        {
+            using var ms = new MemoryStream();
+            await input.CopyToAsync(ms, cancelToken).ConfigureAwait(false);
+            store[remotename] = ms.ToArray();
+        }
+
+        public Task GetAsync(string remotename, string localname, CancellationToken cancellationToken)
+        {
+            if (!store.TryGetValue(remotename, out var data))
+                throw new FileMissingException($"File not found: {remotename}");
+            File.WriteAllBytes(localname, data);
+            return Task.CompletedTask;
+        }
+
+        public async Task GetAsync(string remotename, Stream output, CancellationToken cancellationToken)
+        {
+            if (!store.TryGetValue(remotename, out var data))
+                throw new FileMissingException($"File not found: {remotename}");
+            await output.WriteAsync(data, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task DeleteAsync(string remotename, CancellationToken cancellationToken)
+        {
+            if (!store.TryRemove(remotename, out _))
+                throw new FileMissingException($"File not found: {remotename}");
+            return Task.CompletedTask;
+        }
+
+        public Task TestAsync(bool alsoWrite, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task CreateFolderAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => Task.FromResult<string[]>([]);
+        public void Dispose() { }
+    }
+
+    private const string BackendUrl = "flatmem://issue7271";
+
+    [SetUp]
+    public void Setup()
+    {
+        Library.DynamicLoader.BackendLoader.AddBackend(new FlatMemoryBackend());
+    }
+
+    private Dictionary<string, string> Options => TestOptions.Expand(new
+    {
+        no_encryption = true,
+        prefix = "myjob/duplicati"
+    });
+
+    /// <summary>
+    /// A backup with a slash in the prefix must store the volumes under the full
+    /// unsplit name, and the verification after the backup must find them.
+    /// </summary>
+    [Test]
+    public async Task BackupWithSlashInPrefixKeepsFullVolumeNamesAsync()
+    {
+        File.WriteAllText(Path.Combine(DATAFOLDER, "a.txt"), "a");
+
+        using (var c = new Library.Main.Controller(BackendUrl, Options, null))
+            TestUtils.AssertResults(await c.BackupAsync([DATAFOLDER]));
+
+        var store = FlatMemoryBackend.GetStore(BackendUrl);
+
+        // The volumes must be stored with the full "myjob/duplicati-..." name;
+        // nothing may be stored with a stripped "duplicati-..." name.
+        var strippedNames = store.Keys.Where(x => x.StartsWith("duplicati-", StringComparison.Ordinal)).ToArray();
+        Assert.That(strippedNames, Is.Empty, "Volumes must not be stored with the folder part stripped");
+
+        var fullNames = store.Keys.Where(x => x.StartsWith("myjob/duplicati-", StringComparison.Ordinal)).ToArray();
+        Assert.That(fullNames.Length, Is.GreaterThan(0), "Volumes must be stored under the full prefix name");
+
+        // A list must find the volumes under the same names the database recorded,
+        // which is exactly what the pre-fix version failed to do.
+        using (var c = new Library.Main.Controller(BackendUrl, Options, null))
+            TestUtils.AssertResults(await c.ListAsync());
+
+        // A test of all files must pass as well (this is the operation that
+        // reported the volumes as missing in the regression).
+        using (var c = new Library.Main.Controller(BackendUrl, Options, null))
+            TestUtils.AssertResults(await c.TestAsync(long.MaxValue));
+    }
+}

--- a/Duplicati/UnitTest/LockingDeleteAndCompactTests.cs
+++ b/Duplicati/UnitTest/LockingDeleteAndCompactTests.cs
@@ -59,10 +59,12 @@ namespace Duplicati.UnitTest
             #region Unused interface members
             public Task PutAsync(Duplicati.Library.Main.Volumes.VolumeWriterBase blockVolume, Duplicati.Library.Main.Volumes.IndexVolumeWriter? indexVolume, Func<Task>? indexVolumeFinished, bool waitForComplete, Func<Task>? onDbUpdate, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task PutFileUnencryptedAsync(string remotename, TempFile tempFile, CancellationToken cancelToken) => throw new NotImplementedException();
+            public Task PutFileUnencryptedWithPathAsync(string remotename, TempFile tempFile, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<System.Collections.Generic.IEnumerable<Duplicati.Library.Interface.IFileEntry>> ListAsync(string? path, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task EnsureFolderAsync(string? path, CancellationToken cancelToken) => throw new NotImplementedException();
             public TempFile DecryptFile(TempFile volume, string volume_name, Options options, bool dispose) => throw new NotImplementedException();
             public Task DeleteAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken) => throw new NotImplementedException();
+            public Task DeleteWithPathAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<(TempFile File, string Hash, long Size)> GetWithInfoAsync(string remotename, string hash, long size, bool allowParityRepair, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<TempFile> GetAsync(string remotename, string hash, long size, bool allowParityRepair, CancellationToken cancelToken) => throw new NotImplementedException();

--- a/Duplicati/UnitTest/SetLocksHandlerTests.cs
+++ b/Duplicati/UnitTest/SetLocksHandlerTests.cs
@@ -91,10 +91,12 @@ namespace Duplicati.UnitTest
             #region Unused interface members
             public Task PutAsync(VolumeWriterBase blockVolume, IndexVolumeWriter? indexVolume, Func<Task>? indexVolumeFinished, bool waitForComplete, Func<Task>? onDbUpdate, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task PutFileUnencryptedAsync(string remotename, TempFile tempFile, CancellationToken cancelToken) => throw new NotImplementedException();
+            public Task PutFileUnencryptedWithPathAsync(string remotename, TempFile tempFile, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<IEnumerable<InterfaceFileEntry>> ListAsync(string? path, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task EnsureFolderAsync(string? path, CancellationToken cancelToken) => throw new NotImplementedException();
             public TempFile DecryptFile(TempFile volume, string volume_name, Options options, bool dispose) => throw new NotImplementedException();
             public Task DeleteAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken) => throw new NotImplementedException();
+            public Task DeleteWithPathAsync(string remotename, long size, bool waitForComplete, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<(TempFile File, string Hash, long Size)> GetWithInfoAsync(string remotename, string hash, long size, bool allowParityRepair, CancellationToken cancelToken) => throw new NotImplementedException();
             public Task<TempFile> GetAsync(string remotename, string hash, long size, bool allowParityRepair, CancellationToken cancelToken) => throw new NotImplementedException();


### PR DESCRIPTION
This PR fixes a case where the new support for sync operations need to translate a relative path, like `folder/file.txt` were causing trouble for backups with a prefix like `--prefix=folder/duplicati-`.

The sync code actually does not call the methods on the backend manager as it relies on the enumeration and unencrypted file upload.

To solve both use cases, the backend manager now ignores any translation and passes the prefix directly to the backend as before the sync code was introduced.

The sync code then calls the specific `PutFileUnencryptedWithPathAsync` method that *does* do the relative path translation.

This fixes #7271