### PR TITLE
Say which dlist files were there when FilesetFiles fails

### DIFF
--- a/Duplicati/UnitTest/DisruptionTests.cs
+++ b/Duplicati/UnitTest/DisruptionTests.cs
@@ -151,25 +151,37 @@ namespace Duplicati.UnitTest
                 return (map, filelistFiles);
             }
 
+            // The assertions below are about which dlist file describes which backup, and the file
+            // times are what order them, so a failure can only be read with both in front of it.
+            static string Explain(Dictionary<DateTime, int> map, string versions)
+                => "dlist files: "
+                    + (map.Count == 0
+                        ? "none"
+                        : string.Join(", ", map.OrderByDescending(x => x.Key).Select(x => $"{x.Key:u} {(x.Value == BackupType.FULL_BACKUP ? "full" : "partial")}")))
+                    + $"; database versions: {versions}";
+
             // Purge a file and verify that the fileset file exists in the new dlist files.
             List<string> dlistFiles;
             Dictionary<DateTime, int> backupTypeMap;
+            string versionsAfterPurge;
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
                 TestUtils.AssertResults(await c.PurgeFilesAsync(new Library.Utility.FilterExpression($"{this.DATAFOLDER}/*{this.fileSizes[0]}*")));
 
                 var filesets = (await c.ListAsync()).Filesets.ToList();
-                Assert.AreEqual(2, filesets.Count);
-                Assert.AreEqual(BackupType.FULL_BACKUP, filesets.Single(x => x.Version == 1).IsFullBackup);
-                Assert.AreEqual(BackupType.PARTIAL_BACKUP, filesets.Single(x => x.Version == 0).IsFullBackup);
+                versionsAfterPurge = string.Join(", ", filesets.OrderBy(x => x.Version).Select(x => $"#{x.Version} at {x.Time:u} {(x.IsFullBackup == BackupType.FULL_BACKUP ? "full" : "partial")}"));
+                Assert.AreEqual(2, filesets.Count, versionsAfterPurge);
+                Assert.AreEqual(BackupType.FULL_BACKUP, filesets.Single(x => x.Version == 1).IsFullBackup, versionsAfterPurge);
+                Assert.AreEqual(BackupType.PARTIAL_BACKUP, filesets.Single(x => x.Version == 0).IsFullBackup, versionsAfterPurge);
 
                 (backupTypeMap, dlistFiles) = await GetBackupTypesFromRemoteFilesAsync(c);
             }
 
             var backupTypes = backupTypeMap.OrderByDescending(x => x.Key).Select(x => x.Value).ToArray();
-            Assert.AreEqual(2, backupTypes.Length);
-            Assert.AreEqual(BackupType.FULL_BACKUP, backupTypes[1]);
-            Assert.AreEqual(BackupType.PARTIAL_BACKUP, backupTypes[0]);
+            var explainedAfterPurge = Explain(backupTypeMap, versionsAfterPurge);
+            Assert.AreEqual(2, backupTypes.Length, "after the purge, " + explainedAfterPurge);
+            Assert.AreEqual(BackupType.FULL_BACKUP, backupTypes[1], "after the purge the older dlist file is not the full backup: " + explainedAfterPurge);
+            Assert.AreEqual(BackupType.PARTIAL_BACKUP, backupTypes[0], "after the purge the newer dlist file is not the partial backup: " + explainedAfterPurge);
 
             // Remove the dlist files.
             foreach (string dlistFile in dlistFiles)
@@ -178,22 +190,27 @@ namespace Duplicati.UnitTest
             }
 
             // Run a repair and verify that the fileset file exists in the new dlist files.
+            string versionsAfterRepair;
             using (var c = new Controller("file://" + this.TARGETFOLDER, options, null))
             {
                 TestUtils.AssertResults(await c.RepairAsync());
 
                 var filesets = (await c.ListAsync()).Filesets.ToList();
-                Assert.AreEqual(2, filesets.Count);
-                Assert.AreEqual(BackupType.FULL_BACKUP, filesets.Single(x => x.Version == 1).IsFullBackup);
-                Assert.AreEqual(BackupType.PARTIAL_BACKUP, filesets.Single(x => x.Version == 0).IsFullBackup);
+                versionsAfterRepair = string.Join(", ", filesets.OrderBy(x => x.Version).Select(x => $"#{x.Version} at {x.Time:u} {(x.IsFullBackup == BackupType.FULL_BACKUP ? "full" : "partial")}"));
+                Assert.AreEqual(2, filesets.Count, versionsAfterRepair);
+                Assert.AreEqual(BackupType.FULL_BACKUP, filesets.Single(x => x.Version == 1).IsFullBackup, versionsAfterRepair);
+                Assert.AreEqual(BackupType.PARTIAL_BACKUP, filesets.Single(x => x.Version == 0).IsFullBackup, versionsAfterRepair);
 
                 (backupTypeMap, _) = await GetBackupTypesFromRemoteFilesAsync(c);
             }
 
             backupTypes = backupTypeMap.OrderByDescending(x => x.Key).Select(x => x.Value).ToArray();
-            Assert.AreEqual(2, backupTypes.Length);
-            Assert.AreEqual(BackupType.FULL_BACKUP, backupTypes[1]);
-            Assert.AreEqual(BackupType.PARTIAL_BACKUP, backupTypes[0]);
+
+            // The repair writes each replacement under a name that is free, so these say what the
+            // repair produced. Before it, they said only that a number was not the one expected.
+            Assert.AreEqual(2, backupTypes.Length, "after the repair, " + Explain(backupTypeMap, versionsAfterRepair) + "; before the repair, " + explainedAfterPurge);
+            Assert.AreEqual(BackupType.FULL_BACKUP, backupTypes[1], "after the repair the older dlist file is not the full backup: " + Explain(backupTypeMap, versionsAfterRepair));
+            Assert.AreEqual(BackupType.PARTIAL_BACKUP, backupTypes[0], "after the repair the newer dlist file is not the partial backup: " + Explain(backupTypeMap, versionsAfterRepair));
         }
 
         [Test]


### PR DESCRIPTION
`DisruptionTests.FilesetFilesAsync` failed on `Unit tests (ubuntu-latest)` during the CI run for
[#7290](https://github.com/duplicati/duplicati/pull/7290) — a branch that changes a Google Drive
backend method and cannot reach this test. macOS and Windows passed in the same run. This is
everything the run had to say about it:

```
Failed FilesetFilesAsync [4 s]
  Assert.That(actual, Is.EqualTo(expected))
  Expected: 1
  But was:  0
   at Duplicati.UnitTest.DisruptionTests.FilesetFilesAsync() in DisruptionTests.cs:line 195
```

Line 195 asserts that **the older of the two dlist files at the destination is the full backup**,
after a repair has replaced both of them. Two quite different faults produce that same `0`:

- the two files swapped places — the repair gives each replacement a new name, and the name carries
  the time that orders them; or
- the file describing the full backup was written as partial.

The numbers cannot tell those apart, and the times that would are in the file names, which the run
never printed. So the occurrence was unreadable.

## What the assertions say now

```
after the repair the older dlist file is not the full backup:
dlist files: 2026-09-09 13:32:47Z partial, 2026-09-09 13:32:31Z full;
database versions: #0 at 2026-09-09 22:32:46Z partial, #1 at 2026-09-09 22:32:30Z full
```

Both dlist files with the flag each one carries, and the versions the database holds beside them.
That distinguishes the two explanations immediately, and it also shows whether the destination and
the database agree — the failing run asserted the database side first and passed it, so they had
already diverged by the time the file assertion ran.

The checks before the repair carry the same description, so the next occurrence also says whether
the purge or the repair produced the state.

The output above is real: I inverted one assertion to make it fail and captured what it printed.
A diagnostic that has never failed once is not a diagnostic.

## This fixes nothing, and I could not reproduce it

Before settling for this, I tried to make it fail — **105 runs, all green**:

| what | runs | failures |
|---|---|---|
| the test alone on ubuntu, spacing between the two backups 2000 / 200 / 0 ms, idle and under load | 48 | 0 |
| the test alone on ubuntu, 10 iterations, idle and under load | 20 | 0 |
| the whole `Disruption` class, 4 passes, idle and under load | 8 | 0 |
| the test alone with `--collect:"XPlat Code Coverage"` | 20 | 0 |
| **the full unit suite exactly as `tests.yml` runs it**, twice, ~42 min each | 2 suites | 0 |
| locally on Windows, varying file sizes and spacing | 7 | 0 |

**One hypothesis is disproved by measurement.** The repair replaces a missing dlist under a new
name, probing one second forward until a name is free, so I expected the older version's name to be
able to overtake the newer one's. The margin says otherwise — the two versions are never close
enough for a one-second step to matter:

| where | full backup dlist | partial backup dlist | gap | moved by the repair |
|---|---|---|---|---|
| ubuntu CI, no spacing, under load | 12:02:52 | 12:02:56 | 4 s | +1 s each |
| locally, 1/2/3 MB files, no spacing | 12:03:12 | 12:03:17 | 5 s | +1 s each |
| locally, the test's own 10/20/30 MB files | 11:54:56 | 11:55:14 | 18 s | +1 s each |

Overtaking would need four or more consecutive taken names; every measured probe found a free name
on the first step. So whatever this is, it is not that — which is worth knowing before someone else
spends the same day on it.

## Not measured

- **The failure itself.** Everything above is a negative result: I cannot say what happens, only
  that the next occurrence will now carry the evidence.
- The test still asserts exactly what it asserted before. Nothing about the product changed.
