### PR TITLE
Escape a Windows argument the way Windows reads it back

### DIFF
--- a/Duplicati/Library/Utility/Utility.cs
+++ b/Duplicati/Library/Utility/Utility.cs
@@ -1576,18 +1576,14 @@ namespace Duplicati.Library.Utility
             }
             else
             {
-                // Windows needs " replaced with "", but is prone to %var%
-                // expansion when used in immediate mode (i.e. from command prompt)
+                // Windows is prone to %var% expansion when used in immediate
+                // mode (i.e. from command prompt)
                 // Fortunately it does not expand when processes
                 // are started from within .Net
                 if (!allowEnvExpansion)
                     arg = arg.Replace("%", "%%");
 
-                arg = arg.Replace(@"""", @"""""");
-
-                // Also fix the case where the argument ends with a slash
-                if (arg[arg.Length - 1] == '\\')
-                    arg += @"\";
+                arg = EscapeWindowsCommandLineElement(arg);
             }
 
             // Check that all characters are in the safe set
@@ -1595,6 +1591,52 @@ namespace Duplicati.Library.Utility
                 return @"""" + arg + @"""";
             else
                 return arg;
+        }
+
+        /// <summary>
+        /// Escapes an argument the way Windows reads it back: a quote is written
+        /// as \", and a run of backslashes that meets a quote is doubled. A
+        /// backslash that does not meet a quote is an ordinary character.
+        /// The run at the end meets the closing quote, so it is doubled as well;
+        /// that is correct because an argument that needed escaping is always
+        /// quoted, a backslash and a quote both being outside
+        /// <see cref="COMMANDLINE_SAFE" />.
+        /// </summary>
+        /// <returns>The escaped argument, without the surrounding quotes.</returns>
+        /// <param name="arg">The argument to escape.</param>
+        private static string EscapeWindowsCommandLineElement(string arg)
+        {
+            var sb = new StringBuilder(arg.Length);
+            var backslashes = 0;
+
+            foreach (var c in arg)
+            {
+                if (c == '\\')
+                {
+                    backslashes++;
+                }
+                else if (c == '"')
+                {
+                    // Two backslashes for each one that is to survive, and one
+                    // more to make the quote itself a literal one
+                    sb.Append('\\', backslashes * 2 + 1);
+                    sb.Append('"');
+                    backslashes = 0;
+                }
+                else
+                {
+                    sb.Append('\\', backslashes);
+                    sb.Append(c);
+                    backslashes = 0;
+                }
+            }
+
+            // An odd number in front of the closing quote would make that quote
+            // a literal one, and the argument would then swallow the rest of the
+            // commandline
+            sb.Append('\\', backslashes * 2);
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/Duplicati/UnitTest/CommandLineWrappingTests.cs
+++ b/Duplicati/UnitTest/CommandLineWrappingTests.cs
@@ -19,6 +19,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Duplicati.Library.Utility;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
@@ -42,12 +45,73 @@ namespace Duplicati.UnitTest
             Assert.AreEqual("\"abc%TEMP%def\"", Utility.WrapCommandLineElement("abc%TEMP%def", true, true));
         }
 
+        /// <summary>
+        /// The shapes that were already right, kept so that a change to the
+        /// escaping cannot quietly move them
+        /// </summary>
+        /// <param name="argument">The argument to wrap</param>
+        /// <param name="expected">The expected wrapping</param>
         [Test]
         [Category("Utility")]
-        public static void WrapCommandLineElementKeepsExistingWindowsQuotingBehavior()
+        [TestCase(@"plain-value_1", @"plain-value_1")]
+        [TestCase(@"has space", @"""has space""")]
+        [TestCase(@"C:\Temp\file.txt", @"""C:\Temp\file.txt""")]
+        [TestCase(@"a\b", @"""a\b""")]
+        [TestCase(@"\", @"""\\""")]
+        [TestCase(@"C:\Temp\folder\", @"""C:\Temp\folder\\""")]
+        public static void WrapCommandLineElementLeavesTheAlreadyCorrectWindowsShapesAlone(string argument, string expected)
         {
-            Assert.AreEqual("\"has\"\"quote\"", Utility.WrapCommandLineElement("has\"quote", false, true));
-            Assert.AreEqual("\"C:\\Temp\\folder\\\\\"", Utility.WrapCommandLineElement("C:\\Temp\\folder\\", false, true));
+            Assert.AreEqual(expected, Utility.WrapCommandLineElement(argument, false, true));
+        }
+
+        /// <summary>
+        /// A quote is escaped with a backslash, not by doubling it. Doubling is
+        /// read back correctly by the C runtime that hands arguments to
+        /// Main(string[]), but not by CommandLineToArgvW, so the two parsers
+        /// disagree about the same string.
+        /// </summary>
+        /// <remarks>
+        /// The literals are verbatim, so the characters are:
+        ///   has"quote          -> "has\"quote"
+        ///   "                  -> "\""
+        ///   a"b"c              -> "a\"b\"c"
+        ///   --passphrase=p"ss  -> "--passphrase=p\"ss"
+        /// </remarks>
+        /// <param name="argument">The argument to wrap</param>
+        /// <param name="expected">The expected wrapping</param>
+        [Test]
+        [Category("Utility")]
+        [TestCase(@"has""quote", @"""has\""quote""")]
+        [TestCase(@"""", @"""\""""")]
+        [TestCase(@"a""b""c", @"""a\""b\""c""")]
+        [TestCase(@"--passphrase=p""ss", @"""--passphrase=p\""ss""")]
+        public static void WrapCommandLineElementEscapesAWindowsQuoteWithABackslash(string argument, string expected)
+        {
+            Assert.AreEqual(expected, Utility.WrapCommandLineElement(argument, false, true));
+        }
+
+        /// <summary>
+        /// Every backslash in a run that meets a quote has to be doubled, both
+        /// for a quote inside the argument and for the closing quote. Leaving an
+        /// odd number in front of a quote makes that quote a literal one, and
+        /// the argument then never ends.
+        /// </summary>
+        /// <remarks>
+        /// The literals are verbatim, so the characters are:
+        ///   C:\dir\"x           -> "C:\dir\\\"x"
+        ///   C:\Temp\folder\\    -> "C:\Temp\folder\\\\"
+        ///   C:\Temp\folder\\\   -> "C:\Temp\folder\\\\\\"
+        /// </remarks>
+        /// <param name="argument">The argument to wrap</param>
+        /// <param name="expected">The expected wrapping</param>
+        [Test]
+        [Category("Utility")]
+        [TestCase(@"C:\dir\""x", @"""C:\dir\\\""x""")]
+        [TestCase(@"C:\Temp\folder\\", @"""C:\Temp\folder\\\\""")]
+        [TestCase(@"C:\Temp\folder\\\", @"""C:\Temp\folder\\\\\\""")]
+        public static void WrapCommandLineElementDoublesEveryBackslashThatMeetsAQuote(string argument, string expected)
+        {
+            Assert.AreEqual(expected, Utility.WrapCommandLineElement(argument, false, true));
         }
 
         [Test]
@@ -57,5 +121,116 @@ namespace Duplicati.UnitTest
             Assert.AreEqual("\"$HOME/file\"", Utility.WrapCommandLineElement("$HOME/file", true, false));
             Assert.AreEqual("\"\\$HOME/file\"", Utility.WrapCommandLineElement("$HOME/file", false, false));
         }
+
+        /// <summary>
+        /// The point of all of the above: what Windows reads back has to be the
+        /// argument that went in, and the argument after it has to survive.
+        /// </summary>
+        /// <param name="argument">The argument to wrap and read back</param>
+        [Test]
+        [Category("Utility")]
+        [TestCase(@"plain-value_1")]
+        [TestCase(@"has space")]
+        [TestCase(@"C:\Temp\file.txt")]
+        [TestCase(@"C:\Temp\folder\")]
+        [TestCase(@"C:\Temp\folder\\")]
+        [TestCase(@"C:\Temp\folder\\\")]
+        [TestCase(@"C:\Program Files\Duplicati\")]
+        [TestCase(@"has""quote")]
+        [TestCase(@"""")]
+        [TestCase(@"a""b""c")]
+        [TestCase(@"C:\dir\""x")]
+        [TestCase(@"\")]
+        [TestCase(@"a\b")]
+        [TestCase(@"--passphrase=p""ss")]
+        public static void AWrappedWindowsArgumentIsReadBackAsItself(string argument)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Ignore("The Windows commandline parser is only available on Windows.");
+                return;
+            }
+
+            var wrapped = Utility.WrapCommandLineElement(argument, true, true);
+            var parsed = ParseWindowsCommandLine(@"C:\program.exe " + wrapped + " --next=1");
+
+            // Three, because the program name is the first of them. Anything
+            // less means the argument swallowed what came after it.
+            Assert.AreEqual(3, parsed.Length, $"<{wrapped}> was read as {parsed.Length} arguments");
+            Assert.AreEqual(argument, parsed[1]);
+            Assert.AreEqual("--next=1", parsed[2]);
+        }
+
+        /// <summary>
+        /// The same thing for a whole commandline, which is the shape the
+        /// Windows service registers as its image path
+        /// </summary>
+        [Test]
+        [Category("Utility")]
+        public static void AWrappedWindowsCommandLineIsReadBackAsItsArguments()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Ignore("The Windows commandline parser is only available on Windows.");
+                return;
+            }
+
+            var arguments = new[]
+            {
+                "--portable-mode",
+                @"--webservice-sslcertificatefile=C:\Program Files\certs\Default Web Site-all.pfx",
+                @"--webservice-sslcertificatepassword=p""ss",
+                @"--dbpath=C:\Temp\folder\\",
+                "--log-retention=3M"
+            };
+
+            var commandline = Utility.WrapAsCommandLine(arguments, true);
+            var parsed = ParseWindowsCommandLine(@"C:\program.exe " + commandline);
+
+            Assert.AreEqual(arguments.Length + 1, parsed.Length, $"<{commandline}> was read as {parsed.Length} arguments");
+            for (var i = 0; i < arguments.Length; i++)
+                Assert.AreEqual(arguments[i], parsed[i + 1]);
+        }
+
+        /// <summary>
+        /// Splits a commandline the way Windows does when it hands the arguments
+        /// to a program
+        /// </summary>
+        /// <returns>The arguments, the program name first.</returns>
+        /// <param name="commandline">The commandline to split.</param>
+        [SupportedOSPlatform("windows")]
+        private static string[] ParseWindowsCommandLine(string commandline)
+        {
+            var block = CommandLineToArgvW(commandline, out var count);
+            if (block == IntPtr.Zero)
+                throw new InvalidOperationException($"CommandLineToArgvW failed with {Marshal.GetLastWin32Error()}");
+
+            try
+            {
+                var result = new string[count];
+                for (var i = 0; i < count; i++)
+                    result[i] = Marshal.PtrToStringUni(Marshal.ReadIntPtr(block, i * IntPtr.Size));
+
+                return result;
+            }
+            finally
+            {
+                LocalFree(block);
+            }
+        }
+
+        /// <summary>
+        /// Splits a commandline into arguments, as Windows itself does
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        [DllImport("shell32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CommandLineToArgvW([MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine, out int pNumArgs);
+
+        /// <summary>
+        /// Releases the block that CommandLineToArgvW allocated
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr LocalFree(IntPtr hMem);
     }
 }


### PR DESCRIPTION
## The rule

Windows reads a run of backslashes as ordinary characters unless the run meets a quote:

- `2n` backslashes then `"` → `n` backslashes, and the quote is a quote mark
- `2n+1` backslashes then `"` → `n` backslashes, and the quote is a **literal** `"`

`Utility.WrapCommandLineElement` doubles only **one** trailing backslash. When the run in front
of the closing quote is odd, that closing quote becomes a literal one and the argument never
ends — it takes everything after it.

## Measured

A small console program prints what its `Main(string[])` received. Each argument was wrapped by
the shipped code, `--next=1` was appended, and the program was launched with that raw command
line. The same string was also handed to `CommandLineToArgvW`.

**Before:**

| argument | wrapped | `Main(string[])` received | `CommandLineToArgvW` |
|---|---|---|---|
| `C:\dir\"x` | `"C:\dir\""x"` | **one argument** `C:\dir"x --next=1` | same |
| `C:\Temp\folder\\` | `"C:\Temp\folder\\\"` | **one argument** `C:\Temp\folder\" --next=1` | same |
| `C:\Temp\folder\\\` | `"C:\Temp\folder\\\\"` | `C:\Temp\folder\\` — **a backslash short** | same |
| `C:\Temp\folder\` | `"C:\Temp\folder\\"` | `C:\Temp\folder\` | same |
| `has"quote` | `"has""quote"` | `has"quote` — correct | **one argument** `has"quote --next=1` |

**After:** every one of them comes back as the argument that went in, with `--next=1` still a
separate argument, and the two parsers agree.

| argument | wrapped |
|---|---|
| `C:\dir\"x` | `"C:\dir\\\"x"` |
| `C:\Temp\folder\\` | `"C:\Temp\folder\\\\"` |
| `C:\Temp\folder\\\` | `"C:\Temp\folder\\\\\\"` |
| `C:\Temp\folder\` | `"C:\Temp\folder\\"` — unchanged, it was already right |
| `has"quote` | `"has\"quote"` |

Two separate findings there.

**The backslash handling is broken for the real consumer.** Three shapes: a backslash
immediately before a quote, and a trailing run of two or three. Two of them swallow every
following argument; the third silently drops a backslash. Reachable through any advanced
option value or filter expression a user can write.

**Doubling a quote is not broken, but it is ambiguous.** The C runtime that fills
`Main(string[])` reads `""` back correctly; `CommandLineToArgvW` does not, so the same string
means two different things depending on who reads it. The escaping now uses `\"`, which both
read alike, and which this tree already uses in `RunScript.ARGREGEX` and
`SynologyAuthMiddleware.EscapeArg` — `WrapCommandLineElement` was the only place writing `""`.

## Where it lands

- `WindowsService/Program.cs:84` and `:134` build the service image path, which goes to
  `CreateService` and is read by the argument parser **with no shell in between**.
- `RestAPI/Runner.cs:720-735` builds the command line the UI offers for export. Source paths,
  every advanced option value, and filter expressions all pass through it.

## The existing assertion

`CommandLineWrappingTests` pinned `has"quote` → `"has""quote"` in a test named
`WrapCommandLineElementKeepsExistingWindowsQuotingBehavior` — a characterization test, not a
claim that the form was right. That assertion is replaced. The shapes that were already
correct (`C:\Temp\folder\`, `a\b`, `\`, a plain value, a value with a space) are pinned in a
test of their own so this change cannot move them, and the `%` and Linux tests are untouched.

## Tests

`Duplicati/UnitTest/CommandLineWrappingTests.cs`, `[Category("Utility")]`, 31 cases.

Before the change: **15 red, 16 green**. After: **31 green**. The red was in exactly the
measured shapes — the three backslash cases and the four quote cases, in both the string
assertions and the round-trip.

Beyond asserting strings, each argument is wrapped and then read back through
`CommandLineToArgvW` together with a following `--next=1`, so an expected string that was
merely updated could not make the test pass. There is also a whole-command-line round trip in
the shape the service registers. Those two are Windows-only and `Assert.Ignore` elsewhere; the
string assertions run on every platform through the existing `isWindows` overload.

Full solution build: 0 errors, and the same 2 pre-existing `MSB3246` warnings as before.

## Not measured, and one behaviour that changes

- **Pasting the exported line into a shell.** Measured with a `.cmd` and a `.ps1` file.
  `cmd.exe` improves strictly: the three broken cases become correct and nothing regresses.
  **Windows PowerShell does not read either form correctly** — before this change
  `"has""quote"` arrives as `hasquote` and `"C:\Temp\folder\\"` as `C:\Temp\folder\\`, so
  values with quotes or trailing backslashes were already wrong there. After the change the
  backslash cases stay equally wrong and the quote cases become a parse error instead of a
  silently wrong value. This function emits `cmd`-style quoting; a PowerShell-shaped export
  would be a separate piece of work.
- The `%` → `%%` behaviour is untouched, and `%`-bearing arguments are deliberately not
  round-tripped: `%%` is a shell-layer artefact that the argument parser does not undo.
- An empty or whitespace-only argument is still returned unquoted and therefore disappears
  from the command line. It is the same class of defect, but I could not find a caller that
  can produce one, so I have not changed it and have not pinned the current behaviour either.

## Where this came from

[#3123](https://github.com/duplicati/duplicati/issues/3123). I am not marking it fixed:
**the example in that report is not affected.** `--webservice-sslcertificatepassword=` contains
`=`, which is outside the safe set, so it is already quoted correctly, and the `.pfx` path with
spaces is too. The `"""..."""` form the reporter expected is not what the parser wants. What
the issue's title points at is real, though, and this is what I found while checking it.
