### PR TITLE
Take the database lock in the server paths that skipped it

### DIFF
--- a/Duplicati/Library/RestAPI/Database/Connection.cs
+++ b/Duplicati/Library/RestAPI/Database/Connection.cs
@@ -1180,28 +1180,30 @@ namespace Duplicati.Server.Database
         //Workaround to clean up the database after invalid settings update
         public void FixInvalidBackupId()
         {
-            using (var tr = m_connection.BeginTransaction())
-            using (var cmd = m_connection.CreateCommand(tr))
-            {
-                cmd.SetCommandAndParameters(@"DELETE FROM ""Option"" WHERE ""BackupID"" = @BackupId")
-                    .SetParameterValue("@BackupId", -1)
-                    .ExecuteNonQuery();
-                cmd.SetCommandAndParameters(@"DELETE FROM ""Metadata"" WHERE ""BackupID"" = @BackupId")
-                    .SetParameterValue("@BackupId", -1)
-                    .ExecuteNonQuery();
-                cmd.SetCommandAndParameters(@"DELETE FROM ""Filter"" WHERE ""BackupID"" = @BackupId")
-                    .SetParameterValue("@BackupId", -1)
-                    .ExecuteNonQuery();
-                cmd.SetCommandAndParameters(@"DELETE FROM ""Source"" WHERE ""BackupID"" = @BackupId")
-                    .SetParameterValue("@BackupId", -1)
-                    .ExecuteNonQuery();
+            lock (m_lock)
+                using (var tr = m_connection.BeginTransaction())
+                using (var cmd = m_connection.CreateCommand(tr))
+                {
+                    cmd.SetCommandAndParameters(@"DELETE FROM ""Option"" WHERE ""BackupID"" = @BackupId")
+                        .SetParameterValue("@BackupId", -1)
+                        .ExecuteNonQuery();
+                    cmd.SetCommandAndParameters(@"DELETE FROM ""Metadata"" WHERE ""BackupID"" = @BackupId")
+                        .SetParameterValue("@BackupId", -1)
+                        .ExecuteNonQuery();
+                    cmd.SetCommandAndParameters(@"DELETE FROM ""Filter"" WHERE ""BackupID"" = @BackupId")
+                        .SetParameterValue("@BackupId", -1)
+                        .ExecuteNonQuery();
+                    cmd.SetCommandAndParameters(@"DELETE FROM ""Source"" WHERE ""BackupID"" = @BackupId")
+                        .SetParameterValue("@BackupId", -1)
+                        .ExecuteNonQuery();
 
-                cmd.SetCommandAndParameters(@"DELETE FROM ""Schedule"" WHERE ""Tags"" = @Tag")
-                    .SetParameterValue("@Tag", "ID=-1")
-                    .ExecuteNonQuery();
-                tr.Commit();
-            }
+                    cmd.SetCommandAndParameters(@"DELETE FROM ""Schedule"" WHERE ""Tags"" = @Tag")
+                        .SetParameterValue("@Tag", "ID=-1")
+                        .ExecuteNonQuery();
+                    tr.Commit();
+                }
 
+            // Left outside the lock: saving a setting signals the rest of the server
             ApplicationSettings.FixedInvalidBackupId = true;
         }
 
@@ -1299,7 +1301,10 @@ namespace Duplicati.Server.Database
                 Expires = expires
             };
 
-            OverwriteAndUpdateDb(null, null, [tempfile], false);
+            // Runs on the queue runner's worker thread, and reads the row id back in a second
+            // statement, so the write and the read of it have to stay together
+            lock (m_lock)
+                OverwriteAndUpdateDb(null, null, [tempfile], false);
 
             return tempfile.ID;
         }
@@ -1308,15 +1313,19 @@ namespace Duplicati.Server.Database
         {
             var t = Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(purgeDate);
 
-            using (var tr = m_connection.BeginTransaction())
-            using (var cmd = m_connection.CreateCommand(tr))
-            {
-                cmd.SetCommandAndParameters(@"DELETE FROM ""ErrorLog"" WHERE ""Timestamp"" < @Time")
-                    .SetParameterValue("@Time", t)
-                    .ExecuteNonQuery();
+            // This runs from a timer, so it is concurrent with everything the server does. While
+            // the transaction below is open, no command that does not carry it can run on the
+            // connection, and the reads carry none.
+            lock (m_lock)
+                using (var tr = m_connection.BeginTransaction())
+                using (var cmd = m_connection.CreateCommand(tr))
+                {
+                    cmd.SetCommandAndParameters(@"DELETE FROM ""ErrorLog"" WHERE ""Timestamp"" < @Time")
+                        .SetParameterValue("@Time", t)
+                        .ExecuteNonQuery();
 
-                tr.Commit();
-            }
+                    tr.Commit();
+                }
         }
 
         private static DateTime ConvertToDateTime(IDataReader rd, int index)
@@ -1387,12 +1396,15 @@ namespace Duplicati.Server.Database
         {
             if (transaction == null)
             {
-                using (var tr = m_connection.BeginTransaction())
-                {
-                    var r = DeleteFromDb(tablename, id, tr);
-                    tr.Commit();
-                    return r;
-                }
+                // Every caller that lands here holds the lock already, but the transaction below
+                // is on the shared connection, so it cannot be reached without it
+                lock (m_lock)
+                    using (var tr = m_connection.BeginTransaction())
+                    {
+                        var r = DeleteFromDb(tablename, id, tr);
+                        tr.Commit();
+                        return r;
+                    }
             }
             else
             {

--- a/Duplicati/UnitTest/ServerDatabaseLockingTests.cs
+++ b/Duplicati/UnitTest/ServerDatabaseLockingTests.cs
@@ -1,0 +1,179 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duplicati.Library.AutoUpdater;
+using Duplicati.Library.SQLiteHelper;
+using Duplicati.Server.Database;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The server keeps one database connection and serializes access to it with a single lock.
+    /// A path that skips the lock breaks the ones that take it: while a transaction is open on
+    /// the connection, Microsoft.Data.Sqlite refuses any command that does not carry that same
+    /// transaction, and the read helpers in <see cref="Connection"/> carry none. The reads then
+    /// fail with "The transaction object is not associated with the same connection object as
+    /// this command", which is what a REST request returned as a 500 during a CI run.
+    /// </summary>
+    [TestFixture]
+    [Category("ServerDatabase")]
+    public class ServerDatabaseLockingTests
+    {
+        /// <summary>How long a call is given to prove it is not blocked.</summary>
+        private const int BlockedMilliseconds = 500;
+
+        /// <summary>How long a call is given to finish once it is no longer blocked.</summary>
+        private const int CompletionMilliseconds = 15000;
+
+        private string _tempDataFolder = null!;
+        private string _databasePath = null!;
+        private Connection _connection = null!;
+
+        [SetUp]
+        public async Task SetUpAsync()
+        {
+            _tempDataFolder = Path.Combine(Path.GetTempPath(), $"duplicati-server-db-lock-test-{Guid.NewGuid()}");
+            Directory.CreateDirectory(_tempDataFolder);
+
+            _databasePath = Path.Combine(_tempDataFolder, DataFolderManager.SERVER_DATABASE_FILENAME);
+
+            var dbConnection = await SQLiteLoader.LoadConnectionAsync(_databasePath);
+            DatabaseUpgrader.UpgradeDatabase(dbConnection, _databasePath, typeof(Library.RestAPI.Database.DatabaseSchemaMarker));
+
+            _connection = new Connection(dbConnection, true, null, _tempDataFolder, () => { });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _connection?.Dispose();
+
+            if (Directory.Exists(_tempDataFolder))
+            {
+                try
+                {
+                    Directory.Delete(_tempDataFolder, true);
+                }
+                catch
+                {
+                    // Best effort cleanup
+                }
+            }
+        }
+
+        /// <summary>
+        /// Runs <paramref name="call"/> on another thread while the database lock is held, and
+        /// asserts that it waits for the lock rather than reaching the connection anyway.
+        /// </summary>
+        /// <param name="name">The name of the call, for the failure message.</param>
+        /// <param name="call">The call to make.</param>
+        private void AssertWaitsForTheDatabaseLock(string name, Action call)
+        {
+            var entered = new ManualResetEventSlim(false);
+            Task worker;
+
+            lock (_connection.m_lock)
+            {
+                worker = Task.Run(() =>
+                {
+                    entered.Set();
+                    call();
+                });
+
+                Assert.IsTrue(entered.Wait(CompletionMilliseconds), $"{name} never started");
+                Assert.IsFalse(worker.Wait(BlockedMilliseconds), $"{name} used the connection while the database lock was held by another thread");
+            }
+
+            Assert.IsTrue(worker.Wait(CompletionMilliseconds), $"{name} did not finish after the database lock was released");
+            Assert.IsNull(worker.Exception, $"{name} failed: {worker.Exception}");
+        }
+
+        /// <summary>
+        /// The log purge runs from a timer (Program.cs), so it is concurrent with every REST
+        /// request. It opens a transaction on the shared connection, which is exactly the state
+        /// the reads cannot survive.
+        /// </summary>
+        [Test]
+        public void ThePurgeOfLogDataWaitsForTheDatabaseLock()
+            => AssertWaitsForTheDatabaseLock("PurgeLogData", () => _connection.PurgeLogData(DateTime.Now));
+
+        /// <summary>
+        /// Registering a temporary file runs on the queue runner's worker thread, and writes
+        /// without a transaction - but it reads the row id back in a second statement, so it
+        /// needs the lock for its own sake as much as for everyone else's.
+        /// </summary>
+        [Test]
+        public void RegisteringATempFileWaitsForTheDatabaseLock()
+            => AssertWaitsForTheDatabaseLock("RegisterTempFile", () => _connection.RegisterTempFile("unittest", Path.Combine(_tempDataFolder, "tempfile.txt"), DateTime.Now.AddDays(1)));
+
+        /// <summary>
+        /// The symptom itself: a reader and the log purge running at the same time, which is what
+        /// a timer tick during a REST request amounts to. Without the lock the reader fails with
+        /// "The transaction object is not associated with the same connection object as this
+        /// command" the first time it lands inside the purge's transaction.
+        /// </summary>
+        [Test]
+        public void ReadingWhileTheLogIsPurgedReportsNoError()
+        {
+            for (var i = 0; i < 5; i++)
+                _connection.LogError(null, "unittest", new Exception("unittest"));
+
+            var errors = new ConcurrentQueue<Exception>();
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+
+            void Hammer(Action call)
+            {
+                while (DateTime.UtcNow < deadline)
+                {
+                    try
+                    {
+                        call();
+                    }
+                    catch (Exception ex)
+                    {
+                        errors.Enqueue(ex);
+                        return;
+                    }
+                }
+            }
+
+            var purging = Task.Run(() => Hammer(() => _connection.PurgeLogData(DateTime.Now)));
+            var reading = Task.Run(() => Hammer(() =>
+            {
+                _ = _connection.Backups;
+                _ = _connection.GetNotifications();
+            }));
+
+            Assert.IsTrue(Task.WaitAll([purging, reading], CompletionMilliseconds), "the workers did not finish");
+            Assert.IsEmpty(errors, $"reading while the log was purged failed: {string.Join(Environment.NewLine, errors.Select(x => x.Message))}");
+        }
+    }
+}


### PR DESCRIPTION
The `Playwright UI tests` job failed on the CI run for
[#7293](https://github.com/duplicati/duplicati/pull/7293) — a branch whose diff is one condition in
the remote synchronization tool, which that test never touches. The UI test timed out clicking a
file in the restore list, and the server log says why:

```
fail: Duplicati.WebserverCore.DuplicatiWebserver[0]
System.InvalidOperationException: The transaction object is not associated with the same
  connection object as this command.
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
   at Duplicati.Server.Database.Connection.Read[T](IDbCommand cmd, Func`2 f)
   at Duplicati.Server.Database.Connection.GetBackupTargetUrls(Int64 backupId)
   at Duplicati.Server.Database.Backup.LoadChildren(Connection con)      Backup.cs:54
   at Duplicati.Server.Database.Connection.GetBackup(Int64 id)           Connection.cs:565
   at ...Endpoints.V1.Backup.BackupPost.GetBackup(...)
```

## Why that exception

Microsoft.Data.Sqlite refuses a command whose transaction is not the connection's current one — and
**`null` counts**. The read helper on `Connection` attaches none:

```csharp
private IEnumerable<T> ReadFromDb<T>(Func<IDataReader, T> f, Action<IDbCommand>? prep)
{
    using (var cmd = m_connection.CreateCommand())   // Transaction stays null
```

So *any* read fails while *any* transaction is open on that connection. The class already knows
this: it keeps one connection and serializes access with `lock (m_lock)`, and over forty methods
take it.

## The paths that did not

| path | called from | when it runs |
|---|---|---|
| `PurgeLogData` (opens a transaction) | `Program.cs:536`, a `System.Threading.Timer` (armed at :544) | **concurrent with every REST request** |
| `RegisterTempFile` | `Runner.cs:993`, `CreateReport` | **on the queue runner's worker thread** |
| `FixInvalidBackupId` (opens a transaction) | `Program.cs:263` | startup, before the webserver is listening |
| `DeleteFromDb`, transaction-less branch | four call sites inside `Connection.cs` | only reachable from callers already holding the lock |

The first one is the failure above: the timer fires, opens its transaction, and a REST read that
lands in that window gets a 500. The window is short, which is why this shows up rarely and on a
branch that has nothing to do with it — and a UI test issues enough requests to find it.

`RegisterTempFile` is the second real one. It is not a transaction, but it inserts and then reads
`last_insert_rowid()` in a separate statement, so a concurrent writer can hand it back somebody
else's id.

## The change

Those four take the lock. **No SQL and no logic changed** — the diff is the `lock` statement and the
indentation it forces. The settings write at the end of `FixInvalidBackupId` is deliberately left
outside it, because saving a setting signals the rest of the server and there is no reason to do
that while holding the connection.

The read side is untouched on purpose. Making reads join whatever transaction happens to be open
would put them inside someone else's write, which is not what a reader wants; what was missing here
is the serialization, not the transaction.

**No deadlock risk**: all four are leaves that issue SQL and call nothing else, `lock` is reentrant
for the thread that already holds it, and `m_lock` is the same public object that `BackupListService`,
`BackupPutDelete` and `ServerSettings` already take around their own sequences.

## Red, then green

`Duplicati/UnitTest/ServerDatabaseLockingTests.cs` is new. It builds a real server database the way
`RelativeDbPathTests` does — `SQLiteLoader.LoadConnectionAsync`, `DatabaseUpgrader.UpgradeDatabase`,
`new Connection(...)` — so it needs nothing but a temp folder.

| test | before | after |
|---|---|---|
| reading while the log is purged reports no error | **red** — the CI exception, in one second | green |
| the log purge waits for the database lock | **red** | green |
| registering a temp file waits for the database lock | **red** | green |

```
ReadingWhileTheLogIsPurgedReportsNoError
  reading while the log was purged failed:
  The transaction object is not associated with the same connection object as this command.

ThePurgeOfLogDataWaitsForTheDatabaseLock
  PurgeLogData used the connection while the database lock was held by another thread

RegisteringATempFileWaitsForTheDatabaseLock
  RegisterTempFile used the connection while the database lock was held by another thread
```

The first test is the symptom — two threads, one reading and one purging, asserting that neither
throws. It reproduces the CI failure locally and to the character.

The other two do not race at all. `m_lock` is public, so the test can hold it, start the call on
another thread, and assert that it has **not** finished half a second later — then release and
assert that it finishes. That pins "this path takes the lock" without depending on winning a race,
which is what keeps them from going quiet if the timing changes.

Full solution build: 0 errors, 0 warnings.

## Not measured

- **I did not reproduce the CI run itself.** The mechanism is reproduced exactly and the exception
  matches, but that particular Playwright failure cannot be replayed.
- **How long the lock is now held** in the purge and the temp-file write — both are single
  statements against small tables, so this should not be visible, but I did not measure contention
  under load.

## Found while measuring, not fixed here

`ReWriteAllFieldsIfEncryptionChanged` (`Connection.cs:131`) is the one remaining unlocked path, and
it is not startup-only in the way it looks: `Program.cs:324` runs it **after** the webserver starts
(:295) and after both timers are armed (:305-306). It holds no lock while it runs `VACUUM` and
re-encrypts every stored field.

I left it alone because the fix is not free: wrapping it would hold the database lock for the whole
`VACUUM` and rewrite, which would stall REST for as long as that takes. Serializing it is clearly
more correct, and how much startup latency that is worth is your call rather than mine.
