### PR TITLE
Layered defense for secrets in lists

### DIFF
--- a/Duplicati/Library/RestAPI/Database/Backup.cs
+++ b/Duplicati/Library/RestAPI/Database/Backup.cs
@@ -227,9 +227,10 @@ namespace Duplicati.Server.Database
                     if (target != null)
                         target.TargetUrl = QuerystringMasking.Mask(target.TargetUrl, protectedNames);
 
-            foreach (var setting in this.Settings)
-                if (protectedNames.Contains(setting.Name))
-                    setting.Value = Connection.PASSWORD_PLACEHOLDER;
+            if (Settings != null)
+                foreach (var setting in Settings)
+                    if (protectedNames.Contains(setting.Name))
+                        setting.Value = Connection.PASSWORD_PLACEHOLDER;
         }
 
         /// <inheritdoc/>

--- a/Duplicati/UnitTest/ServerApiIntegrationTests.cs
+++ b/Duplicati/UnitTest/ServerApiIntegrationTests.cs
@@ -227,6 +227,49 @@ public class ServerApiIntegrationTests : BasicSetupHelper
 
     [Test]
     [Category("Integration")]
+    public async Task ServerBackupListMasksTargetUrl_Async()
+    {
+        var secret = $"secret-{Guid.NewGuid():N}";
+        var backupName = $"API masking backup {Guid.NewGuid():N}";
+        Directory.CreateDirectory(this.TARGETFOLDER);
+        var targetUrl = BuildFileBackendUrl(this.TARGETFOLDER) + "?auth-username=user&auth-password=" + secret;
+
+        await WithAuthenticatedServerAsync(async httpClient =>
+        {
+            var request = new BackupAndScheduleInputDto
+            {
+                Backup = new BackupAndScheduleInputDto.BackupInputDto
+                {
+                    Name = backupName,
+                    Description = "Masking test backup",
+                    TargetURL = targetUrl,
+                    Sources = new[] { this.DATAFOLDER },
+                    Settings = new[] { new BackupAndScheduleInputDto.SettingInputDto { Name = "passphrase", Value = "integration-passphrase" } },
+                    Filters = Array.Empty<BackupAndScheduleInputDto.FilterInputDto>(),
+                    Metadata = new Dictionary<string, string>()
+                }
+            };
+
+            var response = await httpClient.PostAsJsonAsync("/api/v1/backups", request, JsonOptions).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var created = await response.Content.ReadFromJsonAsync<CreateBackupDto>(JsonOptions).ConfigureAwait(false)
+                          ?? throw new InvalidOperationException("Backup creation response was empty");
+
+            var listedBackup = await AssertBackupListedAsync(httpClient, created.ID!, backupName).ConfigureAwait(false);
+            Assert.That(listedBackup.TargetURL, Does.Not.Contain(secret), "Backup list should not expose the target URL password");
+            Assert.That(listedBackup.TargetURL, Does.Contain(Duplicati.Server.Database.Connection.PASSWORD_PLACEHOLDER), "Backup list should mask the target URL password");
+            Assert.That(listedBackup.TargetURL, Does.Contain("auth-username=user"), "Backup list should keep non-secret query parameters");
+
+            var getResponse = await httpClient.GetAsync($"/api/v1/backup/{created.ID}").ConfigureAwait(false);
+            getResponse.EnsureSuccessStatusCode();
+            var single = await getResponse.Content.ReadFromJsonAsync<BackupGet.GetBackupResultDto>(JsonOptions).ConfigureAwait(false)
+                         ?? throw new InvalidOperationException("Backup get response was empty");
+            Assert.That(single.Backup.TargetURL, Is.EqualTo(listedBackup.TargetURL), "List and single-backup GET should mask the target URL the same way");
+        }).ConfigureAwait(false);
+    }
+
+    [Test]
+    [Category("Integration")]
     public async Task ServerRepairUpdateListsRootPaths_Async()
     {
         var backupPassphrase = "repair-update-passphrase";

--- a/Duplicati/WebserverCore/Services/BackupListService.cs
+++ b/Duplicati/WebserverCore/Services/BackupListService.cs
@@ -311,11 +311,16 @@ public class BackupListService(Connection connection) : IBackupListService
             return backups;
         }
 
-        var all = backups.Select(n => new
+        var all = backups.Select(n =>
         {
-            IsUnencryptedOrPassphraseStored = connection.IsUnencryptedOrPassphraseStored(long.Parse(n.ID)),
-            Backup = n,
-            Schedule = schedules.FirstOrDefault(x => x.Tags != null && x.Tags.Contains("ID=" + n.ID))
+            // Mask passwords in target URLs, sources and settings, same as the single-backup GET
+            n.MaskSensitiveInformation();
+            return new
+            {
+                IsUnencryptedOrPassphraseStored = connection.IsUnencryptedOrPassphraseStored(long.Parse(n.ID)),
+                Backup = n,
+                Schedule = schedules.FirstOrDefault(x => x.Tags != null && x.Tags.Contains("ID=" + n.ID))
+            };
         });
 
         var res = all.Select(x => new Dto.BackupAndScheduleOutputDto()
@@ -329,7 +334,7 @@ public class BackupListService(Connection connection) : IBackupListService
                 IsTemporary = x.Backup.IsTemporary,
                 IsUnencryptedOrPassphraseStored = x.IsUnencryptedOrPassphraseStored,
                 Metadata = x.Backup.Metadata,
-                Sources = Server.SourceMasking.MaskSources(x.Backup.Sources, Connection.PasswordFieldNames),
+                Sources = x.Backup.Sources,
                 Settings = x.Backup.Settings?.Select(y => new Dto.SettingDto()
                 {
                     Name = y.Name,


### PR DESCRIPTION
The list of backups is already omitting loading various values for performance reasons, but should anyone decide to change that, the output may leak keys to the UI (authentication is still required).

With this PR, the output is masked similar to how the calls that fetch the full details are masked so secrets are not delivered to the UI.

If we later decide to load settings for the backup list, it will be guarded.