### PR TITLE
Fix commandline parsing issues

### DIFF
--- a/Duplicati/CommandLine/DatabaseTool/Program.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Program.cs
@@ -52,11 +52,14 @@ public static class Program
 
         // Registered so the option is accepted and shown in help; the value is read directly
         // from the process arguments/environment by DataFolderManager/Util.
+        // The option is marked recursive so it applies to all subcommands,
+        // matching the behavior of the previous AddGlobalOption API.
         rootCmd.Options.Add(new Option<bool>(
             $"--{DataFolderManager.ALLOW_INSECURE_DATAFOLDER_OPTION}")
         {
             Description = "Allow the data folder to have insecure permissions instead of rejecting it",
-            DefaultValueFactory = _ => false
+            DefaultValueFactory = _ => false,
+            Recursive = true
         });
 
         rootCmd.UseAdditionalHelpAliases();

--- a/Duplicati/CommandLine/ServerUtil/Program.cs
+++ b/Duplicati/CommandLine/ServerUtil/Program.cs
@@ -20,9 +20,12 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.CommandLine;
+using System.Runtime.CompilerServices;
 using Duplicati.CommandLine.ServerUtil.Commands;
 using Duplicati.Library.AutoUpdater;
 using Duplicati.Library.Utility;
+
+[assembly: InternalsVisibleTo("Duplicati.UnitTest")]
 
 namespace Duplicati.CommandLine.ServerUtil;
 
@@ -32,14 +35,11 @@ namespace Duplicati.CommandLine.ServerUtil;
 public static class Program
 {
     /// <summary>
-    /// Invokes the builder
+    /// Creates the root command with all subcommands and global options.
     /// </summary>
-    /// <param name="args"></param>
-    /// <returns>The return code</returns>
-    public static async Task<int> MainAsync(string[] args)
+    /// <returns>The configured root command</returns>
+    internal static RootCommand CreateRootCommand()
     {
-        PreloadSettingsLoader.ConfigurePreloadSettings(ref args, PackageHelper.NamedExecutable.ServerUtil);
-
         var rootCmd = new RootCommand("Server CLI tool for Duplicati")
             {
                 Pause.Create(),
@@ -59,10 +59,32 @@ public static class Program
 
         rootCmd = SettingsBinder.AddGlobalOptions(rootCmd);
         rootCmd.UseAdditionalHelpAliases();
+        return rootCmd;
+    }
+
+    /// <summary>
+    /// Invokes the builder
+    /// </summary>
+    /// <param name="args"></param>
+    /// <returns>The return code</returns>
+    public static async Task<int> MainAsync(string[] args)
+    {
+        PreloadSettingsLoader.ConfigurePreloadSettings(ref args, PackageHelper.NamedExecutable.ServerUtil);
+
+        var rootCmd = CreateRootCommand();
+        var parseResult = rootCmd.Parse(args);
+
+        // Create the output interceptor up-front, mirroring the middleware that
+        // ran before the command handlers in the previous System.CommandLine version.
+        // If a command handler throws before it creates the interceptor itself
+        // (e.g. while loading the settings), the catch block below can still
+        // report the failure to the console instead of exiting silently.
+        if (parseResult.Errors.Count == 0)
+            OutputInterceptorBinder.GetConsoleInterceptor(parseResult);
 
         try
         {
-            var exitCode = await rootCmd.Parse(args).InvokeAsync(new InvocationConfiguration
+            var exitCode = await parseResult.InvokeAsync(new InvocationConfiguration
             {
                 EnableDefaultExceptionHandler = false
             });

--- a/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
+++ b/Duplicati/CommandLine/ServerUtil/SettingsBinder.cs
@@ -46,7 +46,21 @@ public static class SettingsBinder
     public static readonly Option<Uri> hostUrlOption = new Option<Uri>("--hosturl")
     {
         Description = "The host URL to use",
-        DefaultValueFactory = _ => new Uri($"http://{Utility.IpVersionCompatibleLoopback}:8200")
+        DefaultValueFactory = _ => new Uri($"http://{Utility.IpVersionCompatibleLoopback}:8200"),
+        // System.CommandLine does not have a built-in string-to-Uri converter,
+        // so supply a custom parser to keep accepting URLs from the command line
+        CustomParser = result =>
+        {
+            var value = result.Tokens.SingleOrDefault()?.Value;
+            if (string.IsNullOrWhiteSpace(value))
+                return new Uri($"http://{Utility.IpVersionCompatibleLoopback}:8200");
+
+            if (Uri.TryCreate(value, UriKind.Absolute, out var uri))
+                return uri;
+
+            result.AddError($"The value '{value}' is not a valid URL");
+            return null!;
+        }
     };
     /// <summary>
     /// The server datafolder option.
@@ -153,25 +167,37 @@ public static class SettingsBinder
 
     /// <summary>
     /// Adds global options to the root command.
+    /// The options are marked recursive so they apply to all subcommands,
+    /// matching the behavior of the previous AddGlobalOption API.
     /// </summary>
     /// <param name="rootCommand">The root command to add the options to.</param>
     /// <returns>The root command with the options added.</returns>
     public static RootCommand AddGlobalOptions(RootCommand rootCommand)
     {
-        rootCommand.Options.Add(passwordOption);
-        rootCommand.Options.Add(hostUrlOption);
-        rootCommand.Options.Add(serverDatafolderOption);
-        rootCommand.Options.Add(portableModeOption);
-        rootCommand.Options.Add(allowInsecureDatafolderOption);
-        rootCommand.Options.Add(settingsFileOption);
-        rootCommand.Options.Add(insecureOption);
-        rootCommand.Options.Add(settingsEncryptionKeyOption);
-        rootCommand.Options.Add(secretProviderOption);
-        rootCommand.Options.Add(secretProviderCacheOption);
-        rootCommand.Options.Add(secretProviderPatternOption);
-        rootCommand.Options.Add(acceptedHostCertificateOption);
-        rootCommand.Options.Add(ignoreRevocationFailureOption);
-        rootCommand.Options.Add(jsonOutputOption);
+        Option[] globalOptions =
+        [
+            passwordOption,
+            hostUrlOption,
+            serverDatafolderOption,
+            portableModeOption,
+            allowInsecureDatafolderOption,
+            settingsFileOption,
+            insecureOption,
+            settingsEncryptionKeyOption,
+            secretProviderOption,
+            secretProviderCacheOption,
+            secretProviderPatternOption,
+            acceptedHostCertificateOption,
+            ignoreRevocationFailureOption,
+            jsonOutputOption
+        ];
+
+        foreach (var option in globalOptions)
+        {
+            option.Recursive = true;
+            rootCommand.Options.Add(option);
+        }
+
         return rootCommand;
     }
 

--- a/Duplicati/UnitTest/DatabaseToolTests.cs
+++ b/Duplicati/UnitTest/DatabaseToolTests.cs
@@ -57,6 +57,39 @@ namespace Duplicati.UnitTest
         }
 
         /// <summary>
+        /// The --allow-insecure-datafolder option is registered on the root command
+        /// but must be accepted after a subcommand, like the global option it
+        /// replaced during the System.CommandLine 2.0 migration.
+        /// </summary>
+        [Test]
+        [Category("DatabaseTool")]
+        public async Task GlobalOptionIsAcceptedAfterSubcommandAsync()
+        {
+            using var dbfile = new TempFile();
+
+            var output = new StringWriter();
+            var originalOut = Console.Out;
+            int exitCode;
+            try
+            {
+                Console.SetOut(output);
+                // The database is empty, so "list" fails with a message about the
+                // database not existing. A parse error would instead complain about
+                // an unrecognized option.
+                exitCode = await Program.MainAsync(["list", dbfile, "--allow-insecure-datafolder"]);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+
+            var consoleOutput = output.ToString();
+            Assert.IsFalse(consoleOutput.Contains("Unrecognized"),
+                $"The global option was not accepted after the subcommand: {consoleOutput}");
+            Assert.AreEqual(0, exitCode, $"Unexpected exit code, output was: {consoleOutput}");
+        }
+
+        /// <summary>
         /// The backup taken before an upgrade must carry an unambiguous timestamp.
         /// The format string used to specify <c>hh</c> (12-hour clock) without an
         /// AM/PM designator, so a backup taken at 13:30 was named as if it had been

--- a/Duplicati/UnitTest/Duplicati.UnitTest.csproj
+++ b/Duplicati/UnitTest/Duplicati.UnitTest.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../CommandLine/DatabaseTool/Duplicati.CommandLine.DatabaseTool.csproj" />
+    <ProjectReference Include="..\CommandLine\ServerUtil\Duplicati.CommandLine.ServerUtil.csproj" />
     <ProjectReference Include="..\CommandLine\BackendTester\Duplicati.CommandLine.BackendTester.csproj" />
     <ProjectReference Include="..\CommandLine\CLI\Duplicati.CommandLine.csproj" />
     <ProjectReference Include="..\Library\Backend\OAuthHelper\Duplicati.Library.OAuthHelper.csproj" />

--- a/Duplicati/UnitTest/ServerUtilTests.cs
+++ b/Duplicati/UnitTest/ServerUtilTests.cs
@@ -1,0 +1,311 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Duplicati.Library.Encryption;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using ServerUtilProgram = Duplicati.CommandLine.ServerUtil.Program;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Tests that the System.CommandLine parsers used by the ServerUtil tool
+    /// are wired up correctly. These tests exist because a migration to a new
+    /// System.CommandLine release caused the tool to silently do nothing
+    /// (no output, exit code 1) for all commands.
+    /// </summary>
+    [TestFixture]
+    [Category("ServerUtil")]
+    [NonParallelizable] // Tests redirect Console.Out and use a shared OutputInterceptorBinder singleton
+    public class ServerUtilTests
+    {
+        /// <summary>
+        /// Valid argument lists for each command that must parse without errors.
+        /// </summary>
+        private static readonly string[][] ValidCommandLines =
+        {
+            ["pause"],
+            ["pause", "10m"],
+            ["resume"],
+            ["delete", "1"],
+            ["delete", "my-backup", "--delete-remote-files", "--delete-local-db", "--force", "--quiet"],
+            ["list-backups"],
+            ["list-backups", "--detailed"],
+            ["run", "1"],
+            ["run", "my-backup", "--wait", "--skip-queue", "--poll-interval", "10", "--quiet"],
+            ["login"],
+            ["change-password"],
+            ["change-password", "new-secret"],
+            ["logout"],
+            ["import", "somefile.json"],
+            ["import", "somefile.json", "passphrase", "--import-metadata", "--backup-passphrase", "pw", "--backup-url", "file:///tmp"],
+            ["export", "all"],
+            ["export", "1", "2", "--encryption-passphrase", "pw", "--export-passwords", "--overwrite", "--unencrypted", "--destination", "/tmp"],
+            ["health"],
+            ["issue-forever-token"],
+            ["status"],
+        };
+
+        /// <summary>
+        /// Global options that must parse on every command.
+        /// </summary>
+        private static readonly string[] GlobalOptions =
+        {
+            "--password", "secret",
+            "--hosturl", "http://localhost:8200/",
+            "--settings-file", "some-settings.json",
+            "--insecure",
+            "--settings-encryption-key", "encryption-key",
+            "--secret-provider-cache", "None",
+            "--secret-provider-pattern", "$",
+            "--host-cert", "abc123",
+            "--ignore-revocation-failure",
+            "--json",
+        };
+
+        [Test]
+        public void AllCommandsParseWithoutErrors()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+            foreach (var args in ValidCommandLines)
+            {
+                var parseResult = rootCmd.Parse(args);
+                Assert.AreEqual(0, parseResult.Errors.Count,
+                    $"Parse errors for '{string.Join(" ", args)}': {string.Join("; ", parseResult.Errors.Select(e => e.Message))}");
+            }
+        }
+
+        [Test]
+        public void AllCommandsParseWithoutErrorsWithGlobalOptions()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+            foreach (var args in ValidCommandLines)
+            {
+                var fullArgs = args.Concat(GlobalOptions).ToArray();
+                var parseResult = rootCmd.Parse(fullArgs);
+                Assert.AreEqual(0, parseResult.Errors.Count,
+                    $"Parse errors for '{string.Join(" ", fullArgs)}': {string.Join("; ", parseResult.Errors.Select(e => e.Message))}");
+            }
+        }
+
+        [Test]
+        public void AllCommandsAreRegistered()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+            var expected = new[]
+            {
+                "pause", "resume", "delete", "list-backups", "run", "login",
+                "change-password", "logout", "import", "export", "health",
+                "issue-forever-token", "status"
+            };
+
+            var actual = rootCmd.Subcommands.Select(c => c.Name).ToArray();
+            foreach (var name in expected)
+                Assert.Contains(name, actual, $"Command '{name}' is not registered on the root command");
+        }
+
+        [Test]
+        public void RequiredArgumentsAreEnforced()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+
+            // Commands with required arguments must fail parsing when the argument is missing
+            string[][] invalidCommandLines =
+            {
+                ["delete"],
+                ["run"],
+                ["import"],
+                ["export"],
+            };
+
+            foreach (var args in invalidCommandLines)
+            {
+                var parseResult = rootCmd.Parse(args);
+                Assert.Greater(parseResult.Errors.Count, 0,
+                    $"Expected parse errors for '{string.Join(" ", args)}' but there were none");
+            }
+        }
+
+        [Test]
+        public void UnknownOptionsAreRejected()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+            var parseResult = rootCmd.Parse(["list-backups", "--no-such-option"]);
+            Assert.Greater(parseResult.Errors.Count, 0, "Unknown option did not produce a parse error");
+        }
+
+        [Test]
+        public void UnknownCommandIsRejected()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+            var parseResult = rootCmd.Parse(["no-such-command"]);
+            Assert.Greater(parseResult.Errors.Count, 0, "Unknown command did not produce a parse error");
+        }
+
+        [Test]
+        public void GlobalOptionsBindToSettings()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+            using var settingsFile = new Library.Utility.TempFile();
+            File.WriteAllText(settingsFile.Name, "[]");
+
+            var parseResult = rootCmd.Parse([
+                "list-backups",
+                "--hosturl", "http://example.com:1234/",
+                "--password", "secret",
+                "--settings-file", settingsFile.Name,
+                "--insecure",
+            ]);
+            Assert.AreEqual(0, parseResult.Errors.Count);
+
+            var settings = CommandLine.ServerUtil.SettingsBinder.GetSettings(parseResult);
+            Assert.AreEqual(new Uri("http://example.com:1234/"), settings.HostUrl);
+            Assert.AreEqual("secret", settings.Password);
+            Assert.IsTrue(settings.Insecure);
+        }
+
+        [Test]
+        public void GlobalOptionDefaultsBindToSettings()
+        {
+            var rootCmd = ServerUtilProgram.CreateRootCommand();
+            using var settingsFile = new Library.Utility.TempFile();
+            File.WriteAllText(settingsFile.Name, "[]");
+
+            var parseResult = rootCmd.Parse(["list-backups", "--settings-file", settingsFile.Name]);
+            Assert.AreEqual(0, parseResult.Errors.Count);
+
+            var settings = CommandLine.ServerUtil.SettingsBinder.GetSettings(parseResult);
+            Assert.IsNotNull(settings.HostUrl, "HostUrl should have a default value");
+            Assert.IsFalse(settings.Insecure);
+        }
+
+        /// <summary>
+        /// Regression test for the 2.0.100 canary issue where ServerUtil silently
+        /// exited with code 1 and no output at all. The trigger is a settings file
+        /// that holds an encrypted refresh token while no encryption key is supplied.
+        /// The settings load then throws before the command handler runs, and the
+        /// failure must be reported to the console instead of being swallowed.
+        /// </summary>
+        [Test]
+        public async Task FailureToLoadSettingsReportsErrorToConsole()
+        {
+            var encryptionKey = EncryptedFieldHelper.KeyInstance.CreateKey("test-encryption-key");
+
+            using var settingsFile = new Library.Utility.TempFile();
+            var persistedSettings = new[]
+            {
+                new
+                {
+                    RefreshToken = EncryptedFieldHelper.Encrypt("dummy-refresh-token", encryptionKey),
+                    RefreshNonce = (string)null,
+                    HostUrl = new Uri("http://127.0.0.1:8200/"),
+                    ServerDatafolder = (string)null
+                }
+            };
+            File.WriteAllText(settingsFile.Name, JsonSerializer.Serialize(persistedSettings));
+
+            // Make sure no ambient encryption key can satisfy the settings file
+            var previousKey = Environment.GetEnvironmentVariable(EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME);
+            Environment.SetEnvironmentVariable(EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME, null);
+
+            var originalOut = Console.Out;
+            try
+            {
+                // Plain console output
+                var output = new StringWriter();
+                int exitCode;
+                try
+                {
+                    Console.SetOut(output);
+                    exitCode = await ServerUtilProgram.MainAsync(["--settings-file", settingsFile.Name, "list-backups"]);
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                }
+
+                Assert.AreNotEqual(0, exitCode, "Expected a non-zero exit code when settings cannot be loaded");
+                var consoleOutput = output.ToString();
+                Assert.IsFalse(string.IsNullOrWhiteSpace(consoleOutput),
+                    "The tool produced no console output; failures must be visible to the user");
+                Assert.IsTrue(consoleOutput.Contains("key", StringComparison.OrdinalIgnoreCase),
+                    $"The console output should mention the encryption key problem, but was: {consoleOutput}");
+
+                // JSON output mode was silent as well
+                output = new StringWriter();
+                try
+                {
+                    Console.SetOut(output);
+                    exitCode = await ServerUtilProgram.MainAsync(["--settings-file", settingsFile.Name, "--json", "list-backups"]);
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                }
+
+                Assert.AreNotEqual(0, exitCode, "Expected a non-zero exit code when settings cannot be loaded");
+                var jsonOutput = output.ToString();
+                Assert.IsFalse(string.IsNullOrWhiteSpace(jsonOutput),
+                    "The tool produced no JSON output; failures must be visible to the user");
+                Assert.IsTrue(jsonOutput.Contains("key", StringComparison.OrdinalIgnoreCase),
+                    $"The JSON output should mention the encryption key problem, but was: {jsonOutput}");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(EncryptedFieldHelper.ENVIROMENT_VARIABLE_NAME, previousKey);
+            }
+        }
+
+        /// <summary>
+        /// Invoking with an unknown command must produce a non-zero exit code
+        /// and print an error message, not exit silently.
+        /// </summary>
+        [Test]
+        public async Task InvalidCommandProducesVisibleError()
+        {
+            var originalOut = Console.Out;
+            var originalError = Console.Error;
+            var output = new StringWriter();
+            var error = new StringWriter();
+            int exitCode;
+            try
+            {
+                Console.SetOut(output);
+                Console.SetError(error);
+                exitCode = await ServerUtilProgram.MainAsync(["no-such-command"]);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+
+            Assert.AreNotEqual(0, exitCode, "Invalid command should return a non-zero exit code");
+            var combined = output.ToString() + error.ToString();
+            Assert.IsFalse(string.IsNullOrWhiteSpace(combined),
+                "An invalid command produced no visible error message");
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes some issues as a follow-up to the switch to the stable System.Commandline package.

A test suite is introduced to catch regressions should this happen again later.