### PR TITLE
Count failed deletes and renames in the synchronization tool's return code

### DIFF
--- a/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
+++ b/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs
@@ -137,7 +137,7 @@ public static class RemoteSynchronizationRunner
     /// <param name="token">The cancellation token to use for the asynchronous operations.</param>
     /// <param name="progressUpdater">Optional progress updater for reporting file count and transfer progress to the UI.</param>
     /// <param name="backendProgressUpdater">Optional backend progress updater for reporting transfer speed to the UI.</param>
-    /// <returns>The return code (0 on success).</returns>
+    /// <returns>The return code: 0 on success, -1 on abort, and the number of errors encountered otherwise.</returns>
     internal static async Task<int> RunAsync(RemoteSynchronizationConfig config, CancellationToken token, IOperationProgressUpdater? progressUpdater = null, IBackendProgressUpdater? backendProgressUpdater = null, IBasicResults? results = null)
     {
         // Parse the log level
@@ -204,7 +204,7 @@ public static class RemoteSynchronizationRunner
     /// <param name="token">The cancellation token to use for the asynchronous operations.</param>
     /// <param name="progressUpdater">Optional progress updater for reporting file count and transfer progress to the UI.</param>
     /// <param name="backendProgressUpdater">Optional backend progress updater for reporting transfer speed to the UI.</param>
-    /// <returns>The return code (0 on success).</returns>
+    /// <returns>The return code: 0 on success, -1 on abort, and the number of errors encountered otherwise.</returns>
     private static async Task<int> RunCoreAsync(RemoteSynchronizationConfig config, CancellationToken token, IOperationProgressUpdater? progressUpdater = null, IBackendProgressUpdater? backendProgressUpdater = null, RemoteSynchronizationResults? results = null)
     {
         // Unpack and parse the multi token options
@@ -344,6 +344,12 @@ public static class RemoteSynchronizationRunner
         // The delete/rename phase now reports progress incrementally, so we don't need a separate update here
         var deletedOrRenamed = Math.Max(deleted, renamed);
 
+        // Every file that was neither deleted nor renamed was logged by the phase above, and counts as an error
+        var cleanupErrors = (int)(deleteCount - deletedOrRenamed);
+        if (cleanupErrors > 0)
+            Duplicati.Library.Logging.Log.WriteErrorMessage(LOGTAG, config.Retention ? "RenameFailed" : "DeleteFailed", null,
+                "Could not {0} {1} of {2} files in {3}.", config.Retention ? "rename" : "delete", cleanupErrors, deleteCount, b2m.DisplayName);
+
         // Copy the files
         var (copied, copy_errors) = await CopyAsync(b1m, b2m, to_copy, config, deletedOrRenamed, totalFileCount, token, progressUpdater, backendProgressUpdater).ConfigureAwait(false);
         Duplicati.Library.Logging.Log.WriteVerboseMessage(LOGTAG, "CopyComplete",
@@ -380,7 +386,7 @@ public static class RemoteSynchronizationRunner
                 results?.VerifiedFileCount = verified;
                 results?.FailedVerificationCount = failed_verify;
                 results?.CopiedFileSize = totalFileSize;
-                return copy_errors.Count();
+                return copy_errors.Count() + cleanupErrors;
             }
         }
 
@@ -406,8 +412,9 @@ public static class RemoteSynchronizationRunner
                     "Renamed {0} files in {1}", renamed, b2m.DisplayName);
         }
 
-        Duplicati.Library.Logging.Log.WriteInformationMessage(LOGTAG, "SynchronizationComplete",
-            "Remote synchronization completed successfully");
+        if (cleanupErrors == 0)
+            Duplicati.Library.Logging.Log.WriteInformationMessage(LOGTAG, "SynchronizationComplete",
+                "Remote synchronization completed successfully");
 
         results?.DeletedFileCount = deleted;
         results?.RenamedFileCount = renamed;
@@ -416,7 +423,7 @@ public static class RemoteSynchronizationRunner
         results?.FailedVerificationCount = failed_verify;
         results?.CopiedFileSize = totalFileSize;
 
-        return 0;
+        return cleanupErrors;
     }
 
     // TODO have concurrency parameters: uploaders, downloaders

--- a/Duplicati/UnitTest/RemoteSynchronizationHandlerTests.cs
+++ b/Duplicati/UnitTest/RemoteSynchronizationHandlerTests.cs
@@ -1343,6 +1343,57 @@ namespace Duplicati.UnitTest
             await AssertRestoreWorksAsync([TARGETFOLDER, syncDest1, syncDest3]);
         }
 
+        /// <summary>
+        /// The handler records a sync as done when the runner returns 0, and an Interval or Counting
+        /// destination is not tried again until its next trigger. A run in which every delete failed
+        /// has not synchronized anything, so it must not be recorded as done.
+        /// </summary>
+        [Test]
+        [Category("RemoteSync")]
+        public async Task TestRunAsync_FailedDeletes_DoNotRecordASyncAsync()
+        {
+            // An empty source, so every destination file is due for a delete
+            Directory.CreateDirectory(Path.Combine(TARGETFOLDER, "source"));
+            await ToolTests.GenerateTestDataAsync(Path.Combine(TARGETFOLDER, "dest1"), 3, 0, 0, 1024);
+
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            DeterministicErrorBackend.ErrorGenerator = (action, _) => action == DeterministicErrorBackend.BackendAction.DeleteBefore;
+            try
+            {
+                var options = new Dictionary<string, string>
+                {
+                    ["remote-sync-json-config"] = @$"{{""destinations"": [
+                        {{""url"": ""deterror://{dest1}"", ""backend-retries"": 1, ""backend-retry-delay"": 0}}
+                    ]}}",
+                    ["dbpath"] = DBFILE
+                };
+
+                var remoteurl = $"file://{source}";
+                var result = new BasicBackupResults(ParsedResultType.Success);
+                var handler = new RemoteSynchronizationHandler(remoteurl, new Options(options), result);
+
+                using var db = await SQLiteLoader.LoadConnectionAsync(DBFILE);
+                using var cmd = db.CreateCommand();
+                EnsureOperationTableCreated(cmd);
+
+                await handler.RunAsync();
+
+                cmd.CommandText = @"
+                    SELECT COUNT(*)
+                    FROM ""Operation""
+                    WHERE ""Description"" LIKE 'Rsync %'
+                ";
+                var count = (long)await cmd.ExecuteScalarAsync();
+
+                Assert.AreEqual(0, count, "A sync that could not delete anything was recorded as done.");
+                Assert.AreEqual(3, Directory.EnumerateFiles(Path.Combine(TARGETFOLDER, "dest1")).Count(), "A file went missing although its delete failed.");
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+            }
+        }
+
     }
 
     /// <summary>

--- a/Duplicati/UnitTest/ToolTests.cs
+++ b/Duplicati/UnitTest/ToolTests.cs
@@ -997,5 +997,93 @@ namespace Duplicati.UnitTest
             }
         }
 
+        /// <summary>
+        /// Makes every delete on a deterror:// destination fail. The generator is static, so a test that
+        /// sets it has to clear it in a finally, or the failure leaks into the next test that uses the
+        /// backend.
+        /// </summary>
+        private static void FailEveryDelete()
+        {
+            Library.DynamicLoader.BackendLoader.AddBackend(new DeterministicErrorBackend());
+            DeterministicErrorBackend.ErrorGenerator = (action, _) => action == DeterministicErrorBackend.BackendAction.DeleteBefore;
+        }
+
+        /// <summary>
+        /// A delete or rename that fails is an error the tool has already logged, and the contract at
+        /// the top of the runner says the return code is the number of errors. A run that could not
+        /// delete anything must not return 0, and must not say it completed successfully, because the
+        /// server records a sync as done on a 0 and will not try again until the next trigger.
+        /// </summary>
+        [TestCase(false)]
+        [TestCase(true)]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestFailedDeletesAreReportedInTheExitCodeAsync(bool retention)
+        {
+            var l1 = Path.Combine(TARGETFOLDER, $"faildel_src_{retention}");
+            var l2 = Path.Combine(TARGETFOLDER, $"faildel_dst_{retention}");
+            var logfile = Path.Combine(TARGETFOLDER, $"faildel_{retention}.log");
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            // The source is left empty, so every destination file is due for a delete or a rename
+            await GenerateTestDataAsync(l2, 3, 0, 0, 1024).ConfigureAwait(false);
+            var before = Directory.EnumerateFiles(l2).Select(x => Path.GetFileName(x)!).OrderBy(x => x, StringComparer.Ordinal).ToList();
+
+            FailEveryDelete();
+            try
+            {
+                var args = new List<string> { $"file://{l1}", $"deterror://{l2}", "--confirm", "--backend-retries", "1", "--backend-retry-delay", "0", "--log-file", logfile, "--log-level", "Information" };
+                if (retention)
+                    args.Add("--retention");
+
+                var return_code = await RemoteSynchronization.Program.MainAsync([.. args]).ConfigureAwait(false);
+
+                Assert.AreEqual(3, return_code, "The return code should be the number of files the tool could not delete or rename.");
+
+                // deterror:// cannot rename, so --retention goes through download, upload and delete, and the upload may
+                // have left the new name behind; what matters is that every old name is still there
+                var remaining = Directory.EnumerateFiles(l2).Select(x => Path.GetFileName(x)!).OrderBy(x => x, StringComparer.Ordinal).ToList();
+                Assert.IsTrue(before.All(remaining.Contains), $"A file went missing although its delete failed: {string.Join(", ", remaining)}");
+
+                var log = File.ReadAllText(logfile);
+                Assert.IsFalse(log.Contains("-SynchronizationComplete]"), "The run claimed to have completed successfully.");
+                Assert.IsTrue(log.Contains(retention ? "-RenameFailed]" : "-DeleteFailed]"), $"The failures were not summarized in the log:{Environment.NewLine}{log}");
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+            }
+        }
+
+        /// <summary>
+        /// A dry run never calls the backend's delete, so a destination that cannot delete is not an
+        /// error there: the files it would delete are counted as if they had been.
+        /// </summary>
+        [Test]
+        [Category("Tools/RemoteSynchronization")]
+        public async Task TestADryRunWithAFailingDeleteStillSucceedsAsync()
+        {
+            var l1 = Path.Combine(TARGETFOLDER, "faildel_dry_src");
+            var l2 = Path.Combine(TARGETFOLDER, "faildel_dry_dst");
+            Directory.CreateDirectory(l1);
+            Directory.CreateDirectory(l2);
+
+            await GenerateTestDataAsync(l2, 3, 0, 0, 1024).ConfigureAwait(false);
+
+            FailEveryDelete();
+            try
+            {
+                var args = new string[] { $"file://{l1}", $"deterror://{l2}", "--confirm", "--dry-run", "--backend-retries", "1", "--backend-retry-delay", "0" };
+                var return_code = await RemoteSynchronization.Program.MainAsync(args).ConfigureAwait(false);
+
+                Assert.AreEqual(0, return_code, "A dry run does not delete, so it has nothing to fail on.");
+                Assert.AreEqual(3, Directory.EnumerateFiles(l2).Count(), "A dry run must not touch the destination.");
+            }
+            finally
+            {
+                DeterministicErrorBackend.ErrorGenerator = null;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## What happens

The remote synchronization tool returns 0 and logs `Remote synchronization completed successfully`
when it could not delete or rename a single file in the destination.

The contract at the top of `RemoteSynchronizationRunner` says:

```csharp
/// <returns>0 on success, -1 on abort, and the number of errors encountered otherwise.</returns>
public static async Task<int> RunAsync(string[] args)
```

`RunCoreAsync` does not keep it for the delete and rename phase. `DeleteAsync` and `RenameAsync` catch
every failure, log it as `DeleteError` / `RenameError` and return the number of *successes*
([RemoteSynchronizationRunner.cs:619-632](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs#L619-L632),
[:901-914](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs#L901-L914)).
The caller stores that number, never compares it with the number of files it asked for - `deleteCount`
at [:330](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs#L330)
is computed and never read - and returns either `copy_errors.Count()` or `0`
([:383](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs#L383),
[:419](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs#L419)).
The success message at [:409](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/RemoteSynchronization/RemoteSynchronizationRunner.cs#L409)
is unconditional.

This is what a run with three files to delete and a destination that refuses every delete logs today
(from the test below, before the change):

```
[Error-...RemoteSynchronizationRunner-DeleteError]: Error deleting file_0.txt: Operation 'Delete file_0.txt' failed after 1 attempts.
[Error-...RemoteSynchronizationRunner-DeleteError]: Error deleting file_1.txt: Operation 'Delete file_1.txt' failed after 1 attempts.
[Error-...RemoteSynchronizationRunner-DeleteError]: Error deleting file_2.txt: Operation 'Delete file_2.txt' failed after 1 attempts.
[Information-...RemoteSynchronizationRunner-SynchronizationComplete]: Remote synchronization completed successfully
```

and the exit code is 0.

### Where the 0 goes

- `Duplicati.CommandLine.SyncTool` exits with it, so a script or scheduler that checks the exit code
  sees success.
- `RemoteSynchronizationHandler` records the sync as done on it
  ([RemoteSynchronizationHandler.cs:342-343](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/RemoteSynchronizationHandler.cs#L342-L343)).
  For an `Interval` or `Counting` destination that means the run whose deletes all failed satisfies the
  trigger, and the destination is not tried again until the next interval or the next N backups.

## The change

`RunCoreAsync` only. The files that were neither deleted nor renamed are the difference between what the
phase was given and what it reports back; that difference is:

- summarized once, after the per-file messages, as `DeleteFailed` or `RenameFailed`
  (`Could not delete 3 of 3 files in <destination>.`),
- added to the return code on both exits, so a run with copy failures and delete failures reports
  both,
- the condition for `SynchronizationComplete`, which is only written when it is zero.

A dry run counts every file as done, as it did before, so `--dry-run` against a destination that
cannot delete still returns 0. `IRemoteSynchronizationResults` is unchanged: the failures are already in
its `Errors` collection through the log scope, and the handler already writes `RemoteSyncFailed` with
the exit code when it is not 0. The two inner `RunAsync` / `RunCoreAsync` doc comments now state the
same contract as the public one.

## Red to green

`--filter "FullyQualifiedName~ToolTests.TestFailedDeletes|FullyQualifiedName~ToolTests.TestADryRunWithAFailingDelete|FullyQualifiedName~RemoteSynchronizationHandlerTests.TestRunAsync_FailedDeletes"`:
**3 failed, 1 passed** before, **4 passed** after. `TestCategory=Tools/RemoteSynchronization|TestCategory=RemoteSync`
is green (68).

| Test | Before |
|---|---|
| `TestFailedDeletesAreReportedInTheExitCodeAsync(False)` | fails: `Expected: 3 But was: 0` |
| `TestFailedDeletesAreReportedInTheExitCodeAsync(True)` (`--retention`) | fails: `Expected: 3 But was: 0` |
| `TestRunAsync_FailedDeletes_DoNotRecordASyncAsync` | fails: one `Rsync %` row in `Operation` for a run that deleted nothing |
| `TestADryRunWithAFailingDeleteStillSucceedsAsync` | passes before and after: a dry run does not call delete |

The failures are injected with the existing `DeterministicErrorBackend` (`deterror://`) and its
`DeleteBefore` action. The existing `TestRemoteSynchronizationWithFaultyBackendAsync` only injects
`GetBefore` / `PutBefore`, so no test had ever asked what the tool returns when a delete fails. The
CLI tests also read the `--log-file` and assert that `SynchronizationComplete` is absent and
`DeleteFailed` / `RenameFailed` present; the handler test asserts on the `Operation` table the way
`TestRunAsync_WithWarningResult_TriggersSync_Async` does.

## What changes for existing users

- A run in which any delete or rename fails now exits with the number of files it could not delete or
  rename (plus the number it could not copy, as before), and does not log
  `Remote synchronization completed successfully`. Scripts that treat a non-zero exit as failure will
  start seeing these runs as the failures they are.
- In the server, such a run is logged as `RemoteSyncFailed` and is not recorded as a completed sync,
  so an `Interval` or `Counting` destination is tried again on the next backup rather than after the
  next trigger.
- Nothing changes for runs whose deletes and renames all succeed, or for dry runs.

## Not measured

- Only `file://` behind `deterror://` was exercised; the change is in the runner, not in any backend.
- With `--retention` on a destination that cannot rename, the fallback (download, upload, delete)
  can leave the new name behind when the final delete fails. That is unchanged by this PR and out of
  its scope; the test only asserts that every old name is still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
