### PR TITLE
Let the synchronization tool rename through the backend and compare through temporary files

### DIFF
--- a/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
+++ b/Duplicati/Library/Main/Backend/LightWeightBackendManager.cs
@@ -296,8 +296,11 @@ namespace Duplicati.Library.Main.Backend
 
         /// <summary>
         /// Renames a file in the remote backend.
-        /// If the backend supports renaming, it uses the RenameAsync method.
-        /// If the backend does not support renaming, it downloads the file, renames it, and deletes the old one.
+        /// If the backend implements <see cref="IRenameEnabledBackend"/> its own rename is used, so no
+        /// data passes through this machine; the option prevent-backend-rename=true forces the fallback,
+        /// as it does in the backup path. Otherwise the file is downloaded to a temporary file, uploaded
+        /// under the new name and deleted under the old one. The backend is read inside the retry lambda,
+        /// because every retry disposes and re-instantiates it.
         /// </summary>
         /// <param name="oldname">The current name of the remote file.</param>
         /// <param name="newname">The new name for the remote file.</param>
@@ -305,43 +308,33 @@ namespace Duplicati.Library.Main.Backend
         /// <returns>A task representing the asynchronous rename operation.</returns>
         public Task RenameAsync(string oldname, string newname, CancellationToken token)
         {
-            Instantiate();
+            var preventRename = Duplicati.Library.Utility.Utility.ParseBoolOption(_options, "prevent-backend-rename");
 
-            return _backend switch
-            {
-                IStreamingBackend sb =>
-                    RetryWithDelayAsync(
-                        $"Rename {oldname} to {newname}",
-                        async () =>
-                        {
-                            // Download the file, rename it, and delete the old one
-                            using var downloaded = new MemoryStream();
-                            await sb.GetAsync(oldname, downloaded, token).ConfigureAwait(false);
-                            downloaded.Seek(0, SeekOrigin.Begin);
-                            await sb.PutAsync(newname, downloaded, token).ConfigureAwait(false);
-                            await sb.DeleteAsync(oldname, token).ConfigureAwait(false);
-                            _anyUploaded = true;
-                            _anyDownloaded = true;
-                        },
-                        null,
-                        false,
-                        token
-                    ),
-                IRenameEnabledBackend ireb =>
-                    RetryWithDelayAsync(
-                        $"Rename {oldname} to {newname}",
-                        async () =>
-                        {
-                            await ireb.RenameAsync(oldname, newname, token).ConfigureAwait(false);
-                            _anyUploaded = true;
-                            _anyDownloaded = true;
-                        },
-                        null,
-                        false,
-                        token
-                    ),
-                _ => throw new InvalidOperationException("Backend does not support renaming."),
-            };
+            return RetryWithDelayAsync(
+                $"Rename {oldname} to {newname}",
+                async () =>
+                {
+                    if (!preventRename && _backend is IRenameEnabledBackend renameBackend)
+                    {
+                        await renameBackend.RenameAsync(oldname, newname, token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // A fresh temporary file per attempt, so a half-written download is never re-uploaded
+                        using var downloaded = TempFileStream.Create();
+                        await _streamingBackend!.GetAsync(oldname, downloaded, token).ConfigureAwait(false);
+                        downloaded.Position = 0;
+                        await _streamingBackend!.PutAsync(newname, downloaded, token).ConfigureAwait(false);
+                        await _streamingBackend!.DeleteAsync(oldname, token).ConfigureAwait(false);
+                    }
+
+                    _anyUploaded = true;
+                    _anyDownloaded = true;
+                },
+                null,
+                false,
+                token
+            );
         }
 
         /// <summary>

--- a/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
@@ -849,7 +849,8 @@ public static class RemoteSynchronizationRunner
 
     /// <summary>
     /// Renames the files in a backend.
-    /// The renaming is done by deleting the file and re-uploading it with a new name.
+    /// The renaming is delegated to the backend manager, which uses the backend's own rename when it has one and
+    /// falls back to downloading, uploading under the new name and deleting the old one otherwise.
     /// </summary>
     /// <param name="bm">The lightweight backend manager to issue rename operations to.</param>
     /// <param name="files">The files to rename.</param>
@@ -864,7 +865,6 @@ public static class RemoteSynchronizationRunner
     {
         long successful_renames = 0;
         string prefix = $"{System.DateTime.UtcNow:yyyyMMddHHmmss}.old";
-        using var downloaded = new MemoryStream();
         long i = 0, n = files.Count();
 
         var sw = new System.Diagnostics.Stopwatch();
@@ -933,7 +933,8 @@ public static class RemoteSynchronizationRunner
 
     /// <summary>
     /// Verifies the files in the destination backend.
-    /// The verification is done by downloading the files from the destination backend and comparing them to the source files.
+    /// The verification is done by downloading both copies to temporary files and comparing them in chunks, so a
+    /// volume is never held in memory.
     /// </summary>
     /// <param name="b_src">The source lightweight backend manager.</param>
     /// <param name="b_dst">The destination lightweight backend manager.</param>
@@ -944,8 +945,9 @@ public static class RemoteSynchronizationRunner
     private static async Task<IEnumerable<IFileEntry>> VerifyAsync(LightWeightBackendManager b_src, LightWeightBackendManager b_dst, IEnumerable<IFileEntry> files, RemoteSynchronizationConfig config, CancellationToken token)
     {
         var errors = new List<IFileEntry>();
-        using var s_src = new MemoryStream();
-        using var s_dst = new MemoryStream();
+        // Temporary files instead of memory: a volume can be gigabytes, and two of them are compared at a time
+        using var s_src = Duplicati.Library.Utility.TempFileStream.Create();
+        using var s_dst = Duplicati.Library.Utility.TempFileStream.Create();
         long i = 0, n = files.Count();
         var sw_get = new System.Diagnostics.Stopwatch();
         var sw_cmp = new System.Diagnostics.Stopwatch();
@@ -958,7 +960,7 @@ public static class RemoteSynchronizationRunner
             Duplicati.Library.Logging.Log.WriteVerboseMessage(LOGTAG, "VerifyingFile",
                 "Verifying {0} by downloading and comparing {1} bytes from {2} and {3}",
                 f.Name,
-                Duplicati.Library.Utility.Utility.FormatSizeString(s_src.Length),
+                Duplicati.Library.Utility.Utility.FormatSizeString(Math.Max(f.Size, 0)),
                 b_dst.DisplayName, b_src.DisplayName);
 
             try
@@ -970,9 +972,11 @@ public static class RemoteSynchronizationRunner
                 await Task.WhenAll(fs, ds).ConfigureAwait(false);
                 sw_get.Stop();
 
-                // Compare the contents
+                // Compare the contents in chunks; neither file is held in memory
                 sw_cmp.Start();
-                if (s_src.Length != s_dst.Length || !s_src.ToArray().SequenceEqual(s_dst.ToArray()))
+                s_src.Position = 0;
+                s_dst.Position = 0;
+                if (!Duplicati.Library.Utility.Utility.CompareStreams(s_src, s_dst, true))
                 {
                     errors.Add(f);
                 }

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -997,5 +997,241 @@ namespace Duplicati.UnitTest
             }
         }
 
+        /// <summary>
+        /// A file backend that counts how the synchronization tool reaches it, so a test can tell the
+        /// backend's own rename from the download, upload and delete fallback.
+        /// </summary>
+        public class RenameCountingBackend : IBackend, IStreamingBackend, IRenameEnabledBackend
+        {
+            /// <summary>
+            /// The protocol key this backend is registered under.
+            /// </summary>
+            public const string Key = "renamecounttest";
+
+            public static int Renames, Gets, Puts, Deletes;
+
+            public static void ResetCounters() => Renames = Gets = Puts = Deletes = 0;
+
+            private readonly Library.Backend.File? m_backend;
+
+            public RenameCountingBackend() { }
+
+            public RenameCountingBackend(string url, Dictionary<string, string> options)
+            {
+                m_backend = (Library.Backend.File)Library.DynamicLoader.BackendLoader.GetBackend(url.Replace($"{Key}://", "file://"), options);
+            }
+
+            public string DisplayName => "Rename counting test backend";
+            public string ProtocolKey => Key;
+            public string Description => "A testing backend that counts renames, gets, puts and deletes";
+            public bool SupportsStreaming => m_backend?.SupportsStreaming ?? false;
+            public IList<ICommandLineArgument> SupportedCommands
+                => m_backend?.SupportedCommands ?? Library.DynamicLoader.BackendLoader.GetSupportedCommands("file://").ToList();
+
+            public IAsyncEnumerable<IFileEntry> ListAsync(CancellationToken cancelToken) => m_backend!.ListAsync(cancelToken);
+            public Task CreateFolderAsync(CancellationToken cancelToken) => m_backend!.CreateFolderAsync(cancelToken);
+            public Task TestAsync(bool alsoWrite, CancellationToken cancelToken) => m_backend!.TestAsync(alsoWrite, cancelToken);
+            public Task<string[]> GetDNSNamesAsync(CancellationToken cancelToken) => m_backend!.GetDNSNamesAsync(cancelToken);
+
+            public Task RenameAsync(string oldname, string newname, CancellationToken cancelToken)
+            {
+                Interlocked.Increment(ref Renames);
+                return m_backend!.RenameAsync(oldname, newname, cancelToken);
+            }
+
+            public Task GetAsync(string remotename, Stream stream, CancellationToken cancelToken)
+            {
+                Interlocked.Increment(ref Gets);
+                return m_backend!.GetAsync(remotename, stream, cancelToken);
+            }
+
+            public Task GetAsync(string remotename, string filename, CancellationToken cancelToken)
+            {
+                Interlocked.Increment(ref Gets);
+                return m_backend!.GetAsync(remotename, filename, cancelToken);
+            }
+
+            public Task PutAsync(string remotename, Stream stream, CancellationToken cancelToken)
+            {
+                Interlocked.Increment(ref Puts);
+                return m_backend!.PutAsync(remotename, stream, cancelToken);
+            }
+
+            public Task PutAsync(string remotename, string filename, CancellationToken cancelToken)
+            {
+                Interlocked.Increment(ref Puts);
+                return m_backend!.PutAsync(remotename, filename, cancelToken);
+            }
+
+            public Task DeleteAsync(string remotename, CancellationToken cancelToken)
+            {
+                Interlocked.Increment(ref Deletes);
+                return m_backend!.DeleteAsync(remotename, cancelToken);
+            }
+
+            public void Dispose() => m_backend?.Dispose();
+        }
+
+        /// <summary>
+        /// Checks that every file in <paramref name="before"/> now sits under a name that carries the
+        /// retention prefix and the original name, with the same contents, and that the original name
+        /// is gone.
+        /// </summary>
+        private static void AssertRenamedIntact(string dir, Dictionary<string, byte[]> before)
+        {
+            var after = Directory.EnumerateFiles(dir).Select(x => Path.GetFileName(x)!).ToList();
+            Assert.AreEqual(before.Count, after.Count, $"Unexpected files after the rename: {string.Join(", ", after)}");
+            foreach (var (name, contents) in before)
+            {
+                var renamed = after.SingleOrDefault(x => x.EndsWith($".old.{name}", StringComparison.Ordinal));
+                Assert.IsNotNull(renamed, $"{name} was not renamed with the retention prefix: {string.Join(", ", after)}");
+                Assert.IsFalse(File.Exists(Path.Combine(dir, name)), $"{name} is still present under its original name.");
+                Assert.IsTrue(contents.SequenceEqual(File.ReadAllBytes(Path.Combine(dir, renamed!))), $"{renamed} does not hold the contents of {name}.");
+            }
+        }
+
+        /// <summary>
+        /// A destination that can rename must be asked to rename. Downloading, re-uploading and deleting
+        /// moves every byte of every retained volume through this machine for nothing. The option
+        /// prevent-backend-rename forces the fallback, as it does in the backup path.
+        /// </summary>
+        [TestCase(false)]
+        [TestCase(true)]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestRetentionUsesTheBackendsOwnRenameAsync(bool preventRename)
+        {
+            var l1 = Path.Combine(TARGETFOLDER, $"rename_src_{preventRename}");
+            var l2 = Path.Combine(TARGETFOLDER, $"rename_dst_{preventRename}");
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l2, 3, 0, 0, 1024).ConfigureAwait(false);
+            var before = Directory.EnumerateFiles(l2).ToDictionary(x => Path.GetFileName(x)!, x => File.ReadAllBytes(x));
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new RenameCountingBackend());
+            RenameCountingBackend.ResetCounters();
+
+            var args = new List<string> { $"file://{l1}", $"{RenameCountingBackend.Key}://{l2}", "--confirm", "--retention", "--backend-retry-delay", "0" };
+            if (preventRename)
+                args.AddRange(["--dst-options", "prevent-backend-rename=true"]);
+
+            var return_code = await RemoteSynchronization.Program.MainAsync([.. args]).ConfigureAwait(false);
+
+            Assert.AreEqual(0, return_code, "Remote synchronization tool did not return 0.");
+            if (preventRename)
+            {
+                Assert.AreEqual(0, RenameCountingBackend.Renames, "The backend's own rename was used although it was turned off.");
+                Assert.AreEqual(3, RenameCountingBackend.Gets, "Every retained file should be downloaded once.");
+                Assert.AreEqual(3, RenameCountingBackend.Puts, "Every retained file should be uploaded once.");
+                Assert.AreEqual(3, RenameCountingBackend.Deletes, "Every retained file should be deleted once under its old name.");
+            }
+            else
+            {
+                Assert.AreEqual(3, RenameCountingBackend.Renames, "Every retained file should be renamed by the backend itself.");
+                Assert.AreEqual(0, RenameCountingBackend.Gets, "No file should be downloaded to rename it.");
+                Assert.AreEqual(0, RenameCountingBackend.Puts, "No file should be uploaded to rename it.");
+                Assert.AreEqual(0, RenameCountingBackend.Deletes, "No file should be deleted to rename it.");
+            }
+            AssertRenamedIntact(l2, before);
+        }
+
+        /// <summary>
+        /// A destination that cannot rename still gets its files renamed: downloaded to a temporary
+        /// file, uploaded under the new name and deleted under the old one.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestRetentionFallsBackToCopyingForAStreamingOnlyBackendAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "renamefb_src");
+            var l2 = Path.Combine(TARGETFOLDER, "renamefb_dst");
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l2, 3, 0, 0, 1024).ConfigureAwait(false);
+            var before = Directory.EnumerateFiles(l2).ToDictionary(x => Path.GetFileName(x)!, x => File.ReadAllBytes(x));
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            // The generator is static, and another test may have left one behind
+            DeterministicErrorBackend.ErrorGenerator = (_, _) => false;
+
+            var args = new string[] { $"file://{l1}", $"deterror://{l2}", "--confirm", "--retention", "--backend-retry-delay", "0" };
+            var return_code = await RemoteSynchronization.Program.MainAsync(args).ConfigureAwait(false);
+
+            Assert.AreEqual(0, return_code, "Remote synchronization tool did not return 0.");
+            AssertRenamedIntact(l2, before);
+        }
+
+        /// <summary>
+        /// A rename that fails once is retried on the backend instance the manager creates for the
+        /// retry, not on the one it has already disposed.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestRetentionRetriesARenameThatFailedOnceAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "renameretry_src");
+            var l2 = Path.Combine(TARGETFOLDER, "renameretry_dst");
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l2, 3, 0, 0, 1024).ConfigureAwait(false);
+            var before = Directory.EnumerateFiles(l2).ToDictionary(x => Path.GetFileName(x)!, x => File.ReadAllBytes(x));
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            var failed = 0;
+            DeterministicErrorBackend.ErrorGenerator = (action, _) =>
+                action == DeterministicErrorBackend.BackendAction.GetBefore && Interlocked.Exchange(ref failed, 1) == 0;
+
+            var args = new string[] { $"file://{l1}", $"deterror://{l2}", "--confirm", "--retention", "--backend-retries", "3", "--backend-retry-delay", "0", "--retry", "0" };
+            var return_code = await RemoteSynchronization.Program.MainAsync(args).ConfigureAwait(false);
+
+            Assert.AreEqual(1, failed, "The injected failure did not fire.");
+            Assert.AreEqual(0, return_code, "Remote synchronization tool did not return 0.");
+            // The exit code does not report rename failures, so the directory is what tells a retried rename from a dropped one
+            AssertRenamedIntact(l2, before);
+        }
+
+        /// <summary>
+        /// A file whose name, size and timestamp match on both sides can still differ, and
+        /// --verify-contents is what finds it. The timestamps are pinned, so only the byte comparison
+        /// can tell the file apart.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestVerifyContentsFindsASameSizeSameTimestampChangeAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "verify_src");
+            var l2 = Path.Combine(TARGETFOLDER, "verify_dst");
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l1, 4, 0, 0, 1024).ConfigureAwait(false);
+            foreach (var f in Directory.EnumerateFiles(l1))
+            {
+                var copy = Path.Combine(l2, Path.GetFileName(f));
+                File.Copy(f, copy);
+                File.SetLastWriteTimeUtc(copy, File.GetLastWriteTimeUtc(f));
+            }
+
+            // Flip one byte of one destination file and give it back its timestamp, so the listing cannot tell
+            var changed = Directory.EnumerateFiles(l2).First();
+            var stamp = File.GetLastWriteTimeUtc(changed);
+            var bytes = File.ReadAllBytes(changed);
+            bytes[0] ^= 0xFF;
+            File.WriteAllBytes(changed, bytes);
+            File.SetLastWriteTimeUtc(changed, stamp);
+
+            var results = new RemoteSynchronizationResults();
+            var config = SyncConfig($"file://{l1}", $"file://{l2}") with { DryRun = false, VerifyContents = true, BackendRetryDelay = 0 };
+            var return_code = await Library.Main.Operation.RemoteSynchronization.RemoteSynchronizationRunner
+                .RunAsync(config, CancellationToken.None, results: results).ConfigureAwait(false);
+
+            Assert.AreEqual(0, return_code, "Remote synchronization tool did not return 0.");
+            Assert.AreEqual(1, results.FailedVerificationCount, "The changed file was not caught by the verification.");
+            Assert.AreEqual(3, results.VerifiedFileCount, "The unchanged files did not pass the verification.");
+            Assert.IsTrue(DirectoriesAndContentsAreEqual(l1, l2), "The changed file was not copied again.");
+        }
+
     }
 }


### PR DESCRIPTION
## What happens

Two operations of the remote synchronization tool pull whole remote volumes into memory, and one of
them never uses the rename a backend offers.

### `--retention` renames by download, re-upload and delete - always

`LightWeightBackendManager.RenameAsync` reads:

```csharp
/// If the backend does not support renaming, it downloads the file, renames it, and deletes the old one.
public Task RenameAsync(string oldname, string newname, CancellationToken token)
{
    Instantiate();
    return _backend switch
    {
        IStreamingBackend sb => /* Get → new MemoryStream() → Put → Delete */,
        IRenameEnabledBackend ireb => /* ireb.RenameAsync(oldname, newname) */,
        _ => throw new InvalidOperationException("Backend does not support renaming."),
    };
}
```

`Instantiate()` rejects any backend that is not an `IStreamingBackend`, so the first arm always
matches and the `IRenameEnabledBackend` arm is unreachable - for all 27 backends that implement it
(`file://`, S3, B2, Azure, OneDrive, Google Drive, Dropbox, FTP, Box, Jottacloud, pCloud, Mega,
Drime, rclone, ...). Every retained volume is downloaded into a `MemoryStream`, uploaded again under
the new name and deleted. On `file://` that is a read-write copy where `File.Move` would do.

The lambda also captures `sb` from the pattern match. `RetryWithDelayAsync` disposes the backend
after a failed attempt and instantiates a new one for the next, so a retried rename runs on the
disposed instance. Every other operation reads `_streamingBackend!` inside its lambda.

The backup path's soft-delete (`BackendManager.DeleteOperation.cs:108-121`) has had it right all
along: native rename when the backend has one and `--prevent-backend-rename` is not set, otherwise
Get through a `TempFile`, Put, Delete.

### `--verify-contents` holds four copies of a volume

`VerifyAsync` downloads both sides into two `MemoryStream`s and then compares
`s_src.ToArray().SequenceEqual(s_dst.ToArray())`, which copies both again. The streams keep their
capacity across files. The verbose message logs `s_src.Length` before the download, which is always
zero.

`CopyAsync` in the same file already does the right thing (`TempFile` for the download,
`TempFileStream.Create()` for the read-back), so this is the tool being half converted.

## Measured

`Duplicati.CommandLine.SyncTool.exe` (Debug), a 512 MiB file, `file://` on both sides, peak working
set sampled from `Process.PeakWorkingSet64` every 50 ms while the process ran. Baseline for a run
with no files is 45 MB.

| Run | Before | After |
|---|---|---|
| `--retention`, one 512 MiB file in the destination, empty source | **1050 MB** | **45 MB** (native rename) |
| the same with `--dst-options prevent-backend-rename=true` (the fallback) | 1045 MB | **56 MB** |
| `--verify-contents`, the same 512 MiB file on both sides | **2999 MB** | **55 MB** |

The 1 GB for a 512 MiB file is the `MemoryStream` doubling its buffer; the 3 GB is two of those plus
the two `ToArray()` copies alive at the comparison. The verify run takes longer afterwards (9.6 s
against 5.7 s here): it now writes both copies to the temp directory and reads them back, the same
requirement `--verify-get-after-put` already has.

## The change

- `RenameAsync` is one `RetryWithDelayAsync` whose lambda reads the backend at each attempt. If the
  backend implements `IRenameEnabledBackend` and `prevent-backend-rename` is not set, its own rename
  is used. Otherwise the file goes through a `TempFileStream` (a fresh one per attempt, so a
  half-written download is never re-uploaded), then Put, then Delete. `prevent-backend-rename` is the
  existing option the backup path honours (`Options.cs:424`); in the tool it arrives through
  `--dst-options prevent-backend-rename=true`, the same way `quota-disable` does.
- `VerifyAsync` downloads into two `TempFileStream`s and compares them with the existing
  `Utility.CompareStreams`, which reads in chunks and stops at the first difference. The verbose
  message now reports the listed size.
- The unused `MemoryStream` in the runner's `RenameAsync` is gone, and both doc comments say what the
  code does.

## Red to green

`--filter "FullyQualifiedName~ToolTests.TestRetention|FullyQualifiedName~ToolTests.TestVerifyContents"`:
**2 failed, 3 passed** before, **5 passed** after; the `Tools/RemoteSynchronization` category is
green (29).

| Test | Before |
|---|---|
| `TestRetentionUsesTheBackendsOwnRenameAsync(False)` | fails: 0 renames, 3 downloads, 3 uploads, 3 deletes |
| `TestRetentionRetriesARenameThatFailedOnceAsync` | fails: the file whose first download was made to fail is never renamed - the two retries ran on the disposed backend |
| `TestRetentionUsesTheBackendsOwnRenameAsync(True)` (`prevent-backend-rename=true`) | passes before and after: 0 renames, 3 downloads/uploads/deletes |
| `TestRetentionFallsBackToCopyingForAStreamingOnlyBackendAsync` | passes before and after: a backend without rename still gets its files renamed and intact |
| `TestVerifyContentsFindsASameSizeSameTimestampChangeAsync` | passes before and after: one destination file with one flipped byte and its timestamp pinned is the one file that fails verification |

The counting is done by a test backend that wraps `file://` and implements `IRenameEnabledBackend`,
so it can tell the backend's rename from the fallback. The retry test uses the existing
`DeterministicErrorBackend`, whose `Dispose` drops its inner backend - exactly the situation the
captured `sb` walked into. The last test drives the runner directly with a results object, because
the existing `TestVerifiesAsync` never reaches the comparison: both of its files differ in timestamp
and are copied, not verified, so `--verify-contents` had no test that proved the comparison runs.

## What changes for existing users

- `--retention` no longer moves data. On a cloud backend a rename becomes a server-side copy and
  delete instead of a download, an upload and a delete; on `file://` it becomes a move. The renamed
  object keeps its metadata instead of being re-uploaded.
- Backends with limits on server-side copies (S3 `CopyObject` stops at 5 GB) now hit those limits
  on a rename; the failure is logged as `RenameError` and the file is left under its old name, as a
  failed fallback was. `--dst-options prevent-backend-rename=true` restores the old path. A volume
  that large needs a deliberately large `--dblock-size`.
- `--verify-contents` and the fallback rename write to the temp directory instead of holding the
  volume in memory.

## Not measured

- Native rename was exercised on `file://` only; the other 26 implementations were read, not run.
- The measurement is a Debug build on one Windows machine; the relative sizes are what matters, not
  the seconds.
