### PR TITLE
Keep the manual quota when the backend quota is disabled

### DIFF
--- a/Duplicati/Library/Main/Operation/FilelistProcessor.cs
+++ b/Duplicati/Library/Main/Operation/FilelistProcessor.cs
@@ -563,14 +563,23 @@ namespace Duplicati.Library.Main.Operation
         private static bool OnlyReadsFromBackend(OperationMode operation)
             => operation is OperationMode.Restore or OperationMode.ListBrokenFiles;
 
+        /// <summary>
+        /// Reports on the two quotas a backup can run into: the one the destination reports, and the
+        /// one the user set with --quota-size.
+        /// </summary>
+        /// <remarks>
+        /// --quota-disable turns off the first of those only. Its help text says as much - "Disable
+        /// the quota reported by the backend. The option --quota-size can still be used to set a
+        /// manual quota" - and it exists because some destinations report a quota that is wrong or
+        /// meaningless, which says nothing about the limit the user set for themselves.
+        /// </remarks>
         private static async Task CheckQuotaAsync(IBackendManager backendManager, Options options, IBackendWriter log, long knownFileSize)
         {
-            if (options.QuotaDisable)
-                return;
-
             var reportShortage = !OnlyReadsFromBackend(log.MainOperation);
 
-            var quota = await backendManager.GetQuotaInfoAsync(CancellationToken.None).ConfigureAwait(false);
+            var quota = options.QuotaDisable
+                ? null
+                : await backendManager.GetQuotaInfoAsync(CancellationToken.None).ConfigureAwait(false);
             if (quota != null)
             {
                 log.TotalQuotaSpace = quota.TotalQuotaSpace;

--- a/Duplicati/UnitTest/QuotaReportingTests.cs
+++ b/Duplicati/UnitTest/QuotaReportingTests.cs
@@ -109,6 +109,97 @@ namespace Duplicati.UnitTest
         }
 
         /// <summary>
+        /// There are two quotas, and --quota-disable only turns off one of them. Its own help text
+        /// says so: "Disable the quota reported by the backend. The option --quota-size can still be
+        /// used to set a manual quota".
+        /// </summary>
+        [Test]
+        [Category("Quota")]
+        public async Task AManualQuotaAppliesEvenWhenTheBackendQuotaIsDisabledAsync()
+        {
+            // One byte, so the backup is over the manual quota whatever it ends up weighing
+            var testopts = TestOptions.Expand(new { no_encryption = true, quota_disable = true, quota_size = "1b" });
+            CreateSourceData();
+
+            using (var c = new Controller(FullTarget, testopts, null))
+            {
+                var results = await c.BackupAsync([DATAFOLDER]);
+
+                Assert.That(results.Errors.Any(x => x.Contains("Assigned quota")), Is.True,
+                    "The manual quota was not applied: "
+                        + string.Join(System.Environment.NewLine, results.Errors.Concat(results.Warnings)));
+
+                Assert.That(results.Errors.Concat(results.Warnings).Any(x => x.Contains("Backend quota")), Is.False,
+                    "The backend quota was reported although it was disabled");
+            }
+        }
+
+        /// <summary>
+        /// The other half of the option, and the guard on the change above: a destination with no
+        /// room left says nothing when its quota is disabled.
+        /// </summary>
+        [Test]
+        [Category("Quota")]
+        public async Task ADisabledBackendQuotaStaysSilentAsync()
+        {
+            var testopts = TestOptions.Expand(new { no_encryption = true, quota_disable = true });
+            CreateSourceData();
+
+            using (var c = new Controller(FullTarget, testopts, null))
+            {
+                var results = await c.BackupAsync([DATAFOLDER]);
+                var quotaMessages = results.Errors.Concat(results.Warnings).Where(x => x.Contains("quota")).ToList();
+
+                Assert.That(quotaMessages, Is.Empty,
+                    "A disabled backend quota was still reported: "
+                        + string.Join(System.Environment.NewLine, quotaMessages));
+            }
+        }
+
+        /// <summary>
+        /// A manual quota that is nowhere near being reached says nothing either, so the check is
+        /// applied rather than merely being loud.
+        /// </summary>
+        [Test]
+        [Category("Quota")]
+        public async Task AManualQuotaThatIsNotReachedSaysNothingAsync()
+        {
+            var testopts = TestOptions.Expand(new { no_encryption = true, quota_disable = true, quota_size = "100mb" });
+            CreateSourceData();
+
+            using (var c = new Controller(FullTarget, testopts, null))
+            {
+                var results = await c.BackupAsync([DATAFOLDER]);
+                var quotaMessages = results.Errors.Concat(results.Warnings).Where(x => x.Contains("quota")).ToList();
+
+                Assert.That(quotaMessages, Is.Empty,
+                    "A backup well inside its manual quota reported one anyway: "
+                        + string.Join(System.Environment.NewLine, quotaMessages));
+            }
+        }
+
+        /// <summary>
+        /// The manual quota is also what the run reports it used, which is what reaches the command
+        /// line summary and the JSON result. Skipping the check left this at its default of zero.
+        /// </summary>
+        [Test]
+        [Category("Quota")]
+        public async Task TheManualQuotaIsReportedWhenTheBackendQuotaIsDisabledAsync()
+        {
+            var testopts = TestOptions.Expand(new { no_encryption = true, quota_disable = true, quota_size = "100mb" });
+            CreateSourceData();
+
+            using (var c = new Controller(FullTarget, testopts, null))
+            {
+                var results = await c.BackupAsync([DATAFOLDER]);
+                var stats = (Library.Interface.IParsedBackendStatistics)results.BackendStatistics;
+
+                Assert.That(stats.AssignedQuotaSpace, Is.EqualTo(100 * 1024 * 1024L),
+                    "The manual quota was not recorded on the result");
+            }
+        }
+
+        /// <summary>
         /// A destination that cannot say what it has room for is not a destination with no room:
         /// there is no quota to be close to exceeding, so nothing is reported. A Google shared
         /// drive is exactly this, and reporting the signed-in user's own drive instead is what


### PR DESCRIPTION
There are two quotas a backup can run into: the one the destination reports, and the one the user
sets with `--quota-size`. The option that turns off the first promises, in its own help text
(`Strings.Options.QuotaDisableLong`, rendered with `quota-size` filled in):

> Disable the quota reported by the backend. **The option --quota-size can still be used to set a
> manual quota**

It turned off both.

## Measured

A backup to a destination reporting no free space, with `--quota-size=1b`, reading the errors and
warnings straight off the result:

| | result |
|---|---|
| `--quota-disable` **set** | **no errors, no warnings at all** |
| `--quota-disable` **unset** | `Assigned quota has been exceeded` |

The manual check works. Setting the option removed it.

The same run left `AssignedQuotaSpace` at its default `0` instead of the configured size, so the
command line summary (`Commands.cs`) and the JSON result under-reported it as well.

## Why

`CheckQuotaAsync` returned at the top, and the manual quota is checked further down the same method:

```csharp
if (options.QuotaDisable)
    return;                                     // ← here
...
log.AssignedQuotaSpace = options.QuotaSize;     // ← the manual quota starts here
if (log.AssignedQuotaSpace != -1) { ... }
```

`FilelistProcessor.cs:602-621` is the **only** place the manual quota is checked — `BackupHandler.cs:576`
assigns the field for reporting but tests nothing, and that path only runs under
`--no-backend-verification`.

## The change

The backend lookup becomes the only thing the option skips. `BackupHandler.UpdateStorageStatsFromDatabaseAsync`
already had this shape — the backend block guarded, `AssignedQuotaSpace` outside it — so the two paths
disagreed; they now agree. `RemoteSynchronizationRunner` reads the same option in the same ternary form.

**No decision logic changed.** The manual quota block below is untouched and simply runs again.

`BackendManager.QuotaInfoOperation` already declines to ask the backend when the option is set, so
this cannot cause an extra request; keeping the check here just avoids queueing an operation whose
answer would be `null`.

## Red, then green

| test | before | after |
|---|---|---|
| `--quota-disable` + `--quota-size=1b`: the manual quota is applied, and the backend quota is still silent | **red** — nothing reported at all | green |
| `--quota-disable` alone: a full destination stays silent | green | green |
| `--quota-disable` + `--quota-size=100mb`: nothing reported | green | green |
| `--quota-disable` + `--quota-size=100mb`: the result records 104857600 | **red** — recorded 0 | green |

```
AManualQuotaAppliesEvenWhenTheBackendQuotaIsDisabledAsync
  The manual quota was not applied:
  Expected: True  But was: False        (the message list was empty)

TheManualQuotaIsReportedWhenTheBackendQuotaIsDisabledAsync
  The manual quota was not recorded on the result
  Expected: 104857600  But was: 0
```

Rows 2 and 3 are the guards: the first keeps `--quota-disable` doing its job, the second keeps the
manual quota from firing when it is nowhere near being reached. The existing
`ABackupToAFullDestinationStillReportsAQuotaErrorAsync` continues to cover the option being unset.

No test anywhere in the repository set `--quota-disable` or `--quota-size` before this, so nothing
pinned the old behaviour.

Full solution build: 0 errors, 0 warnings.

## Behaviour change worth naming

Anyone who sets **both** options today gets no quota messages at all. After this they get the
warnings and errors `--quota-size` is supposed to produce. That is the documented behaviour, and the
combination is exactly what a user is told to reach for when a destination reports a quota that does
not apply to them — which is how I found this, while measuring
[#4230](https://github.com/duplicati/duplicati/issues/4230) / [#7290](https://github.com/duplicati/duplicati/pull/7290)
(a Google shared drive reporting the signed-in user's personal quota).

## Not measured

- **Only the `Quota` category and a full build locally**; the rest is left to CI.
- I did not change the help text or the documentation, because they already describe the behaviour
  this restores. The `quota-disable` line in `changelog.txt` is about the remote synchronization
  tool, which is a different code path and is not affected.
