### PR TITLE
Dispose the primary sync database when a sync run ends

### DIFF
--- a/Duplicati/Library/Main/Operation/Sync/SyncHandler.cs
+++ b/Duplicati/Library/Main/Operation/Sync/SyncHandler.cs
@@ -100,8 +100,12 @@ internal class SyncHandler
 
         var planSummary = new PlanSummary();
         var additionalManagers = CreateAdditionalBackendManagers();
+        // The primary backend manager belongs to the caller, but the primary sync
+        // database is created here and has to be closed here, after the folder loop
+        // and the additional targets; the additional targets are disposed in the finally.
+        using var primaryDatabase = new LocalSyncDatabase(primaryDbPath);
         var allManagers = new List<ManagerInstance>([
-            new ManagerInstance(backendManager, new LocalSyncDatabase(primaryDbPath)),
+            new ManagerInstance(backendManager, primaryDatabase),
             .. additionalManagers
             ]);
 

--- a/Duplicati/UnitTest/SyncHandlerTests.cs
+++ b/Duplicati/UnitTest/SyncHandlerTests.cs
@@ -319,6 +319,39 @@ public class SyncHandlerTests : BasicSetupHelper
         Assert.IsTrue(File.Exists(Path.Combine(targetDir, "file2.txt")), "File2 should NOT be deleted on remote");
     }
 
+    /// <summary>
+    /// The handler owns the sync database of the primary destination and has to close it
+    /// when the run is over. Windows refuses to delete a SQLite file that is still open,
+    /// so this is where a connection that is never disposed shows; Linux and macOS
+    /// unlink an open file without complaint, so there the test passes either way.
+    /// </summary>
+    [Test]
+    [Category("Sync")]
+    public async Task TestSyncReleasesItsDatabaseFileAsync()
+    {
+        var dataFolder = Path.Combine(BASEFOLDER, "sync_data_release");
+        if (Directory.Exists(dataFolder)) Directory.Delete(dataFolder, true);
+        Directory.CreateDirectory(dataFolder);
+        File.WriteAllText(Path.Combine(dataFolder, "file1.txt"), "Hello");
+
+        var dbPath = Path.Combine(BASEFOLDER, $"sync-release-{Guid.NewGuid():N}.sqlite");
+        var opts = new Dictionary<string, string>
+        {
+            ["no-encryption"] = "true",
+            ["snapshot-policy"] = "off",
+            ["dbpath"] = dbPath
+        };
+
+        using (var c = new Controller(backendUrl, opts, null))
+        {
+            await c.SyncAsync(new[] { dataFolder }, null);
+        }
+
+        Assert.IsTrue(File.Exists(dbPath), "The sync did not create its database.");
+        File.Delete(dbPath);
+        Assert.IsFalse(File.Exists(dbPath), "The sync database is still there after the delete.");
+    }
+
     [Test]
     [Category("Sync")]
     public async Task TestSyncHashVerificationAsync()


### PR DESCRIPTION
## What happens

The `sync` command never closes the sync database of its primary destination.

`SyncHandler.RunAsync` creates it inline
([SyncHandler.cs:110-113](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/Sync/SyncHandler.cs#L110-L113)):

```csharp
var allManagers = new List<ManagerInstance>([
    new ManagerInstance(backendManager, new LocalSyncDatabase(primaryDbPath)),
    .. additionalManagers
    ]);
```

and the `finally` block disposes only `additionalManagers`
([:238-249](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Operation/Sync/SyncHandler.cs#L238-L249)).
`LocalSyncDatabase` is a SQLite connection opened with `Pooling=false`
([SQLiteLoader.cs:292](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/SQLiteHelper/SQLiteLoader.cs#L292)),
so nothing else releases the handle: the file stays open until the process exits. The controller does
not open a database of its own for `Sync`, so this is the only connection to the file.

Seen while writing the tests for #7313: a test that passes `dbpath` and lets the base fixture delete
the file afterwards fails on Windows with

```
System.IO.IOException : The process cannot access the file '...\sync-release-f623dbb6d5db4d6080e2cdcd8f0fdbbc.sqlite' because it is being used by another process.
```

In a process that runs syncs repeatedly this is one open handle per run, and on Windows the database
cannot be moved or deleted while that process is up.

## The change

The primary database becomes a `using` declaration in `RunAsync`, so it is disposed when the method
ends - after the folder loop and after the additional targets, which the `finally` still disposes. The
primary backend manager is untouched; it belongs to the controller
([Controller.cs:574](https://github.com/duplicati/duplicati/blob/df30f7032e032850eca2da3b9e51ecc255dfb352/Duplicati/Library/Main/Controller.cs#L574)).

## Red to green

`TestSyncReleasesItsDatabaseFileAsync` runs one sync with an explicit `dbpath` and then deletes the
file: on Windows it fails before the change with the `IOException` above and passes after it. Linux and
macOS unlink an open file without complaint, so there the test passes either way; the leak is only
observable on the Windows job. `TestCategory=Sync` is green (30).

#7313 works around this leak with a per-test database name in `CaseInsensitiveDestinationSyncTests`;
that workaround (and its comment) can go once both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
