### PR TITLE
Support path in source tool

### DIFF
--- a/Duplicati/CommandLine/SourceTool/Commands/List.cs
+++ b/Duplicati/CommandLine/SourceTool/Commands/List.cs
@@ -19,6 +19,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Duplicati.Library.Interface;
 
 namespace Duplicati.CommandLine.SourceTool.Commands;
 
@@ -28,43 +31,139 @@ namespace Duplicati.CommandLine.SourceTool.Commands;
 public static class List
 {
     /// <summary>
+    /// The JSON serializer options used for JSON output
+    /// </summary>
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    /// <summary>
+    /// DTO for a single entry in JSON output
+    /// </summary>
+    /// <param name="Path">The path of the entry</param>
+    /// <param name="IsFolder">True if the entry is a folder</param>
+    /// <param name="IsMetaEntry">True if the entry is a meta entry</param>
+    /// <param name="IsRootEntry">True if the entry is the root entry</param>
+    /// <param name="CreatedUtc">The creation time of the entry</param>
+    /// <param name="LastModificationUtc">The last modification time of the entry</param>
+    /// <param name="Size">The size of the entry</param>
+    /// <param name="IsSymlink">True if the entry is a symlink</param>
+    /// <param name="SymlinkTarget">The target of the symlink, if the entry is a symlink</param>
+    /// <param name="Attributes">The entry attributes</param>
+    /// <param name="IsBlockDevice">True if the entry is a block device</param>
+    /// <param name="IsCharacterDevice">True if the entry is a character device</param>
+    /// <param name="IsAlternateStream">True if the entry is an alternate stream</param>
+    /// <param name="HardlinkTargetId">The hardlink target id, if the entry is a hardlink</param>
+    /// <param name="Metadata">The minor metadata of the entry</param>
+    private sealed record EntryDto(
+        string Path,
+        bool IsFolder,
+        bool IsMetaEntry,
+        bool IsRootEntry,
+        DateTime CreatedUtc,
+        DateTime LastModificationUtc,
+        long Size,
+        bool IsSymlink,
+        string? SymlinkTarget,
+        FileAttributes Attributes,
+        bool IsBlockDevice,
+        bool IsCharacterDevice,
+        bool IsAlternateStream,
+        string? HardlinkTargetId,
+        Dictionary<string, string?> Metadata
+    );
+
+    /// <summary>
     /// Creates the list command
     /// </summary>
     /// <returns>The command</returns>
     public static Command Create()
     {
         var urlArgument = new Argument<string>("url") { Description = "The source URL", Arity = ArgumentArity.ExactlyOne };
+        var pathArgument = new Argument<string?>("path") { Description = "The path to start listing from", Arity = ArgumentArity.ZeroOrOne };
         var maxDepthOption = new Option<int>("--max-depth") { Description = "The maximum depth to list", DefaultValueFactory = _ => 0 };
+        var outputJsonOption = new Option<bool>("--output-json") { Description = "Output as JSON", DefaultValueFactory = _ => false };
 
         var cmd = new Command("list", "Lists all paths on the remote")
         {
             urlArgument,
-            maxDepthOption
+            pathArgument,
+            maxDepthOption,
+            outputJsonOption
         };
 
         cmd.SetAction(async (parseResult, cancellationToken) =>
         {
             var url = parseResult.GetValue(urlArgument)!;
+            var path = parseResult.GetValue(pathArgument);
             var maxdepth = parseResult.GetValue(maxDepthOption);
+            var outputjson = parseResult.GetValue(outputJsonOption);
 
             var folders = 0L;
             var files = 0L;
+            var entries = outputjson ? new List<EntryDto>() : null;
 
             using var source = await Common.GetProvider(url);
-            await Common.Visit(source, maxdepth, (entry, level) =>
+
+            var visitor = async (ISourceProviderEntry entry, int level) =>
             {
                 if (entry.IsFolder)
                     folders++;
                 else
                     files++;
-                if (entry.IsFolder && level > 0)
-                    level--;
-                if (!entry.IsRootEntry)
-                    Console.WriteLine($"{new string(' ', (level + 1) * 2)}{entry.Path}");
-                return Task.FromResult(true);
-            }, cancellationToken);
 
-            Console.WriteLine($"Found {folders} folders and {files} files");
+                if (entries != null)
+                {
+                    if (!entry.IsRootEntry)
+                        entries.Add(new EntryDto(
+                            entry.Path,
+                            entry.IsFolder,
+                            entry.IsMetaEntry,
+                            entry.IsRootEntry,
+                            entry.CreatedUtc,
+                            entry.LastModificationUtc,
+                            entry.Size,
+                            entry.IsSymlink,
+                            entry.SymlinkTarget,
+                            entry.Attributes,
+                            entry.IsBlockDevice,
+                            entry.IsCharacterDevice,
+                            entry.IsAlternateStream,
+                            entry.HardlinkTargetId,
+                            await entry.GetMinorMetadata(cancellationToken)
+                        ));
+                }
+                else
+                {
+                    if (entry.IsFolder && level > 0)
+                        level--;
+                    if (!entry.IsRootEntry)
+                        Console.WriteLine($"{new string(' ', (level + 1) * 2)}{entry.Path}");
+                }
+
+                return true;
+            };
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                await Common.Visit(source, maxdepth, visitor, cancellationToken);
+            }
+            else
+            {
+                var entry = await source.GetEntryAsync(path, true, cancellationToken);
+                if (entry == null || !entry.IsFolder)
+                    throw new UserInformationException("Folder does not exist", "FolderDoesNotExist");
+
+                await Common.Visit(entry, maxdepth, visitor, cancellationToken);
+            }
+
+            if (entries != null)
+                Console.WriteLine(JsonSerializer.Serialize(entries, JsonOptions));
+            else
+                Console.WriteLine($"Found {folders} folders and {files} files");
         });
 
         return cmd;

--- a/Duplicati/CommandLine/SourceTool/ListEnumerator.cs
+++ b/Duplicati/CommandLine/SourceTool/ListEnumerator.cs
@@ -35,10 +35,43 @@ public static partial class Common
     /// <param name="visitor">The visitor function</param>
     /// <param name="token">The cancellation token</param>
     /// <returns>An awaitable task</returns>
-    public static async Task Visit(ISourceProvider source, int maxdepth, Func<ISourceProviderEntry, int, Task<bool>> visitor, CancellationToken token)
+    public static Task Visit(ISourceProvider source, int maxdepth, Func<ISourceProviderEntry, int, Task<bool>> visitor, CancellationToken token)
+        => Visit(source.EnumerateAsync(token), maxdepth, visitor, token);
+
+    /// <summary>
+    /// Visits all entries from a starting entry
+    /// </summary>
+    /// <param name="entry">The entry to start visiting from</param>
+    /// <param name="maxdepth">The maximum depth to visit</param>
+    /// <param name="visitor">The visitor function</param>
+    /// <param name="token">The cancellation token</param>
+    /// <returns>An awaitable task</returns>
+    public static Task Visit(ISourceProviderEntry entry, int maxdepth, Func<ISourceProviderEntry, int, Task<bool>> visitor, CancellationToken token)
+        => Visit(EnumerateSingle(entry), maxdepth, visitor, token);
+
+    /// <summary>
+    /// Wraps a single entry in an async enumerable
+    /// </summary>
+    /// <param name="entry">The entry to wrap</param>
+    /// <returns>The async enumerable with the single entry</returns>
+    private static async IAsyncEnumerable<ISourceProviderEntry> EnumerateSingle(ISourceProviderEntry entry)
+    {
+        await Task.CompletedTask;
+        yield return entry;
+    }
+
+    /// <summary>
+    /// Visits all entries from the given entries
+    /// </summary>
+    /// <param name="entries">The entries to visit</param>
+    /// <param name="maxdepth">The maximum depth to visit</param>
+    /// <param name="visitor">The visitor function</param>
+    /// <param name="token">The cancellation token</param>
+    /// <returns>An awaitable task</returns>
+    private static async Task Visit(IAsyncEnumerable<ISourceProviderEntry> entries, int maxdepth, Func<ISourceProviderEntry, int, Task<bool>> visitor, CancellationToken token)
     {
         var visit = new Stack<(ISourceProviderEntry Entry, int Level)>();
-        await foreach (var item in source.EnumerateAsync(token))
+        await foreach (var item in entries.WithCancellation(token))
             visit.Push((item, 0));
 
         while (visit.Count() != 0)

--- a/Duplicati/Library/SourceProvider/Builtin/BackendSourceFileEntry.cs
+++ b/Duplicati/Library/SourceProvider/Builtin/BackendSourceFileEntry.cs
@@ -329,15 +329,5 @@ public class BackendSourceFileEntry(BackendSourceProvider parent, string path, b
             .Replace('/', separator)
             .Replace('\\', separator);
     }
-
-    /// <summary>
-    /// Creates a new backend source entry from a file entry
-    /// </summary>
-    /// <param name="parent">The parent backend</param>
-    /// <param name="entry">The file entry</param>
-    /// <param name="prefix">The prefix to add to the path</param>
-    /// <returns>The new backend source entry</returns>
-    public static BackendSourceFileEntry FromFileEntry(BackendSourceProvider parent, string prefix, IFileEntry entry)
-        => new BackendSourceFileEntry(parent, SystemIO.IO_OS.PathCombine(prefix, entry.Name), entry.IsFolder, false, entry.Created, entry.LastModification, entry.Size);
 }
 

--- a/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
+++ b/Duplicati/Library/SourceProvider/Builtin/BackendSourceProvider.cs
@@ -97,7 +97,9 @@ public class BackendSourceProvider(IFolderEnabledBackend backend, string mounted
     public async Task<ISourceProviderEntry?> GetEntryAsync(string path, bool isFolder, CancellationToken cancellationToken)
     {
         var entry = await backend.GetEntryAsync(BackendSourceFileEntry.NormalizePathTo(path, '/'), cancellationToken).ConfigureAwait(false);
-        return entry == null ? null : BackendSourceFileEntry.FromFileEntry(this, path, entry);
+        return entry == null
+            ? null
+            : new BackendSourceFileEntry(this, path, entry.IsFolder, false, entry.Created, entry.LastModification, entry.Size);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
This adds support for supplying a path to the SourceTool, such that the url can be kept the same while exploring different sub-paths