### PR TITLE
Say which side has duplicate remote files instead of crashing

### DIFF
--- a/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
@@ -222,6 +222,15 @@ public static class RemoteSynchronizationRunner
                 dst_opts[x.Key] = x.Value;
         }
 
+        // The two listings are matched against each other, so one comparer has to answer for both
+        // sides, and it is applied if either side asks for it. This mirrors what the backup path
+        // does with the same question in FilelistProcessor. The option defaults to false, which is
+        // the ordinal comparison the lookups below have always used.
+        var name_comparer = Library.Utility.Utility.ParseBoolOption(src_opts, "case-insensitive-remote")
+            || Library.Utility.Utility.ParseBoolOption(dst_opts, "case-insensitive-remote")
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+
         // Check if we only had to parse the arguments
         if (config.ParseArgumentsOnly)
         {
@@ -233,7 +242,7 @@ public static class RemoteSynchronizationRunner
         using var b2m = new LightWeightBackendManager(config.Dst, dst_opts, config.BackendRetries, config.BackendRetryDelay, config.BackendRetryWithExponentialBackoff, progressUpdater: progressUpdater, backendProgressUpdater: backendProgressUpdater);
 
         // Prepare the operations
-        var (to_copy, to_delete, to_verify) = await PrepareFileListsAsync(b1m, b2m, config, token).ConfigureAwait(false);
+        var (to_copy, to_delete, to_verify) = await PrepareFileListsAsync(b1m, b2m, config, name_comparer, token).ConfigureAwait(false);
         var disableQuota = Library.Utility.Utility.ParseBoolOption(dst_opts, "quota-disable");
 
         // Check if we have enough free space in the destination to perform the synchronization.
@@ -723,17 +732,24 @@ public static class RemoteSynchronizationRunner
     /// <param name="b_src">The source lightweight backend manager.</param>
     /// <param name="b_dst">The destination lightweight backend manager.</param>
     /// <param name="config">The parsed configuration for the tool.</param>
+    /// <param name="name_comparer">The comparer to use for the remote filenames.</param>
     /// <param name="token">The cancellation token to use for the asynchronous operations.</param>
     /// <returns>A tuple of Lists each holding the files to copy, delete and verify.</returns>
-    private static async Task<(IEnumerable<IFileEntry>, IEnumerable<IFileEntry>, IEnumerable<IFileEntry>)> PrepareFileListsAsync(LightWeightBackendManager b_src, LightWeightBackendManager b_dst, RemoteSynchronizationConfig config, CancellationToken token)
+    private static async Task<(IEnumerable<IFileEntry>, IEnumerable<IFileEntry>, IEnumerable<IFileEntry>)> PrepareFileListsAsync(LightWeightBackendManager b_src, LightWeightBackendManager b_dst, RemoteSynchronizationConfig config, IEqualityComparer<string> name_comparer, CancellationToken token)
     {
         IEnumerable<IFileEntry> files_src, files_dst;
 
         using (new Duplicati.Library.Logging.Timer(LOGTAG, "ListSource", "Prepare | List source"))
             files_src = await b_src.ListAsync(token).ConfigureAwait(false);
 
+        // Checked before the shortcuts below, because neither of them makes two entries that share
+        // a name any easier to tell apart
+        VerifyNoDuplicateNames(files_src, "source", config.Src, name_comparer);
+
         using (new Duplicati.Library.Logging.Timer(LOGTAG, "ListDestination", "Prepare | List destination"))
             files_dst = await b_dst.ListAsync(token).ConfigureAwait(false);
+
+        VerifyNoDuplicateNames(files_dst, "destination", config.Dst, name_comparer);
 
         // Shortcut for force
         if (config.Force)
@@ -750,12 +766,12 @@ public static class RemoteSynchronizationRunner
         Dictionary<string, IFileEntry> lookup_src, lookup_dst;
         using (new Duplicati.Library.Logging.Timer(LOGTAG, "BuildLookup", "Prepare | Build lookup for source and destination"))
         {
-            lookup_src = files_src.ToDictionary(x => x.Name);
-            lookup_dst = files_dst.ToDictionary(x => x.Name);
+            lookup_src = files_src.ToDictionary(x => x.Name, name_comparer);
+            lookup_dst = files_dst.ToDictionary(x => x.Name, name_comparer);
         }
 
         var to_copy = new List<IFileEntry>();
-        var to_delete = new HashSet<string>();
+        var to_delete = new HashSet<string>(name_comparer);
         var to_verify = new List<IFileEntry>();
 
         // Find all of the files in src that are not in dst, where the dst has a different size than src or src a more recent modification date than dst
@@ -801,6 +817,34 @@ public static class RemoteSynchronizationRunner
             to_delete_lookedup = [.. to_delete.Select(x => lookup_dst[x])];
 
         return (to_copy, to_delete_lookedup, to_verify);
+    }
+
+    /// <summary>
+    /// Verifies that a remote listing does not report the same name more than once.
+    /// Every operation in this tool addresses a remote file by its name alone, so two entries that
+    /// share a name cannot be copied, deleted, renamed or verified apart. This reports the same
+    /// thing the backup path reports for the same condition, instead of failing with the exception
+    /// that building a lookup out of the listing throws.
+    /// </summary>
+    /// <param name="files">The listing to check.</param>
+    /// <param name="side">The side the listing was read from, for the error message.</param>
+    /// <param name="url">The url the listing was read from, for the error message.</param>
+    /// <param name="name_comparer">The comparer to use for the remote filenames.</param>
+    /// <exception cref="RemoteListVerificationException">If a name is reported more than once.</exception>
+    private static void VerifyNoDuplicateNames(IEnumerable<IFileEntry> files, string side, string url, IEqualityComparer<string> name_comparer)
+    {
+        Library.Utility.Utility.GetUniqueItems(files.Select(x => x.Name), name_comparer, out var doubles);
+        if (doubles.Count == 0)
+            return;
+
+        var message = string.Format(
+            "Found remote files reported as duplicates in the {0} ({1}), either the backend module is broken or you need to manually remove the extra copies.\nThe following files were found multiple times: {2}",
+            side,
+            Library.Utility.Utility.GetUrlWithoutCredentials(url),
+            string.Join(", ", doubles));
+
+        Duplicati.Library.Logging.Log.WriteErrorMessage(LOGTAG, "DuplicateRemoteFiles", null, message);
+        throw new RemoteListVerificationException(message, "DuplicateRemoteFiles");
     }
 
     /// <summary>

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -785,5 +785,217 @@ namespace Duplicati.UnitTest
             Assert.IsTrue(DirectoriesAndContentsAreEqual(l1, l2), "Directories should be synchronized.");
         }
 
+        /// <summary>
+        /// A test backend that reports the same remote name more than once, which is what a broken
+        /// backend module - or a remote holding two objects under one name - looks like to the
+        /// synchronization tool. The mode is read from a backend option rather than a static, so a
+        /// single run can have a broken source and an intact destination, or the other way round.
+        /// </summary>
+        public class DuplicateListingBackend : IBackend, IStreamingBackend
+        {
+            /// <summary>
+            /// The protocol key this backend is registered under.
+            /// </summary>
+            public const string Key = "duplistingtest";
+
+            /// <summary>
+            /// The option that selects how the listing repeats itself: "exact" repeats the name as
+            /// it is, "case" repeats it in upper case.
+            /// </summary>
+            public const string ModeOption = "duplicate-listing";
+
+            /// <summary>
+            /// The backend the listing is taken from.
+            /// </summary>
+            private readonly IStreamingBackend? m_backend;
+
+            /// <summary>
+            /// The mode read from <see cref="ModeOption"/>.
+            /// </summary>
+            private readonly string m_mode = "none";
+
+            public DuplicateListingBackend() { }
+
+            public DuplicateListingBackend(string url, Dictionary<string, string> options)
+            {
+                m_backend = (IStreamingBackend)Library.DynamicLoader.BackendLoader.GetBackend(url.Replace($"{Key}://", "file://"), options);
+                if (options.TryGetValue(ModeOption, out var mode) && !string.IsNullOrWhiteSpace(mode))
+                    m_mode = mode;
+            }
+
+            public string DisplayName => "Duplicate listing test backend";
+
+            public string ProtocolKey => Key;
+
+            public string Description => "A testing backend that reports the same remote name twice";
+
+            public bool SupportsStreaming => m_backend?.SupportsStreaming ?? false;
+
+            public IList<ICommandLineArgument> SupportedCommands
+                => m_backend?.SupportedCommands ?? Library.DynamicLoader.BackendLoader.GetSupportedCommands("file://").ToList();
+
+            public async IAsyncEnumerable<IFileEntry> ListAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancelToken)
+            {
+                await foreach (var entry in m_backend!.ListAsync(cancelToken).ConfigureAwait(false))
+                {
+                    yield return entry;
+
+                    // The repeat is made up instead of read back from the filesystem, so a case
+                    // difference shows up where filenames are not case sensitive as well
+                    if (m_mode == "exact")
+                        yield return entry;
+                    else if (m_mode == "case")
+                        yield return new FileEntry(entry.Name.ToUpperInvariant(), entry.Size, entry.LastAccess, entry.LastModification, entry.IsFolder, entry.IsArchived);
+                }
+            }
+
+            public Task CreateFolderAsync(CancellationToken cancelToken) => m_backend!.CreateFolderAsync(cancelToken);
+            public Task DeleteAsync(string remotename, CancellationToken cancelToken) => m_backend!.DeleteAsync(remotename, cancelToken);
+            public Task GetAsync(string remotename, Stream stream, CancellationToken cancelToken) => m_backend!.GetAsync(remotename, stream, cancelToken);
+            public Task GetAsync(string remotename, string filename, CancellationToken cancelToken) => m_backend!.GetAsync(remotename, filename, cancelToken);
+            public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => m_backend!.GetDNSNamesAsync(cancelToken);
+            public Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken) => m_backend!.PutAsync(remotename, stream, cancelToken);
+            public Task PutAsync(string remotename, string filename, CancellationToken cancelToken) => m_backend!.PutAsync(remotename, filename, cancelToken);
+            public Task TestAsync(bool alsoWrite, CancellationToken cancelToken) => m_backend!.TestAsync(alsoWrite, cancelToken);
+            public void Dispose() => m_backend?.Dispose();
+        }
+
+        /// <summary>
+        /// Builds a configuration for the synchronization runner with the defaults the commandline
+        /// parser applies, so a test only has to state what it cares about. The runs are dry, as
+        /// the listings are read before anything is transferred.
+        /// </summary>
+        private static Library.Main.Operation.RemoteSynchronization.RemoteSynchronizationConfig SyncConfig(string src, string dst, List<string>? srcOptions = null, List<string>? dstOptions = null, bool force = false)
+            => new Library.Main.Operation.RemoteSynchronization.RemoteSynchronizationConfig(
+                Src: src,
+                Dst: dst,
+                AutoCreateFolders: true,
+                BackendRetries: 3,
+                BackendRetryDelay: 1000,
+                BackendRetryWithExponentialBackoff: true,
+                Confirm: true,
+                DryRun: true,
+                DstOptions: dstOptions ?? [],
+                Force: force,
+                GlobalOptions: [],
+                LogFile: "",
+                LogLevel: "Information",
+                ParseArgumentsOnly: false,
+                Progress: false,
+                Retention: false,
+                Retry: 3,
+                SrcOptions: srcOptions ?? [],
+                VerifyContents: false,
+                VerifyGetAfterPut: false);
+
+        /// <summary>
+        /// Runs the synchronization the way the server does, rather than through the commandline
+        /// entry point, which turns every exception into an exit code.
+        /// </summary>
+        private static Task<int> RunSyncAsync(Library.Main.Operation.RemoteSynchronization.RemoteSynchronizationConfig config)
+            => Library.Main.Operation.RemoteSynchronization.RemoteSynchronizationRunner.RunAsync(config, CancellationToken.None);
+
+        /// <summary>
+        /// A destination that reports the same name twice cannot be told apart by name, and a name
+        /// is all this tool has to work with. It has to say so the way the backup path does, rather
+        /// than fail with the dictionary exception that reached the user in issue #7285.
+        /// </summary>
+        [TestCase(false)]
+        [TestCase(true)]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestRemoteSynchronizationDuplicateDestinationListingIsReportedAsync(bool force)
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "dupdst_src");
+            var l2 = Path.Combine(TARGETFOLDER, "dupdst_dst");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l1, 3, 0, 0, 1024).ConfigureAwait(false);
+
+            // The destination needs a file of its own, so there is something to report twice
+            await GenerateTestDataAsync(l2, 1, 0, 0, 1024).ConfigureAwait(false);
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DuplicateListingBackend());
+
+            var config = SyncConfig($"file://{l1}", $"{DuplicateListingBackend.Key}://{l2}",
+                dstOptions: [$"{DuplicateListingBackend.ModeOption}=exact"], force: force);
+
+            var error = Assert.ThrowsAsync<RemoteListVerificationException>(async () => await RunSyncAsync(config).ConfigureAwait(false));
+
+            Assert.AreEqual("DuplicateRemoteFiles", error!.HelpID);
+            Assert.IsTrue(error.Message.Contains("destination"), $"The error did not say which side reported the duplicates: {error.Message}");
+        }
+
+        /// <summary>
+        /// The same for the source, with an empty destination. That takes the shortcut which never
+        /// builds the lookups, so the duplicates are only found if the listing itself is checked.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestRemoteSynchronizationDuplicateSourceListingIsReportedAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "dupsrc_src");
+            var l2 = Path.Combine(TARGETFOLDER, "dupsrc_dst");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l1, 3, 0, 0, 1024).ConfigureAwait(false);
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DuplicateListingBackend());
+
+            var config = SyncConfig($"{DuplicateListingBackend.Key}://{l1}", $"file://{l2}",
+                srcOptions: [$"{DuplicateListingBackend.ModeOption}=exact"]);
+
+            var error = Assert.ThrowsAsync<RemoteListVerificationException>(async () => await RunSyncAsync(config).ConfigureAwait(false));
+
+            Assert.AreEqual("DuplicateRemoteFiles", error!.HelpID);
+            Assert.IsTrue(error.Message.Contains("source"), $"The error did not say which side reported the duplicates: {error.Message}");
+        }
+
+        /// <summary>
+        /// Two names that differ only in case are duplicates on a remote that does not tell them
+        /// apart, and two separate files anywhere else. The answer follows --case-insensitive-remote,
+        /// which is what the backup path does with the same question, and the default is unchanged.
+        /// </summary>
+        [TestCase("src", true)]
+        [TestCase("dst", true)]
+        [TestCase("none", false)]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestRemoteSynchronizationCaseOnlyDuplicatesFollowCaseInsensitiveRemoteAsync(string optionSide, bool expectFailure)
+        {
+            var l1 = Path.Combine(TARGETFOLDER, $"dupcase_src_{optionSide}");
+            var l2 = Path.Combine(TARGETFOLDER, $"dupcase_dst_{optionSide}");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            // The source is left empty, so the run does not depend on any transfer
+            await GenerateTestDataAsync(l2, 3, 0, 0, 1024).ConfigureAwait(false);
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DuplicateListingBackend());
+
+            var srcOptions = new List<string>();
+            var dstOptions = new List<string> { $"{DuplicateListingBackend.ModeOption}=case" };
+            if (optionSide == "src")
+                srcOptions.Add("case-insensitive-remote=true");
+            else if (optionSide == "dst")
+                dstOptions.Add("case-insensitive-remote=true");
+
+            var config = SyncConfig($"file://{l1}", $"{DuplicateListingBackend.Key}://{l2}", srcOptions, dstOptions);
+
+            if (expectFailure)
+            {
+                var error = Assert.ThrowsAsync<RemoteListVerificationException>(async () => await RunSyncAsync(config).ConfigureAwait(false));
+                Assert.AreEqual("DuplicateRemoteFiles", error!.HelpID);
+            }
+            else
+            {
+                Assert.AreEqual(0, await RunSyncAsync(config).ConfigureAwait(false),
+                    "Names that differ in case are two files unless the remote is said to be case insensitive.");
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## What happens

A backup job with an inline remote-synchronization destination fails with a framework exception,
reported in the comments of #7285 on 2.4.0.0:

```
[Error-Duplicati.Library.Main.Operation.RemoteSynchronizationHandler-RemoteSyncFailed]:
  Remote synchronization to drimecloud://... failed:
  An item with the same key has already been added. Key: duplicati-iba2c72287a6a4831b103e1381b1d83bd.dindex.zip.aes
System.ArgumentException: An item with the same key has already been added. ...
   at System.Linq.Enumerable.SpanToDictionary[TSource,TKey](...)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey](...)
   at Duplicati.Library.Main.Operation.RemoteSynchronization.RemoteSynchronizationRunner.PrepareFileListsAsync(...)
```

The operator is told that a dictionary key was added twice, and nothing else: not which of the two
remotes is at fault, and not what to do about it.

## Why

`PrepareFileListsAsync` builds its lookups with `ToDictionary(x => x.Name)`, so a listing that
reports one name twice throws before anything else happens.

The backup path answers the same question with something the operator can act on. `FilelistProcessor`
collects the repeated names with `Utility.GetUniqueItems` and raises

> Found remote files reported as duplicates, either the backend module is broken or you need to
> manually remove the extra copies. The following files were found multiple times: …

as a `RemoteListVerificationException` with the help id `DuplicateRemoteFiles`. The synchronization
path has no such check at all.

## The change

- **Each listing is checked as soon as it is read**, with the same helper, and reported with the same
  message and help id - plus **which side** it came from and the credential-free url. A backup has one
  remote and can leave the side out; a synchronization has two and cannot.
- **The check runs before the two shortcuts**, not at the lookup. `--force` returns both listings
  untouched and an empty destination returns the source untouched, so neither builds a lookup and
  neither crashes today. They act on names they cannot tell apart instead: every operation in this
  tool addresses a remote file by its name alone (`CopyAsync`, `DeleteAsync`, `RenameAsync`,
  `VerifyAsync`), so with `--force` a repeated name is downloaded and re-uploaded twice and deleted
  twice, and with an empty destination a repeated source file is copied twice - silently, in both
  cases.
- **The comparison follows `--case-insensitive-remote`**, which the backup path already applies to the
  same check. One comparer answers for both sides and is applied if either side asks for it: matching
  two listings against each other is a single relation, and `to_delete.Select(x => lookup_dst[x])` is
  an unguarded indexer, so a per-side comparer could delete a destination file without copying it
  back, or throw `KeyNotFoundException`. The option defaults to false, so **the default behaviour is
  the ordinal comparison the lookups have always used**.

## Red to green

Measured with `mise exec dotnet -- dotnet test Duplicati/UnitTest/Duplicati.UnitTest.csproj --filter
"FullyQualifiedName~ToolTests.TestRemoteSynchronizationDuplicate|FullyQualifiedName~ToolTests.TestRemoteSynchronizationCaseOnly"`:
**5 failed, 1 passed** before the change, **6 passed** after.

| Test case | Before the change |
|---|---|
| `DuplicateDestinationListingIsReported(False)` | `System.ArgumentException: An item with the same key has already been added. Key: file_0.txt`, through `SpanToDictionary` - the reported stack, reproduced |
| `DuplicateDestinationListingIsReported(True)` (`--force`) | no exception at all; the run copies and deletes the repeated name twice |
| `DuplicateSourceListingIsReported` (empty destination) | no exception at all; every source file is copied twice |
| `CaseOnlyDuplicatesFollowCaseInsensitiveRemote("src", true)` | no exception; the option is ignored |
| `CaseOnlyDuplicatesFollowCaseInsensitiveRemote("dst", true)` | no exception; the option is ignored |
| `CaseOnlyDuplicatesFollowCaseInsensitiveRemote("none", false)` | passes, and still passes - the guard that the default is unchanged |

The listing is broken by a test backend that wraps the file backend and repeats each entry. The mode
comes from a backend option rather than a static, so one run can have a broken source and an intact
destination, and the repeated entry is synthesized rather than read back from disk, so the
case-difference cases behave the same where filenames are not case sensitive.

Regression: `--filter "TestCategory=Tools/RemoteSynchronization|FullyQualifiedName~Issue1282"` -
**26 passed**. Those existing tests are the net for a false positive: `TestRemoteSynchronizationAsync`
runs a real backup through the tool including `--force --retention` and restores from the result, and
`Issue1282` covers the backup path whose help id this reuses.

## What this does not do

- **It does not fix #7285.** That report is a Drime listing that repeats a page when a folder holds
  more than 2,500 entries, and the reporter has a patch for the backend. This only changes what the
  product says when a duplicated listing arrives, so there is no `Fixes` on this PR.
- I have not reproduced the Drime listing itself; the tests break the listing deliberately.
- `--force` now fails on a duplicated listing where it used to run to completion. That is the
  intent - the run was copying and deleting the same name twice - but it is the one behaviour change
  visible with default options.

## Reported, not fixed

`Duplicati/Library/Main/Operation/RemoteSynchronizationHandler.cs:242` builds the source options as

```csharp
SrcOptions: [.. options.RawOptions.Select((k, v) => $"{k}={v}")],
```

The two-parameter lambda binds `Select<TSource, int, TResult>`, so `k` is the `KeyValuePair` and `v`
is the *index*: the strings produced are `"[key, value]=0"`, `"[key2, value2]=1"`, and so on. They
survive the round-trip validation in `ParseOptions` and are then ignored by the backends, so the
inline path currently forwards no usable option to the source backend at all.

I left it alone deliberately: repairing it would suddenly forward the entire backup option set -
`passphrase` included - into both synchronization backends, which is a behaviour and security change
that deserves its own review rather than riding along here.
