### PR TITLE
Let a disk with no partitions answer that it has no volumes

### DIFF
--- a/Duplicati/UnitTest/DiskImage/UnitTests/VssDiskVolumeLookupTests.cs
+++ b/Duplicati/UnitTest/DiskImage/UnitTests/VssDiskVolumeLookupTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+using System;
+using System.Runtime.Versioning;
+using System.Threading;
+using Duplicati.Proprietary.DiskImage.Disk;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest.DiskImage.UnitTests;
+
+#nullable enable
+
+/// <summary>
+/// Looking up the volumes on a disk asks PowerShell for them. A disk with no
+/// partitions is an ordinary thing to meet - a raw disk, or one waiting to be
+/// partitioned - and it has to answer "no volumes" rather than failing the run.
+/// </summary>
+[TestFixture]
+[Category("DiskImageUnit")]
+public class VssDiskVolumeLookupTests
+{
+    /// <summary>
+    /// A number no machine running these tests is expected to have a disk for,
+    /// which asks PowerShell the same question a partitionless disk does
+    /// </summary>
+    private const string AbsentDisk = @"\\.\PhysicalDrive99";
+
+    [Test]
+    [SupportedOSPlatform("windows")]
+    public void ADiskWithNoPartitionsGivesNoVolumes()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The disk wrapper is Windows-only.");
+            return;
+        }
+
+        // This throwing is the fault: PowerShell answers with exit code 1 and no
+        // text when there is nothing to list, and that became an IOException
+        // carrying an empty message
+        Assert.DoesNotThrowAsync(async () =>
+            await VssDiskWrapper.GetVolumesOnDiskAsync(AbsentDisk, CancellationToken.None));
+    }
+
+    [Test]
+    public void ASingleDigitDriveIsReadAsItself()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The disk wrapper is Windows-only.");
+            return;
+        }
+
+        Assert.IsTrue(VssDiskWrapper.TryGetDiskNumber(@"\\.\PhysicalDrive0", out var number));
+        Assert.AreEqual(0, number);
+    }
+
+    [Test]
+    public void ATwoDigitDriveIsNotTruncated()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The disk wrapper is Windows-only.");
+            return;
+        }
+
+        // Reading only the last character turned disk 10 into disk 0, so the
+        // volumes of an entirely different disk were reported
+        Assert.IsTrue(VssDiskWrapper.TryGetDiskNumber(@"\\.\PhysicalDrive10", out var number));
+        Assert.AreEqual(10, number);
+    }
+
+    [Test]
+    public void ATrailingSeparatorIsIgnored()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The disk wrapper is Windows-only.");
+            return;
+        }
+
+        Assert.IsTrue(VssDiskWrapper.TryGetDiskNumber(@"\\.\PhysicalDrive7\", out var number));
+        Assert.AreEqual(7, number);
+    }
+
+    [Test]
+    public void APathWithoutANumberIsRejected()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("The disk wrapper is Windows-only.");
+            return;
+        }
+
+        Assert.IsFalse(VssDiskWrapper.TryGetDiskNumber(@"\\.\PhysicalDrive", out _));
+        Assert.IsFalse(VssDiskWrapper.TryGetDiskNumber(string.Empty, out _));
+    }
+}

--- a/proprietary/DiskImage/Disk/VssDiskWrapper.cs
+++ b/proprietary/DiskImage/Disk/VssDiskWrapper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Text.Json;
 using System.Threading;
@@ -13,6 +14,8 @@ using Duplicati.Proprietary.DiskImage.Disk;
 using Duplicati.Proprietary.DiskImage.General;
 using Vanara.PInvoke;
 using static Vanara.PInvoke.Kernel32;
+
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
 
 namespace Duplicati.Proprietary.DiskImage.Disk;
 
@@ -315,6 +318,23 @@ internal sealed class VssDiskWrapper : IRawDisk
         => Windows.ListPhysicalDrivesAsync(cancellationToken);
 
     /// <summary>
+    /// Reads the disk number off a device path, e.g. "\\.\PhysicalDrive0" gives 0.
+    /// </summary>
+    /// <param name="devicePath">The disk device path.</param>
+    /// <param name="diskNumber">The disk number, when the path carries one.</param>
+    /// <returns>True when the path ends in a disk number.</returns>
+    internal static bool TryGetDiskNumber(string devicePath, out int diskNumber)
+    {
+        var trimmed = (devicePath ?? string.Empty).TrimEnd('\\', '/');
+        var start = trimmed.Length;
+        while (start > 0 && char.IsAsciiDigit(trimmed[start - 1]))
+            start--;
+
+        diskNumber = 0;
+        return start < trimmed.Length && int.TryParse(trimmed.AsSpan(start), out diskNumber);
+    }
+
+    /// <summary>
     /// Gets the volumes on the specified disk.
     /// </summary>
     /// <param name="devicePath">The disk device path (e.g., "\\.\PhysicalDrive0").</param>
@@ -322,13 +342,11 @@ internal sealed class VssDiskWrapper : IRawDisk
     /// <returns>A list of volumes on the disk with their offsets and sizes.</returns>
     internal static async Task<List<VolumeInfo>> GetVolumesOnDiskAsync(string devicePath, CancellationToken cancellationToken)
     {
-        // Extract disk number from device path (e.g., "\\.\PhysicalDrive0" -> 0)
-        var trimmed = devicePath.TrimEnd('\\', '/');
-        if (!int.TryParse(trimmed[^1..], out var diskNumber))
+        if (!TryGetDiskNumber(devicePath, out var diskNumber))
             return [];
 
         var script = $@"
-Get-Partition -DiskNumber {diskNumber} -ErrorAction SilentlyContinue |
+Get-CimInstance -ClassName MSFT_Partition -Namespace Root/Microsoft/Windows/Storage -Filter 'DiskNumber={diskNumber}' |
 Where-Object {{ $_.DriveLetter -ne $null -and $_.DriveLetter -ne [char]0 -and $_.DriveLetter -ne '' }} |
 ForEach-Object {{
     [pscustomobject]@{{

--- a/proprietary/DiskImage/Disk/Windows.cs
+++ b/proprietary/DiskImage/Disk/Windows.cs
@@ -469,7 +469,7 @@ namespace Duplicati.Proprietary.DiskImage.Disk
             if (result.ExitCode != 0)
             {
                 Duplicati.Library.Logging.Log.WriteErrorMessage(LOGTAG, "RunPowerShellAsync", null, $"PowerShell script failed with exit code {result.ExitCode}. Output: {result.Output}. Error: {result.Error}");
-                throw new IOException($"PowerShell script failed with exit code {result.ExitCode}. Error: {result.Error}");
+                throw new IOException($"PowerShell script failed with exit code {result.ExitCode}. Output: {result.Output}. Error: {result.Error}");
             }
 
             return result.Output;


### PR DESCRIPTION
Every Windows unit-test job on master is failing, on every branch, including ones whose diff cannot reach the test:

```
Failed Test_Unknown_NoPartitions_Async
  System.IO.IOException : PowerShell script failed with exit code 1. Error:
   at Duplicati.Proprietary.DiskImage.Disk.Windows.RunPowerShellAsync(...) Windows.cs:472
   at Duplicati.Proprietary.DiskImage.Disk.VssDiskWrapper.GetVolumesOnDiskAsync(...) VssDiskWrapper.cs:342
```

It fails the same way on a dependabot branch that only bumps npm packages, and on #7200, whose diff is confined to `Duplicati/Library/Backend/WEBDAV/`. `tests.yml` runs on `pull_request` only, so master itself is never checked and this went in unnoticed.

## What is happening

I reproduced it on a Windows machine. **`Get-Partition` on its own is enough:**

```
Get-Partition -DiskNumber 99 -ErrorAction SilentlyContinue   ->  exit=1, stdout empty, stderr empty
Get-Partition -DiskNumber 99 -ErrorAction Ignore             ->  exit=1
```

`-ErrorAction SilentlyContinue` suppresses the error *text*, not the exit code. A disk with no partitions is a non-terminating error, `powershell.exe` exits 1 with nothing on stderr, and [`RunPowerShellAsync`](https://github.com/duplicati/duplicati/blob/d876f138fe7b43475401e0d1c187feeda671b095/proprietary/DiskImage/Disk/Windows.cs#L469-L474) treats any non-zero exit as fatal. So **a disk with no partitions fails the backup**, which is exactly what `Test_Unknown_NoPartitions_Async` sets up.

Only one of the three `-ErrorAction SilentlyContinue` uses is exposed, and the rule is precise — I measured both shapes:

| shape | exit |
|---|---|
| the failing cmdlet heads the **last** pipeline (`GetVolumesOnDiskAsync`) | **1** |
| the failure is buried and the last statement succeeds (`ListPhysicalDrivesAsync`) | 0 |

`ListPhysicalDrivesAsync` is safe by accident, and is left alone.

## Changes

### Ask the CIM class instead of the cmdlet

`Get-Partition` is a cmdletization wrapper over `MSFT_Partition`, so the query goes to the class directly. Measured, all three:

| case | output | exit |
|---|---|---|
| a real disk (disk 0 on my machine) | `{"DriveLetter":"C","Offset":407896064,"Size":1021945315328}` — **identical to the current script** | 0 |
| a disk with no partitions | nothing, which the C# already reads as "no volumes" | **0** |
| a broken namespace | — | **1** |

That last row is the reason I did not simply append `exit 0`: that would also make a broken Storage subsystem look like "this disk has no volumes". This keeps a genuine failure loud. Only the first line of the script changes; the filtering and projection below it are untouched.

### The disk number was read one character at a time

Noticed while editing the same three lines:

```csharp
var trimmed = devicePath.TrimEnd('\', '/');
if (!int.TryParse(trimmed[^1..], out var diskNumber))   // last character only
```

`\.\PhysicalDrive10` parses as **disk 0**, so on a machine with eleven or more drives the volumes of a different disk are returned. `Win32_DiskDrive.DeviceID` does hand out two-digit names, and both callers ([`VssDiskWrapper.cs:85`](https://github.com/duplicati/duplicati/blob/d876f138fe7b43475401e0d1c187feeda671b095/proprietary/DiskImage/Disk/VssDiskWrapper.cs#L85), [`SourceProvider.cs:127`](https://github.com/duplicati/duplicati/blob/d876f138fe7b43475401e0d1c187feeda671b095/proprietary/DiskImage/SourceProvider.cs#L127)) pass such a path through.

Now it takes the whole run of trailing digits, lifted into `TryGetDiskNumber` so it can be tested without touching a disk. Happy to split this into its own PR if you would rather keep the two apart.

### The exception threw the diagnosis away

```csharp
Log.WriteErrorMessage(... $"... Output: {result.Output}. Error: {result.Error}");  // logged
throw new IOException($"... exit code {result.ExitCode}. Error: {result.Error}");  // thrown, without Output
```

The thrown message is what reaches CI, and `Error` was empty, so the failure arrived saying nothing. `Output` is now included.

## Tests

`Duplicati/UnitTest/DiskImage/UnitTests/VssDiskVolumeLookupTests.cs`, a standalone fixture rather than part of `DiskImageUnitTests`, which builds GPT and MBR disk images per class and is far heavier than this needs. It runs in about two seconds.

Before the change: `Failed: 2, Passed: 3`, and both failures say the symptom —

```
ADiskWithNoPartitionsGivesNoVolumes  ->  IOException, exit code 1, empty message
ATwoDigitDriveIsNotTruncated         ->  Expected: 10  But was: 0
```

After: `Failed: 0, Passed: 5`. The other three (single digit, trailing separator, a path with no number) are green in both states, so only the broken paths moved.

The tests are guarded with `OperatingSystem.IsWindows()` and skip elsewhere — not because parsing a device path is platform-specific, but because `VssDiskWrapper` carries `[SupportedOSPlatform("windows")]` and calling it unguarded would raise CA1416.

`Duplicati.Proprietary.DiskImage` gains `InternalsVisibleTo("Duplicati.UnitTest")`; the test project already references the project directly.

## What is not measured

**I have not run `Test_Unknown_NoPartitions_Async` locally** — it builds disk images, and I did not want to create virtual disks on this machine to find out. The evidence here is the reproduction of the underlying PowerShell behaviour, the measurements above, and the new tests. **The real verdict is this PR's own Windows job.**

I also have not checked the CIM query on a GitHub runner; that is the other thing the CI run will show.

The solution builds with 0 errors and 2 warnings, which is what master gives as well — both are
pre-existing MSB3246 from `Duplicati.Library.WindowsModules` and `Duplicati.WindowsModulesLoader`.

## On the licence

This touches `proprietary/`. `proprietary/LICENSE` says patches may be published and that Duplicati Inc retains all right, title and interest in any such modification — submitted on that basis. If you would rather take the fix yourself from the analysis above, that is fine too; the important part is the measurement, not the authorship.
