### PR TITLE
Report no quota for a Google shared drive, instead of the user's own

### DIFF
--- a/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
+++ b/Duplicati/Library/Backend/GoogleServices/GoogleDrive.cs
@@ -493,8 +493,20 @@ namespace Duplicati.Library.Backend.GoogleDrive
         #endregion
 
         #region IQuotaEnabledBackend implementation
+        /// <inheritdoc/>
+        /// <remarks>
+        /// A shared drive has no quota of its own: its files are owned by the drive, and the
+        /// Drive API reports capacity for the signed-in user only. Reporting that user's own
+        /// figures measured a backup against a different pool of storage, which is what issue
+        /// #4230 reported, so a shared drive answers with no quota at all.
+        /// </remarks>
         public async Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
         {
+            // The "about" resource describes the user's own drive, so it cannot answer for a
+            // shared drive, and there is no other place to ask
+            if (!string.IsNullOrWhiteSpace(m_teamDriveID))
+                return null;
+
             try
             {
                 var about = await this.GetAboutInfoAsync(cancelToken).ConfigureAwait(false);

--- a/Duplicati/UnitTest/GoogleDriveTeamDriveQuotaTests.cs
+++ b/Duplicati/UnitTest/GoogleDriveTeamDriveQuotaTests.cs
@@ -1,0 +1,232 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Backend.GoogleDrive;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+#nullable enable
+
+namespace Duplicati.UnitTest;
+
+/// <summary>
+/// A shared drive has no storage quota of its own: its files are owned by the
+/// drive, and the Drive API exposes no per-drive capacity anywhere. The quota
+/// the backend used to report came from the "about" resource, which describes
+/// the signed-in user's own My Drive, so a backup living on a shared drive was
+/// measured against a completely different pool of storage. Reported as issue
+/// #4230, where a 148 GB backup was compared to a 15 GB personal quota.
+/// </summary>
+[TestFixture]
+public class GoogleDriveTeamDriveQuotaTests
+{
+    /// <summary>
+    /// A host that cannot be resolved, so a request that is not stubbed fails
+    /// instead of reaching the real OAuth service
+    /// </summary>
+    private const string OAuthUrl = "http://oauth.invalid/token";
+
+    /// <summary>
+    /// The option that points the backend at a shared drive. Spelling it wrong
+    /// leaves the backend on the personal drive, which would quietly turn the
+    /// shared drive tests into copies of the personal drive one.
+    /// </summary>
+    private const string TeamDriveOption = "googledrive-teamdrive-id";
+
+    /// <summary>The quota the stubbed personal drive reports</summary>
+    private const long PersonalTotal = 15_000_000_000;
+
+    /// <summary>How much of that personal drive is in use</summary>
+    private const long PersonalUsed = 1_200_000_000;
+
+    /// <summary>An "about" answer of the shape the backend parses</summary>
+    private const string PersonalAbout =
+        "{\"rootFolderId\":\"root\",\"quotaBytesTotal\":15000000000,\"quotaBytesUsed\":1200000000}";
+
+    /// <summary>
+    /// Answers the two endpoints a quota lookup can reach, and records every
+    /// request so a test can assert on the traffic rather than on the answer
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string m_aboutBody;
+        private readonly HttpStatusCode m_aboutStatus;
+
+        /// <summary>Every url that was requested, in order</summary>
+        public List<string> Requests { get; } = new();
+
+        public StubHandler(string aboutBody, HttpStatusCode aboutStatus)
+        {
+            m_aboutBody = aboutBody;
+            m_aboutStatus = aboutStatus;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+            Requests.Add(url);
+
+            if (url.StartsWith(OAuthUrl, StringComparison.Ordinal))
+                return Task.FromResult(Json("{\"access_token\":\"test-token\",\"expires\":3600}"));
+
+            if (url.Contains("/drive/v2/about", StringComparison.Ordinal))
+                return Task.FromResult(m_aboutStatus == HttpStatusCode.OK
+                    ? Json(m_aboutBody)
+                    : new HttpResponseMessage(m_aboutStatus));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        /// <summary>How many times the personal drive was asked about itself</summary>
+        public int AboutRequests
+            => Requests.Count(x => x.Contains("/drive/v2/about", StringComparison.Ordinal));
+
+        private static HttpResponseMessage Json(string body)
+            => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static (GoogleDrive Backend, StubHandler Handler) Create(string? teamDriveId, string aboutBody, HttpStatusCode aboutStatus = HttpStatusCode.OK)
+    {
+        var handler = new StubHandler(aboutBody, aboutStatus);
+        var options = new Dictionary<string, string?>
+        {
+            ["authid"] = "test-authid",
+            ["oauth-url"] = OAuthUrl
+        };
+
+        if (teamDriveId != null)
+            options[TeamDriveOption] = teamDriveId;
+
+        return (new GoogleDrive("googledrive://target", options, new HttpClient(handler)), handler);
+    }
+
+    /// <summary>
+    /// Green before and after. Without a shared drive the destination really is
+    /// the user's own Drive, so the "about" figures describe it and are reported
+    /// as they always were. The request assertion is what keeps
+    /// <see cref="ATeamDriveAsksTheServiceNothing"/> from passing for the wrong
+    /// reason: it shows the recorder sees the call it is later asked to miss.
+    /// </summary>
+    /// <param name="teamDriveId">
+    /// The option left out, empty and blank. The backend treats all three as
+    /// "personal drive" when it resolves folders (GoogleDrive.cs:93), and the
+    /// option's own help says leaving it empty uses the personal drive.
+    /// </param>
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("  ")]
+    [Category("Backend")]
+    public async Task ThePersonalDriveQuotaIsReported(string? teamDriveId)
+    {
+        var (backend, handler) = Create(teamDriveId, PersonalAbout);
+        using var _b = backend;
+
+        var quota = await backend.GetQuotaInfoAsync(CancellationToken.None);
+
+        Assert.IsNotNull(quota);
+        Assert.AreEqual(PersonalTotal, quota!.TotalQuotaSpace);
+        Assert.AreEqual(PersonalTotal - PersonalUsed, quota.FreeQuotaSpace);
+        Assert.AreEqual(1, handler.AboutRequests, "the personal drive was not asked about itself");
+    }
+
+    /// <summary>
+    /// The point of the issue. There is no quota to report for a shared drive,
+    /// and reporting the user's own is what produced "Using 148.83 GB of 15.00
+    /// GB". Saying nothing leaves the check in FilelistProcessor with nothing to
+    /// compare, which is the correct answer rather than a suppressed one.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task ATeamDriveReportsNoQuota()
+    {
+        var (backend, _) = Create("team-drive-1", PersonalAbout);
+        using var _b = backend;
+
+        var quota = await backend.GetQuotaInfoAsync(CancellationToken.None);
+
+        Assert.IsNull(quota, "the personal drive quota was reported for a shared drive");
+    }
+
+    /// <summary>
+    /// Not the same test as <see cref="ATeamDriveReportsNoQuota"/>: fetching the
+    /// personal quota and then dropping it would pass that one. The lookup is
+    /// answered before any request is made, and since the OAuth token is only
+    /// fetched when a request is built, that means no traffic at all.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task ATeamDriveAsksTheServiceNothing()
+    {
+        var (backend, handler) = Create("team-drive-1", PersonalAbout);
+        using var _b = backend;
+
+        await backend.GetQuotaInfoAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, handler.Requests.Count, $"requested: {string.Join(", ", handler.Requests)}");
+    }
+
+    /// <summary>
+    /// Green before and after, and it guards the -1 that the caller reads:
+    /// FilelistProcessor.cs:589 skips the warning on a negative free space with
+    /// the comment "Negative value means the backend didn't return the quota
+    /// info". Note the precedence in "total - used ?? -1", which binds as
+    /// "(total - used) ?? -1", so either field being absent yields -1.
+    /// </summary>
+    [TestCase("{\"rootFolderId\":\"root\"}", -1L, -1L)]
+    [TestCase("{\"rootFolderId\":\"root\",\"quotaBytesTotal\":15000000000}", PersonalTotal, -1L)]
+    [Category("Backend")]
+    public async Task AnAboutAnswerWithoutQuotaFiguresReportsUnknown(string aboutBody, long expectedTotal, long expectedFree)
+    {
+        var (backend, _) = Create(null, aboutBody);
+        using var _b = backend;
+
+        var quota = await backend.GetQuotaInfoAsync(CancellationToken.None);
+
+        Assert.IsNotNull(quota);
+        Assert.AreEqual(expectedTotal, quota!.TotalQuotaSpace);
+        Assert.AreEqual(expectedFree, quota.FreeQuotaSpace);
+    }
+
+    /// <summary>
+    /// Green before and after. The shared drive answer is returned before the
+    /// request is attempted, so this is the test that notices if that early
+    /// return is ever folded into the catch that handles a failed lookup.
+    /// </summary>
+    [Test]
+    [Category("Backend")]
+    public async Task AFailedLookupReportsNoQuota()
+    {
+        var (backend, _) = Create(null, PersonalAbout, HttpStatusCode.InternalServerError);
+        using var _b = backend;
+
+        var quota = await backend.GetQuotaInfoAsync(CancellationToken.None);
+
+        Assert.IsNull(quota);
+    }
+}

--- a/Duplicati/UnitTest/NoFreeSpaceBackend.cs
+++ b/Duplicati/UnitTest/NoFreeSpaceBackend.cs
@@ -62,7 +62,7 @@ namespace Duplicati.UnitTest
                 Directory.CreateDirectory(m_folder);
         }
 
-        public Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
+        public virtual Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
             => Task.FromResult<IQuotaInfo?>(new QuotaInfo(TotalSpace, 0));
 
         public Task TestAsync(bool alsoWrite, CancellationToken cancellationToken)
@@ -108,7 +108,7 @@ namespace Duplicati.UnitTest
             => Task.FromResult(Array.Empty<string>());
 
         public string DisplayName => "No Free Space Backend";
-        public string ProtocolKey => "nofreespace";
+        public virtual string ProtocolKey => "nofreespace";
         public string Description => "A testing backend that stores files locally but reports no free space";
         public IList<ICommandLineArgument> SupportedCommands => new List<ICommandLineArgument>();
 

--- a/Duplicati/UnitTest/QuotaReportingTests.cs
+++ b/Duplicati/UnitTest/QuotaReportingTests.cs
@@ -41,11 +41,17 @@ namespace Duplicati.UnitTest
         /// </summary>
         private const string FullTarget = "nofreespace://destination";
 
+        /// <summary>
+        /// The destination that stores files but cannot say what it has room for.
+        /// </summary>
+        private const string UnknownQuotaTarget = "unknownquota://destination";
+
         [SetUp]
         public void RegisterBackend()
         {
             NoFreeSpaceBackend.Folder = TARGETFOLDER;
             BackendLoader.AddBackend(new NoFreeSpaceBackend());
+            BackendLoader.AddBackend(new UnknownQuotaBackend());
         }
 
         private void CreateSourceData()
@@ -99,6 +105,32 @@ namespace Duplicati.UnitTest
 
                 Assert.That(results.Errors.Any(x => x.Contains("quota")), Is.True,
                     "A backup to a destination with no room left reported no quota error");
+            }
+        }
+
+        /// <summary>
+        /// A destination that cannot say what it has room for is not a destination with no room:
+        /// there is no quota to be close to exceeding, so nothing is reported. A Google shared
+        /// drive is exactly this, and reporting the signed-in user's own drive instead is what
+        /// issue #4230 was about.
+        /// </summary>
+        [Test]
+        [Category("Quota")]
+        public async Task ABackupToADestinationWithNoQuotaSaysNothingAboutQuotaAsync()
+        {
+            // The most sensitive setting there is: any free space the destination claimed would
+            // have to exceed the whole backup to pass without a warning
+            var testopts = TestOptions.Expand(new { no_encryption = true, quota_warning_threshold = 100 });
+            CreateSourceData();
+
+            using (var c = new Controller(UnknownQuotaTarget, testopts, null))
+            {
+                var results = await c.BackupAsync([DATAFOLDER]);
+                var quotaMessages = results.Errors.Concat(results.Warnings).Where(x => x.Contains("quota")).ToList();
+
+                Assert.That(quotaMessages, Is.Empty,
+                    "A destination that reported no quota was treated as one with no room left: "
+                        + string.Join(System.Environment.NewLine, quotaMessages));
             }
         }
     }

--- a/Duplicati/UnitTest/UnknownQuotaBackend.cs
+++ b/Duplicati/UnitTest/UnknownQuotaBackend.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.Interface;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// Stores files the same way <see cref="NoFreeSpaceBackend"/> does, but answers that it
+    /// does not know what the destination has room for.
+    ///
+    /// A destination can be perfectly writable and still have no capacity to report: a Google
+    /// shared drive has no quota of its own, which is what issue #4230 was about.
+    /// </summary>
+    public class UnknownQuotaBackend : NoFreeSpaceBackend
+    {
+        public UnknownQuotaBackend()
+        {
+        }
+
+        public UnknownQuotaBackend(string url, Dictionary<string, string> options)
+            : base(url, options)
+        {
+        }
+
+        public override string ProtocolKey => "unknownquota";
+
+        public override Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken cancelToken)
+            => Task.FromResult<IQuotaInfo?>(null);
+    }
+}


### PR DESCRIPTION
A Google shared drive has no storage quota of its own, and the Drive API offers no way to ask for
one. That is the whole of it: v2 `about` reports the **signed-in user's** storage
(`quotaBytesUsed` is "The number of quota bytes used by Google Drive", and the resource takes no
shared-drive parameter), and the v3 `drives` resource — the shared drive itself — carries no size,
usage or capacity field at all. Shared-drive files are owned by the drive, so on Workspace they
consume the organisation's pooled storage and never appear in the user's figure.

`GetQuotaInfoAsync` fetched the user's figure anyway. `FilelistProcessor` then compares the size of
the files **at the destination** against the free space **the backend reports**, so the two halves
of that comparison described different storage. [#4230](https://github.com/duplicati/duplicati/issues/4230)
is what comes out:

```
Backend quota is close to being exceeded: Using 148.83 GB of 15.00 GB (13.82 GB available)
```

The 148.83 GB is on the shared drive. The 15.00 GB is the reporter's personal Drive, of which
1.2 GB was in use. The arithmetic follows exactly: the default `--quota-warning-threshold` is 10, and
`FilelistProcessor.cs:593` warns when free space is below that fraction of the backup, so
13.82 < 14.88 fires. **If the personal drive happens to be exactly full it is worse** — the
zero-free branch at `FilelistProcessor.cs:584` writes an *error*, so the job reports as failed.

## The change

A shared drive now answers that it has no quota, and returns before any request is built.

Every other request in this backend carries `supportsTeamDrives` / `teamDriveId` /
`includeTeamDriveItems` / `corpora=teamDrive` from `AddTeamDriveParam`, and `AboutInfoUrl()` carries
none — but **that is the mechanism, not the place to fix**. Drive v2 `about` has no such parameter,
and those are `files`-endpoint query parameters, so threading a drive id through `WebApi.cs` would
produce a different wrong number. `WebApi.cs` is untouched.

### Why null rather than `QuotaInfo(-1, -1)`

Both are documented as "unknown" — `IQuotaEnabledBackend` says null means the implementation does
not report quotas, and `IQuotaInfo` says -1 means the same. Null is what `MicrosoftGraphBackend`
already returns for the same kind of untrustworthy answer, for the same reason:

```csharp
// Some sources (SharePoint for example) seem to return 0 for these values even when the quota isn't exceeded..
// As a special test, if all the returned values are 0, we pretend that no quota was reported.
// This way we don't send spurious warnings because the quota looks like it is exceeded.
```

And two callers treat null and -1 differently:

| caller | with null | with `QuotaInfo(-1, -1)` |
|---|---|---|
| `RemoteSynchronizationRunner.cs:245` | skipped | **`sync` aborts** — it checks `is not null` and then compares `FreeQuotaSpace < needed`, so -1 always loses |
| `BackendTester/Program.cs:523` | "Unable to retrieve quota information" | prints `Free Space: -1 bytes` |

**The trade-off, stated plainly:** -1 is the tidier of the two in the backup summary. The result
fields default to 0 and `CheckQuotaAsync` leaves them alone on null, so `Commands.cs:851` — which
prints when the value is `>= 0` — will now say `Total remote quota: 0 bytes` for a shared drive
where it used to print the (wrong) personal figure, and the JSON result payload carries the same
zeros. I took that over breaking `sync`. Every backend that returns null already reads this way.

### What a shared-drive user does instead

`--quota-size` still works and is unaffected: the assigned-quota check at `FilelistProcessor.cs:601`
sits outside the block that needs an answer from the backend.

### Nothing else was reaching `about` there

`GetFolderIdAsync` and `GetEntryAsync` already skip `about` when a team drive is configured and use
the drive id as the parent, so the quota lookup was the last call to it on that path and
`rootFolderId` resolution cannot be affected. `RemoteCalls` accounting is also unchanged —
`QuotaInfoOperation` sends its `Started` event before delegating to the backend.

## Red, then green

`Duplicati/UnitTest/GoogleDriveTeamDriveQuotaTests.cs` is new. It drives the backend against a
stubbed Drive API through a small `HttpMessageHandler`, so it needs no network and no credentials —
the same seam as `GoogleDriveDuplicateNameTests` from #7282. The existing file is deliberately left
alone: its stub hard-codes the `about` body, and adding quota fields there would change the fixture
for four unrelated tests.

| test | before | after |
|---|---|---|
| no team drive: the personal quota is reported, and `about` **is** requested | green | green |
| a team drive reports no quota | **red** — the personal `QuotaInfo` came back | green |
| a team drive asks the service nothing | **red** — 2 requests | green |
| an `about` answer without quota figures still reports -1 | green | green |
| a failed `about` lookup still reports nothing | green | green |

The two red ones:

```
ATeamDriveReportsNoQuota
  the personal drive quota was reported for a shared drive
  Expected: null  But was: <Duplicati.Library.Interface.QuotaInfo>

ATeamDriveAsksTheServiceNothing
  requested: http://oauth.invalid/token, https://www.googleapis.com/drive/v2/about
  Expected: 0  But was: 2
```

That second message is the defect in one line: the request that decided the quota is the plain
`about` URL, with none of the shared-drive parameters every other request in the file carries.

The first row is not decoration. It asserts the `about` request **was** recorded, which is what
stops the "asks nothing" test from passing because a URL match was wrong.

**One test does not go through the backend at all.** `QuotaReportingTests` gains a backup to a
destination that reports no quota, asserting that nothing about quota is said — with
`--quota-warning-threshold=100`, the most sensitive setting there is. It is the only thing anywhere
that holds the link between a backend answering null and the check staying quiet, and I checked it
is not vacuous: making that fake report `QuotaInfo(0, 0)` instead turns it red with
`BackendQuotaExceeded`. The fake is `UnknownQuotaBackend`, which stores files exactly as the
existing `NoFreeSpaceBackend` does — two members of that class became `virtual` for it.

Full solution build: 0 errors, 0 warnings.

## Not measured

- **No real Google Drive.** I have no shared drive to test against, so the API answers are stubbed.
  They are fed through the backend's own `about` parsing, so the shape is the one the code already
  expects, but a difference between my stub and the live API would not show up here.
- **A shared drive with the option unset is not detected** — but it cannot be reached either:
  without `--googledrive-teamdrive-id` the folder lookup starts from the personal root, so there is
  no case where a backup sits on a shared drive that this misses.

## Found while measuring, deliberately not fixed here

Each of these is its own change; say the word and I will send them separately.

- **`--quota-disable` is the workaround being handed to #4230 reporters, and it takes `--quota-size`
  with it.** `CheckQuotaAsync` returns at `FilelistProcessor.cs:568` before the assigned-quota block
  at `:601`, so the manual quota is silently skipped and `AssignedQuotaSpace` is left at 0 rather
  than -1. `Strings.Options.QuotaDisableLong` promises the opposite — "The option --quota-size can
  still be used to set a manual quota" — and `BackupHandler.cs:576` gets it right, so the two paths
  disagree.
- **`RemoteSynchronizationRunner.cs:245` does not guard the negative sentinel** it is given
  elsewhere. Any backend reporting `QuotaInfo(-1, …)` aborts `sync` with "Not enough free space in
  destination". This backend can already produce that today, from an account whose `about` carries
  no quota fields.
- **`m_teamDriveID` is tested three ways in this backend**: `IsNullOrWhiteSpace` at `:93` and `:225`,
  `!= null` at `:325`, and `teamDriveId != null` inside `AddTeamDriveParam`. So an explicitly empty
  option resolves folders against the personal root while still sending `corpora=teamDrive` on every
  list and delete. I matched the guard to `IsNullOrWhiteSpace`, since that is what decides whether
  the personal drive is used at all — which is exactly the question quota asks — and the new tests
  pin all three of unset, empty and blank.
- **`GetQuotaInfoAsync`'s `catch` discards the exception**, so a failed quota lookup leaves no trace
  in the log. This file has no logging at all today, so adding one meant introducing it.

## In release-note terms

Fixed a spurious "Backend quota is close to being exceeded" warning when backing up to a Google
shared drive. The figures reported were the signed-in user's own Drive, which says nothing about the
shared drive the backup is stored on, so a shared drive now reports no quota at all. Use
`--quota-size` to set a manual one.

Fixes #4230
