### PR TITLE
Read the consistency checks without an index SQLite has to build

### DIFF
--- a/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
+++ b/Duplicati/Library/Main/Database/Local/LocalDatabase.cs
@@ -1823,37 +1823,38 @@ namespace Duplicati.Library.Main.Database.Local
         {
             await using var cmd = m_connection.CreateCommand()
                 .SetTransaction(m_rtr);
-            // Calculate the lengths for each blockset
-            var combinedLengths = @"
+            // Calculate the lengths for each blockset, keeping only the ones that do not
+            // match the recorded length. The sum is taken by joining out from "Blockset"
+            // rather than against a grouped subquery: a grouped subquery is materialized
+            // without an index, so SQLite has to build one of its own before it can join
+            // it back. "File" is joined after the aggregate, because joining it before
+            // would repeat every block once per file that shares the blockset.
+            var mismatchedLengths = @"
                 SELECT
-                    ""A"".""ID"" AS ""BlocksetID"",
-                    IFNULL(""B"".""CalcLen"", 0) AS ""CalcLen"",
-                    ""A"".""Length""
-                FROM ""Blockset"" ""A""
-                LEFT OUTER JOIN (
-                    SELECT
-                        ""BlocksetEntry"".""BlocksetID"",
-                        SUM(""Block"".""Size"") AS ""CalcLen""
-                    FROM ""BlocksetEntry""
-                    LEFT OUTER JOIN ""Block""
+                    ""Blockset"".""ID"" AS ""BlocksetID"",
+                    IFNULL(SUM(""Block"".""Size""), 0) AS ""CalcLen"",
+                    ""Blockset"".""Length"" AS ""Length""
+                FROM ""Blockset""
+                LEFT OUTER JOIN ""BlocksetEntry""
+                    ON ""BlocksetEntry"".""BlocksetID"" = ""Blockset"".""ID""
+                LEFT OUTER JOIN ""Block""
                     ON ""Block"".""ID"" = ""BlocksetEntry"".""BlockID""
-                    GROUP BY ""BlocksetEntry"".""BlocksetID""
-                ) ""B""
-                    ON ""A"".""ID"" = ""B"".""BlocksetID""
+                GROUP BY ""Blockset"".""ID""
+                HAVING IFNULL(SUM(""Block"".""Size""), 0) != ""Blockset"".""Length""
             ";
 
-            // For each blockset with wrong lengths, fetch the file path
+            // For each blockset with wrong lengths, fetch the file path. CROSS JOIN pins
+            // the order: on a healthy database the left side is empty, so it has to be the
+            // one that drives the join.
             var reportDetails = @$"
                 SELECT
-                    ""CalcLen"",
-                    ""Length"", ""A"".""BlocksetID"",
+                    ""A"".""CalcLen"",
+                    ""A"".""Length"",
+                    ""A"".""BlocksetID"",
                     ""File"".""Path""
-                FROM
-                    ({combinedLengths}) ""A"",
-                    ""File""
-                WHERE
-                    ""A"".""BlocksetID"" = ""File"".""BlocksetID""
-                    AND ""A"".""CalcLen"" != ""A"".""Length""
+                FROM ({mismatchedLengths}) ""A""
+                CROSS JOIN ""File""
+                    ON ""File"".""BlocksetID"" = ""A"".""BlocksetID""
             ";
 
             await using (var rd = await cmd.ExecuteReaderAsync(reportDetails, token).ConfigureAwait(false))
@@ -1899,6 +1900,12 @@ namespace Duplicati.Library.Main.Database.Local
                 throw new DatabaseInconsistencyException($"Found {real_count} blocklist hashes, but there should be {unique_count}. Run repair to fix it.");
 
             var blocksize_per_hashsize = Library.Utility.Utility.FormatInvariantValue(blocksize / hashsize);
+
+            // The actual count is read one blockset at a time rather than from a second
+            // grouped subquery: the unique index on ("BlocksetID", "Index") answers each of
+            // them, and only the blocksets with more than one block are asked. Grouping the
+            // whole of "BlocklistHash" and joining it back would materialize it without an
+            // index, leaving SQLite to build one of its own.
             var itemswithnoblocklisthash = await cmd.ExecuteScalarInt64Async($@"
                 SELECT COUNT(*)
                 FROM (
@@ -1907,11 +1914,11 @@ namespace Duplicati.Library.Main.Database.Local
                         SELECT
                             ""N"".""BlocksetID"",
                             ((""N"".""BlockCount"" + {blocksize_per_hashsize} - 1) / {blocksize_per_hashsize}) AS ""BlocklistHashCountExpected"",
-                            CASE
-                                WHEN ""G"".""BlocklistHashCount"" IS NULL
-                                THEN 0
-                                ELSE ""G"".""BlocklistHashCount""
-                            END AS ""BlocklistHashCountActual""
+                            (
+                                SELECT COUNT(*)
+                                FROM ""BlocklistHash""
+                                WHERE ""BlocklistHash"".""BlocksetID"" = ""N"".""BlocksetID""
+                            ) AS ""BlocklistHashCountActual""
                         FROM (
                             SELECT
                                 ""BlocksetID"",
@@ -1919,14 +1926,6 @@ namespace Duplicati.Library.Main.Database.Local
                             FROM ""BlocksetEntry""
                             GROUP BY ""BlocksetID""
                         ) ""N""
-                        LEFT OUTER JOIN (
-                            SELECT
-                                ""BlocksetID"",
-                                COUNT(*) AS ""BlocklistHashCount""
-                            FROM ""BlocklistHash""
-                            GROUP BY ""BlocksetID""
-                        ) ""G""
-                            ON ""N"".""BlocksetID"" = ""G"".""BlocksetID""
                         WHERE ""N"".""BlockCount"" > 1
                     )
                     WHERE ""BlocklistHashCountExpected"" != ""BlocklistHashCountActual""

--- a/Duplicati/UnitTest/AutomaticIndexTests.cs
+++ b/Duplicati/UnitTest/AutomaticIndexTests.cs
@@ -55,14 +55,12 @@ namespace Duplicati.UnitTest
         /// </summary>
         private static readonly HashSet<string> Accepted = new HashSet<string>(StringComparer.Ordinal)
         {
-            // Aliases of subqueries, not of tables: the subquery is materialized without any
-            // index, so an index on the tables it reads does not remove these. Removing them
-            // means rewriting the queries.
-            //   LocalDatabase.VerifyConsistencyInnerAsync, the grouped blockset lengths
-            "B(BlocksetID)",
-            //   LocalDatabase.VerifyConsistencyInnerAsync, the grouped blocklist hash counts
-            "G(BlocksetID)",
-            //   LocalDeleteDatabase.GetWastedSpaceReportAsync, the grouped scan times
+            // LocalDeleteDatabase.GetWastedSpaceReportAsync, the grouped scan times.
+            // An alias of a subquery, not of a table, so an index on the tables it reads does
+            // not remove it. Both sides of that join are grouped by "VolumeID", so the index
+            // is built over one row per block volume, which is nothing next to the join that
+            // produces those rows. Rewriting it to read the scan times one volume at a time
+            // was measured and is slower, and it does not remove the index either.
             "B(VolumeID)"
         };
 

--- a/Duplicati/UnitTest/ConsistencyCheckQueriesTests.cs
+++ b/Duplicati/UnitTest/ConsistencyCheckQueriesTests.cs
@@ -1,0 +1,220 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+using Duplicati.Library.Main;
+using Duplicati.Library.Main.Database;
+using Duplicati.Library.Main.Database.Local;
+using Duplicati.Library.SQLiteHelper;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// The consistency check compares the recorded length of a blockset against the blocks it
+/// holds, and the number of blocklist hashes against the number the block count calls for.
+/// Both are read with queries that were rewritten so that SQLite no longer has to build an
+/// index of its own to run them, so what is pinned here is that they still find the same
+/// damage - including the shapes a rewritten outer join drops most easily.
+/// </summary>
+public class ConsistencyCheckQueriesTests : BasicSetupHelper
+{
+    /// <summary>
+    /// Backs up a small file and one that spans several blocks, so that both a single-block
+    /// blockset and a blockset with blocklist hashes are present.
+    /// </summary>
+    /// <returns>The options the backup ran with.</returns>
+    private async Task<Dictionary<string, string>> BackupAsync()
+    {
+        var options = new Dictionary<string, string>(this.TestOptions);
+
+        File.WriteAllText(Path.Combine(this.DATAFOLDER, "small.txt"), "some data");
+
+        // Comfortably more than the test blocksize, so the blockset spans blocks and the
+        // backup writes a blocklist hash for it
+        var large = new byte[512 * 1024];
+        new System.Random(42).NextBytes(large);
+        File.WriteAllBytes(Path.Combine(this.DATAFOLDER, "large.bin"), large);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.BackupAsync([this.DATAFOLDER]));
+
+        return options;
+    }
+
+    /// <summary>
+    /// Runs the consistency check the way the backup does.
+    /// </summary>
+    /// <param name="options">The options the backup ran with.</param>
+    private async Task VerifyAsync(Dictionary<string, string> options)
+    {
+        var opts = new Options(options);
+        await using var db = await LocalDatabase.CreateLocalDatabaseAsync(this.DBFILE, "verify", true, null, CancellationToken.None);
+        await db.VerifyConsistencyAsync(opts.Blocksize, opts.BlockhashSize, true, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// The blockset of the file that spans several blocks.
+    /// </summary>
+    private static long MultiBlockBlocksetId(SqliteCommand cmd)
+    {
+        var id = cmd.ExecuteScalarInt64(@"
+            SELECT ""BlocksetID""
+            FROM ""BlocksetEntry""
+            GROUP BY ""BlocksetID""
+            HAVING COUNT(*) > 1
+            ORDER BY COUNT(*) DESC
+            LIMIT 1
+        ", -1);
+
+        Assert.That(id, Is.GreaterThanOrEqualTo(0), "The backup left no blockset with more than one block");
+        return id;
+    }
+
+    /// <summary>
+    /// Green before and after: an untouched backup has nothing to report
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task AnUntouchedBackupIsConsistent()
+    {
+        var options = await BackupAsync();
+        Assert.DoesNotThrowAsync(async () => await VerifyAsync(options));
+    }
+
+    /// <summary>
+    /// The length that does not match the blocks is what the first query looks for
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task ALengthThatDoesNotMatchTheBlocksIsReported()
+    {
+        var options = await BackupAsync();
+
+        await using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        await using (var cmd = con.CreateCommand())
+        {
+            var id = MultiBlockBlocksetId(cmd);
+            await cmd
+                .SetCommandAndParameters(@"UPDATE ""Blockset"" SET ""Length"" = ""Length"" + 1 WHERE ""ID"" = @Id")
+                .SetParameterValue("@Id", id)
+                .ExecuteNonQueryAsync();
+        }
+
+        Assert.ThrowsAsync<DatabaseInconsistencyException>(async () => await VerifyAsync(options));
+    }
+
+    /// <summary>
+    /// A blockset with a length but no blocks at all. This is the row that disappears first
+    /// when the outer join that produces the sums is written the wrong way round, because
+    /// there is nothing on the other side of it to join to.
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task ABlocksetWithALengthAndNoBlocksIsReported()
+    {
+        var options = await BackupAsync();
+
+        await using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        await using (var cmd = con.CreateCommand())
+        {
+            var id = MultiBlockBlocksetId(cmd);
+            await cmd
+                .SetCommandAndParameters(@"DELETE FROM ""BlocksetEntry"" WHERE ""BlocksetID"" = @Id")
+                .SetParameterValue("@Id", id)
+                .ExecuteNonQueryAsync();
+
+            // The blocklist hashes go with them, so that the run fails on the length rather
+            // than on the blocklist hash count
+            await cmd
+                .SetCommandAndParameters(@"DELETE FROM ""BlocklistHash"" WHERE ""BlocksetID"" = @Id")
+                .SetParameterValue("@Id", id)
+                .ExecuteNonQueryAsync();
+        }
+
+        Assert.ThrowsAsync<DatabaseInconsistencyException>(async () => await VerifyAsync(options));
+    }
+
+    /// <summary>
+    /// A blockset that has more blocks than one and no blocklist hash to describe them is
+    /// what the second query counts
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task AMissingBlocklistHashIsReported()
+    {
+        var options = await BackupAsync();
+
+        await using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        await using (var cmd = con.CreateCommand())
+        {
+            var id = MultiBlockBlocksetId(cmd);
+
+            var before = cmd
+                .SetCommandAndParameters(@"SELECT COUNT(*) FROM ""BlocklistHash"" WHERE ""BlocksetID"" = @Id")
+                .SetParameterValue("@Id", id)
+                .ExecuteScalarInt64(0);
+            Assert.That(before, Is.GreaterThan(0), "The backup left no blocklist hash to remove");
+
+            await cmd
+                .SetCommandAndParameters(@"DELETE FROM ""BlocklistHash"" WHERE ""BlocksetID"" = @Id")
+                .SetParameterValue("@Id", id)
+                .ExecuteNonQueryAsync();
+        }
+
+        Assert.ThrowsAsync<DatabaseInconsistencyException>(async () => await VerifyAsync(options));
+    }
+
+    /// <summary>
+    /// Green before and after: a blockset with one block has no blocklist hash, and that is
+    /// not damage. Counting it as damage is the mistake a rewrite of the second query makes
+    /// when it counts rows of an outer join instead of rows of the table.
+    /// </summary>
+    [Test]
+    [Category("Targeted")]
+    public async Task ASingleBlockBlocksetNeedsNoBlocklistHash()
+    {
+        var options = await BackupAsync();
+
+        await using (var con = await SQLiteLoader.LoadConnectionAsync(options["dbpath"]))
+        await using (var cmd = con.CreateCommand())
+        {
+            var singles = cmd.ExecuteScalarInt64(@"
+                SELECT COUNT(*)
+                FROM (
+                    SELECT ""BlocksetID""
+                    FROM ""BlocksetEntry""
+                    GROUP BY ""BlocksetID""
+                    HAVING COUNT(*) = 1
+                )
+            ", 0);
+
+            Assert.That(singles, Is.GreaterThan(0), "The backup left no single-block blockset, so nothing is being tested");
+        }
+
+        Assert.DoesNotThrowAsync(async () => await VerifyAsync(options));
+    }
+}


### PR DESCRIPTION
## What this is

The last of the automatic indexes [#5976](https://github.com/duplicati/duplicati/issues/5976) is
about, continuing [#7141](https://github.com/duplicati/duplicati/pull/7141) and
[#7173](https://github.com/duplicati/duplicati/pull/7173). Those removed the ones an index could
remove. `AutomaticIndexTests` recorded the three that were left, with the note that removing them
means rewriting the queries. Two of them are rewritten here; the third is measured and kept, with
the reason corrected.

Both are in `LocalDatabase.VerifyConsistencyInnerAsync`, which runs twice on every backup.

## Measured

Against the schema and the engine the product ships — SQLite 3.53.4 from
`SQLitePCLRaw.bundle_e_sqlite3` 3.0.5 — with `SQLiteLoader`'s pragmas applied, inside a
transaction, after `ANALYZE`, as the median of five alternating runs.

| blocksets | shape | query | old | new | |
|---:|---|---|---:|---:|---|
| 20,000 | realistic | blockset lengths | 245 ms | **163 ms** | −34% |
| 20,000 | realistic | blocklist counts | 47 ms | **44 ms** | −6% |
| 100,000 | realistic | blockset lengths | 539 ms | **405 ms** | −25% |
| 100,000 | realistic | blocklist counts | 291 ms | **234 ms** | −20% |
| 20,000 | multi-block | blockset lengths | 332 ms | **217 ms** | −35% |
| 20,000 | multi-block | blocklist counts | 235 ms | **139 ms** | −41% |
| 100,000 | multi-block | blockset lengths | 1,939 ms | **1,140 ms** | −41% |
| 100,000 | multi-block | blocklist counts | 909 ms | **632 ms** | −30% |

"realistic" is mostly single-block files with a tail of larger ones. "multi-block" gives every
blockset several blocks — the shape that could have made a correlated count lose, which is why it
is here. In all eight the plan loses its `SEARCH ... USING AUTOMATIC COVERING INDEX`, and in all
eight both forms return the same rows.

The plan for the blockset lengths goes from

```
MATERIALIZE B / SCAN BlocksetEntry / SEARCH Block ... LEFT-JOIN
SCAN A / SEARCH A USING INTEGER PRIMARY KEY
BLOOM FILTER ON B (BlocksetID=?)
SEARCH B USING AUTOMATIC COVERING INDEX (BlocksetID=?) LEFT-JOIN
```

to

```
CO-ROUTINE A / SCAN Blockset
SEARCH BlocksetEntry USING PRIMARY KEY (BlocksetID=?) LEFT-JOIN
SEARCH Block USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN
SCAN A / SEARCH A USING INDEX nn_FileLookup_BlockMeta (BlocksetID=?)
```

— the subquery is no longer materialized at all, and the join into `File` uses an index that
already exists.

## What changed

**The blockset lengths.** The sum per blockset came from a `GROUP BY` subquery that was then
`LEFT OUTER JOIN`ed back to `Blockset`. A grouped subquery is materialized without an index, so
SQLite built one of its own to join it. The sum is now taken by joining out from `Blockset`
directly, and the comparison moved into `HAVING`.

`File` is joined after the aggregate, not before: joining it first would repeat every block once
per file that shares the blockset and multiply the sum. The join is a `CROSS JOIN` so the order is
pinned — on a healthy database the left side is empty, so it has to be the side that drives.

**The blocklist hash counts.** The same shape: a second `GROUP BY` subquery over `BlocklistHash`
joined back on `BlocksetID`. It is now a correlated count, answered by the existing unique index on
`("BlocksetID", "Index")`, and asked only for the blocksets that have more than one block.

**The wasted space report is left alone.** Rewriting it to read the scan times one volume at a time
was measured: it is slower, and it does not remove the automatic index either, because the
expensive part is the join that produces the rows rather than the index over them. Both sides of
that join are grouped by `VolumeID`, so the index covers one row per block volume. The entry stays
in `Accepted` with that as its reason instead of the old one.

## Same answers

These queries decide whether a backup is reported as inconsistent, so the rewrite must find exactly
the same damage.

- The harness compares the full result sets of the old and new forms, sorted, on every shape and
  scale above, with deliberate damage seeded in: mismatched lengths, blocksets with no blocks at
  all, dangling `BlockID` values, and missing blocklist hashes. They agree everywhere.
- `Duplicati/UnitTest/ConsistencyCheckQueriesTests.cs` is new, and it is **green against the old
  queries and against the new ones**. That is the point of it: it pins behaviour that must not
  change, not behaviour this PR introduces. It covers a length that does not match, a blockset with
  a length and no blocks (the row a badly written outer join drops first), a missing blocklist hash,
  a single-block blockset needing no blocklist hash, and an untouched backup staying quiet.

## Red, then green

`AutomaticIndexTests` is the verification, used the same way as in #7173:

1. Remove the two entries from `Accepted` with no other change — the test **fails**, naming
   `B(BlocksetID)` at `LocalDatabase.cs:1859` and `G(BlocksetID)` at `LocalDatabase.cs:1902`
   with the call stack of each.
2. Rewrite the queries — the test **passes**.

Full solution build: 0 errors, and the same two pre-existing `MSB3246` warnings as before.

## Not measured

- **Only this machine.** The engine is the one the product ships (`SQLitePCLRaw.bundle_e_sqlite3`
  3.0.5, SQLite 3.53.4) and the harness applies the same pragmas as `SQLiteLoader`, but the numbers
  are from one machine with a warm file cache, not from a range of hardware.
- **The log lines in the issue cannot appear on current master.** `SQLite warning (284): ...` and
  `SQLite error (17): ...` are the prefix format of System.Data.SQLite's log handler; the tree now
  uses `Microsoft.Data.Sqlite` with `SQLitePCLRaw`, which installs no handler. So this does not
  claim to fix that message. What it does is remove two of the automatic indexes the issue is
  about, which is the part that is still real and still observable — `AutomaticIndexTests` sees
  them through its own hook.
- Whether removing them changes anything for `PRAGMA optimize` is untested. The causal chain in the
  issue was never confirmed, and I have not confirmed it either.
