### PR TITLE
Keep every copy of a duplicated Google Drive name, and list it once

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -28,6 +28,8 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text;
 
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
+
 namespace Duplicati.Library.Backend.GoogleDrive
 {
     // ReSharper disable once UnusedMember.Global
@@ -68,6 +70,22 @@ namespace Duplicati.Library.Backend.GoogleDrive
             m_teamDriveID = options.GetValueOrDefault(TEAMDRIVE_ID);
             m_oauth = new OAuthHelperHttpClient(auth.AuthId!, this.ProtocolKey, auth.OAuthUrl) { AutoAuthHeader = true };
             m_filecache = new Dictionary<string, GoogleDriveFolderItem[]>();
+        }
+
+        /// <summary>
+        /// Creates a backend that talks through the supplied <see cref="HttpClient"/>,
+        /// so the Drive API responses can be decided by a test
+        /// </summary>
+        /// <param name="url">The backend url</param>
+        /// <param name="options">The options to use</param>
+        /// <param name="httpClient">The client to send the requests through</param>
+        internal GoogleDrive(string url, Dictionary<string, string?> options, HttpClient httpClient)
+            : this(url, options)
+        {
+            var auth = AuthIdOptionsHelper.Parse(options)
+                .RequireCredentials(TOKEN_URL);
+
+            m_oauth = new OAuthHelperHttpClient(auth.AuthId!, this.ProtocolKey, auth.OAuthUrl, httpClient) { AutoAuthHeader = true };
         }
 
         private async Task<string> GetFolderIdAsync(string path, bool autocreate, CancellationToken cancelToken)
@@ -362,21 +380,29 @@ namespace Duplicati.Library.Backend.GoogleDrive
                 {
                     var fe = ParseEntry(n);
 
-                    if (!fe.IsFolder)
+                    // A folder is addressed by its name and is rejected outright when
+                    // the name is ambiguous, so it goes straight out
+                    if (fe.IsFolder)
                     {
-                        if (!m_filecache.TryGetValue(fe.Name, out var lst))
-                        {
-                            m_filecache[fe.Name] = [n];
-                        }
-                        else
-                        {
-                            Array.Resize(ref lst, lst.Length + 1);
-                            lst[lst.Length - 1] = n;
-                        }
+                        yield return fe;
+                        continue;
                     }
 
-                    yield return fe;
+                    // Every copy has to be kept: a delete takes the name away, which
+                    // means all of the files wearing it. Assigning back to the
+                    // dictionary is what makes the second copy survive.
+                    m_filecache[fe.Name] = m_filecache.TryGetValue(fe.Name, out var lst)
+                        ? [.. lst, n]
+                        : [n];
                 }
+
+                // Drive keeps a permanent id for a file and treats the name as a label,
+                // so more than one file can wear the same one. The rest of Duplicati
+                // addresses a remote file by name and stops every operation when a
+                // listing reports one twice, so one entry is reported per name: the
+                // newest, which is the copy a read fetches.
+                foreach (var entries in m_filecache.Values)
+                    yield return ParseEntry(entries.OrderByDescending(x => x.createdDate).First());
 
                 success = true;
             }

--- a/Duplicati/UnitTest/GoogleDriveDuplicateNameTests.cs
+++ b/Duplicati/UnitTest/GoogleDriveDuplicateNameTests.cs
@@ -1,0 +1,232 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.GoogleDrive;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// Google Drive keeps a permanent id for every file and treats the name as a
+/// label, so two files in one folder can carry the same name. The backend keeps
+/// a name to entries cache to resolve them, and every copy has to stay in it:
+/// a delete has to remove all of them, and a read has to pick a definite one.
+/// The listing, on the other hand, has to answer with one entry per name, or the
+/// remote verification refuses to run at all. Reported as issue #5846.
+/// </summary>
+[TestFixture]
+public class GoogleDriveDuplicateNameTests
+{
+    /// <summary>
+    /// A host that cannot be resolved, so a request that is not stubbed fails
+    /// instead of reaching the real OAuth service
+    /// </summary>
+    private const string OAuthUrl = "http://oauth.invalid/token";
+
+    /// <summary>The folder the backend is pointed at</summary>
+    private const string FolderId = "folder-1";
+
+    /// <summary>
+    /// Answers the Drive API from a fixed set of items, and records the deletes
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string[] _items;
+
+        /// <summary>The file ids that were asked to be deleted, in order</summary>
+        public List<string> Deleted { get; } = new();
+
+        public StubHandler(string[] items)
+            => _items = items;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+
+            if (url.StartsWith(OAuthUrl, StringComparison.Ordinal))
+                return Task.FromResult(Json("{\"access_token\":\"test-token\",\"expires\":3600}"));
+
+            if (url.Contains("/drive/v2/about", StringComparison.Ordinal))
+                return Task.FromResult(Json("{\"rootFolderId\":\"root\"}"));
+
+            if (request.Method == HttpMethod.Delete)
+            {
+                // ".../drive/v2/files/<id>" with the query string after it
+                var path = request.RequestUri!.AbsolutePath;
+                Deleted.Add(path[(path.LastIndexOf('/') + 1)..]);
+                return Task.FromResult(Json("{}"));
+            }
+
+            if (url.Contains("/drive/v2/files", StringComparison.Ordinal))
+            {
+                // The query is form encoded, so a space arrives as "+"
+                var query = Uri.UnescapeDataString(request.RequestUri!.Query).Replace('+', ' ');
+
+                // The folder the backend is configured for is looked up by name first
+                if (query.Contains("title = 'target'", StringComparison.Ordinal))
+                    return Task.FromResult(Json(Response([Folder(FolderId, "target")])));
+
+                return Task.FromResult(Json(Response(_items)));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static string Response(IEnumerable<string> items)
+            => $"{{\"items\":[{string.Join(",", items)}]}}";
+
+        private static HttpResponseMessage Json(string body)
+            => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static string Folder(string id, string title)
+        => $"{{\"id\":\"{id}\",\"title\":\"{title}\",\"mimeType\":\"application/vnd.google-apps.folder\"}}";
+
+    /// <summary>
+    /// A file as the Drive listing reports it
+    /// </summary>
+    /// <param name="id">The permanent id of the file</param>
+    /// <param name="title">The name, which is only a label and may repeat</param>
+    /// <param name="size">The size in bytes</param>
+    /// <param name="created">The creation date, which is what decides between copies</param>
+    private static string File(string id, string title, long size, string created)
+        => $"{{\"id\":\"{id}\",\"title\":\"{title}\",\"mimeType\":\"application/octet-stream\","
+            + $"\"fileSize\":{size},\"createdDate\":\"{created}\",\"modifiedDate\":\"{created}\"}}";
+
+    private static (GoogleDrive Backend, StubHandler Handler) Create(params string[] items)
+    {
+        var handler = new StubHandler(items);
+        var backend = new GoogleDrive("googledrive://target", new Dictionary<string, string?>
+        {
+            ["authid"] = "test-authid",
+            ["oauth-url"] = OAuthUrl
+        }, new HttpClient(handler));
+
+        return (backend, handler);
+    }
+
+    private static async Task<string[]> ListNamesAsync(GoogleDrive backend)
+    {
+        var names = new List<string>();
+        await foreach (var e in backend.ListAsync(CancellationToken.None))
+            names.Add(e.Name);
+        return names.ToArray();
+    }
+
+    /// <summary>
+    /// The point of the issue: a name that Drive holds twice must reach the rest
+    /// of Duplicati once, or the remote verification stops every operation with
+    /// "Found remote files reported as duplicates"
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task ANameHeldTwiceIsListedOnce()
+    {
+        var (backend, _) = Create(
+            File("id-old", "duplicate.dblock.zip", 10, "2024-01-01T00:00:00Z"),
+            File("id-new", "duplicate.dblock.zip", 20, "2024-06-01T00:00:00Z"),
+            File("id-other", "single.dblock.zip", 30, "2024-01-01T00:00:00Z"));
+        using var _b = backend;
+
+        var names = await ListNamesAsync(backend);
+
+        Assert.AreEqual(2, names.Length, $"got: {string.Join(", ", names)}");
+        Assert.That(names, Does.Contain("duplicate.dblock.zip"));
+        Assert.That(names, Does.Contain("single.dblock.zip"));
+    }
+
+    /// <summary>
+    /// Which copy is reported has to be the same one a read would fetch, and that
+    /// is the newest
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task TheCopyThatIsListedIsTheNewestOne()
+    {
+        var (backend, _) = Create(
+            File("id-old", "duplicate.dblock.zip", 10, "2024-01-01T00:00:00Z"),
+            File("id-new", "duplicate.dblock.zip", 20, "2024-06-01T00:00:00Z"));
+        using var _b = backend;
+
+        var sizes = new List<long>();
+        await foreach (var e in backend.ListAsync(CancellationToken.None))
+            sizes.Add(e.Size);
+
+        Assert.AreEqual(1, sizes.Count);
+        Assert.AreEqual(20, sizes[0], "the older copy was reported");
+    }
+
+    /// <summary>
+    /// The reason every copy has to stay in the cache: a delete removes the name,
+    /// which means all of the files wearing it. Keeping only one would leave the
+    /// other behind on the destination forever.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task ADeleteAfterAListingRemovesEveryCopy()
+    {
+        var (backend, handler) = Create(
+            File("id-old", "duplicate.dblock.zip", 10, "2024-01-01T00:00:00Z"),
+            File("id-new", "duplicate.dblock.zip", 20, "2024-06-01T00:00:00Z"));
+        using var _b = backend;
+
+        // The listing is what fills the cache, and the delete reads it back
+        await ListNamesAsync(backend);
+        await backend.DeleteAsync("duplicate.dblock.zip", CancellationToken.None);
+
+        Assert.AreEqual(2, handler.Deleted.Count, $"deleted: {string.Join(", ", handler.Deleted)}");
+        Assert.That(handler.Deleted, Does.Contain("id-old"));
+        Assert.That(handler.Deleted, Does.Contain("id-new"));
+    }
+
+    /// <summary>
+    /// Green before and after: names that appear once are reported as they always
+    /// were, so the change reaches no further than the fault did
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task NamesThatAppearOnceAreUnchanged()
+    {
+        var (backend, _) = Create(
+            File("id-a", "a.dblock.zip", 10, "2024-01-01T00:00:00Z"),
+            File("id-b", "b.dblock.zip", 20, "2024-02-01T00:00:00Z"),
+            File("id-c", "c.dblock.zip", 30, "2024-03-01T00:00:00Z"));
+        using var _b = backend;
+
+        var names = await ListNamesAsync(backend);
+
+        Assert.AreEqual(3, names.Length, $"got: {string.Join(", ", names)}");
+        Assert.That(names, Does.Contain("a.dblock.zip"));
+        Assert.That(names, Does.Contain("b.dblock.zip"));
+        Assert.That(names, Does.Contain("c.dblock.zip"));
+    }
+}


### PR DESCRIPTION
Google Drive keeps a permanent id for every file and treats the name as a label, so two files in
one folder can carry the same name. [#5846](https://github.com/duplicati/duplicati/issues/5846)
describes what that costs. Looking into it turned up two separate faults in `ListAsync`, both of
which the new tests pin down.

## 1. Every copy after the first was dropped from the cache

```csharp
Array.Resize(ref lst, lst.Length + 1);
lst[lst.Length - 1] = n;
```

`lst` is the local from `TryGetValue`. `Array.Resize` allocates a new array and assigns it **to the
local**; the dictionary slot still holds the one-element array it already had. The second copy was
written into an array nobody kept.

The cache is what the rest of the backend resolves names through, so:

- **`DeleteAsync` removed one copy and left the other on the destination.** It reads through
  `GetFileEntriesAsync`, which returns the cached array on a hit. The new test lists and then
  deletes, and before this change it recorded exactly one delete — of the **older** id:
  ```
  deleted: id-old
  ```
- **`GetAsync` downloaded the wrong copy.** It primes the cache from the listing and then takes
  `OrderByDescending(x => x.createdDate).First()`, but over a single surviving entry — so the
  newest-wins rule silently resolved to whichever copy Drive listed first.

## 2. The listing reported the name twice, which stops everything

`ListAsync` yielded every entry, so a duplicated name reached
`FilelistProcessor.VerifyRemoteListAsync`:

```csharp
if (doubles.Count > 0)
{
    var s = "Found remote files reported as duplicates, either the backend module is broken or you need to manually remove the extra copies.…";
    throw new RemoteListVerificationException(s, "DuplicateRemoteFiles");
}
```

Backup, restore and repair all stop, with a message that blames the backend module and asks the
user to delete the extra copies by hand. On Drive a repeated name is not a fault, so that is not an
answer.

## The change

Both are fixed the way two other backends already do it:

| backend | how it lists a duplicated name |
|---|---|
| `MegaBackend.cs:212` | `n.OrderByDescending(x => x.ModificationDate).First()` |
| `B2.cs:552` | `x.Value.OrderByDescending(y => y.UploadTimestamp).First()` |
| **GoogleDrive, now** | `entries.OrderByDescending(x => x.createdDate).First()` |

The cache accumulates every copy — that is what lets a delete take all of them — and the listing
reports one entry per name: the newest, which is the copy a read fetches, so the listing and a
subsequent `GetAsync` agree.

Folders are untouched and still go out as they are found; an ambiguous folder name is already
rejected outright by `GetFolderIdAsync`.

`FilelistProcessor` is deliberately left alone. On a backend where a repeated name really is a
fault, that error is the right answer, and `Issue1282` tests it — it stays green.

## Red, then green

`Duplicati/UnitTest/GoogleDriveDuplicateNameTests.cs` is new. It drives the backend against stubbed
Drive API responses through a small `HttpMessageHandler`, so it needs no network and no
credentials — the same shape as the existing `BoxEntryLookupTests`. That needed a seam:
`[assembly: InternalsVisibleTo("Duplicati.UnitTest")]` and an `internal` constructor taking an
`HttpClient`, mirroring `BoxBackend`. The public constructors are unchanged, so the
`BackendLoader`'s parameterless activation is untouched.

| test | before | after |
|---|---|---|
| a name held twice is listed once | **red** — listed twice | green |
| the copy that is listed is the newest one | **red** | green |
| a delete after a listing removes every copy | **red** — one delete, the older id | green |
| names that appear once are unchanged | green | green |

The last one is the regression guard: it is the shape where the current behaviour was already
right, and it shows the change does not reach past the fault.

Full solution build: 0 errors, and the same two pre-existing `MSB3246` warnings as before.

## Not measured

- **No real Google Drive.** I have no credentials, so the API responses are stubbed. The stub feeds
  the backend's own `ListFolder` parsing, so the shape it produces is the shape the code already
  expects, but a difference between my stub and the live API would not show up here.
- **Duplicates are now collapsed silently.** The extra copy stays on Drive until a `PutAsync` or
  `DeleteAsync` touches that name, and nothing tells the user it is there. This file has no logging
  at all today, so adding a log line meant introducing that; I left it out rather than widen the
  change, but say the word and I will add one.
- `IFolderEnabledBackend.EnumerateAsync` — the folder browser — still yields every entry. It feeds
  a file picker rather than the verification, so a repeated row there is cosmetic. Left alone for
  the same reason.

## About the issue

The other half of #5846 — "the results are unpredictable, as one of them will be returned, but
which depends on calling order" — is genuinely about this: `GetAsync` looked deterministic but was
not, because of the cache fault above. `PutAsync` and `DeleteAsync` already handled `N > 1`
correctly once they could see it. I have left the `Fixes` keyword off so you can judge whether the
issue is fully answered; the parts I could reach are covered.

Fixes #5846