### PR TITLE
Fix packaging `libc_wrapper.so`

### DIFF
--- a/ReleaseBuilder/Build/Command.Compile.Post.cs
+++ b/ReleaseBuilder/Build/Command.Compile.Post.cs
@@ -42,6 +42,7 @@ public static partial class Command
         public static async Task PrepareTargetDirectory(string baseDir, string buildDir, PackageTarget target, RuntimeConfig rtcfg, bool keepBuilds)
         {
             await RemoveUnwantedFiles(target.OS, buildDir);
+            await FlattenNativeWrapperLibraries(buildDir, target);
 
             switch (target.OS)
             {
@@ -259,6 +260,70 @@ public static partial class Command
 
             Directory.Move(tmpApp, appDir);
             Directory.Delete(Path.GetDirectoryName(tmpApp) ?? throw new Exception("Unexpected empty path"), true);
+        }
+
+        /// <summary>
+        /// The folders under "runtimes" holding the native wrapper libraries shipped by the DiskImage project
+        /// </summary>
+        static readonly IReadOnlyList<string> NativeWrapperRuntimeFolders = ["osx", "linux-x86", "linux-x64", "linux-arm", "linux-arm64"];
+
+        /// <summary>
+        /// Gets the folder under "runtimes" holding the native wrapper libraries for the target
+        /// </summary>
+        /// <param name="target">The target to get the folder for</param>
+        /// <returns>The folder name, or null if the target has no native wrapper libraries</returns>
+        static string? NativeWrapperRuntimeFolder(PackageTarget target)
+            => target.OS switch
+            {
+                OSType.MacOS => "osx",
+                OSType.Linux => target.Arch switch
+                {
+                    ArchType.x64 => "linux-x64",
+                    ArchType.x86 => "linux-x86",
+                    ArchType.Arm64 => "linux-arm64",
+                    ArchType.Arm7 => "linux-arm",
+                    _ => throw new Exception($"Not supported arch: {target.Arch}")
+                },
+                _ => null
+            };
+
+        /// <summary>
+        /// Moves the native wrapper libraries for the target next to the assemblies
+        /// and removes the "runtimes" folder holding the builds for all other platforms.
+        /// The build output contains all platforms because the libraries are shipped
+        /// as content files by the DiskImage project, and the RID is not known there
+        /// when it is built as a project reference.
+        /// </summary>
+        /// <param name="buildDir">The build directory</param>
+        /// <param name="target">The target being built</param>
+        /// <returns>An awaitable task</returns>
+        static Task FlattenNativeWrapperLibraries(string buildDir, PackageTarget target)
+        {
+            var runtimesDir = Path.Combine(buildDir, "runtimes");
+            if (!Directory.Exists(runtimesDir))
+                throw new Exception($"Expected folder \"{runtimesDir}\" not found, has build changed?");
+
+            var folder = NativeWrapperRuntimeFolder(target);
+            if (folder != null)
+            {
+                var nativeDir = Path.Combine(runtimesDir, folder, "native");
+                if (!Directory.Exists(nativeDir))
+                    throw new Exception($"Expected native wrapper folder \"{nativeDir}\" not found, has build changed?");
+
+                EnvHelper.CopyDirectory(nativeDir, buildDir, recursive: false);
+            }
+
+            foreach (var f in NativeWrapperRuntimeFolders.Select(x => Path.Combine(runtimesDir, x)))
+                if (Directory.Exists(f))
+                    Directory.Delete(f, true);
+
+            var leftovers = Directory.EnumerateFileSystemEntries(runtimesDir).ToList();
+            if (leftovers.Count == 0)
+                Directory.Delete(runtimesDir);
+            else
+                Console.WriteLine($"Warning: unexpected content left in \"{runtimesDir}\": {string.Join(", ", leftovers.Select(Path.GetFileName))}");
+
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/proprietary/DiskImage/Disk/Linux.cs
+++ b/proprietary/DiskImage/Disk/Linux.cs
@@ -73,6 +73,14 @@ namespace Duplicati.Proprietary.DiskImage.Disk
         public bool IsWriteable => m_writeable;
 
         /// <summary>
+        /// Registers the resolver that locates the native wrapper library
+        /// </summary>
+        static Linux()
+        {
+            NativeWrapperResolver.EnsureRegistered();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Linux"/> class.
         /// </summary>
         /// <param name="devicePath">The Linux device path (e.g., "/dev/sda", "/dev/nvme0n1", "/dev/loop0").</param>
@@ -472,16 +480,16 @@ namespace Duplicati.Proprietary.DiskImage.Disk
 
         #region P/Invoke Declarations
 
-        // P/Invoke to the native wrapper library for ioctls
-        // The .NET runtime will automatically load the correct architecture-specific version
-        // from runtimes/linux-{arch}/native/libc_wrapper.so based on the current RID
-        [LibraryImport("libc_wrapper", SetLastError = true)]
+        // P/Invoke to the native wrapper library for ioctls.
+        // The library is located by NativeWrapperResolver, either next to the
+        // assemblies (packaged installs) or under runtimes/linux-{arch}/native/ (source builds).
+        [LibraryImport(NativeWrapperResolver.LinuxLibraryName, SetLastError = true)]
         internal static partial int ioctl_uint32(int fd, uint request, ref uint value);
 
-        [LibraryImport("libc_wrapper", SetLastError = true)]
+        [LibraryImport(NativeWrapperResolver.LinuxLibraryName, SetLastError = true)]
         internal static partial int ioctl_uint64(int fd, ulong request, ref ulong value);
 
-        [LibraryImport("libc_wrapper", SetLastError = true)]
+        [LibraryImport(NativeWrapperResolver.LinuxLibraryName, SetLastError = true)]
         internal static partial int ioctl_no_arg(int fd, uint request);
 
         // Standard libc functions

--- a/proprietary/DiskImage/Disk/Mac.cs
+++ b/proprietary/DiskImage/Disk/Mac.cs
@@ -60,6 +60,14 @@ namespace Duplicati.Proprietary.DiskImage.Disk
         public bool IsWriteable => m_writeable;
 
         /// <summary>
+        /// Registers the resolver that locates the native wrapper library
+        /// </summary>
+        static Mac()
+        {
+            NativeWrapperResolver.EnsureRegistered();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Mac"/> class.
         /// </summary>
         /// <param name="devicePath">The macOS device path (e.g., "/dev/rdisk0").</param>
@@ -444,16 +452,19 @@ namespace Duplicati.Proprietary.DiskImage.Disk
 
         #region P/Invoke Declarations
 
-        [LibraryImport("runtimes/osx/native/libSystem_wrapper.dylib", SetLastError = true)]
+        // P/Invoke to the native wrapper library for ioctls.
+        // The library is located by NativeWrapperResolver, either next to the
+        // assemblies (packaged installs) or under runtimes/osx/native/ (source builds).
+        [LibraryImport(NativeWrapperResolver.MacLibraryName, SetLastError = true)]
         internal static partial int ioctl_uint32(int fd, ulong request, ref uint value);
 
-        [LibraryImport("runtimes/osx/native/libSystem_wrapper.dylib", SetLastError = true)]
+        [LibraryImport(NativeWrapperResolver.MacLibraryName, SetLastError = true)]
         internal static partial int ioctl_uint64(int fd, ulong request, ref ulong value);
 
-        [LibraryImport("runtimes/osx/native/libSystem_wrapper.dylib", SetLastError = true)]
+        [LibraryImport(NativeWrapperResolver.MacLibraryName, SetLastError = true)]
         internal static partial int ioctl_no_arg(int fd, ulong request);
 
-        [LibraryImport("runtimes/osx/native/libSystem_wrapper.dylib", SetLastError = true)]
+        [LibraryImport(NativeWrapperResolver.MacLibraryName, SetLastError = true)]
         internal static partial int fcntl_nocache(int fd);
 
         [LibraryImport("libSystem", SetLastError = true)]

--- a/proprietary/DiskImage/Disk/NativeWrapperResolver.cs
+++ b/proprietary/DiskImage/Disk/NativeWrapperResolver.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Duplicati Inc. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Duplicati.Proprietary.DiskImage.Disk
+{
+    /// <summary>
+    /// Locates the native wrapper libraries used by the raw disk implementations.
+    /// The project file ships one build per platform under
+    /// <c>runtimes/&lt;rid&gt;/native/</c>, which the .NET runtime does not probe
+    /// for libraries that are not listed in the deps.json. This resolver probes
+    /// the application folder first (packaged installs, where the release builder
+    /// places the matching library) and then the runtimes folder for the current
+    /// platform (source checkouts built with <c>dotnet run</c>).
+    /// </summary>
+    internal static class NativeWrapperResolver
+    {
+        /// <summary>
+        /// The library name used by the Linux P/Invoke declarations
+        /// </summary>
+        public const string LinuxLibraryName = "libc_wrapper";
+
+        /// <summary>
+        /// The library name used by the macOS P/Invoke declarations
+        /// </summary>
+        public const string MacLibraryName = "libSystem_wrapper.dylib";
+
+        /// <summary>
+        /// The file names on disk, keyed by the P/Invoke library name
+        /// </summary>
+        private static readonly Dictionary<string, string> FileNames = new(StringComparer.Ordinal)
+        {
+            { LinuxLibraryName, "libc_wrapper.so" },
+            { MacLibraryName, "libSystem_wrapper.dylib" },
+        };
+
+        /// <summary>
+        /// Lock guarding the registration
+        /// </summary>
+        private static readonly object m_lock = new();
+
+        /// <summary>
+        /// Flag indicating if the resolver has been registered
+        /// </summary>
+        private static bool m_registered;
+
+        /// <summary>
+        /// Registers the resolver for the assembly containing this class.
+        /// Safe to call multiple times.
+        /// </summary>
+        public static void EnsureRegistered()
+        {
+            lock (m_lock)
+            {
+                if (m_registered)
+                    return;
+
+                NativeLibrary.SetDllImportResolver(typeof(NativeWrapperResolver).Assembly, Resolve);
+                m_registered = true;
+            }
+        }
+
+        /// <summary>
+        /// The runtimes folder name for the current platform, or null if not supported
+        /// </summary>
+        internal static string? CurrentRuntimeFolder
+        {
+            get
+            {
+                if (OperatingSystem.IsMacOS())
+                    return "osx";
+
+                if (OperatingSystem.IsLinux())
+                    return RuntimeInformation.ProcessArchitecture switch
+                    {
+                        Architecture.X86 => "linux-x86",
+                        Architecture.X64 => "linux-x64",
+                        Architecture.Arm => "linux-arm",
+                        Architecture.Arm64 => "linux-arm64",
+                        _ => null
+                    };
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns the candidate paths for a wrapper library, in probing order
+        /// </summary>
+        /// <param name="libraryName">The P/Invoke library name</param>
+        /// <param name="assembly">The assembly requesting the library</param>
+        /// <returns>The candidate paths, empty if the name is not a wrapper library</returns>
+        internal static IEnumerable<string> GetCandidatePaths(string libraryName, Assembly assembly)
+        {
+            if (!FileNames.TryGetValue(libraryName, out var fileName))
+                yield break;
+
+            var folders = new List<string>();
+            var assemblyDir = string.IsNullOrEmpty(assembly.Location) ? null : Path.GetDirectoryName(assembly.Location);
+            if (!string.IsNullOrEmpty(assemblyDir))
+                folders.Add(assemblyDir);
+            if (!string.IsNullOrEmpty(AppContext.BaseDirectory) && !string.Equals(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar), assemblyDir, StringComparison.Ordinal))
+                folders.Add(AppContext.BaseDirectory);
+
+            var rid = CurrentRuntimeFolder;
+            foreach (var folder in folders)
+            {
+                // Packaged layout: the release builder places the library next to the assemblies
+                yield return Path.Combine(folder, fileName);
+
+                // Build output layout: all platforms are present under runtimes/
+                if (rid != null)
+                    yield return Path.Combine(folder, "runtimes", rid, "native", fileName);
+            }
+        }
+
+        /// <summary>
+        /// The resolver callback invoked by the runtime for each P/Invoke library in the assembly
+        /// </summary>
+        /// <param name="libraryName">The name requested by the P/Invoke declaration</param>
+        /// <param name="assembly">The assembly requesting the library</param>
+        /// <param name="searchPath">The search path flags</param>
+        /// <returns>The library handle, or zero to fall back to the default probing</returns>
+        private static nint Resolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            foreach (var candidate in GetCandidatePaths(libraryName, assembly))
+                if (File.Exists(candidate) && NativeLibrary.TryLoad(candidate, out var handle))
+                    return handle;
+
+            // Fall back to the default probing, which produces the standard error message
+            return nint.Zero;
+        }
+    }
+}


### PR DESCRIPTION
The packaging placed the `libc_wrapper.so` under a runtimes folder. The runtimes folder is used during builds to avoid clashes between the different native libraries for each CPU arch.

Howevever, the loading only looks in the base folder, not the runtimes folder, so the library would fail to load in the published builds.

This PR adds a small resolver so we probe for the file in both the root folder and the appropriate runtime folder and loads the first match.

The release builder process now flattens the runtimes folder, so it is not present on the published builds, and only the target arch version is included.

The resolver also handles the debug case where the solution is started from a clean checkout. Here the build places the files in the runtimes folder, and the resolver picks it up from there.