### PR TITLE
Add option to disable db autocreate

### DIFF
--- a/Duplicati/Library/RestAPI/Strings.cs
+++ b/Duplicati/Library/RestAPI/Strings.cs
@@ -29,6 +29,7 @@ namespace Duplicati.Server.Strings
         public static string AnotherInstanceDetected { get { return LC.L(@"Another instance is running, and was notified"); } }
         public static string DatabaseOpenError(string message) { return LC.L(@"Failed to create, open or upgrade the database.
 Error message: {0}", message); }
+        public static string DatabaseMissingAndAutocreateDisabled(string databasepath, string optionname) { return LC.L(@"The database file does not exist: {0}. Automatic database creation is disabled with the option --{1}.", databasepath, optionname); }
         public static string HelpCommandDescription { get { return LC.L(@"Display this help"); } }
         public static string HelpDisplayDialog { get { return LC.L(@"Supported commandline arguments:
 
@@ -76,6 +77,7 @@ Error message: {0}", error); }
         public static string WebserverResetJwtConfigDescription { get { return LC.L(@"Reset the JWT configuration, invalidating any issued login tokens"); } }
         public static string WebserverEnableForeverTokenDescription { get { return LC.L(@"Enable the use of long-lived access tokens"); } }
         public static string WebserverApiOnlyDescription { get { return LC.L(@"Disable the web interface and only allow API access"); } }
+        public static string WebserverDontAutocreateDatabaseDescription { get { return LC.L(@"Do not automatically create the server database if it does not exist. If the database is missing, the server will not start."); } }
         public static string WebserverDisableSigninTokensDescription { get { return LC.L(@"Disable the use of signin tokens"); } }
         public static string WebserverSpaPathsDescription { get { return LC.L(@"The relative paths that should be served as single page applications, separated with semicolons."); } }
         public static string WebserverCorsOriginsDescription { get { return LC.L(@"A list of CORS origins to allow, separated with semicolons. Each origin must be a valid URL."); } }

--- a/Duplicati/Server/Program.cs
+++ b/Duplicati/Server/Program.cs
@@ -1132,10 +1132,16 @@ namespace Duplicati.Server
             //Create the connection instance
             var con = Library.SQLiteHelper.SQLiteLoader.LoadConnection();
 
+            var databasePath = System.IO.Path.Combine(applicationSettings.DataFolder, DataFolderManager.SERVER_DATABASE_FILENAME);
+
+            // If the user has requested that the database is not automatically created,
+            // verify that it exists before attempting to open it
+            if (Library.Utility.Utility.ParseBoolOption(commandlineOptions, WebServerLoader.OPTION_WEBSERVICE_DONT_AUTOCREATE_DATABASE)
+                && !System.IO.File.Exists(databasePath))
+                throw new UserInformationException(Strings.Program.DatabaseMissingAndAutocreateDisabled(databasePath, WebServerLoader.OPTION_WEBSERVICE_DONT_AUTOCREATE_DATABASE), "DatabaseMissingAutocreateDisabled");
+
             try
             {
-                var databasePath = System.IO.Path.Combine(applicationSettings.DataFolder, DataFolderManager.SERVER_DATABASE_FILENAME);
-
                 // Ensure the directory holding the database exists and has secure permissions.
                 // This creates and locks down a missing folder, and verifies (rejecting an
                 // insecure, non-canonical folder unless the user has opted out) an existing one,
@@ -1579,6 +1585,7 @@ namespace Duplicati.Server
             new CommandLineArgument(WebServerLoader.OPTION_WEBSERVICE_ENABLE_FOREVER_TOKEN, CommandLineArgument.ArgumentType.Boolean, Strings.Program.WebserverEnableForeverTokenDescription, Strings.Program.WebserverEnableForeverTokenDescription),
             new CommandLineArgument(WebServerLoader.OPTION_WEBSERVICE_DISABLEAPIEXTENSIONS, CommandLineArgument.ArgumentType.String, Strings.Program.WebserverDisableApiExtensionsDescription, Strings.Program.WebserverDisableApiExtensionsDescription),
             new CommandLineArgument(WebServerLoader.OPTION_WEBSERVICE_API_ONLY, CommandLineArgument.ArgumentType.Boolean, Strings.Program.WebserverApiOnlyDescription, Strings.Program.WebserverApiOnlyDescription),
+            new CommandLineArgument(WebServerLoader.OPTION_WEBSERVICE_DONT_AUTOCREATE_DATABASE, CommandLineArgument.ArgumentType.Boolean, Strings.Program.WebserverDontAutocreateDatabaseDescription, Strings.Program.WebserverDontAutocreateDatabaseDescription),
             new CommandLineArgument(WebServerLoader.OPTION_WEBSERVICE_DISABLE_SIGNIN_TOKENS, CommandLineArgument.ArgumentType.Boolean, Strings.Program.WebserverDisableSigninTokensDescription, Strings.Program.WebserverDisableSigninTokensDescription),
             new CommandLineArgument(WebServerLoader.OPTION_WEBSERVICE_SPAPATHS, CommandLineArgument.ArgumentType.Path, Strings.Program.WebserverSpaPathsDescription, Strings.Program.WebserverSpaPathsDescription, WebServerLoader.DEFAULT_OPTION_SPAPATHS),
             new CommandLineArgument(WebServerLoader.OPTION_WEBSERVICE_TIMEZONE, CommandLineArgument.ArgumentType.String, Strings.Program.WebserverTimezoneDescription, Strings.Program.WebserverTimezoneDescription, TimeZoneHelper.GetLocalTimeZone(), null, TimeZoneHelper.GetTimeZones().Select(x => x.Id).ToArray()),

--- a/Duplicati/Server/WebServerLoader.cs
+++ b/Duplicati/Server/WebServerLoader.cs
@@ -122,6 +122,11 @@ public static class WebServerLoader
     public const string OPTION_SUPPRESS_WELCOME_PAGE = "webservice-suppress-welcome-page";
 
     /// <summary>
+    /// Option for disabling automatic creation of the server database
+    /// </summary>
+    public const string OPTION_WEBSERVICE_DONT_AUTOCREATE_DATABASE = "webservice-dont-autocreate-database";
+
+    /// <summary>
     /// The default path to the web root
     /// </summary>
     public const string DEFAULT_OPTION_WEBROOT = "webroot";


### PR DESCRIPTION
This PR adds an option that disables the server database creation. Useful for cases where you know the database already exists and do not want Duplicati to start with an empty database due to configuration issues.