### PR TITLE
Ignore the folder entries a remote listing reports

### DIFF
--- a/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
@@ -742,6 +742,10 @@ public static class RemoteSynchronizationRunner
         using (new Duplicati.Library.Logging.Timer(LOGTAG, "ListSource", "Prepare | List source"))
             files_src = await b_src.ListAsync(token).ConfigureAwait(false);
 
+        // Folders are dropped before anything looks at the listing: the shortcuts below return the
+        // listings as they are, and the duplicate check has no use for names that are never addressed
+        files_src = WithoutFolders(files_src, "source");
+
         // Checked before the shortcuts below, because neither of them makes two entries that share
         // a name any easier to tell apart
         VerifyNoDuplicateNames(files_src, "source", config.Src, name_comparer);
@@ -749,6 +753,7 @@ public static class RemoteSynchronizationRunner
         using (new Duplicati.Library.Logging.Timer(LOGTAG, "ListDestination", "Prepare | List destination"))
             files_dst = await b_dst.ListAsync(token).ConfigureAwait(false);
 
+        files_dst = WithoutFolders(files_dst, "destination");
         VerifyNoDuplicateNames(files_dst, "destination", config.Dst, name_comparer);
 
         // Shortcut for force
@@ -817,6 +822,29 @@ public static class RemoteSynchronizationRunner
             to_delete_lookedup = [.. to_delete.Select(x => lookup_dst[x])];
 
         return (to_copy, to_delete_lookedup, to_verify);
+    }
+
+    /// <summary>
+    /// Drops the folder entries from a remote listing.
+    /// Every operation in this tool addresses a remote file by its name, and none of them applies
+    /// to a folder: it cannot be downloaded, uploaded, deleted as a file or compared byte for byte.
+    /// A Duplicati destination is flat, so a folder the backend reports is never part of the backup;
+    /// a destination at the root of a mount or a drive lists lost+found, $RECYCLE.BIN or
+    /// System Volume Information next to the volumes, and the file backend lists any subfolder.
+    /// The backup path never trips over them, because their names do not parse as volume names.
+    /// </summary>
+    /// <param name="files">The listing to filter.</param>
+    /// <param name="side">The side the listing was read from, for the log message.</param>
+    /// <returns>The entries of the listing that are not folders.</returns>
+    private static List<IFileEntry> WithoutFolders(IEnumerable<IFileEntry> files, string side)
+    {
+        var folders = files.Where(x => x.IsFolder).Select(x => x.Name).ToList();
+        if (folders.Count > 0)
+            Duplicati.Library.Logging.Log.WriteInformationMessage(LOGTAG, "IgnoredFolders",
+                "Ignoring {0} folder entries in the {1} listing: {2}",
+                folders.Count, side, string.Join(", ", folders));
+
+        return files.Where(x => !x.IsFolder).ToList();
     }
 
     /// <summary>

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -997,5 +997,90 @@ namespace Duplicati.UnitTest
             }
         }
 
+        /// <summary>
+        /// A folder in the source is not a file the tool can copy. The file backend lists subfolders
+        /// next to the files, and a flat Duplicati destination has no use for them, so they are
+        /// skipped instead of failing the whole run with a copy error.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestFoldersInTheSourceAreIgnoredAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "srcfolder_src");
+            var l2 = Path.Combine(TARGETFOLDER, "srcfolder_dst");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            // Three files and one subfolder holding files of its own
+            await GenerateTestDataAsync(l1, 3, 1, 1, 1024).ConfigureAwait(false);
+            Assert.IsTrue(Directory.Exists(Path.Combine(l1, "dir_0")), "The test data has no subfolder to trip over.");
+
+            // No copy retries, so the failure this guards against is reported at once instead of after the retry delays
+            var args = new string[] {
+                $"file://{l1}", $"file://{l2}", "--confirm",
+                "--backend-retry-delay", "0", "--retry", "0"
+            };
+
+            var return_code = await RemoteSynchronization.Program.MainAsync(args).ConfigureAwait(false);
+
+            Assert.AreEqual(0, return_code, "Remote synchronization tool did not return 0.");
+
+            // Only the top level is compared: DirectoriesAndContentsAreEqual recurses, and the subfolder is meant to stay behind
+            var expected = Directory.EnumerateFiles(l1).Select(Path.GetFileName).OrderBy(x => x).ToList();
+            var actual = Directory.EnumerateFileSystemEntries(l2).Select(Path.GetFileName).OrderBy(x => x).ToList();
+            Assert.IsTrue(expected.SequenceEqual(actual), $"The destination does not hold exactly the top level files of the source: {string.Join(", ", actual)}");
+            foreach (var name in expected)
+                Assert.IsTrue(File.ReadAllBytes(Path.Combine(l1, name)).SequenceEqual(File.ReadAllBytes(Path.Combine(l2, name))), $"{name} did not arrive intact.");
+            Assert.IsFalse(Directory.Exists(Path.Combine(l2, "dir_0")), "The source subfolder was created in the destination.");
+        }
+
+        /// <summary>
+        /// A folder in the destination is not a file the tool can delete or rename, so it is left
+        /// alone rather than reported as a failed delete or rename. A destination at the root of a
+        /// mount or a drive has lost+found or System Volume Information next to the backup.
+        /// </summary>
+        [TestCase(false)]
+        [TestCase(true)]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestFoldersInTheDestinationAreLeftAloneAsync(bool retention)
+        {
+            var l1 = Path.Combine(TARGETFOLDER, $"dstfolder_src_{retention}");
+            var l2 = Path.Combine(TARGETFOLDER, $"dstfolder_dst_{retention}");
+            var log = Path.Combine(TARGETFOLDER, $"dstfolder_{retention}.log");
+
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l1, 3, 0, 0, 1024).ConfigureAwait(false);
+
+            // The destination holds nothing but a folder with a file in it, so it is not empty and
+            // the folder is what would end up in the delete list
+            var nested = Path.Combine(l2, "sub", "nested.txt");
+            Directory.CreateDirectory(Path.Combine(l2, "sub"));
+            await File.WriteAllTextAsync(nested, "nested").ConfigureAwait(false);
+
+            var args = new List<string> {
+                $"file://{l1}", $"file://{l2}", "--confirm",
+                "--log-file", log, "--log-level", "Warning",
+                "--backend-retry-delay", "0"
+            };
+            if (retention)
+                args.Add("--retention");
+
+            var return_code = await RemoteSynchronization.Program.MainAsync([.. args]).ConfigureAwait(false);
+
+            Assert.AreEqual(0, return_code, "Remote synchronization tool did not return 0.");
+            foreach (var f in Directory.EnumerateFiles(l1))
+                Assert.IsTrue(File.ReadAllBytes(f).SequenceEqual(File.ReadAllBytes(Path.Combine(l2, Path.GetFileName(f)))), $"{Path.GetFileName(f)} did not arrive intact.");
+            Assert.IsTrue(File.Exists(nested), "The file in the destination folder was removed.");
+            Assert.AreEqual("nested", await File.ReadAllTextAsync(nested).ConfigureAwait(false), "The file in the destination folder was changed.");
+
+            // The log sink flushes every line and is closed before the run returns
+            var logged = await File.ReadAllLinesAsync(log).ConfigureAwait(false);
+            Assert.IsFalse(logged.Any(x => x.Contains("-DeleteError]") || x.Contains("-RenameError]")),
+                $"The folder was reported as a failed delete or rename:{Environment.NewLine}{string.Join(Environment.NewLine, logged)}");
+        }
+
     }
 }


### PR DESCRIPTION
## What happens

The remote synchronization tool copies, deletes, renames and verifies **every entry a listing
returns**, and never looks at `IFileEntry.IsFolder`. Fourteen backends report folders in their
listings - `file://`, FTP, SMB, S3, OneDrive, Google Drive, Dropbox, Box, SharePoint, Jottacloud
among them - so a source folder that holds a subdirectory fails like this (measured, while working
on #7307):

```
Error during operation: Get source => System.UnauthorizedAccessException: Access to the path '…\source' is denied.   ×3
Error copying source: Operation 'Get source' failed after 3 attempts.
→ exit code 1
```

A subdirectory in the destination is not fatal but is reported on every run as a failed delete, or
as a failed rename with `--retention` (`RenameAsync` is Get → Put → Delete for a streaming backend,
and the Get is what fails):

```
[Error-…LightWeightBackendManager-rsync]: Error during operation: Delete sub          ×3
[Error-…RemoteSynchronizationRunner-DeleteError]: Error deleting sub: Operation 'Delete sub' failed after 3 attempts.
```

Destinations at the root of a mount or a drive always have such entries next to the volumes:
`lost+found`, `$RECYCLE.BIN`, `System Volume Information`. The backup itself never trips over
them - `FilelistProcessor` only considers names that parse as volume names and merely counts the
rest - so a destination that has worked for years as a backup target fails as soon as it is
synchronized. This is the follow-up to what I reported in #7307.

## The change

Folder entries are dropped from both listings as soon as they are read, before the `--force` and
empty-destination shortcuts (which return the listings as they are) and before the duplicate check.
Everything the tool later acts on - `to_copy`, `to_delete`, `to_verify`, the copy retries - derives
from those two lists, so this is the one place to do it.

When something is dropped, one line is logged at **Information**, naming the entries:

```
Ignoring 1 folder entries in the source listing: lost+found
```

Information rather than Verbose because the source side is the case a user needs to see at the
default level: the source has content the tool is not carrying, and the line lands right before the
synchronization plan that asks for confirmation. It fires at most once per side and only when a
folder was there, and in a real destination the list is one to three names long.

`Strings.cs` is untouched; the tool's description is a translated string.

## Red to green

`dotnet test … --filter "FullyQualifiedName~ToolTests.TestFoldersInThe"` - **3 failed** before,
**3 passed** after; the whole `Tools/RemoteSynchronization` category is green.

| Test | Before |
|---|---|
| `TestFoldersInTheSourceAreIgnoredAsync` | exit code 1: the copy of `dir_0` fails three times |
| `TestFoldersInTheDestinationAreLeftAloneAsync(False)` | `DeleteError` for the folder in the log |
| `TestFoldersInTheDestinationAreLeftAloneAsync(True)` (`--retention`) | `RenameError` for the folder in the log |

Both use a plain `file://` backend, whose listing includes subdirectories, so no test backend is
needed. The source test compares the destination's top level against the source's top level by hand
(`DirectoriesAndContentsAreEqual` recurses, and the subfolder is meant to stay behind) and checks the
subfolder was not created. The destination tests run with `--log-file` and assert the log holds no
`-DeleteError]` / `-RenameError]` line, that the folder and the file inside it are still there, and
that the three files arrived; the log sink flushes every line and is disposed before the run
returns, so reading it right after `MainAsync` is safe.

## What changes for existing users

- A synchronization that failed on a stray folder now runs, and says which folders it skipped.
- A source whose listing consists of folders only is now an **empty** source, and an empty source
  deletes the destination. That is not new - before this change the same run deleted the
  destination first and then failed on the copies - but the Information line is the one warning
  the user gets before the plan is confirmed. With `--confirm` (which the inline handler always
  sets) there is no prompt, exactly as before.

## Not measured

- Only `file://` was exercised; the other thirteen backends were identified by reading their
  listing code, not by running them.
- A tree produced by the `sync` *operation* (`SyncHandler`) has never been something this tool
  could mirror; after this change it copies the top-level files and reports the folders it skipped
  instead of failing. I did not try to make it recurse - the tool's job is a flat Duplicati
  destination.
