### PR TITLE
Keep a source inside an excluded folder instead of losing it

### DIFF
--- a/Duplicati/Library/Main/Controller.cs
+++ b/Duplicati/Library/Main/Controller.cs
@@ -1489,6 +1489,19 @@ namespace Duplicati.Library.Main
                             // If there are no excludes, there is no need to keep the folder as a filter
                             if (excludes)
                             {
+                                // An include filter cannot bring it back when a folder on the way
+                                // to it is excluded: the walk of the containing source stops at
+                                // that folder, so the filter is never reached. Keeping it as a
+                                // source is what works, because a source is walked from its own
+                                // root, and the containing source still stops where it is told to.
+                                // Carry on looking: another source may still be able to reach it,
+                                // and keeping one that is reachable would walk the same tree twice.
+                                if (IsCutOffByFilter(sources[i], sources[j], filter))
+                                {
+                                    Logging.Log.WriteVerboseMessage(LOGTAG, "KeepingSubfolderSource", "Keeping source \"{0}\" although it is inside \"{1}\", because a folder between them is excluded", sources[i], sources[j]);
+                                    continue;
+                                }
+
                                 Logging.Log.WriteVerboseMessage(LOGTAG, "RemovingSubfolderSource", "Removing source \"{0}\" because it is a folder or file inside \"{1}\", and using it as an include filter", sources[i], sources[j]);
                                 filter = JoinedFilterExpression.Join(new FilterExpression(sources[i]), filter);
                             }
@@ -1508,6 +1521,47 @@ namespace Duplicati.Library.Main
                 throw new UserInformationException(Strings.Controller.NoSourcesError, "NoSources");
 
             return (sources.ToArray(), filter);
+        }
+
+        /// <summary>
+        /// Reports whether the walk of <paramref name="container"/> stops before it reaches
+        /// <paramref name="source"/>, because a folder on the way is excluded by the filter.
+        /// A folder that the filter excludes is never descended into, so nothing below it is
+        /// reached, no matter what the filter says about the things below it.
+        /// </summary>
+        /// <returns><c>true</c> if a folder between the two is excluded.</returns>
+        /// <param name="source">The source that sits inside the other one.</param>
+        /// <param name="container">The source that contains it, ending with a separator.</param>
+        /// <param name="filter">The filter to ask.</param>
+        internal static bool IsCutOffByFilter(string source, string container, IFilter filter)
+        {
+            if (filter == null || filter.Empty)
+                return false;
+
+            // A mounted source is not a path on this machine, so there are no folders
+            // between the two to ask about
+            if (source.StartsWith("@", StringComparison.Ordinal) || container.StartsWith("@", StringComparison.Ordinal))
+                return false;
+
+            // Every folder between the two, asked for in the form the enumeration uses,
+            // which is with a trailing separator. The source itself is not one of them:
+            // it is the thing being looked for, not a step on the way.
+            var relative = source.Substring(container.Length);
+            for (var at = relative.IndexOf(Util.DirectorySeparatorString, StringComparison.Ordinal);
+                 at >= 0;
+                 at = relative.IndexOf(Util.DirectorySeparatorString, at + 1, StringComparison.Ordinal))
+            {
+                var folder = container + relative.Substring(0, at + 1);
+                if (folder.Length >= source.Length)
+                    break;
+
+                // A path the filter does not mention is not excluded, it only falls to the
+                // default, so what matters is whether an entry matched and said to exclude it
+                if (filter.Matches(folder, out var include, out _) && !include)
+                    return true;
+            }
+
+            return false;
         }
 
         /// <inheritdoc />

--- a/Duplicati/UnitTest/NestedSourceExclusionTests.cs
+++ b/Duplicati/UnitTest/NestedSourceExclusionTests.cs
@@ -1,0 +1,222 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duplicati.Library.Common.IO;
+using Duplicati.Library.Main;
+using Duplicati.Library.Utility;
+using NUnit.Framework;
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A source that sits inside another source is taken out of the source list and turned
+/// into an include filter. When a folder on the way to it is excluded, the walk of the
+/// outer source stops at that folder, so the include filter is never reached and the
+/// folder the user asked for is quietly absent from the backup. Reported as issue #3220.
+/// </summary>
+/// <remarks>
+/// Every backup here goes through <see cref="TestUtils.AssertResults" />, which fails on
+/// any error or warning. That is deliberate: keeping a source that another source can
+/// still reach would walk the same tree twice, and the second pass reports a duplicate -
+/// as a warning for a file, and as an error for a folder.
+/// </remarks>
+public class NestedSourceExclusionTests : BasicSetupHelper
+{
+    /// <summary>Written into every file, so none of them is empty</summary>
+    private const string Contents = "some data";
+
+    /// <summary>
+    /// Creates a file and the folders above it, and returns the path.
+    /// </summary>
+    /// <param name="parts">The path of the file, relative to the data folder</param>
+    /// <returns>The full path of the file.</returns>
+    private string WriteFile(params string[] parts)
+    {
+        var path = Path.Combine([this.DATAFOLDER, .. parts]);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, Contents);
+        return path;
+    }
+
+    /// <summary>The given folder below the data folder, with a trailing separator</summary>
+    /// <param name="parts">The path of the folder, relative to the data folder</param>
+    /// <returns>The full path of the folder.</returns>
+    private string Folder(params string[] parts)
+        => Util.AppendDirSeparator(Path.Combine([this.DATAFOLDER, .. parts]));
+
+    /// <summary>
+    /// Runs a backup and reports the names of the files it recorded.
+    /// </summary>
+    /// <param name="sources">The sources to back up</param>
+    /// <param name="filter">The filter to apply</param>
+    /// <returns>The file names, without their folders.</returns>
+    private async Task<string[]> BackupAndListAsync(string[] sources, IFilter filter)
+    {
+        var options = new Dictionary<string, string>(this.TestOptions);
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+            TestUtils.AssertResults(await c.BackupAsync(sources, filter));
+
+        using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
+        {
+            var r = await c.ListAsync("*");
+            TestUtils.AssertResults(r);
+            return r.Files
+                .Select(x => x.Path)
+                .Where(x => !x.EndsWith(Util.DirectorySeparatorString, StringComparison.Ordinal))
+                .Select(Path.GetFileName)
+                .ToArray()!;
+        }
+    }
+
+    /// <summary>
+    /// The point of the issue: naming a folder as a source has to keep it in the backup
+    /// even when a folder above it is excluded.
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public async Task ASourceInsideAnExcludedFolderIsStillBackedUp()
+    {
+        WriteFile("kept.txt");
+        WriteFile("excluded", "dropped.txt");
+        WriteFile("excluded", "wanted", "wanted.txt");
+
+        var files = await BackupAndListAsync(
+            [this.DATAFOLDER, Folder("excluded", "wanted")],
+            new FilterExpression(Folder("excluded"), false));
+
+        Assert.That(files, Does.Contain("wanted.txt"),
+            $"the source inside the excluded folder was dropped; got: {string.Join(", ", files)}");
+        Assert.That(files, Does.Contain("kept.txt"), "the rest of the backup should be unaffected");
+        Assert.That(files, Does.Not.Contain("dropped.txt"), "the excluded folder itself should stay excluded");
+    }
+
+    /// <summary>
+    /// The same thing two levels down, so that more than one folder has to be looked at
+    /// on the way
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public async Task ASourceSeveralLevelsInsideAnExcludedFolderIsStillBackedUp()
+    {
+        WriteFile("kept.txt");
+        WriteFile("a", "a.txt");
+        WriteFile("a", "b", "b.txt");
+        WriteFile("a", "b", "c", "c.txt");
+
+        var files = await BackupAndListAsync(
+            [this.DATAFOLDER, Folder("a", "b", "c")],
+            new FilterExpression(Folder("a", "b"), false));
+
+        Assert.That(files, Does.Contain("c.txt"), $"got: {string.Join(", ", files)}");
+        Assert.That(files, Does.Contain("a.txt"), "only the excluded folder should be gone");
+        Assert.That(files, Does.Contain("kept.txt"));
+        Assert.That(files, Does.Not.Contain("b.txt"), "the excluded folder itself should stay excluded");
+    }
+
+    /// <summary>
+    /// Two sources under the same excluded folder. Neither contains the other, so each is
+    /// judged on its own, and neither may be walked twice.
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public async Task TwoSourcesUnderTheSameExcludedFolderAreBothBackedUp()
+    {
+        WriteFile("kept.txt");
+        WriteFile("excluded", "dropped.txt");
+        WriteFile("excluded", "one", "one.txt");
+        WriteFile("excluded", "two", "two.txt");
+
+        var files = await BackupAndListAsync(
+            [this.DATAFOLDER, Folder("excluded", "one"), Folder("excluded", "two")],
+            new FilterExpression(Folder("excluded"), false));
+
+        Assert.That(files, Does.Contain("one.txt"), $"got: {string.Join(", ", files)}");
+        Assert.That(files, Does.Contain("two.txt"), $"got: {string.Join(", ", files)}");
+        Assert.That(files, Does.Contain("kept.txt"));
+        Assert.That(files, Does.Not.Contain("dropped.txt"));
+    }
+
+    /// <summary>
+    /// Green before and after, and the reason the rule is as narrow as it is: an exclude
+    /// that names the nested source itself is overruled by the include filter that
+    /// replaces it, so that source is still taken out of the list.
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public async Task AnExcludeOnTheSourceItselfIsStillOverruled()
+    {
+        WriteFile("kept.txt");
+        WriteFile("sub", "sub.txt");
+
+        var files = await BackupAndListAsync(
+            [this.DATAFOLDER, Folder("sub")],
+            new FilterExpression(Folder("sub"), false));
+
+        Assert.That(files, Does.Contain("sub.txt"), $"got: {string.Join(", ", files)}");
+        Assert.That(files, Does.Contain("kept.txt"));
+    }
+
+    /// <summary>
+    /// Green before and after: with nothing excluded, the nested source adds nothing and
+    /// is still taken out, so the tree is not walked twice
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public async Task ANestedSourceWithNoExcludesIsStillCovered()
+    {
+        WriteFile("kept.txt");
+        WriteFile("excluded", "dropped.txt");
+        WriteFile("excluded", "wanted", "wanted.txt");
+
+        var files = await BackupAndListAsync([this.DATAFOLDER, Folder("excluded", "wanted")], null);
+
+        Assert.That(files, Does.Contain("wanted.txt"));
+        Assert.That(files, Does.Contain("dropped.txt"));
+        Assert.That(files, Does.Contain("kept.txt"));
+    }
+
+    /// <summary>
+    /// Green before and after: an exclude that no source sits inside still excludes
+    /// everything below it
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public async Task AnExcludedFolderWithNoSourceInsideStaysExcluded()
+    {
+        WriteFile("kept.txt");
+        WriteFile("excluded", "dropped.txt");
+        WriteFile("excluded", "wanted", "wanted.txt");
+
+        var files = await BackupAndListAsync(
+            [this.DATAFOLDER],
+            new FilterExpression(Folder("excluded"), false));
+
+        Assert.That(files, Does.Contain("kept.txt"));
+        Assert.That(files, Does.Not.Contain("dropped.txt"));
+        Assert.That(files, Does.Not.Contain("wanted.txt"), "everything below the excluded folder should be gone");
+    }
+}

--- a/Duplicati/UnitTest/SourcePathExpansionTests.cs
+++ b/Duplicati/UnitTest/SourcePathExpansionTests.cs
@@ -79,6 +79,76 @@ public class SourcePathExpansionTests
         }
     }
 
+    /// <summary>
+    /// A source that sits inside another source is normally taken out of the list and
+    /// replaced by an include filter. That cannot work when a folder on the way to it is
+    /// excluded, because the walk of the outer source stops there and never reaches the
+    /// filter, so such a source is kept instead. Issue #3220.
+    /// </summary>
+    /// <param name="excludeNested">Whether the filter excludes the nested source or the folder above it</param>
+    /// <param name="expectKept">Whether the nested source is expected to survive</param>
+    [Test]
+    [Category("Controller")]
+    [TestCase(false, true, TestName = "ASourceUnderAnExcludedFolderIsKept")]
+    [TestCase(true, false, TestName = "ASourceThatIsItselfExcludedIsStillReplacedByAFilter")]
+    public void ANestedSourceIsOnlyKeptWhenNothingElseCanReachIt(bool excludeNested, bool expectKept)
+    {
+        var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var middle = Path.Combine(root, "middle");
+        var nested = Path.Combine(middle, "nested");
+        Directory.CreateDirectory(nested);
+
+        try
+        {
+            var filter = new Library.Utility.FilterExpression(
+                Util.AppendDirSeparator(excludeNested ? nested : middle), false);
+
+            var (sources, resulting) = Controller.ExpandInputSources(
+                [root, nested], filter, new Options(new Dictionary<string, string?>()));
+
+            var kept = sources.Contains(Util.AppendDirSeparator(nested), Library.Utility.Utility.ClientFilenameStringComparer);
+            Assert.AreEqual(expectKept, kept,
+                $"sources: {string.Join(", ", sources)}");
+
+            if (expectKept)
+                // Nothing is added to the filter, so an argument that only excludes stays
+                // that way and the outer walk still stops where it was told to
+                Assert.AreSame(filter, resulting, "the filter should be left alone when the source is kept");
+            else
+                Assert.AreNotSame(filter, resulting, "the source should have become an include filter");
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    /// <summary>
+    /// Green before and after: with nothing excluded there is nothing that can hide the
+    /// nested source, so it is taken out as it always was
+    /// </summary>
+    [Test]
+    [Category("Controller")]
+    public void ANestedSourceWithNoFilterIsStillRemoved()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var nested = Path.Combine(root, "middle", "nested");
+        Directory.CreateDirectory(nested);
+
+        try
+        {
+            var sources = Controller.ExpandInputSources(
+                [root, nested], null, new Options(new Dictionary<string, string?>())).Sources;
+
+            Assert.AreEqual(1, sources.Length, $"sources: {string.Join(", ", sources)}");
+            Assert.AreEqual(Util.AppendDirSeparator(root), sources[0]);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
     [Test]
     [Category("Controller")]
     public void ABareDriveMeansTheRootOfIt()


### PR DESCRIPTION
## The symptom

Back up `C:\`, exclude `C:\Windows`, and also add `C:\Windows\Fonts` as a source. **`Fonts` is not
backed up.** No warning, no error — the data the user picked is simply not there.

Reported as [#3220](https://github.com/duplicati/duplicati/issues/3220) in 2018. It still happens,
and it is reproduced by the first test in this change: with sources `<data>` and
`<data>/excluded/wanted/` and an exclude on `<data>/excluded/`, the backup keeps only the file
that sits outside the excluded folder.

## Why

A source that sits inside another source is taken out of the source list and re-added as an include
filter, in the "sanity check for multiple inclusions of the same folder" loop at the end of
`Controller.ExpandInputSources`. The intent is right. It cannot work, for two reasons that compound:

1. `new FilterExpression("C:\Windows\Fonts\")` is a `FilterType.Simple` entry, and
   `FilterEntry.Matches` compares it with **exact string equality**. It names that one folder —
   not `C:\Windows\` above it, not `arial.ttf` below it.

2. `FileEnumerationProcess` builds a separate filter for deciding **what to recurse into**:

   ```csharp
   // The enumeration filter is used to determine what paths to
   // recurse into. If the emit filter only has includes,
   // the enumeration filter will also include all folders,
   // as nothing will match otherwise
   var enumeratefilter = emitfilter;
   FilterExpression.AnalyzeFilters(emitfilter, out var includes, out var excludes);
   if (includes && !excludes)
       enumeratefilter = FilterExpression.Combine(emitfilter, new FilterExpression("*" + Path.DirectorySeparatorChar, true)) ?? ...;
   ```

   **The mechanism that lets a walk reach a nested include already exists**, and its comment says
   exactly why it is needed. But adding an include to a filter that already excludes produces
   *both*, so the widening is skipped.

`RecurseEntriesAsync` pushes an entry onto the work stack only if it passes that filter, so
`C:\Windows\` is never enumerated and nothing below it is ever seen. **The include filter that
`ExpandInputSources` adds is never consulted.**

Everything else in the backup is unaffected, because with both includes and excludes present an
unmatched path falls to include by default — which is why the report is "one folder is missing"
rather than "the backup is empty".

## The change

Keep the source instead of converting it, when the conversion cannot work.

A source is walked from its own root, and `SourceFileEntryFilterAsync` never filters a root entry,
so a kept source is reached. The containing source still stops where the exclude tells it to, so
nothing is walked twice.

The rule is deliberately narrow — keep it **only** when a folder between the two is explicitly
excluded, and keep checking the other sources, because one that can still reach it means removing
is right. That matters: walking the same tree twice is not harmless. A duplicate file is a warning
(`FileBlockProcessor` catches it), but a duplicate **folder** reaches an unguarded insert in
`MetadataPreProcess` and **fails the backup**. Every test here asserts zero errors and zero
warnings, which is what guards that.

### What I did not do

Widening the folder pass-through to the both-includes-and-excludes case looks like the smaller
change, and it is wrong. Un-pruning `C:\Windows\` makes the walk descend into it, and then
`C:\Windows\System32\` matches neither the includes nor the exact exclude on `C:\Windows\`, so it
falls to include by default and **the whole of `C:\Windows` gets backed up**. It also makes every
backup that excludes a folder walk that folder in full.

## Red, then green

`Duplicati/UnitTest/NestedSourceExclusionTests.cs` is new — six real backups, checked with
`ListAsync("*")`. Without the change:

| test | before | after |
|---|---|---|
| a source inside an excluded folder | **red** | green |
| a source several levels inside an excluded folder | **red** | green |
| two sources under the same excluded folder | **red** | green |
| an exclude naming the source itself is still overruled | green | green |
| a nested source with no excludes is still removed | green | green |
| an excluded folder with no source inside stays excluded | green | green |

The three that were already green are the regression guards: they are the shapes where the current
removal is correct, and they show the new rule does not reach them.

`Duplicati/UnitTest/SourcePathExpansionTests.cs` gains three cases at the level of
`ExpandInputSources` itself, which are quick and do not touch a backend. The first
(`ASourceUnderAnExcludedFolderIsKept`) is red before the change; it also asserts that the returned
filter is **the same object** that went in, i.e. that nothing was added to it — an excludes-only
filter has to stay excludes-only, or `AnalyzeFilters` changes verdict for the whole backup.

`Issue7189` covers the same loop from the other direction and stays green.

Full solution build: 0 errors, and the same two pre-existing `MSB3246` warnings as before.

## Not measured

- **Windows path shapes are not exercised on Windows-specific input.** The tests build their trees
  under the test data folder, so they run on all three platforms, but I have not tested a drive
  root (`C:\`) as the containing source — the reporter's exact case. The code path does not treat
  it specially, and `ASourceSeveralLevelsInsideAnExcludedFolderIsStillBackedUp` covers the
  more-than-one-folder-deep shape, but the literal `C:\` case is untested.
- **Mounted (`@`) sources** are skipped by the new check rather than reasoned about; they are not
  filesystem paths, so there are no folders between them to ask about.
- I have not looked at whether `MetadataPreProcess` should guard its insert the way
  `FileBlockProcessor` does. It is a real difference, but it is not this change.
