### PR TITLE
Pass the right arguments to the synchronization backends

### DIFF
--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -484,7 +484,10 @@ namespace Duplicati.Library.Main.Backend
             {
                 await Task.Delay(_currentRetryDelay, token).ConfigureAwait(false);
 
-                if (_retryWithExponentialBackoff)
+                // The doubling is capped at the same 1024x the main backend manager uses
+                // (Utility.GetRetryDelay), so a large retry count cannot grow the delay without
+                // bound or overflow the int
+                if (_retryWithExponentialBackoff && (long)_currentRetryDelay < (long)_retryDelay * 1024)
                     _currentRetryDelay <<= 1; // Double the delay for exponential backoff
             }
         }

--- a/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
@@ -238,8 +238,21 @@ public static class RemoteSynchronizationRunner
             return 0;
         }
 
-        using var b1m = new LightWeightBackendManager(config.Src, src_opts, config.BackendRetries, config.BackendRetryDelay, config.BackendRetryWithExponentialBackoff, progressUpdater: progressUpdater, backendProgressUpdater: backendProgressUpdater);
-        using var b2m = new LightWeightBackendManager(config.Dst, dst_opts, config.BackendRetries, config.BackendRetryDelay, config.BackendRetryWithExponentialBackoff, progressUpdater: progressUpdater, backendProgressUpdater: backendProgressUpdater);
+        using var b1m = new LightWeightBackendManager(config.Src, src_opts,
+            maxRetries: config.BackendRetries,
+            retryDelay: config.BackendRetryDelay,
+            // The source is only ever read from. Creating a missing source folder would turn "the
+            // source is gone" into "the source is empty", and an empty source deletes every file in
+            // the destination
+            autoCreateFolders: false,
+            retryWithExponentialBackoff: config.BackendRetryWithExponentialBackoff,
+            progressUpdater: progressUpdater, backendProgressUpdater: backendProgressUpdater);
+        using var b2m = new LightWeightBackendManager(config.Dst, dst_opts,
+            maxRetries: config.BackendRetries,
+            retryDelay: config.BackendRetryDelay,
+            autoCreateFolders: config.AutoCreateFolders,
+            retryWithExponentialBackoff: config.BackendRetryWithExponentialBackoff,
+            progressUpdater: progressUpdater, backendProgressUpdater: backendProgressUpdater);
 
         // Prepare the operations
         var (to_copy, to_delete, to_verify) = await PrepareFileListsAsync(b1m, b2m, config, name_comparer, token).ConfigureAwait(false);

--- a/Duplicati/Library/Main/Operation/RemoteSynchronizationHandler.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronizationHandler.cs
@@ -239,7 +239,7 @@ internal class RemoteSynchronizationHandler : IDisposable
                                 Progress: destination.Progress,
                                 Retention: destination.Retention,
                                 Retry: destination.Retry,
-                                SrcOptions: [.. options.RawOptions.Select((k, v) => $"{k}={v}")],
+                                SrcOptions: [.. options.RawOptions.Select(x => $"{x.Key}={x.Value}")],
                                 VerifyContents: destination.VerifyContents,
                                 VerifyGetAfterPut: destination.VerifyGetAfterPut
                             ),

--- a/Duplicati/UnitTest/RemoteSynchronizationHandlerTests.cs
+++ b/Duplicati/UnitTest/RemoteSynchronizationHandlerTests.cs
@@ -821,6 +821,10 @@ namespace Duplicati.UnitTest
             using var cmd = db.CreateCommand();
             EnsureOperationTableCreated(cmd);
 
+            // The source of a synchronization is a backend that exists: the inline path reads
+            // the backup's own destination
+            Directory.CreateDirectory(Path.Combine(TARGETFOLDER, "source"));
+
             await handler.RunAsync();
 
             // Check that two syncs were recorded (skipping the empty one)
@@ -891,6 +895,10 @@ namespace Duplicati.UnitTest
             cmd.AddNamedParameter("@ts", Library.Utility.Utility.NormalizeDateTimeToEpochSeconds(DateTime.UtcNow));
             await cmd.ExecuteNonQueryAsync();
 
+            // The source of a synchronization is a backend that exists: the inline path reads
+            // the backup's own destination
+            Directory.CreateDirectory(Path.Combine(TARGETFOLDER, "source"));
+
             await handler.RunAsync();
 
             // Check that one additional sync was recorded (dest1 inline, dest2 interval not due)
@@ -924,6 +932,10 @@ namespace Duplicati.UnitTest
             using var db = await SQLiteLoader.LoadConnectionAsync(DBFILE);
             using var cmd = db.CreateCommand();
             EnsureOperationTableCreated(cmd);
+
+            // The source of a synchronization is a backend that exists: the inline path reads
+            // the backup's own destination
+            Directory.CreateDirectory(Path.Combine(TARGETFOLDER, "source"));
 
             await handler.RunAsync();
 
@@ -1341,6 +1353,48 @@ namespace Duplicati.UnitTest
             DestinationsAreEqual(true, TARGETFOLDER, syncDest1, syncDest3);
             Assert.IsFalse(DestinationsAreEqual(false, TARGETFOLDER, syncDest2)); // syncDest2 should be out of date
             await AssertRestoreWorksAsync([TARGETFOLDER, syncDest1, syncDest3]);
+        }
+
+        /// <summary>
+        /// The source of an inline synchronization is the backup's own destination, so the backup's
+        /// options have to reach it: FTP, WebDAV and SSH read their credentials from the options,
+        /// not only from the url.
+        /// </summary>
+        [Test]
+        [Category("RemoteSync")]
+        public async Task TestConfigure_ForwardsBackupOptionsAsSourceOptionsAsync()
+        {
+            var options = new Dictionary<string, string>
+            {
+                ["remote-sync-json-config"] = @$"{{""destinations"": [
+                    {{""url"": ""file://{dest1}""}}
+                ]}}",
+                ["auth-username"] = "someuser",
+                ["auth-password"] = "some=password=with=equals",
+                ["no-encryption"] = "true"
+            };
+
+            var handler = new RemoteSynchronizationHandler($"file://{source}", new Options(options), new BackupResults());
+
+            var destinations = handler.GetType().GetField("m_destinations", BINDING_FLAGS).GetValue(handler) as List<RemoteSyncDestinationConfig>;
+            Assert.AreEqual(1, destinations.Count);
+
+            var srcOptions = destinations[0].Config.SrcOptions;
+
+            Assert.IsTrue(srcOptions.Contains("auth-username=someuser"),
+                $"The username was not forwarded: {string.Join(", ", srcOptions)}");
+            Assert.IsTrue(srcOptions.Contains("auth-password=some=password=with=equals"),
+                $"The password was not forwarded verbatim: {string.Join(", ", srcOptions)}");
+            Assert.IsTrue(srcOptions.Contains("no-encryption=true"),
+                $"An option was not forwarded: {string.Join(", ", srcOptions)}");
+            Assert.AreEqual(options.Count, srcOptions.Count, "Not every option was forwarded.");
+
+            // And the forwarded list is what the runner's own parser reads. This does not catch the
+            // shape above - a wrong string round-trips just as well - but it does show that a value
+            // containing an equals sign survives
+            var parseOnly = destinations[0].Config with { Src = $"file://{source}", ParseArgumentsOnly = true };
+            Assert.AreEqual(0, await Duplicati.Library.Main.Operation.RemoteSynchronization.RemoteSynchronizationRunner.RunAsync(parseOnly, System.Threading.CancellationToken.None).ConfigureAwait(false),
+                "The forwarded options were rejected by the option parser.");
         }
 
     }

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -185,6 +185,8 @@ namespace Duplicati.UnitTest
                 ["source", "destination", "--parse-arguments-only", "--backend-retries", "5"],
                 ["source", "destination", "--parse-arguments-only", "--backend-retry-delay", "1000"],
                 ["source", "destination", "--parse-arguments-only", "--backend-retry-with-exponential-backoff"],
+                ["source", "destination", "--parse-arguments-only", "--auto-create-folders=false"],
+                ["source", "destination", "--parse-arguments-only", "--backend-retry-with-exponential-backoff=false"],
                 ["source", "destination", "--parse-arguments-only", "--dry-run"],
                 ["source", "destination", "--parse-arguments-only", "--force"],
                 ["source", "destination", "--parse-arguments-only", "--dry-run", "--force"],
@@ -995,6 +997,99 @@ namespace Duplicati.UnitTest
                 Assert.AreEqual(0, await RunSyncAsync(config).ConfigureAwait(false),
                     "Names that differ in case are two files unless the remote is said to be case insensitive.");
             }
+        }
+
+        /// <summary>
+        /// Tests that a missing destination folder is created when the tool is asked to. The
+        /// exponential backoff flag is deliberately set to the opposite value: if the two are ever
+        /// bound to the wrong constructor parameters again, this test fails.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestAutoCreateFoldersCreatesMissingDestinationAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "autocreate_src");
+            var l2 = Path.Combine(TARGETFOLDER, "autocreate_dst");
+
+            Directory.CreateDirectory(l1);
+            await GenerateTestDataAsync(l1, 5, 0, 0, 1024).ConfigureAwait(false);
+
+            Assert.IsFalse(Directory.Exists(l2), "The destination folder must not exist before the run.");
+
+            // A retry delay of zero keeps the run instant if the folder is not created after all
+            var args = new string[] {
+                $"file://{l1}", $"file://{l2}", "--confirm",
+                "--auto-create-folders=true",
+                "--backend-retry-with-exponential-backoff=false",
+                "--backend-retry-delay", "0"
+            };
+
+            var async_call = RemoteSynchronization.Program.MainAsync(args);
+            var return_code = await async_call.ConfigureAwait(false);
+
+            Assert.AreEqual(0, return_code, "Remote synchronization tool did not return 0.");
+            Assert.IsTrue(Directory.Exists(l2), "The destination folder was not created.");
+            Assert.IsTrue(DirectoriesAndContentsAreEqual(l1, l2), "Synchronized directories are not equal");
+        }
+
+        /// <summary>
+        /// The other half: a missing destination folder is left alone when the tool is told not to
+        /// create it, whatever the exponential backoff flag says.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestAutoCreateFoldersDisabledLeavesMissingDestinationAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "noautocreate_src");
+            var l2 = Path.Combine(TARGETFOLDER, "noautocreate_dst");
+
+            Directory.CreateDirectory(l1);
+            await GenerateTestDataAsync(l1, 5, 0, 0, 1024).ConfigureAwait(false);
+
+            Assert.IsFalse(Directory.Exists(l2), "The destination folder must not exist before the run.");
+
+            var args = new string[] {
+                $"file://{l1}", $"file://{l2}", "--confirm",
+                "--auto-create-folders=false",
+                "--backend-retry-with-exponential-backoff=true",
+                "--backend-retry-delay", "0"
+            };
+
+            var async_call = RemoteSynchronization.Program.MainAsync(args);
+            var return_code = await async_call.ConfigureAwait(false);
+
+            Assert.AreNotEqual(0, return_code, "Remote synchronization should fail when the destination folder is missing and it is not allowed to create it.");
+            Assert.IsFalse(Directory.Exists(l2), "The destination folder was created although it was not allowed.");
+        }
+
+        /// <summary>
+        /// A missing source is not the same as an empty source. Creating it would make the listing
+        /// come back empty, and an empty source means every file in the destination is deleted.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestMissingSourceIsNotCreatedAndDestinationSurvivesAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "missingsrc_src");
+            var l2 = Path.Combine(TARGETFOLDER, "missingsrc_dst");
+
+            Directory.CreateDirectory(l2);
+            await GenerateTestDataAsync(l2, 5, 0, 0, 1024).ConfigureAwait(false);
+            var before = Directory.GetFiles(l2).Length;
+
+            Assert.IsFalse(Directory.Exists(l1), "The source folder must not exist before the run.");
+
+            var args = new string[] {
+                $"file://{l1}", $"file://{l2}", "--confirm",
+                "--backend-retry-delay", "0"
+            };
+
+            var async_call = RemoteSynchronization.Program.MainAsync(args);
+            var return_code = await async_call.ConfigureAwait(false);
+
+            Assert.AreEqual(before, Directory.GetFiles(l2).Length, "The destination was emptied because a created source folder was read as an empty source.");
+            Assert.IsFalse(Directory.Exists(l1), "The source folder was created, which turns a missing source into an empty one.");
+            Assert.AreNotEqual(0, return_code, "Remote synchronization should fail when the source folder is missing.");
         }
 
     }


### PR DESCRIPTION
Two arguments in the remote-synchronization feature are silently bound to something other than what
they are named. Both compile, neither is covered by a test, and one of them ends in deleted files.

## 1. A missing source folder is created, and the destination is then emptied

`RemoteSynchronizationRunner.cs:232-233` constructs both backend managers positionally:

```csharp
new LightWeightBackendManager(config.Src, src_opts, config.BackendRetries, config.BackendRetryDelay,
    config.BackendRetryWithExponentialBackoff, progressUpdater: …, backendProgressUpdater: …);
```

but the constructor is

```csharp
LightWeightBackendManager(string backendUrl, Dictionary<string, string?> options,
    int maxRetries = 3, int retryDelay = 1000,
    bool autoCreateFolders = false, bool retryWithExponentialBackoff = false, …)
```

so the fifth positional argument lands in **`autoCreateFolders`**, `retryWithExponentialBackoff`
keeps its default of `false`, and `config.AutoCreateFolders` is passed to nothing at all - it
appears only in `RemoteSynchronizationConfig.ToString()`.

Because `--backend-retry-with-exponential-backoff` defaults to `true`, **the source manager
auto-creates folders**. That is not a harmless coincidence:

```
duplicati-remote-synchronization file:///gone file:///mirror --confirm
```

`ListAsync` on the missing source throws `FolderMissingException`,
`LightWeightBackendManager.cs:476` creates the folder, the retried listing comes back **empty**, and
an empty source means every file in the destination is scheduled for deletion. Measured, with five
files in the destination: the run returns **0** and the destination ends up with **0 files**. The
inline handler always passes `Confirm: true`, so nothing asks first.

| what is set | effective `autoCreateFolders` | effective backoff |
|---|---|---|
| defaults (backoff `true`) | `true` **on both sides** | never |
| `--backend-retry-with-exponential-backoff=false` | `false` - a missing *destination* folder is not created either | never |
| `--auto-create-folders=false` | ignored, follows the backoff flag | - |

## 2. The inline synchronization forwards none of the backup's options

`RemoteSynchronizationHandler.cs:242` builds the source options as

```csharp
SrcOptions: [.. options.RawOptions.Select((k, v) => $"{k}={v}")],
```

The two-parameter lambda binds `Select<TSource, int, TResult>`, so `k` is the `KeyValuePair` and `v`
is the *index*. What is produced is `"[auth-username, bob]=0"`, `"[dbpath, /var/…]=1"`, and so on.
Those strings pass the round-trip check in `ParseOptions` and are then ignored by the backend, so
nothing complains.

It matters because **the source of an inline synchronization is the backup's own destination** -
`RemoteSynchronizationHandler.cs:330` runs `dest.Config with { Src = m_source! }`, where `m_source`
is the backup's `BackendUrl`. The options that reach that backend are supposed to be the backup's
own: FTP, WebDAV and SSH read their credentials from the options rather than only from the url
(`AuthOptionsHelper.Parse(options, u.Username, u.Password)` in `FTPBackend.cs:320`, `WEBDAV.cs:239`,
`SSHv2Backend.cs:127`), and every backend-specific option a job carries belongs there too. Today
none of them arrive. This is the follow-up to what I reported in #7300.

## The change

- The lambda takes the pair: `Select(x => $"{x.Key}={x.Value}")`.
- Both managers are constructed with **named arguments**. The tail of that constructor is
  `int, int, bool, bool`, which is exactly the shape that swallowed this, and there are two
  overloads differing only in trailing optional parameters. The call already passed
  `progressUpdater:` by name.
- The source manager is given `autoCreateFolders: false` explicitly, with a comment. Beyond the
  option's own help text ("...in the destination backend"), the source is only ever read from, and
  the measurement above is what creating it costs.
- One line in `LightWeightBackendManager`: `_currentRetryDelay <<= 1` is an unclamped `int` that has
  never been reachable, because the flag was never true. Turning the flag on makes it reachable, and
  around 22 doublings it goes negative and `Task.Delay` throws from inside the recovery path. The
  cap is the same 1024x the main `BackendManager` uses through `Utility.GetRetryDelay`
  (`Utility.cs:1711`, `Math.Min(retryAttempt - 1, 10)`). **Happy to drop this hunk, or to convert
  `LightWeightBackendManager` to `GetRetryDelay` in a separate PR, if you prefer.**

## Red to green

Measured by reverting the two production files and running the four new tests: **4 failed, 0
passed**; with the change, **62 passed** across `TestCategory=Tools/RemoteSynchronization` and
`TestCategory=RemoteSync`.

| Test | Before |
|---|---|
| `ToolTests.TestMissingSourceIsNotCreatedAndDestinationSurvivesAsync` | fails: the destination goes from 5 files to **0**, and the run returns 0 |
| `ToolTests.TestAutoCreateFoldersCreatesMissingDestinationAsync` | fails: with `--backend-retry-with-exponential-backoff=false` the auto-create flag is bound to `false`, the listing fails three times and the tool returns non-zero |
| `ToolTests.TestAutoCreateFoldersDisabledLeavesMissingDestinationAsync` | fails: with `--auto-create-folders=false` the folder is created anyway and the tool returns 0 |
| `RemoteSynchronizationHandlerTests.TestConfigure_ForwardsBackupOptionsAsSourceOptionsAsync` | fails: `SrcOptions` holds `"[auth-username, someuser]=0"` |

The two auto-create tests set the two flags to *opposite* values, so they pin the relative position
of both arguments: swapping them again breaks both. They use `--backend-retry-delay 0`, which keeps
a failing run instant (`LightWeightBackendManager.cs:483` skips the sleep when the delay is zero),
and a plain `file://` backend, which raises `FolderMissingException` from its listing
(`FileBackend.cs:253`) - no test backend needed.

Two rows were added to `TestMainMethodParsesArgumentsCorrectly` for `--auto-create-folders=false`
and `--backend-retry-with-exponential-backoff=false`. Without them the second test could pass for
the wrong reason: an unparseable option also returns non-zero and also leaves the folder missing.

The handler test also feeds the forwarded list back through the runner's own parser
(`ParseArgumentsOnly` returns after `ParseOptions`). That check does **not** detect the bug - the
broken strings round-trip just as well - it shows that a value containing an equals sign survives.

**Three existing tests needed a line.** `TestRunAsync_WithEmptyDestinations_SkipsSync_Async`,
`TestRunAsync_WithMultipleDestinations_SelectiveSync_Async` and
`TestRunAsync_WithWarningResult_TriggersSync_Async` sync from a folder that is never created, and
passed only because the tool created it for them - the behaviour this PR removes. They now create it
themselves, which is what the inline path always has: the backup's own destination.

## What changes for existing users

- **A missing source now fails instead of emptying the destination.** That is the point of the
  change, but a job that "worked" against a source that had gone away will start reporting an error.
- **`--auto-create-folders=false` starts being honoured.** Anyone who set it and still got their
  destination folders created will now see the synchronization fail against a missing folder.
- **Exponential backoff starts happening.** It defaults to on and has never actually run. With the
  stock `--backend-retries 3 --backend-retry-delay 1000` a fully failing operation goes from about
  3s to about 7s (1s + 2s + 4s); with `--backend-retries 10`, from 10s to about 17 minutes. The cap
  above only binds beyond that, at the eleventh doubling. Worth a changelog line.
- The backup's options now reach the **source** backend only. The destination still gets just the
  `dst-options` and `global-options` from the JSON configuration.

## Secrets

`SrcOptions` now carries whatever the job carries, `passphrase` included. It does not reach a log:
`RemoteSynchronizationConfig.ToString()` deliberately omits `SrcOptions`, `DstOptions` and
`GlobalOptions` and runs both urls through `GetUrlWithoutCredentials`, and the sites that log a
destination format the record, so they go through that override. The values reach
`LightWeightBackendManager` and the backend constructor, which ignore what they do not know. If you
would rather forward an allowlist, say so and I will follow up.

## Reported, not fixed

While debugging the tests I hit this: the tool copies **every entry a listing returns, including
folders**. A `file://` source whose folder contains a subdirectory produces
`Get <subdirectory> => UnauthorizedAccessException` three times and fails the run. Backup
destinations do not normally hold subfolders, so this is not what the PR is about, but
`PrepareFileListsAsync` and `CopyAsync` never look at `IFileEntry.IsFolder`.

## Not measured

- I have no FTP/WebDAV/SSH destination to confirm the payoff of the second fix on; the test asserts
  the strings, not a live connection.
- The exponential-backoff half has **no test**. Its only effect is `_currentRetryDelay <<= 1` on a
  private field of a local instance: no log line, no counter, no seam - it is observable only as
  elapsed time, and a timing assertion would be flaky rather than honest. The two auto-create tests
  pin its argument position, not its behaviour.
- This touches `RemoteSynchronizationRunner.cs` a few lines away from #7300. If that one lands first
  and this needs a rebase, say the word. The two fixes here are also independent of each other if
  you would rather take one; the only coupling is the three-test change above.
