### PR TITLE
Stop resolving the native ijwhost.dll as a managed reference

### DIFF
--- a/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
+++ b/Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj
@@ -28,6 +28,19 @@
     <ProjectReference Include="..\Interface\Duplicati.Library.Interface.csproj" />
   </ItemGroup>
 
+  <!--
+    Vanara.PInvoke.VssApi ships the native ijwhost.dll inside its "lib" folder, so NuGet
+    offers it as a managed reference and the assembly resolver reports that it holds no
+    metadata (MSB3246). The copy that belongs in the output is the one from the targeting
+    pack, which the target below takes.
+  -->
+  <Target Name="DropVanaraIjwhostReference" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_VanaraIjwhost Include="@(Reference)" Condition="'%(Filename)' == 'Ijwhost'" />
+      <Reference Remove="@(_VanaraIjwhost)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="IncludeIjwhostForVanara" BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <_Ijwhost Include="$(NetCoreTargetingPackRoot)\Microsoft.NETCore.App.Host.win-x64\$([System.String]::Copy('$(TargetFrameworkVersion)').TrimStart('v')).*\runtimes\win-x64\native\ijwhost.dll" />

--- a/Executables/Duplicati.WindowsModulesLoader/Duplicati.WindowsModulesLoader.csproj
+++ b/Executables/Duplicati.WindowsModulesLoader/Duplicati.WindowsModulesLoader.csproj
@@ -17,4 +17,17 @@
     <ProjectReference Include="..\..\Duplicati\Library\Snapshots\Duplicati.Library.Snapshots.csproj" />
   </ItemGroup>
 
+  <!--
+    Vanara.PInvoke.VssApi ships the native ijwhost.dll inside its "lib" folder, so NuGet
+    offers it as a managed reference and the assembly resolver reports that it holds no
+    metadata (MSB3246). It reaches this project through Duplicati.Library.WindowsModules,
+    which drops it the same way and takes the copy from the targeting pack instead.
+  -->
+  <Target Name="DropVanaraIjwhostReference" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_VanaraIjwhost Include="@(Reference)" Condition="'%(Filename)' == 'Ijwhost'" />
+      <Reference Remove="@(_VanaraIjwhost)" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## The warning

Every build of the solution reports MSB3246 twice:

```
Primary reference "Ijwhost".
  Resolved file path is "…/.nuget/packages/vanara.pinvoke.vssapi/5.0.7/lib/net8.0-windows7.0/Ijwhost.dll".
  warning MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible.
  PE image does not have metadata.
  [Duplicati/Library/WindowsModules/Duplicati.Library.WindowsModules.csproj]
  [Executables/Duplicati.WindowsModulesLoader/Duplicati.WindowsModulesLoader.csproj]
```

## Why

`Vanara.PInvoke.VssApi` 5.0.7 ships the **native** `ijwhost.dll` — the host shim its C++/CLI
`Vanara.PInvoke.VssApiMgd.dll` needs — inside the package's `lib` folder:

| in the package | what it is |
|---|---|
| `lib/net8.0-windows7.0/Vanara.PInvoke.VssApi.dll` | managed |
| `lib/net8.0-windows7.0/Vanara.PInvoke.VssApiMgd.dll` | C++/CLI, mixed mode |
| **`lib/net8.0-windows7.0/Ijwhost.dll`** | **native** |
| `runtimes/` | **not present** |

NuGet treats everything under `lib` as a managed assembly, so it becomes a primary reference,
the assembly resolver opens it, finds no metadata, and warns. A native binary belongs under
`runtimes/<rid>/native/`, so this is a packaging problem upstream — and **5.0.7 is the newest
published version**, so it cannot be fixed by moving forward.

This is the other half of what [#7239](https://github.com/duplicati/duplicati/pull/7239) ran
into. That change fixed the symptom — `ijwhost.dll` missing from the run folder when debugging —
by taking a copy from the targeting pack. The cause, the bogus managed reference, stayed.

## The change

The reference is dropped before it is resolved:

```xml
<Target Name="DropVanaraIjwhostReference" BeforeTargets="ResolveAssemblyReferences">
  <ItemGroup>
    <_VanaraIjwhost Include="@(Reference)" Condition="'%(Filename)' == 'Ijwhost'" />
    <Reference Remove="@(_VanaraIjwhost)" />
  </ItemGroup>
</Target>
```

**Two projects need it and no more.** The package is referenced directly by
`Duplicati.Library.WindowsModules`, and reaches `Duplicati.WindowsModulesLoader` through the
project reference. Nothing else in the solution references Vanara, and the solution reported
exactly those two warnings — one per project.

There is no `Directory.Build.targets` in the repo, so the target is repeated in both files. Happy
to fold it into a new one instead if you would rather have it in a single place — that seemed
like your call to make rather than mine.

`IncludeIjwhostForVanara` is untouched, and so is the `ijwhost.dll` probe in
`ReleaseBuilder/Build/Command.Compile.Verify.cs`.

## Nothing that ships changes

Only the compile-time reference goes; the file itself is still deployed by the package's runtime
assets.

| | before | after |
|---|---|---|
| solution build, Debug, `--no-incremental` | 0 errors, **2 warnings** | 0 errors, **0 warnings** |
| `ijwhost.dll` in `Duplicati.Library.WindowsModules`' build output | 137,000 bytes | **unchanged** |
| `Ijwhost.dll` after `dotnet publish` of `Duplicati.WindowsModulesLoader` | 129,832 bytes | **`cmp` says byte-for-byte identical** |

(Those two projects are the only ones this PR touches. Which `ijwhost.dll` each of them ends up
with — and it is not the same one — is the separate matter in the next section; this PR does not
change it either way.)

## Not fixed here, but worth knowing: which ijwhost ships is decided by accident

Checking that nothing shipped had changed turned up something separate, so here it is rather than
in a drive-by change. **Nothing below is fixed by this PR** — I looked into it, measured it, and
concluded it does not currently break anything. Recording it so the decision is yours.

**Three different builds of `ijwhost.dll` are candidates**, all genuine Microsoft binaries:

| source | where in the package | product version | size |
|---|---|---|---|
| `AlphaVSS.Native.NetCore` 2.0.3 | `runtimes/win-x64/native/Ijwhost.dll` | **3.100.19** (.NET Core 3.1) | 342,392 |
| `Vanara.PInvoke.VssApi` 5.0.7 | `lib/net8.0-windows7.0/Ijwhost.dll` | **8.0.30** | 129,832 |
| the SDK host pack | `Microsoft.NETCore.App.Host.win-x64/10.0.x/…/ijwhost.dll` | **10.0.9 / 10.0.11** | 137,040 |

**Which one wins depends on ordering, and it differs per context.** Measured:

| | winner |
|---|---|
| `dotnet build` of `Duplicati.Library.WindowsModules` | 10.0.11 |
| `dotnet publish` of `Duplicati.WindowsModulesLoader` | 8.0.30 |
| `dotnet publish` of `Duplicati.GUI.TrayIcon` | **3.100.19** |

Two things make it order-dependent:

1. The SDK copy is linked as lowercase `ijwhost.dll` while both package copies are `Ijwhost.dll`.
   MSBuild treats those as different relative paths and copies both; Windows treats them as one
   file, so the later copy wins. Because the spellings differ, **`NETSDK1152` — the error that
   exists to catch exactly this — never fires.**
2. `ReleaseBuilder/Build/Command.Compile.cs` merges each project's publish output into one folder
   and asks `CompareAssemblyVersions` whether to overwrite. `AssemblyName.GetAssemblyName` throws
   on a native DLL, the `catch {}` swallows it and returns `0`, so `c >= 0` overwrites. **The last
   project published wins**, and `Duplicati.GUI.TrayIcon` is published last.

`Duplicati.Library.Snapshots` → `AlphaVSS` reaches 19 of the 21 published projects, while the SDK
copy is produced only by `Duplicati.Library.WindowsModules`, which only the *ephemeral*
`Duplicati.WindowsModulesLoader` references. So **the released build carries the .NET Core 3.1
shim.** The probe added in #7239 only checks that a file by that name exists, and its comparer is
case-insensitive, so `Ijwhost.dll` satisfies the `ijwhost.dll` probe.

**Measured: this does not appear to break anything.** `Duplicati.WindowsModulesLoader` exists to
force-load these components, so I published it self-contained and ran it with each shim swapped in:

| shim in the folder | AlphaVSS | Vanara / Native |
|---|---|---|
| 8.0.30 | loads; fails later in `VssBackupComponents..ctor` with `UnauthorizedAccessException` | loads; `E_ACCESSDENIED` |
| **3.100.19 (what ships)** | **loads**; same | **loads**; same |

Both mixed-mode assemblies load under both shims — the only failure is VSS itself refusing without
administrator rights, identically in both cases. So this reads as untidy rather than broken.

**Why I am not fixing it here.** Dropping the package copies is not enough: for 19 of the 21
published projects the AlphaVSS copy is the *only* source, so removing it would leave no shim at
all. Doing it properly means supplying the host-pack copy to every published project — a repo-root
`Directory.Build.targets`, which would be the first repo-wide MSBuild file here — and that changes
what ships across the whole Windows release for no benefit I could demonstrate. I also cannot run
VSS end-to-end locally (it needs administrator rights), so I would be changing the release layout
on a guess. Happy to do it if you want it; it seemed like your call rather than mine.

## Not measured

- Only this machine, Windows x64, SDK 10.0.400. I have not built for `win-arm64`, where #7239's
  probe skips `ijwhost.dll` anyway.
- Whether `Reference Remove` keeps working across SDK updates: it matches an item whose spec is
  `Ijwhost`. If a future SDK shapes that differently the warning comes back — but nothing breaks,
  since the deployed file does not come from this item.
