### PR TITLE
Root the data folder when the account has no home folder

### DIFF
--- a/Duplicati/CommandLine/DatabaseTool/Commands/Verify.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Commands/Verify.cs
@@ -217,11 +217,7 @@ public static class Verify
                 {
                     var path = rd.ConvertValueToString(0);
                     if (!string.IsNullOrEmpty(path))
-                    {
-                        if (!Path.IsPathRooted(path))
-                            path = Path.Combine(datafolder, path);
-                        serverDbPaths.Add(Path.GetFullPath(path));
-                    }
+                        serverDbPaths.Add(Path.GetFullPath(DataFolderManager.ResolveDataFolderRelativePath(datafolder, path)));
                 }
             }
             catch (Exception ex)

--- a/Duplicati/CommandLine/DatabaseTool/Helper.cs
+++ b/Duplicati/CommandLine/DatabaseTool/Helper.cs
@@ -79,7 +79,7 @@ public static class Helper
                     var rawPath = rd.ConvertValueToString(0) ?? "";
                     if (!string.IsNullOrEmpty(rawPath))
                     {
-                        var resolvedPath = Path.IsPathRooted(rawPath) ? rawPath : Path.Combine(datafolder, rawPath);
+                        var resolvedPath = DataFolderManager.ResolveDataFolderRelativePath(datafolder, rawPath);
                         dbpaths.Add(Path.GetFullPath(resolvedPath));
                     }
                 }

--- a/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderLocator.cs
@@ -78,12 +78,16 @@ public static class DataFolderLocator
     /// </summary>
     /// <param name="targetfilename">The filename to look for</param>
     /// <param name="appName">The name of the application</param>
+    /// <param name="applicationDataFolder">The application data folder to build the path from;
+    /// defaults to the folder reported by the operating system. This is a seam for the tests,
+    /// because the no-home-folder case cannot be provoked through the environment: clearing HOME
+    /// still yields a folder through the password database.</param>
     /// <returns>The default storage folder</returns>
-    internal static string GetDefaultStorageFolderInternal(string targetfilename, string appName)
+    internal static string GetDefaultStorageFolderInternal(string targetfilename, string appName, string? applicationDataFolder = null)
     {
         //Normal mode uses the systems "(Local) Application Data" folder
         // %LOCALAPPDATA% on Windows, ~/.config on Linux
-        var folder = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appName);
+        var folder = System.IO.Path.Combine(applicationDataFolder ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appName);
 
         if (OperatingSystem.IsWindows())
         {
@@ -134,15 +138,23 @@ public static class DataFolderLocator
             // Special handling for Linux with no home folder:
             //   - Older versions use /
             //   - but new versions use /var/lib/
-            var libfolder = System.IO.Path.Combine("var", "lib", appName);
+            // Both candidates are rooted explicitly. The application data folder is reported as an
+            // empty string when the process runs under an account with no home folder, which leaves
+            // this folder relative, and a relative data folder is resolved against the working
+            // directory of whichever process reads it. The server database also stores it verbatim
+            // as the database path of a backup, which is then joined onto the data folder a second
+            // time, producing /var/lib/Duplicati/var/lib/Duplicati/<name>.sqlite (issue #7284).
+            var rootfolder = System.IO.Path.Combine("/", appName);
+            var libfolder = System.IO.Path.Combine("/", "var", "lib", appName);
 
             var curfile = System.IO.Path.Combine(libfolder, targetfilename);
-            var prevfile = System.IO.Path.Combine(folder, targetfilename);
+            var prevfile = System.IO.Path.Combine(rootfolder, targetfilename);
 
             // If the old file exists, and not the new file, we use the old
             // Otherwise we use the new location
-            if (System.IO.File.Exists(curfile) || !System.IO.File.Exists(prevfile))
-                folder = libfolder;
+            folder = System.IO.File.Exists(curfile) || !System.IO.File.Exists(prevfile)
+                ? libfolder
+                : rootfolder;
         }
 
         return folder;

--- a/Duplicati/Library/AutoUpdater/DataFolderManager.cs
+++ b/Duplicati/Library/AutoUpdater/DataFolderManager.cs
@@ -160,6 +160,45 @@ public static class DataFolderManager
     }
 
     /// <summary>
+    /// Resolves a path that is stored relative to the data folder.
+    ///
+    /// Database paths have been stored relative to the data folder since 2.4.0.0. Installs made
+    /// before the data folder itself was rooted stored something else: a Linux service with no home
+    /// folder resolved its data folder to the relative path "var/lib/Duplicati", and the paths
+    /// written into the server database were joined onto that, so they name the file from the root
+    /// without saying so, as in "var/lib/Duplicati/XXXX.sqlite". Joining such a value onto the data
+    /// folder again doubles it (issue #7284), so a relative path that begins with the data folder's
+    /// own path minus its root is resolved against that root instead.
+    ///
+    /// The rule is textual: the filesystem is never consulted, so the answer does not depend on
+    /// which files happen to exist.
+    /// </summary>
+    /// <param name="dataFolder">The data folder that a relative path is relative to.</param>
+    /// <param name="path">The stored path.</param>
+    /// <returns>The resolved path. An empty or already rooted path is returned unchanged.</returns>
+    public static string ResolveDataFolderRelativePath(string dataFolder, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path))
+            return path ?? "";
+
+        if (string.IsNullOrWhiteSpace(dataFolder))
+            return Path.GetFullPath(path);
+
+        // The separator is appended before the root is removed, so the prefix always ends on a
+        // directory boundary and a sibling folder with a longer name does not match
+        var fullDataFolder = Util.AppendDirSeparator(Path.GetFullPath(dataFolder));
+        var root = Path.GetPathRoot(fullDataFolder) ?? "";
+        var rootless = fullDataFolder.Substring(root.Length);
+
+        // An empty remainder means the data folder is the root itself; there is then no prefix to
+        // look for, and an empty prefix would match every path
+        if (rootless.Length > 0 && path.StartsWith(rootless, Library.Utility.Utility.ClientFilenameStringComparison))
+            return Path.GetFullPath(Path.Combine(root, path));
+
+        return Path.GetFullPath(Path.Combine(fullDataFolder, path));
+    }
+
+    /// <summary>
     /// Prepares a data folder for secure use.
     ///
     /// The rules are:

--- a/Duplicati/Library/RestAPI/Database/Connection.cs
+++ b/Duplicati/Library/RestAPI/Database/Connection.cs
@@ -764,12 +764,7 @@ namespace Duplicati.Server.Database
         /// <param name="dbPath">The DB path to resolve.</param>
         /// <returns>The absolute DB path.</returns>
         private string ResolveDbPath(string? dbPath)
-        {
-            if (string.IsNullOrWhiteSpace(dbPath) || Path.IsPathRooted(dbPath))
-                return dbPath ?? "";
-
-            return Path.GetFullPath(Path.Combine(m_dataFolder, dbPath));
-        }
+            => DataFolderManager.ResolveDataFolderRelativePath(m_dataFolder, dbPath);
 
         /// <summary>
         /// Converts an absolute DB path to a relative path if it is under the data folder.
@@ -785,7 +780,15 @@ namespace Duplicati.Server.Database
             var fullDbPath = Path.GetFullPath(dbPath);
 
             if (fullDbPath.StartsWith(fullDataFolder, Library.Utility.Utility.ClientFilenameStringComparison))
-                return fullDbPath.Substring(fullDataFolder.Length);
+            {
+                var relative = fullDbPath.Substring(fullDataFolder.Length);
+
+                // Only store the relative form if it reads back as the same path. ResolveDbPath
+                // reinterprets a relative path that begins with the data folder's own path minus
+                // its root, so a database placed in a folder of that shape has to stay absolute
+                if (string.Equals(ResolveDbPath(relative), fullDbPath, Library.Utility.Utility.ClientFilenameStringComparison))
+                    return relative;
+            }
 
             return dbPath;
         }

--- a/Duplicati/UnitTest/DataFolderLocatorTests.cs
+++ b/Duplicati/UnitTest/DataFolderLocatorTests.cs
@@ -1,0 +1,121 @@
+// Copyright (C) 2026, The Duplicati Team
+// https://duplicati.com, hello@duplicati.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.IO;
+using Duplicati.Library.AutoUpdater;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+
+namespace Duplicati.UnitTest
+{
+    /// <summary>
+    /// The data folder has to be an absolute path. An account with no home folder gets an empty
+    /// application data folder from the operating system, and the Linux fallback that then takes
+    /// over used to answer with the relative path "var/lib/Duplicati". Every consumer resolves such
+    /// a path against its own working directory, and the server database stored it as part of a
+    /// backup's database path, where it was joined onto the data folder a second time (issue #7284).
+    ///
+    /// The application data folder is injected, because the case cannot be provoked through the
+    /// environment: clearing HOME still yields a folder through the password database.
+    /// </summary>
+    [TestFixture]
+    [Category("DataFolderLocator")]
+    public class DataFolderLocatorTests
+    {
+        /// <summary>
+        /// An application name no installation can own, so neither candidate folder exists on the
+        /// machine running the test and the branch outcome is fixed.
+        /// </summary>
+        private static string UniqueAppName() => $"duplicati-locator-test-{Guid.NewGuid():N}";
+
+        /// <summary>
+        /// Skips a test on the platforms where the fallback does not run.
+        /// </summary>
+        private static void RequireLinux()
+        {
+            if (!OperatingSystem.IsLinux())
+                Assert.Ignore("The no-home-folder fallback is Linux-only.");
+        }
+
+        /// <summary>
+        /// No home folder at all, and a home folder that is the root: both are the shapes that send
+        /// the lookup into the fallback.
+        /// </summary>
+        [TestCase("")]
+        [TestCase("/")]
+        public void TheNoHomeFolderFallbackIsRooted(string applicationDataFolder)
+        {
+            RequireLinux();
+
+            var appName = UniqueAppName();
+            var folder = DataFolderLocator.GetDefaultStorageFolderInternal($"{appName}.sqlite", appName, applicationDataFolder);
+
+            Assert.AreEqual(Path.Combine("/", "var", "lib", appName), folder);
+            Assert.IsTrue(Path.IsPathRooted(folder), $"The data folder is not an absolute path: {folder}");
+        }
+
+        /// <summary>
+        /// The other half of the fallback: an installation that predates /var/lib keeps the folder
+        /// it is already using, and that one has to be rooted as well. The application name is "tmp"
+        /// because /tmp is the only folder directly below the root that a test can write to.
+        /// </summary>
+        [Test]
+        public void TheLegacyRootFolderIsRootedWhenItIsInUse()
+        {
+            RequireLinux();
+
+            var targetfilename = $"duplicati-locator-test-{Guid.NewGuid():N}.sqlite";
+            var probe = Path.Combine("/tmp", targetfilename);
+            File.WriteAllText(probe, "");
+
+            try
+            {
+                var folder = DataFolderLocator.GetDefaultStorageFolderInternal(targetfilename, "tmp", "");
+
+                Assert.AreEqual("/tmp", folder);
+                Assert.IsTrue(Path.IsPathRooted(folder), $"The data folder is not an absolute path: {folder}");
+            }
+            finally
+            {
+                File.Delete(probe);
+            }
+        }
+
+        /// <summary>
+        /// An ordinary account is not affected: the fallback only runs when the application data
+        /// folder gives nothing to work with.
+        /// </summary>
+        [Test]
+        public void AnApplicationDataFolderThatExistsIsUsedAsIs()
+        {
+            RequireLinux();
+
+            var appName = UniqueAppName();
+            var applicationDataFolder = Path.Combine("/home", "someone", ".config");
+
+            Assert.AreEqual(Path.Combine(applicationDataFolder, appName),
+                DataFolderLocator.GetDefaultStorageFolderInternal($"{appName}.sqlite", appName, applicationDataFolder));
+        }
+    }
+}

--- a/Duplicati/UnitTest/DatabaseToolTests.cs
+++ b/Duplicati/UnitTest/DatabaseToolTests.cs
@@ -1103,5 +1103,56 @@ INSERT INTO ""Version"" (""Version"") VALUES (12);
                 Assert.AreEqual("True", (string)cmd.ExecuteScalar());
             }
         }
+
+        /// <summary>
+        /// A Linux installation with no home folder used to resolve its data folder to the relative
+        /// path "var/lib/Duplicati" and stored the database paths joined onto it, so the server
+        /// database holds a path that names the file from the root without saying so. Resolving that
+        /// against the data folder a second time points at a file that is not there, and the real
+        /// database is then reported as orphaned - which is what "cleanup" offers to delete.
+        /// </summary>
+        [Test]
+        [Category("DatabaseTool")]
+        public async Task TestVerifyCommandWithLegacyRootlessDbPathAsync()
+        {
+            using var tempFolder = new Library.Utility.TempFolder();
+            string tempDir = tempFolder;
+
+            var serverTargetPath = Path.Combine(tempDir, "Duplicati-server.sqlite");
+            var localDb = Path.Combine(tempDir, "local1.sqlite");
+
+            // The data folder's own path without its root, which is the shape that was stored
+            var fullDataFolder = Duplicati.Library.Common.IO.Util.AppendDirSeparator(Path.GetFullPath(tempDir));
+            var legacyDbPath = fullDataFolder.Substring((Path.GetPathRoot(fullDataFolder) ?? "").Length) + "local1.sqlite";
+
+            using (var db = await SQLiteLoader.LoadConnectionAsync(serverTargetPath))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = ServerSchemaV6;
+                await cmd.ExecuteNonQueryAsync();
+
+                cmd.CommandText = $@"
+                    INSERT INTO ""Backup"" (""Name"", ""Tags"", ""TargetURL"", ""DBPath"")
+                    VALUES ('Test Backup', '', 'file:///test', '{legacyDbPath.Replace("'", "''")}');
+                ";
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            using (var db = await SQLiteLoader.LoadConnectionAsync(localDb))
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = LocalSchemaV12;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            var results = await Duplicati.CommandLine.DatabaseTool.Commands.Verify
+                .AnalyzeDatabasesAsync(tempDir, includeServer: true);
+
+            var byPath = results.ToDictionary(r => r.Path, StringComparer.OrdinalIgnoreCase);
+
+            Assert.IsTrue(byPath.ContainsKey(localDb), "the database the backup uses should be reported");
+            Assert.AreEqual("Found", byPath[localDb].Status,
+                "the database the backup uses was reported as orphaned, which is what cleanup deletes");
+        }
     }
 }

--- a/Duplicati/UnitTest/RelativeDbPathTests.cs
+++ b/Duplicati/UnitTest/RelativeDbPathTests.cs
@@ -217,5 +217,159 @@ namespace Duplicati.UnitTest
                 Directory.Delete(outsideFolder, true);
             }
         }
+
+        /// <summary>
+        /// Writes a value straight into the DBPath column, so a test can plant the shape an older
+        /// version stored rather than the shape <see cref="Connection.UpdateBackupDBPath"/> writes.
+        /// </summary>
+        private void SetRawDbPath(string backupId, string rawValue)
+        {
+            _connection.ExecuteWithCommand(cmd =>
+            {
+                cmd.CommandText = @"UPDATE ""Backup"" SET ""DBPath"" = @path WHERE ""ID"" = @id";
+
+                var path = cmd.CreateParameter();
+                path.ParameterName = "@path";
+                path.Value = rawValue;
+                cmd.Parameters.Add(path);
+
+                var id = cmd.CreateParameter();
+                id.ParameterName = "@id";
+                id.Value = long.Parse(backupId);
+                cmd.Parameters.Add(id);
+
+                cmd.ExecuteNonQuery();
+            });
+        }
+
+        /// <summary>
+        /// The data folder without its root, ending in a directory separator. A Linux install with
+        /// no home folder resolved its data folder to the relative path "var/lib/Duplicati", and
+        /// the database paths it stored were joined onto that, so they look like this.
+        /// </summary>
+        private string RootlessDataFolder()
+        {
+            var full = Library.Common.IO.Util.AppendDirSeparator(Path.GetFullPath(_tempDataFolder));
+            return full.Substring((Path.GetPathRoot(full) ?? "").Length);
+        }
+
+        /// <summary>
+        /// A path stored before the data folder was rooted names the file from the root, so joining
+        /// it onto the data folder again doubles it (issue #7284).
+        /// </summary>
+        [Test]
+        public void LegacyRootlessDbPath_GetBackup_ResolvesInsideDataFolder()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+            SetRawDbPath(backup.ID!, RootlessDataFolder() + "legacy.sqlite");
+
+            var loadedBackup = _connection.GetBackup(backup.ID);
+            Assert.IsNotNull(loadedBackup);
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(_tempDataFolder, "legacy.sqlite")), loadedBackup!.DBPath,
+                "A path stored by an install whose data folder was itself relative was joined onto the data folder again");
+        }
+
+        /// <summary>
+        /// The backup list reads the same column through its own query, so it has to agree.
+        /// </summary>
+        [Test]
+        public void LegacyRootlessDbPath_BackupsProperty_ResolvesInsideDataFolder()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+            SetRawDbPath(backup.ID!, RootlessDataFolder() + "legacy.sqlite");
+
+            var listed = _connection.Backups.Single();
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(_tempDataFolder, "legacy.sqlite")), listed.DBPath);
+        }
+
+        /// <summary>
+        /// An ordinary relative path with a folder in it is still relative to the data folder, so
+        /// the rule above must not swallow it.
+        /// </summary>
+        [Test]
+        public void RelativeDbPath_WithSubfolder_ResolvesUnderDataFolder()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+            SetRawDbPath(backup.ID!, Path.Combine("sub", "guard.sqlite"));
+
+            var loadedBackup = _connection.GetBackup(backup.ID);
+            Assert.IsNotNull(loadedBackup);
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(_tempDataFolder, "sub", "guard.sqlite")), loadedBackup!.DBPath);
+        }
+
+        /// <summary>
+        /// The match has to be on a whole directory component: a sibling folder whose name merely
+        /// starts with the data folder's name is not the data folder.
+        /// </summary>
+        [Test]
+        public void RelativeDbPath_SiblingOfDataFolderPrefix_IsNotTreatedAsLegacy()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+            var sibling = RootlessDataFolder().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + "-sibling";
+            SetRawDbPath(backup.ID!, Path.Combine(sibling, "guard.sqlite"));
+
+            var loadedBackup = _connection.GetBackup(backup.ID);
+            Assert.IsNotNull(loadedBackup);
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(_tempDataFolder, sibling, "guard.sqlite")), loadedBackup!.DBPath);
+        }
+
+        /// <summary>
+        /// A path that is already absolute is never joined onto anything, including one that points
+        /// inside the data folder.
+        /// </summary>
+        [Test]
+        public void AbsoluteDbPathInsideDataFolder_IsReturnedUnchanged()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+            var absolute = Path.Combine(_tempDataFolder, "abs.sqlite");
+            SetRawDbPath(backup.ID!, absolute);
+
+            var loadedBackup = _connection.GetBackup(backup.ID);
+            Assert.IsNotNull(loadedBackup);
+            Assert.AreEqual(absolute, loadedBackup!.DBPath);
+        }
+
+        /// <summary>
+        /// A data folder that is the root itself has no path to recognise, and an empty prefix would
+        /// match every path.
+        /// </summary>
+        [Test]
+        public void LegacyRule_DataFolderIsRoot_DoesNotRewrite()
+        {
+            var root = Path.GetPathRoot(Path.GetFullPath(_tempDataFolder)) ?? "";
+            Assert.IsNotEmpty(root);
+
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(root, "X.sqlite")),
+                DataFolderManager.ResolveDataFolderRelativePath(root, "X.sqlite"));
+        }
+
+        /// <summary>
+        /// The one path the rule above would misread if it were stored relative: a database that
+        /// really does live in a folder inside the data folder named after the data folder itself.
+        /// It has to survive a write and a read.
+        /// </summary>
+        [Test]
+        public void UpdateBackupDbPath_MirroredNestedPath_RoundTrips()
+        {
+            var backup = CreateTestBackup();
+            _connection.AddOrUpdateBackupAndSchedule(backup, null);
+
+            var newPath = Path.Combine(_tempDataFolder, RootlessDataFolder(), "mirrored.sqlite");
+            Directory.CreateDirectory(Path.GetDirectoryName(newPath)!);
+            File.WriteAllText(newPath, "");
+
+            _connection.UpdateBackupDBPath(backup, newPath);
+
+            var loadedBackup = _connection.GetBackup(backup.ID);
+            Assert.IsNotNull(loadedBackup);
+            Assert.AreEqual(Path.GetFullPath(newPath), loadedBackup!.DBPath);
+        }
     }
 }


### PR DESCRIPTION
## What happens

Reported in #7284: after upgrading to 2.4.0.0, every backup job on a Linux service installation
started using

```
/var/lib/Duplicati/var/lib/Duplicati/SHLJKYLXSX.sqlite
```

instead of `/var/lib/Duplicati/SHLJKYLXSX.sqlite`. A new, nearly empty database was created at the
doubled path and each job then failed with `Found 3874 remote files that are not recorded in local
storage`. The original databases were still there and intact, and pointing each job back at its own
database by hand fixed it without a repair.

## Why

**The data folder was never an absolute path on those installations.** When the account has no home
folder, `DataFolderLocator.GetDefaultStorageFolderInternal` falls back to `/var/lib/<appname>` - but
it built that path without a root:

```csharp
var libfolder = System.IO.Path.Combine("var", "lib", appName);   // "var/lib/Duplicati"
```

It names the intended folder only because the packaged unit file leaves systemd's default working
directory of `/` in place: `ReleaseBuilder/Resources/debian/systemd/duplicati.service` sets no
`User=` and no `WorkingDirectory=`, and `duplicati.default` ships `DAEMON_OPTS=""`, so there is no
`--server-datafolder` either. The Docker image is not affected, because it sets
`XDG_CONFIG_HOME=/data`, and neither is any installation that passes `--server-datafolder`,
`DUPLICATI_HOME` or `--portable-mode`.

**Before 2.4.0.0 that relative string was written into the server database.** `AddOrUpdateBackup`
stored `Path.Combine(dataFolder, name)`, so the `DBPath` column of such an installation holds
`var/lib/Duplicati/XXXX.sqlite`: a path that names the file from the root without saying so. It
worked for the same reason - the process resolved it against `/`.

**2.4.0.0 started reading that column as relative to the data folder.**
[#6970](https://github.com/duplicati/duplicati/pull/6970)
([5c1b477cda5a45c796105a11e12905c36d18b6c1](https://github.com/duplicati/duplicati/commit/5c1b477cda5a45c796105a11e12905c36d18b6c1))
added `ResolveDbPath`, which joins a relative value onto the data folder. The stored path was
therefore combined with the data folder a second time, which is the doubled path in the report.

Two more consequences of a relative data folder, outside what was reported: the `control_dir_v2`
exclusion filter built in `FilterGroups` can never match, because a relative prefix does not match an
absolute source path; and the data folder is handed to child processes through the environment in
`ControllerRpcProxy`, where it is resolved against whatever working directory that process has.

## The change

1. `DataFolderLocator` roots both candidates of the no-home-folder fallback: the current
   `/var/lib/<appname>` and the older `/<appname>` it probes for. With the working directory at `/`
   this is the same folder as before, so an installation that is not affected sees no change.
2. `DataFolderManager.ResolveDataFolderRelativePath` is now the single place that resolves a stored
   path against the data folder. A relative path that begins with the data folder's own path minus
   its root is resolved against that root instead, so the values already in the database keep naming
   the same file. The rule is textual - the filesystem is never consulted - and the prefix ends on a
   directory boundary, so `var/lib/DuplicatiX/...` is not read as `var/lib/Duplicati/`.
3. `Connection.ResolveDbPath` delegates to it, and `GetRelativeDbPath` stores the relative form only
   when it reads back as the same path.
4. The database tool repeated the same join in two hand-written copies, and that one matters: with
   the stored path resolving to a file that is not there, `verify` reports the *real* database as
   `Orphaned`, and `cleanup` offers to delete it - `--force` deletes it without asking. Both call
   sites now use the shared rule.

Nothing rewrites the stored rows. Resolving on read is idempotent, and a row is written back in the
short form the next time the database path is changed through the UI.

## Red to green

Measured on Linux (WSL Ubuntu, .NET 10.0.401), because the fallback only runs there. The "before"
run puts the old behaviour back while keeping the new signatures, so the tests still compile.

| Run | Result |
|---|---|
| the behaviour before this change | 6 failed, 15 passed |
| the compatibility rule in, the round-trip guard in `GetRelativeDbPath` left out | 1 failed, 20 passed |
| this change | **21 passed** |

The six that fail without the change:

- `DataFolderLocatorTests.TheNoHomeFolderFallbackIsRooted("")` and `("/")` - the data folder comes
  back as `var/lib/<appname>` instead of `/var/lib/<appname>`
- `DataFolderLocatorTests.TheLegacyRootFolderIsRootedWhenItIsInUse` - the same for the older folder
- `RelativeDbPathTests.LegacyRootlessDbPath_GetBackup_ResolvesInsideDataFolder` and
  `LegacyRootlessDbPath_BackupsProperty_ResolvesInsideDataFolder` - the stored path is joined onto
  the data folder a second time
- `DatabaseToolTests.TestVerifyCommandWithLegacyRootlessDbPathAsync` - `verify` calls the database
  the backup actually uses `Orphaned`

The seventh test, `UpdateBackupDbPath_MirroredNestedPath_RoundTrips`, is the one that fails with the
compatibility rule in and the round-trip guard left out: a database that really does live in a folder
shaped like the data folder's own path has to keep being stored as an absolute path.

On Windows the two `LegacyRootlessDbPath` tests fail the same way before the change - the reported
shape, with the data folder repeated inside itself - and the four Linux-only tests are skipped:
17 passed, 4 skipped.

`dotnet build Duplicati.slnx -c Debug --no-incremental`: 0 errors, 0 warnings.

## What I did not measure

- **I have not reproduced the report on a machine with a home-less account.** The chain above is read
  out of the code and the packaging; the tests reproduce the resolution, not the environment that
  produced the stored value.
- The branch that keeps an old installation on `/<appname>` is covered through `/tmp`, because
  creating `/Duplicati` needs root. Nothing fakes `File.Exists`.
- No row is rewritten, so a database whose path was stored by an affected installation stays in the
  rootless form until the path is next changed. It resolves correctly either way.

## Two things worth knowing before this ships

- On a home-less account whose working directory is **not** `/`, the data folder moves from
  `$PWD/var/lib/<appname>` to `/var/lib/<appname>`. Nothing is deleted, and `--server-datafolder`
  names the old location for anyone in that position. The packaged service is not in it: systemd's
  default working directory is `/`.
- After this change, `duplicati-database-tool verify` reports the *empty doubled* database as
  orphaned instead of the real one. That is the right way round, but it is still a file the operator
  has to look at before running `cleanup`.

Fixes https://github.com/duplicati/duplicati/issues/7284
