### PR TITLE
Fix MS365 large email restore

### DIFF
--- a/proprietary/Office365/APIHelper.cs
+++ b/proprietary/Office365/APIHelper.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Duplicati.Library.Interface;
 using Duplicati.Library.Logging;
 using Duplicati.Library.Utility;
@@ -32,6 +33,17 @@ internal class APIHelper : IDisposable
     internal static readonly JsonSerializerOptions GraphJsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// The options used when serializing Microsoft Graph create/update payloads. Null values
+    /// are omitted because the Graph OData deserializer rejects explicit JSON nulls for its
+    /// non-nullable properties (dates, enums, complex types, collections) with a
+    /// "UnableToDeserializePostBody" 400 error.
+    /// </summary>
+    internal static readonly JsonSerializerOptions IgnoreNullJsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     /// <summary>

--- a/proprietary/Office365/DTOs.cs
+++ b/proprietary/Office365/DTOs.cs
@@ -203,6 +203,67 @@ internal sealed class GraphBody
     public string? Content { get; set; }
 }
 
+/// <summary>
+/// The payload for creating a new draft message (POST /users/{id}/messages).
+/// Only contains writable properties, and must be serialized with null values omitted:
+/// the Graph OData deserializer rejects explicit JSON nulls for its non-nullable
+/// properties (dates, recipients, collections) with "UnableToDeserializePostBody",
+/// and read-only properties such as id and receivedDateTime must not be sent.
+/// </summary>
+internal sealed class GraphCreateMessageRequest
+{
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    [JsonPropertyName("body")]
+    public GraphBody? Body { get; set; }
+
+    [JsonPropertyName("from")]
+    public GraphRecipient? From { get; set; }
+
+    [JsonPropertyName("sender")]
+    public GraphRecipient? Sender { get; set; }
+
+    [JsonPropertyName("toRecipients")]
+    public List<GraphRecipient>? ToRecipients { get; set; }
+
+    [JsonPropertyName("ccRecipients")]
+    public List<GraphRecipient>? CcRecipients { get; set; }
+
+    [JsonPropertyName("bccRecipients")]
+    public List<GraphRecipient>? BccRecipients { get; set; }
+}
+
+/// <summary>
+/// The payload for adding a file attachment to a draft message
+/// (POST /users/{id}/messages/{id}/attachments).
+/// Like <see cref="GraphCreateMessageRequest"/>, this only contains writable
+/// properties and must be serialized with null values omitted.
+/// </summary>
+internal sealed class GraphCreateAttachmentRequest
+{
+    [JsonPropertyName("@odata.type")]
+    public string? ODataType { get; set; } // "#microsoft.graph.fileAttachment"
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; set; }
+
+    [JsonPropertyName("size")]
+    public int? Size { get; set; }
+
+    [JsonPropertyName("isInline")]
+    public bool? IsInline { get; set; }
+
+    [JsonPropertyName("contentId")]
+    public string? ContentId { get; set; }
+
+    [JsonPropertyName("contentBytes")]
+    public string? ContentBytes { get; set; } // Base64
+}
+
 internal sealed class GraphAttachment
 {
     [JsonPropertyName("id")]

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.Calendar.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.Calendar.cs
@@ -127,6 +127,10 @@ partial class RestoreProvider
             var calendar = Uri.EscapeDataString(calendarId);
             var url = $"{baseUrl}/v1.0/users/{user}/calendars/{calendar}/events";
 
+            // Note: the payload is serialized with null values omitted. Callers clear
+            // read-only and unwanted properties (id, dates, seriesMasterId, type, ...) by
+            // setting them to null, and the Graph OData deserializer rejects explicit
+            // JSON nulls with "UnableToDeserializePostBody".
             async Task<HttpRequestMessage> requestFactory(CancellationToken rct)
                 => new HttpRequestMessage(HttpMethod.Post, new System.Uri(url))
                 {
@@ -134,7 +138,7 @@ partial class RestoreProvider
                     {
                         Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false)
                     },
-                    Content = JsonContent.Create(eventItem)
+                    Content = JsonContent.Create(eventItem, options: APIHelper.IgnoreNullJsonOptions)
                 };
 
             using var resp = await provider.SendWithRetryShortAsync(
@@ -165,7 +169,7 @@ partial class RestoreProvider
                     {
                         Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false)
                     },
-                    Content = JsonContent.Create(eventUpdate)
+                    Content = JsonContent.Create(eventUpdate, options: APIHelper.IgnoreNullJsonOptions)
                 };
 
             using var resp = await provider.SendWithRetryShortAsync(

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.Channel.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.Channel.cs
@@ -45,7 +45,9 @@ public partial class RestoreProvider
             {
                 var req = new HttpRequestMessage(HttpMethod.Post, new Uri(url));
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(payload);
+                // Null values (e.g. description) are omitted: the Graph OData deserializer
+                // rejects explicit JSON nulls with "UnableToDeserializePostBody".
+                req.Content = JsonContent.Create(payload, options: APIHelper.IgnoreNullJsonOptions);
                 return req;
             }
 

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.Contact.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.Contact.cs
@@ -29,12 +29,28 @@ partial class RestoreProvider
             // POST /users/{id}/contactFolders/{id}/contacts
             var url = $"{baseUrl}/v1.0/users/{user}/contactFolders/{folder}/contacts";
 
+            // The backup stores the full GraphContact JSON, including read-only properties
+            // (id, createdDateTime, lastModifiedDateTime, parentFolderId) and explicit nulls.
+            // Round-trip through the DTO so read-only properties can be dropped and nulls
+            // omitted; the Graph OData deserializer rejects explicit JSON nulls for
+            // non-nullable properties with "UnableToDeserializePostBody".
+            if (contactJsonStream.CanSeek)
+                contactJsonStream.Position = 0;
+            var contact = await JsonSerializer.DeserializeAsync<GraphContact>(contactJsonStream, cancellationToken: cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Failed to deserialize backed-up contact.");
+
+            contact.Id = null!;
+            contact.CreatedDateTime = null;
+            contact.LastModifiedDateTime = null;
+            contact.ParentFolderId = null;
+
+            var sanitizedBody = JsonSerializer.SerializeToUtf8Bytes(contact, APIHelper.IgnoreNullJsonOptions);
+
             async Task<HttpRequestMessage> requestFactory(CancellationToken ct)
             {
                 var req = new HttpRequestMessage(HttpMethod.Post, new Uri(url));
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, ct).ConfigureAwait(false);
-                contactJsonStream.Position = 0;
-                req.Content = new StreamContent(contactJsonStream);
+                req.Content = new ByteArrayContent(sanitizedBody);
                 req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                 return req;
             }
@@ -345,7 +361,7 @@ partial class RestoreProvider
             {
                 var req = new HttpRequestMessage(HttpMethod.Patch, new Uri(url));
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(body);
+                req.Content = JsonContent.Create(body, options: APIHelper.IgnoreNullJsonOptions);
                 return req;
             }
 

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.Drive.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.Drive.cs
@@ -316,7 +316,10 @@ partial class RestoreProvider
             {
                 var req = new HttpRequestMessage(HttpMethod.Patch, new Uri(url));
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, ct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(body);
+                // Null values are omitted (only one of created/modified may be known): the
+                // Graph OData deserializer rejects explicit JSON nulls for non-nullable
+                // properties with "UnableToDeserializePostBody".
+                req.Content = JsonContent.Create(body, options: APIHelper.IgnoreNullJsonOptions);
                 return req;
             }
 

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.Group.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.Group.cs
@@ -43,7 +43,7 @@ public partial class RestoreProvider
                 ["displayName"] = graphGroup.DisplayName
             };
 
-            var json = JsonSerializer.Serialize(payload);
+            var json = JsonSerializer.Serialize(payload, APIHelper.IgnoreNullJsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             await provider.PatchGraphItemAsync(url, content, ct);
@@ -103,6 +103,9 @@ public partial class RestoreProvider
             var group = Uri.EscapeDataString(groupId);
             var url = $"{baseUrl}/v1.0/groups/{group}/events";
 
+            // Null values are omitted: the Graph OData deserializer rejects explicit JSON
+            // nulls for non-nullable properties with "UnableToDeserializePostBody", and
+            // callers clear read-only properties by setting them to null.
             async Task<HttpRequestMessage> requestFactory(CancellationToken rct)
                 => new HttpRequestMessage(HttpMethod.Post, new Uri(url))
                 {
@@ -110,7 +113,7 @@ public partial class RestoreProvider
                     {
                         Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false)
                     },
-                    Content = JsonContent.Create(eventItem)
+                    Content = JsonContent.Create(eventItem, options: APIHelper.IgnoreNullJsonOptions)
                 };
 
             using var resp = await provider.SendWithRetryShortAsync(
@@ -143,7 +146,7 @@ public partial class RestoreProvider
                 }
             };
 
-            var json = JsonSerializer.Serialize(payload);
+            var json = JsonSerializer.Serialize(payload, APIHelper.IgnoreNullJsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             return await provider.PostGraphItemAsync<GraphConversationThread>(url, content, ct);
@@ -165,7 +168,7 @@ public partial class RestoreProvider
                 }
             };
 
-            var json = JsonSerializer.Serialize(payload);
+            var json = JsonSerializer.Serialize(payload, APIHelper.IgnoreNullJsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             await provider.PostGraphItemNoResponseAsync(url, content, ct);
@@ -251,7 +254,7 @@ public partial class RestoreProvider
                 ["membershipType"] = membershipType ?? "standard"
             };
 
-            var json = JsonSerializer.Serialize(payload);
+            var json = JsonSerializer.Serialize(payload, APIHelper.IgnoreNullJsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             return await provider.PostGraphItemAsync<GraphChannel>(url, content, ct).ConfigureAwait(false);
@@ -284,7 +287,7 @@ public partial class RestoreProvider
             if (createdDateTimeUtc.HasValue)
                 payload["createdDateTime"] = createdDateTimeUtc.Value.UtcDateTime.ToGraphTimeString();
 
-            var json = JsonSerializer.Serialize(payload);
+            var json = JsonSerializer.Serialize(payload, APIHelper.IgnoreNullJsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             return await provider.PostGraphItemAsync<GraphChannel>(url, content, ct).ConfigureAwait(false);
@@ -403,7 +406,7 @@ public partial class RestoreProvider
                 payload["teamsApp@odata.bind"] = $"https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/{teamsAppId}";
             }
 
-            var json = JsonSerializer.Serialize(payload);
+            var json = JsonSerializer.Serialize(payload, APIHelper.IgnoreNullJsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             return await provider.PostGraphItemAsync<GraphTeamsTab>(url, content, ct);
@@ -921,7 +924,7 @@ public partial class RestoreProvider
                 }
 
                 // Clean up properties that shouldn't be sent on creation
-                graphEvent.Id = "";
+                graphEvent.Id = null!;
                 graphEvent.CreatedDateTime = null;
                 graphEvent.LastModifiedDateTime = null;
                 // Group events don't support all properties that user events do, but Graph API should handle it or ignore extra fields.

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.User.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.User.cs
@@ -19,16 +19,6 @@ partial class RestoreProvider
         /// </summary>
         private const long MAX_SIZE_FOR_SIMPLE_EMAIL_RESTORE = (long)((4 * 1024 * 1024) * (1 - 0.33)) - 1024; // 4MB - 33% base64 overhead - 1KB margin
 
-        /// <summary>
-        /// Serializer options that omit null values. The Graph OData deserializer rejects
-        /// explicit JSON nulls for non-nullable properties with "UnableToDeserializePostBody",
-        /// so create payloads must only include properties that have a value.
-        /// </summary>
-        private static readonly JsonSerializerOptions IgnoreNullJsonOptions = new()
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
         public async Task<string> RestoreEmailToFolderAsync(
             string userId,
             string targetFolderId,
@@ -202,7 +192,7 @@ partial class RestoreProvider
             {
                 var req = new HttpRequestMessage(HttpMethod.Post, url);
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(message, options: IgnoreNullJsonOptions);
+                req.Content = JsonContent.Create(message, options: APIHelper.IgnoreNullJsonOptions);
                 return req;
             }
 
@@ -284,7 +274,7 @@ partial class RestoreProvider
             {
                 var req = new HttpRequestMessage(HttpMethod.Post, url);
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(attach, options: IgnoreNullJsonOptions);
+                req.Content = JsonContent.Create(attach, options: APIHelper.IgnoreNullJsonOptions);
                 return req;
             }
 

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.User.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.User.cs
@@ -18,6 +18,17 @@ partial class RestoreProvider
         /// Limit for ensuring we stay under the 4MB limit for simple email restore.
         /// </summary>
         private const long MAX_SIZE_FOR_SIMPLE_EMAIL_RESTORE = (long)((4 * 1024 * 1024) * (1 - 0.33)) - 1024; // 4MB - 33% base64 overhead - 1KB margin
+
+        /// <summary>
+        /// Serializer options that omit null values. The Graph OData deserializer rejects
+        /// explicit JSON nulls for non-nullable properties with "UnableToDeserializePostBody",
+        /// so create payloads must only include properties that have a value.
+        /// </summary>
+        private static readonly JsonSerializerOptions IgnoreNullJsonOptions = new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
         public async Task<string> RestoreEmailToFolderAsync(
             string userId,
             string targetFolderId,
@@ -121,7 +132,7 @@ partial class RestoreProvider
             var message = await MimeMessage.LoadAsync(contentStream, ct);
 
             // 2. Create Draft Message (without attachments)
-            var draft = new GraphMessage
+            var draft = new GraphCreateMessageRequest
             {
                 Subject = message.Subject,
                 Body = new GraphBody
@@ -133,8 +144,7 @@ partial class RestoreProvider
                 Sender = ConvertToGraphRecipient(message.Sender),
                 ToRecipients = ConvertToGraphRecipients(message.To),
                 CcRecipients = ConvertToGraphRecipients(message.Cc),
-                BccRecipients = ConvertToGraphRecipients(message.Bcc),
-                HasAttachments = message.Attachments.Any()
+                BccRecipients = ConvertToGraphRecipients(message.Bcc)
             };
 
             var createdDraft = await CreateMessageAsync(userId, draft, ct);
@@ -182,7 +192,7 @@ partial class RestoreProvider
             return movedId;
         }
 
-        private async Task<GraphCreatedMessage> CreateMessageAsync(string userId, GraphMessage message, CancellationToken ct)
+        private async Task<GraphCreatedMessage> CreateMessageAsync(string userId, GraphCreateMessageRequest message, CancellationToken ct)
         {
             var baseUrl = provider.GraphBaseUrl.TrimEnd('/');
             var user = Uri.EscapeDataString(userId);
@@ -192,7 +202,7 @@ partial class RestoreProvider
             {
                 var req = new HttpRequestMessage(HttpMethod.Post, url);
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(message);
+                req.Content = JsonContent.Create(message, options: IgnoreNullJsonOptions);
                 return req;
             }
 
@@ -259,7 +269,7 @@ partial class RestoreProvider
             await part.Content.DecodeToAsync(ms, ct);
             var bytes = ms.ToArray();
 
-            var attach = new GraphAttachment
+            var attach = new GraphCreateAttachmentRequest
             {
                 ODataType = "#microsoft.graph.fileAttachment",
                 Name = part.FileName ?? "attachment",
@@ -274,7 +284,7 @@ partial class RestoreProvider
             {
                 var req = new HttpRequestMessage(HttpMethod.Post, url);
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(attach);
+                req.Content = JsonContent.Create(attach, options: IgnoreNullJsonOptions);
                 return req;
             }
 

--- a/proprietary/Office365/RestoreProvider/RestoreProvider.UserProfile.cs
+++ b/proprietary/Office365/RestoreProvider/RestoreProvider.UserProfile.cs
@@ -72,11 +72,16 @@ partial class RestoreProvider
 
             if (updateDict.Count == 0) return;
 
+            // Note: null values (e.g. a cleared jobTitle in the backup) are omitted from the
+            // payload rather than sent as explicit nulls; the Graph OData deserializer
+            // rejects explicit JSON nulls for non-nullable properties with
+            // "UnableToDeserializePostBody". This also means a null in the backup leaves
+            // the target property unchanged instead of clearing it.
             async Task<HttpRequestMessage> requestFactory(CancellationToken rct)
             {
                 var req = new HttpRequestMessage(HttpMethod.Patch, new Uri(url));
                 req.Headers.Authorization = await provider.GetAuthenticationHeaderAsync(false, rct).ConfigureAwait(false);
-                req.Content = JsonContent.Create(updateDict);
+                req.Content = JsonContent.Create(updateDict, options: APIHelper.IgnoreNullJsonOptions);
                 return req;
             }
 


### PR DESCRIPTION
This PR fixes a bug with restoring large emails to MS365 tenant.

The issue was that the retore path for large emails would attempt to set all parameters on the email, but some were missing or not set-able in the email creation call.

With this update, only the allowed properties are set on the restored email.