### PR TITLE
Do not read an unknown destination quota as a full destination

### DIFF
--- a/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
@@ -237,8 +237,10 @@ public static class RemoteSynchronizationRunner
         var disableQuota = Library.Utility.Utility.ParseBoolOption(dst_opts, "quota-disable");
 
         // Check if we have enough free space in the destination to perform the synchronization.
+        // A negative free space means the backend did not return the quota info, so there is
+        // nothing to compare the required size against.
         var dst_quota = disableQuota ? null : await b2m.GetQuotaInfoAsync(token).ConfigureAwait(false);
-        if (dst_quota is not null)
+        if (dst_quota is not null && dst_quota.FreeQuotaSpace >= 0)
         {
             var total_delete_size = to_delete.Sum(x => Math.Max(x.Size, 0));
             var total_copy_size = to_copy.Sum(x => Math.Max(x.Size, 0));

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -662,6 +662,25 @@ namespace Duplicati.UnitTest
         }
 
         /// <summary>
+        /// A test backend that does not know what the destination has room for, which is what a
+        /// negative quota means. A Google Drive account whose "about" answer carries no quota
+        /// fields reports exactly this.
+        /// </summary>
+        public class FileBackendWithUnknownQuota : Library.Backend.File
+        {
+            public FileBackendWithUnknownQuota() { }
+
+            public FileBackendWithUnknownQuota(string url, Dictionary<string, string?> options) : base(url.Replace("unknownquotatest://", "file://"), options) { }
+
+            public override string ProtocolKey => "unknownquotatest";
+
+            public override Task<IQuotaInfo?> GetQuotaInfoAsync(CancellationToken token)
+            {
+                return Task.FromResult<IQuotaInfo?>(new QuotaInfo(-1, -1));
+            }
+        }
+
+        /// <summary>
         /// A test backend that simulates a quota of 1KB for testing quota checks in the remote synchronization tool.
         /// </summary>
         public class FileBackendWith1Kb : Library.Backend.File
@@ -732,6 +751,37 @@ namespace Duplicati.UnitTest
             var return_code = await async_call.ConfigureAwait(false);
 
             Assert.AreEqual(0, return_code, "Remote synchronization should succeed with sufficient quota.");
+            Assert.IsTrue(DirectoriesAndContentsAreEqual(l1, l2), "Directories should be synchronized.");
+        }
+
+        /// <summary>
+        /// Tests that a destination which does not report a quota is not read as a full one. A
+        /// negative free space is how a backend says it does not know, which is not the same as
+        /// saying there is no room, and the tool has nothing to compare against.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestRemoteSynchronizationUnknownQuotaIsNotTreatedAsFullAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "quota_src3");
+            var l2 = Path.Combine(TARGETFOLDER, "quota_dst3");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            // Enough data that the required size is comfortably positive, so an unknown quota
+            // read as a number would lose the comparison
+            await GenerateTestDataAsync(l1, 5, 0, 0, 2048).ConfigureAwait(false);
+
+            // Register the test backend
+            Library.DynamicLoader.BackendLoader.AddBackend(new FileBackendWithUnknownQuota());
+
+            var args = new string[] { $"file://{l1}", $"unknownquotatest://{l2}", "--confirm" };
+
+            var async_call = RemoteSynchronization.Program.MainAsync(args);
+            var return_code = await async_call.ConfigureAwait(false);
+
+            Assert.AreEqual(0, return_code, "Remote synchronization should not stop for a destination that reports no quota.");
             Assert.IsTrue(DirectoriesAndContentsAreEqual(l1, l2), "Directories should be synchronized.");
         }
 


### PR DESCRIPTION
A backend that cannot say what the destination has room for reports a negative free space. That is
what `IQuotaInfo` documents — "This may return -1 if the particular host implementation does not
support quotas, but the backend does" — and the backup path reads it that way, guarded at
`FilelistProcessor.cs:589`:

```csharp
else if (reportShortage && !log.ReportedQuotaWarning && !log.ReportedQuotaError && quota.FreeQuotaSpace >= 0) // Negative value means the backend didn't return the quota info
```

`RemoteSynchronizationRunner` checked only that the object existed:

```csharp
if (dst_quota is not null)
{
    ...
    if (dst_quota.FreeQuotaSpace < total_copy_size - total_delete_size)
        throw new UserInformationException("Not enough free space in destination to perform the synchronization.", "NotEnoughDestinationSpace");
}
```

So `-1` loses against anything there is to copy, and the run stops — telling the user a destination
is out of room when the destination never said so.

**This is reachable today, not hypothetically.** The Google Drive backend builds its answer from the
`about` resource:

```csharp
return new QuotaInfo(about.quotaBytesTotal ?? -1, about.quotaBytesTotal - about.quotaBytesUsed ?? -1);
```

An account whose answer carries no quota fields therefore reports `QuotaInfo(-1, -1)`, and `sync` to
it cannot run at all. This came up while measuring [#7290](https://github.com/duplicati/duplicati/pull/7290);
that PR returns `null` for a shared drive partly because `-1` would land here.

## The change

One condition. The check runs only when the destination actually reported a free space.

**Zero is untouched.** Zero is a real answer — the destination is full — and it still stops the run.
That is what `TestRemoteSynchronizationQuotaCheckFailsAsync` covers, and it stays green.

## Red, then green

`ToolTests` gains a destination that reports an unknown quota, next to the existing
`FileBackendWith1Kb`, and a test that syncs ~5 KB to it.

| test | before | after |
|---|---|---|
| a destination reporting no quota does not stop the sync | **red** — exit code 1 | green |
| a destination with 1 KB free still stops a 5 KB sync | green | green |
| a destination with 1 KB free allows a 500 B sync | green | green |

The red one, in full:

```
Remote synchronization should not stop for a destination that reports no quota.
  Expected: 0  But was: 1

Unhandled exception: Duplicati.Library.Interface.UserInformationException:
  Not enough free space in destination to perform the synchronization.
   at ...RemoteSynchronizationRunner.RunCoreAsync(...) RemoteSynchronizationRunner.cs:line 251
```

The second row is the one that matters after the change: it is the shape the check exists for, and
it shows the guard narrowed the check rather than removed it.

Whole `Tools/RemoteSynchronization` category: 18/18. Full solution build: 0 errors, 0 warnings.

## Not measured

- **The `--dst-options freequota=` path.** The existing tests drive the quota through a test backend
  rather than a real destination, and so does this one. What is exercised is the comparison in the
  runner, which is where the fault was.
- I have not audited other tools for the same pattern; the two consumers in `Duplicati.Library.Main`
  (`FilelistProcessor` and `BackupHandler`) both handle it correctly already.

Related: #7290, which is where this was found.
